### PR TITLE
Feature/2388/open jdk11 warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ server-url = https://www.dockstore.org/api
 
 ### Migration to Dockstore 1.7
 
-1. Ensure that you are using Java 11
+1. Ensure that you are using Java 11. Java 8 (both Open and Oracle) will not work.
 
 ### Migration to Dockstore 1.3
 

--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -260,12 +260,6 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-            <version>1.1.1</version>
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>

--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -266,7 +266,6 @@
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
             <version>1.1.1</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -351,6 +350,7 @@
                                 <usedDependency>javax.annotation:javax.annotation-api</usedDependency>
                                 <usedDependency>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base</usedDependency>
                                 <usedDependency>io.spray:spray-json_2.12</usedDependency>
+                                <usedDependency>javax.activation:activation</usedDependency>
                             </usedDependencies>
 
                         </configuration>

--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -266,6 +266,8 @@
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
             <version>1.1.1</version>
+            <scope>runtime</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -350,7 +352,6 @@
                                 <usedDependency>javax.annotation:javax.annotation-api</usedDependency>
                                 <usedDependency>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base</usedDependency>
                                 <usedDependency>io.spray:spray-json_2.12</usedDependency>
-                                <usedDependency>javax.activation:activation</usedDependency>
                             </usedDependencies>
 
                         </configuration>

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/ClientTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/ClientTestIT.java
@@ -49,7 +49,8 @@ public class ClientTestIT {
      */
     @Test
     public void noErrorLogs() {
-        String[] command = { "--version" };
+        String clientConfig = ResourceHelpers.resourceFilePath("clientConfig");
+        String[] command = { "--help", "--config", clientConfig };
         Client.main(command);
         Assert.assertTrue("There are unexpected error logs", systemErrRule.getLog().isBlank());
     }

--- a/dockstore-client/src/test/java/io/dockstore/client/cli/ClientTestIT.java
+++ b/dockstore-client/src/test/java/io/dockstore/client/cli/ClientTestIT.java
@@ -41,4 +41,16 @@ public class ClientTestIT {
         Assert.assertTrue(!systemErrRule.getLog().contains("Override and run with"));
         Assert.assertTrue(!systemOutRule.getLog().contains("Override and run with"));
     }
+
+    /**
+     * When javax.activation is missing (because using Java 11), there will be error logs
+     * Check that there are no error logs
+     * Careful, test scope may interfere with validity of this test
+     */
+    @Test
+    public void noErrorLogs() {
+        String[] command = { "--version" };
+        Client.main(command);
+        Assert.assertTrue("There are unexpected error logs", systemErrRule.getLog().isBlank());
+    }
 }


### PR DESCRIPTION
For #2388 

The issue is that Java 11 removed some Java EE related packages (namely javax.activation).

In the dockstore-client, jersey-client 2.25.1 uses javax.activation.  However, even after updating jersey-client to the latest (2.28), it is still using javax.activation.  

So we either include javax.activation (or a third-party alternative) or we wait until jersey-client is updated to not use it

Decided to use include javax.activation during runtime

javax.xml.bind includes javax.activation