### PR TITLE
unique error code for lambda failures

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -54,6 +54,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 import static io.dockstore.common.CommonTestUtilities.getTestingPostgres;
+import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -214,7 +215,7 @@ public class ServiceIT extends BaseIT {
         try {
             client.addService(serviceRepo, "iamnotarealuser", installationId);
         } catch (ApiException ex) {
-            assertEquals("Should have error code 418", 418, ex.getCode());
+            assertEquals("Should have error code 418", LAMBDA_FAILURE, ex.getCode());
         }
 
         final long count = testingPostgres
@@ -242,7 +243,7 @@ public class ServiceIT extends BaseIT {
         try {
             client.addService(serviceRepo, "admin@admin.com", installationId);
         } catch (ApiException ex) {
-            assertEquals("Should have error code 418", 418, ex.getCode());
+            assertEquals("Should have error code 418", LAMBDA_FAILURE, ex.getCode());
         }
 
         final long count = testingPostgres
@@ -272,7 +273,7 @@ public class ServiceIT extends BaseIT {
         try {
             client.upsertServiceVersion(serviceRepo, "admin@admin.com", "1.0-fake", installationId);
         } catch (ApiException ex) {
-            assertEquals("Should have error code 418", 418, ex.getCode());
+            assertEquals("Should have error code 418", LAMBDA_FAILURE, ex.getCode());
         }
 
         final long count = testingPostgres
@@ -306,14 +307,14 @@ public class ServiceIT extends BaseIT {
         try {
             client.upsertServiceVersion(serviceRepo, "admin@admin.com", "noYml", installationId);
         } catch (ApiException ex) {
-            assertEquals("Should have error code 418", 418, ex.getCode());
+            assertEquals("Should have error code 418", LAMBDA_FAILURE, ex.getCode());
         }
 
         // Add version that has invalid dockstore.yml
         try {
             client.upsertServiceVersion(serviceRepo, "admin@admin.com", "invalidYml", installationId);
         } catch (ApiException ex) {
-            assertEquals("Should have error code 418", 418, ex.getCode());
+            assertEquals("Should have error code 418", LAMBDA_FAILURE, ex.getCode());
         }
     }
 
@@ -333,7 +334,7 @@ public class ServiceIT extends BaseIT {
         try {
             io.swagger.client.model.Workflow service = client.addService(serviceRepo, "admin@admin.com", installationId);
         } catch (ApiException ex) {
-            assertEquals("Should have error code 418", 418, ex.getCode());
+            assertEquals("Should have error code 418", LAMBDA_FAILURE, ex.getCode());
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/Constants.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/Constants.java
@@ -21,6 +21,7 @@ package io.dockstore.webservice;
  */
 public final class Constants {
     public static final String JWT_SECURITY_DEFINITION_NAME = "BEARER";
+    public static final int LAMBDA_FAILURE = 418; // Tell lambda to not try again
     private Constants() {
         // not called
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -71,8 +71,10 @@ import org.kohsuke.github.extras.ImpatientHttpConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.error.YAMLException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
 
 /**
  * @author dyuen
@@ -324,7 +326,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
      * @param repositoryId of the form organization/repository (Ex. dockstore/dockstore-ui2)
      * @return GitHub repository
      */
-    private GHRepository getRepository(String repositoryId) {
+    public GHRepository getRepository(String repositoryId) {
         GHRepository repository;
         try {
             repository = github.getRepository(repositoryId);
@@ -407,6 +409,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         if (workflow.getMode() == WorkflowMode.SERVICE) {
             version = setupServiceFilesForVersion(calculatedPath, ref, repository, version);
             if (version == null) {
+                // Returning null implies either no yml or an invalid yml
                 return null;
             }
         } else {
@@ -499,17 +502,29 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
             // Grab all files from files array
             Yaml yaml = new Yaml();
-            Map<String, Object> map = yaml.load(dockstoreYmlContent);
-            Map<String, Object> serviceObject = (Map<String, Object>)map.get("service");
-            List<String> files = (List<String>)serviceObject.get("files");
+            List<String> files;
+            try {
+                Map<String, Object> map = yaml.load(dockstoreYmlContent);
+                Map<String, Object> serviceObject = (Map<String, Object>)map.get("service");
+                files = (List<String>)serviceObject.get("files");
+            } catch (YAMLException | ClassCastException ex) {
+                String msg = "Invalid dockstore.yml";
+                LOG.error(msg, ex);
+                throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
+            }
             for (String filePath: files) {
                 String fileContent = this.readFileFromRepo(filePath, ref.getLeft(), repository);
-                SourceFile file = new SourceFile();
-                file.setAbsolutePath(filePath);
-                file.setPath(filePath);
-                file.setContent(fileContent);
-                file.setType(DescriptorLanguage.FileType.DOCKSTORE_SERVICE_OTHER);
-                version.getSourceFiles().add(file);
+                if (fileContent != null) {
+                    SourceFile file = new SourceFile();
+                    file.setAbsolutePath(filePath);
+                    file.setPath(filePath);
+                    file.setContent(fileContent);
+                    file.setType(DescriptorLanguage.FileType.DOCKSTORE_SERVICE_OTHER);
+                    version.getSourceFiles().add(file);
+                } else {
+                    // File not found or null
+                    LOG.info("Could not find file " + filePath + " in repo " + repository);
+                }
             }
             return version;
         } else {
@@ -664,18 +679,26 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
      * @param repository Github repostory name (ex. dockstore/dockstore-ui2)
      * @param gitReference GitHub reference object
      * @param workflows Workflows to upsert version
+     * @param workflowMode Mode of workflow
      * @return workflows with new/updated version
      */
-    public List<Workflow> upsertVersionForWorkflows(String repository, String gitReference, List<Workflow> workflows) {
+    public List<Workflow> upsertVersionForWorkflows(String repository, String gitReference, List<Workflow> workflows, WorkflowMode workflowMode) {
         GHRepository ghRepository = getRepository(repository);
         for (Workflow workflow : workflows) {
 
             WorkflowVersion version;
             try {
                 version = getTagVersion(ghRepository, gitReference, workflow);
+                if (version == null && workflowMode == WorkflowMode.SERVICE) {
+                    String msg = "Could not create a version. Please ensure that the dockstore.yml is present and valid.";
+                    LOG.error(msg);
+                    throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
+                }
                 workflow.addWorkflowVersion(version);
             } catch (IOException ex) {
-                LOG.error("Cannot retrieve the workflow reference from GitHub, ensure that " + gitReference + " is a valid tag.");
+                String msg = "Cannot retrieve the workflow reference from GitHub, ensure that " + gitReference + " is a valid tag.";
+                LOG.error(msg);
+                throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
             }
         }
         return workflows;
@@ -694,8 +717,9 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
         Triple<String, Date, String> ref = getRef(ghRef, ghRepository);
         if (ref == null) {
-            LOG.error(gitUsername + ": Cannot retrieve the workflow reference from GitHub, ensure that " + gitReference + " is a valid tag.");
-            throw new CustomWebApplicationException("Could not reach GitHub, please try again later", HttpStatus.SC_SERVICE_UNAVAILABLE);
+            String msg = "Cannot retrieve the workflow reference from GitHub, ensure that " + gitReference + " is a valid tag.";
+            LOG.error(msg);
+            throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
         }
 
         // Find existing version if it exists

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.7.0-alpha.9-SNAPSHOT
+  version: 1.7.0-alpha.11-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:
@@ -4872,7 +4872,8 @@ paths:
       tags:
         - workflows
       summary: Create a service for the given repository (ex. dockstore/dockstore-ui2).
-      description: To be called by a lambda function.
+      description: To be called by a lambda function. Error code 418 is returned to tell
+        lambda not to retry.
       operationId: addService
       requestBody:
         content:
@@ -4908,7 +4909,8 @@ paths:
         - workflows
       summary: Add or update a service version for a given GitHub tag for a service
         with the given repository (ex. dockstore/dockstore-ui2).
-      description: To be called by a lambda function.
+      description: To be called by a lambda function. Error code 418 is returned to tell
+        lambda not to retry.
       operationId: upsertServiceVersion
       requestBody:
         content:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1309,7 +1309,7 @@ paths:
           description: default response
   /api/ga4gh/v2/extended/containers/{organization}:
     get:
-      operationId: entriesOrgGet
+      operationId: entriesOrgGet_1
       parameters:
       - in: path
         name: organization
@@ -1324,7 +1324,7 @@ paths:
           description: default response
   /api/ga4gh/v2/extended/organizations:
     get:
-      operationId: entriesOrgGet_1
+      operationId: entriesOrgGet
       responses:
         default:
           content:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.7.0-alpha.10"
+  version: "1.7.0-alpha.11-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:
@@ -4587,7 +4587,8 @@ paths:
       tags:
       - "workflows"
       summary: "Create a service for the given repository (ex. dockstore/dockstore-ui2)."
-      description: "To be called by a lambda function."
+      description: "To be called by a lambda function. Error code 418 is returned\
+        \ to tell lambda not to retry."
       operationId: "addService"
       consumes:
       - "application/x-www-form-urlencoded"
@@ -4622,7 +4623,8 @@ paths:
       - "workflows"
       summary: "Add or update a service version for a given GitHub tag for a service\
         \ with the given repository (ex. dockstore/dockstore-ui2)."
-      description: "To be called by a lambda function."
+      description: "To be called by a lambda function. Error code 418 is returned\
+        \ to tell lambda not to retry."
       operationId: "upsertServiceVersion"
       consumes:
       - "application/x-www-form-urlencoded"


### PR DESCRIPTION
For certain cases for add service and add version to service, return a 418. These are for failures that we don't want lambda to retry.

Lambda will not retry 400 level errors (client errors) but will retry 500 level errors (server errors)