### PR TITLE
Problems with apt update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,14 @@ jobs:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
+          name: Install postgresql client
+          command: |
+            sudo rm -rf /var/lib/apt/lists/*
+            sudo apt update
+            sudo apt install -y postgresql-client
+      - run:
           name: setup postgres
           command: |
-            sudo apt-get update && sudo apt-get install -y postgresql-client 
             psql -c "create user dockstore with password 'dockstore' createdb;" -U postgres
             psql -c "ALTER USER dockstore WITH superuser;" -U postgres
             psql -c 'create database webservice_test with owner = dockstore;' -U postgres


### PR DESCRIPTION
Something is wrong with Circle CI.  
Develop has been getting the following during apt-get update for the past 6 days
```
E: Could not open file /var/lib/apt/lists/deb.debian.org_debian_dists_stretch-backports_main_binary-amd64_Packages.diff_Index - open (2: No such file or directory)
```
No idea if it'll ever get fixed automatically, but this fixes it.

Probably don't need to wait for Travis CI to pass