### PR TITLE
Surfacing toil issues

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/CwltoolLauncher.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/CwltoolLauncher.java
@@ -66,7 +66,8 @@ public class CwltoolLauncher extends BaseLauncher {
         if (outputMap.size() > 0) {
             System.out.println("Provisioning your output files to their final destinations");
             List<ImmutablePair<String, FileProvisioning.FileInfo>> outputList = CWLClient.registerOutputFiles(outputMap, outputObj, "");
-            this.fileProvisioning.uploadFiles(outputList);
+            // short circuit file provisioning because the paths are screwed up
+            // this.fileProvisioning.uploadFiles(outputList);
         }
     }
 

--- a/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
+++ b/dockstore-client/src/main/java/io/github/collaboratory/cwl/CWLClient.java
@@ -1088,11 +1088,11 @@ public class CWLClient extends BaseLanguageClient implements LanguageClientInter
             return outputSet;
         }
         Path path = Paths.get(cwlOutputPath);
-        if (!path.isAbsolute() || !java.nio.file.Files.exists(path)) {
-            // changing the cwlOutput path to an absolute path (bunny uses absolute, cwltool uses relative, but can change?!)
-            Path currentRelativePath = Paths.get("");
-            cwlOutputPath = currentRelativePath.toAbsolutePath().toString() + cwlOutputPath;
-        }
+        //        if (!path.isAbsolute() || !java.nio.file.Files.exists(path)) {
+        //            // changing the cwlOutput path to an absolute path (bunny uses absolute, cwltool uses relative, but can change?!)
+        //            Path currentRelativePath = Paths.get("");
+        //            cwlOutputPath = currentRelativePath.toAbsolutePath().toString() + cwlOutputPath;
+        //        }
 
         LOG.info("NAME: {} URL: {} FILENAME: {} CWL OUTPUT PATH: {}", file.getLocalPath(), file.getUrl(), key, cwlOutputPath);
         System.out.println("Registering: #" + key + " to provision from " + cwlOutputPath + " to : " + file.getUrl());


### PR DESCRIPTION
!!! DO NOT MERGE !!!

Talked a bit about toil integration in dockstore in the office today. This PR short circuits provisioning to enable running workflows via toil. There's a minor bug in the output provisioning that someone who worked on it might recognize. The output path gets concatenated so it is trying to download from a concatenated path that's incorrect.

0) build the client jar with this patch
1) install toil `pip3 install toil`
2) Edit `~/.dockstore/config` with a line `cwlrunner: toil`
3) Entry2json -> launch -> ...
* Note that the `datastore` directory is created with your outputs due to the short circuit of output provisioning.