### PR TITLE
reverted jetty to a version that works

### DIFF
--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.7.0-alpha.2-SNAPSHOT
+  version: 1.7.0-alpha.4-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:
@@ -3725,6 +3725,77 @@ paths:
                 $ref: "#/components/schemas/Organization"
       security:
         - BEARER: []
+  "/organizations/{organizationId}/star":
+    put:
+      tags:
+        - organizations
+      summary: Star an organization.
+      description: ""
+      operationId: starOrganization
+      parameters:
+        - name: organizationId
+          in: path
+          description: Organization to star.
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StarRequest"
+        description: StarRequest to star an organization for a user
+        required: true
+      responses:
+        default:
+          description: successful operation
+      security:
+        - BEARER: []
+  "/organizations/{organizationId}/starredUsers":
+    get:
+      tags:
+        - organizations
+      summary: Returns list of users who starred the given approved organization.
+      description: ""
+      operationId: getStarredUsersForApprovedOrganization
+      parameters:
+        - name: organizationId
+          in: path
+          description: Get starred users of an approved organization by id.
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/User"
+  "/organizations/{organizationId}/unstar":
+    delete:
+      tags:
+        - organizations
+      summary: Unstar an organization.
+      description: ""
+      operationId: unstarOrganization
+      parameters:
+        - name: organizationId
+          in: path
+          description: Organization to unstar.
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        default:
+          description: successful operation
+      security:
+        - BEARER: []
   "/organizations/{organizationId}/user":
     post:
       tags:
@@ -3920,6 +3991,24 @@ paths:
             application/json:
               schema:
                 type: boolean
+      security:
+        - BEARER: []
+  /users/starredOrganizations:
+    get:
+      tags:
+        - users
+      summary: Get the logged-in user's starred organizations.
+      description: ""
+      operationId: getStarredOrganizations
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Organization"
       security:
         - BEARER: []
   /users/starredTools:
@@ -6846,6 +6935,12 @@ components:
           type: string
           description: Logo URL
           pattern: ([^\s]+)(?i)(\.jpg|\.jpeg|\.png|\.gif)
+        starredUsers:
+          type: array
+          description: This indicates the users that have starred this organization
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/User"
     OrganizationUser:
       type: object
       required:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -4629,7 +4629,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
   /workflows/hostedEntry/{entryId}:
     delete:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.7.0-alpha.3"
+  version: "1.7.0-alpha.4-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:
@@ -6067,10 +6067,6 @@ definitions:
       custom_docker_registry_path:
         type: "string"
         readOnly: true
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6086,6 +6082,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1
@@ -6282,10 +6282,6 @@ definitions:
         type: "integer"
         format: "int64"
         description: "The Id of the corresponding topic on Dockstore Discuss"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6301,6 +6297,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1
@@ -7350,10 +7350,6 @@ definitions:
         type: "integer"
         format: "int64"
         readOnly: true
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -7369,6 +7365,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <maven-failsafe.version>2.21.0</maven-failsafe.version>
         <httpcomponents.version>4.5.8</httpcomponents.version>
         <httpcore.version>4.4.11</httpcore.version>
-        <jetty-servlet.version>9.4.17.v20190418</jetty-servlet.version>
+        <jetty-servlet.version>9.4.14.v20181114</jetty-servlet.version>
         <netty.version>4.1.33.Final</netty.version>
 
         <skipTests>false</skipTests>


### PR DESCRIPTION
Revert Jetty 9.4.17.v20190418 to 9.4.14.v20181114.

The issue was that the DropwizardSlf4jRequestLog was trying to call the default constructor of the  AbstractNCSARequestLog, but this no longer seems to be there in newer versions of Jetty.

For now we should keep it at 9.4.14...

https://github.com/dockstore/dockstore/issues/2484