### PR TITLE
Feature/2444/gtmid

### DIFF
--- a/dockstore-integration-testing/src/test/resources/dockstore.yml
+++ b/dockstore-integration-testing/src/test/resources/dockstore.yml
@@ -113,3 +113,5 @@ uiConfig:
 
   enableLaunchWithFireCloud: true
 
+  tagManagerId: <fill me in>
+

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
@@ -18,7 +18,6 @@ package io.dockstore.webservice;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -576,7 +575,7 @@ public class DockstoreWebserviceConfiguration extends Configuration {
 
         private boolean enableLaunchWithFireCloud;
 
-        private Optional<String> tagManagerId;
+        private String tagManagerId;
 
 
         public String getDiscourseUrl() {
@@ -723,11 +722,11 @@ public class DockstoreWebserviceConfiguration extends Configuration {
             this.enableLaunchWithFireCloud = enableLaunchWithFireCloud;
         }
 
-        public Optional<String> getTagManagerId() {
+        public String getTagManagerId() {
             return tagManagerId;
         }
 
-        public void setTagManagerId(Optional<String> tagManagerId) {
+        public void setTagManagerId(String tagManagerId) {
             this.tagManagerId = tagManagerId;
         }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
@@ -18,6 +18,7 @@ package io.dockstore.webservice;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -575,6 +576,8 @@ public class DockstoreWebserviceConfiguration extends Configuration {
 
         private boolean enableLaunchWithFireCloud;
 
+        private Optional<String> tagManagerId;
+
 
         public String getDiscourseUrl() {
             return discourseUrl;
@@ -719,5 +722,14 @@ public class DockstoreWebserviceConfiguration extends Configuration {
         public void setEnableLaunchWithFireCloud(boolean enableLaunchWithFireCloud) {
             this.enableLaunchWithFireCloud = enableLaunchWithFireCloud;
         }
+
+        public Optional<String> getTagManagerId() {
+            return tagManagerId;
+        }
+
+        public void setTagManagerId(Optional<String> tagManagerId) {
+            this.tagManagerId = tagManagerId;
+        }
+
     }
 }

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -6177,6 +6177,8 @@ components:
           type: string
         enableLaunchWithFireCloud:
           type: boolean
+        tagManagerId:
+          type: string
         githubClientId:
           type: string
         quayIoClientId:

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.7.0-alpha.5-SNAPSHOT
+  version: 1.7.0-alpha.6-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -125,6 +125,8 @@ components:
           type: string
         quayIoScope:
           type: string
+        tagManagerId:
+          type: string
         terraImportUrl:
           type: string
       type: object
@@ -1183,7 +1185,7 @@ paths:
           description: default response
   /api/ga4gh/v2/extended/containers/{organization}:
     get:
-      operationId: entriesOrgGet
+      operationId: entriesOrgGet_1
       parameters:
       - in: path
         name: organization
@@ -1198,7 +1200,7 @@ paths:
           description: default response
   /api/ga4gh/v2/extended/organizations:
     get:
-      operationId: entriesOrgGet_1
+      operationId: entriesOrgGet
       responses:
         default:
           content:
@@ -1812,7 +1814,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Tool'
           description: default response
   /containers/hostedEntry/{entryId}:
     delete:
@@ -3119,7 +3121,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Collection'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
   /organizations/name/{name}:
     get:
@@ -4594,7 +4596,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Workflow'
           description: default response
     patch:
       operationId: editHosted_1

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -4570,7 +4570,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Workflow'
           description: default response
   /workflows/hostedEntry/{entryId}:
     delete:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1812,7 +1812,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tool'
+                $ref: '#/components/schemas/Entry'
           description: default response
   /containers/hostedEntry/{entryId}:
     delete:
@@ -4033,7 +4033,7 @@ paths:
                 type: boolean
           description: default response
     get:
-      operationId: getUser_1
+      operationId: getUser
       requestBody:
         content:
           '*/*':
@@ -4192,7 +4192,7 @@ paths:
           description: default response
   /users/{userId}:
     get:
-      operationId: getUser
+      operationId: getUser_1
       parameters:
       - in: path
         name: userId
@@ -4594,7 +4594,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
     patch:
       operationId: editHosted_1

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5801,6 +5801,8 @@ definitions:
         type: "string"
       enableLaunchWithFireCloud:
         type: "boolean"
+      tagManagerId:
+        type: "string"
       githubClientId:
         type: "string"
       quayIoClientId:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.7.0-alpha.5"
+  version: "1.7.0-alpha.6-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:


### PR DESCRIPTION
Add Google Tag Manager id to config.json

#2444

Made it optional so developers don't have to update their
dockstore.yml for a setting they will never set.
