### PR TITLE
Feature/2098/recursive wdl

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -261,8 +261,12 @@ public class WDLHandler implements LanguageHandlerInterface {
             } catch (NoSuchMethodException e) {
                 //FIXME: the best we can do is be generous and assume that unknown methods are WDL 1.0 methods until we update
                 // https://github.com/ga4gh/dockstore/issues/2139
-                validationMessageObject.put(primaryDescriptorFilePath, "Unknown methods were found, indicating that this may be a WDL 1.0 file. Currently Dockstore cannot parse WDL 1.0, so validation has been skipped. It is likely that the import processing and DAG generation will be broken.\n" + e.getMessage());
+                validationMessageObject.put(primaryDescriptorFilePath,
+                        "Unknown methods were found, indicating that this may be a WDL 1.0 file. Currently Dockstore cannot parse WDL 1.0, so validation has been skipped. It is likely that the import processing and DAG generation will be broken.\n"
+                                + e.getMessage());
                 return new VersionTypeValidation(true, validationMessageObject);
+            } catch (CustomWebApplicationException e) {
+                throw e;
             } catch (Exception e) {
                 throw new CustomWebApplicationException(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
             } finally {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -15,7 +15,6 @@
  */
 package io.dockstore.webservice.languages;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -17,6 +17,7 @@ package io.dockstore.webservice.languages;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -46,6 +47,7 @@ import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
@@ -148,7 +150,7 @@ public class WDLHandler implements LanguageHandlerInterface {
         if (node instanceof WdlParser.Ast) {
             WdlParser.Ast nodeAst = (WdlParser.Ast)node;
             if (nodeAst.getAttribute("key") instanceof WdlParser.Terminal && (((WdlParser.Terminal)nodeAst.getAttribute("key"))
-                .getSourceString().equalsIgnoreCase(key))) {
+                    .getSourceString().equalsIgnoreCase(key))) {
                 return ((WdlParser.Terminal)nodeAst.getAttribute("value")).getSourceString();
             }
         }
@@ -213,7 +215,7 @@ public class WDLHandler implements LanguageHandlerInterface {
         if (filteredSourceFiles.size() > 0) {
             try {
                 Optional<SourceFile> primaryDescriptor = filteredSourceFiles.stream()
-                    .filter(sourceFile -> Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath)).findFirst();
+                        .filter(sourceFile -> Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath)).findFirst();
 
                 if (primaryDescriptor.isPresent()) {
                     if (primaryDescriptor.get().getContent() == null || primaryDescriptor.get().getContent().trim().replaceAll("\n", "").isEmpty()) {
@@ -246,6 +248,8 @@ public class WDLHandler implements LanguageHandlerInterface {
                 Bridge bridge = new Bridge(tempMainDescriptor.getParent());
                 bridge.setSecondaryFiles((HashMap<String, String>)secondaryDescContent);
                 Files.asCharSink(tempMainDescriptor, StandardCharsets.UTF_8).write(mainDescriptor);
+                String content = FileUtils.readFileToString(tempMainDescriptor, StandardCharsets.UTF_8);
+                checkForRecursiveHTTPImports(content, new HashSet<>());
                 if (Objects.equals(type, "tool")) {
                     bridge.isValidTool(tempMainDescriptor);
                 } else {
@@ -259,9 +263,6 @@ public class WDLHandler implements LanguageHandlerInterface {
                 // https://github.com/ga4gh/dockstore/issues/2139
                 validationMessageObject.put(primaryDescriptorFilePath, "Unknown methods were found, indicating that this may be a WDL 1.0 file. Currently Dockstore cannot parse WDL 1.0, so validation has been skipped. It is likely that the import processing and DAG generation will be broken.\n" + e.getMessage());
                 return new VersionTypeValidation(true, validationMessageObject);
-            } catch (StackOverflowError e) {
-                // This is niche and should be fixed properly with a new WDL parser.
-                throw new CustomWebApplicationException("Error parsing workflow. You may have a recursive import.", HttpStatus.SC_BAD_REQUEST);
             } catch (Exception e) {
                 throw new CustomWebApplicationException(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
             } finally {
@@ -272,6 +273,33 @@ public class WDLHandler implements LanguageHandlerInterface {
             return new VersionTypeValidation(false, validationMessageObject);
         }
         return new VersionTypeValidation(true, null);
+    }
+
+    public void checkForRecursiveHTTPImports(String content, Set<String> currentFileImports) throws IOException {
+        // Use matcher to get imports
+        String[] lines = StringUtils.split(content, '\n');
+
+        for (String line : lines) {
+            Matcher m = IMPORT_PATTERN.matcher(line);
+
+            while (m.find()) {
+                String match = m.group(1);
+                if (match.startsWith("http://") || match.startsWith("https://")) { // Don't resolve URLs
+                    System.out.println("Found match: " + match);
+                    if (currentFileImports.contains(match)) {
+                        throw new CustomWebApplicationException("Error parsing workflow. You may have a recursive import.",
+                                HttpStatus.SC_BAD_REQUEST);
+                    } else {
+                        System.out.println("New match: " + match);
+                        currentFileImports.add(match);
+                        URL url = new URL(match);
+                        String s = IOUtils.toString(url, StandardCharsets.UTF_8);
+                        checkForRecursiveHTTPImports(s, currentFileImports);
+                    }
+                    currentFileImports.add(match.replaceFirst("file://", "")); // remove file:// from path
+                }
+            }
+        }
     }
 
     @Override
@@ -291,12 +319,12 @@ public class WDLHandler implements LanguageHandlerInterface {
 
     @Override
     public Map<String, SourceFile> processImports(String repositoryId, String content, Version version,
-        SourceCodeRepoInterface sourceCodeRepoInterface, String filepath) {
+            SourceCodeRepoInterface sourceCodeRepoInterface, String filepath) {
         return processImports(repositoryId, content, version, sourceCodeRepoInterface, new HashMap<>(), filepath);
     }
 
     private Map<String, SourceFile> processImports(String repositoryId, String content, Version version,
-        SourceCodeRepoInterface sourceCodeRepoInterface, Map<String, SourceFile> imports, String currentFilePath) {
+            SourceCodeRepoInterface sourceCodeRepoInterface, Map<String, SourceFile> imports, String currentFilePath) {
         SourceFile.FileType fileType = SourceFile.FileType.DOCKSTORE_WDL;
 
         // Use matcher to get imports
@@ -348,7 +376,7 @@ public class WDLHandler implements LanguageHandlerInterface {
      */
     @Override
     public String getContent(String mainDescName, String mainDescriptor, Map<String, String> secondaryDescContent,
-        LanguageHandlerInterface.Type type, ToolDAO dao) {
+            LanguageHandlerInterface.Type type, ToolDAO dao) {
         // Initialize general variables
         String callType = "call"; // This may change later (ex. tool, workflow)
         String toolType = "tool";

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -259,6 +259,9 @@ public class WDLHandler implements LanguageHandlerInterface {
                 // https://github.com/ga4gh/dockstore/issues/2139
                 validationMessageObject.put(primaryDescriptorFilePath, "Unknown methods were found, indicating that this may be a WDL 1.0 file. Currently Dockstore cannot parse WDL 1.0, so validation has been skipped. It is likely that the import processing and DAG generation will be broken.\n" + e.getMessage());
                 return new VersionTypeValidation(true, validationMessageObject);
+            } catch (StackOverflowError e) {
+                // This is niche and should be fixed properly with a new WDL parser.
+                throw new CustomWebApplicationException("Error parsing workflow. You may have a recursive import.", HttpStatus.SC_BAD_REQUEST);
             } catch (Exception e) {
                 throw new CustomWebApplicationException(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
             } finally {

--- a/dockstore-webservice/src/test/java/core/WDLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/WDLParseTest.java
@@ -90,7 +90,7 @@ public class WDLParseTest {
         } catch (IOException e) {
             Assert.fail();
         } catch (CustomWebApplicationException e) {
-            Assert.assertEquals("Error parsing workflow. You may have a recursive import.", e.getResponse().getEntity());
+            Assert.assertEquals("Error parsing workflow. You may have a recursive import.", e.getErrorMessage());
         }
     }
 }

--- a/dockstore-webservice/src/test/resources/recursive.wdl
+++ b/dockstore-webservice/src/test/resources/recursive.wdl
@@ -1,0 +1,11 @@
+import "https://raw.githubusercontent.com/ga4gh/dockstore/e8eb05ec0dff7bd1585eebcb32c3f10f2d8ea681/dockstore-webservice/src/test/resources/recursive.wdl" as f1
+
+# TODO: Change the above import to a tagged version
+
+workflow RecursiveWorkflow {
+  File inputFile
+
+  call f1.thing as thing {
+      input: inputFile = inputFile
+  }
+}


### PR DESCRIPTION
For #2098 

The issue ended up being about recursive imports and how Dockstore didn't indicate to the user well that there was the possibility of recursive imports.

This merely catches the error.  Hopefully the WDL Parser changes will actually figure it out before the error occurs.

TODO: Create a ticket to change the recursive.wdl to use a tagged URL