### PR TITLE
constrain service path

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -388,7 +388,7 @@ public class ServiceIT extends BaseIT {
             test2Service.setMode(WorkflowMode.SERVICE);
             test2Service.setDescriptorType(DescriptorLanguage.SERVICE);
             test2Service.setOrganization("hydra");
-            test2Service.setRepository("hydra_repo");
+            test2Service.setRepository("hydra_repo2");
             test2Service.setDefaultWorkflowPath(".dockstore.yml");
 
             final Map<DescriptorLanguage.FileType, String> defaultPaths = test2Service.getDefaultPaths();

--- a/dockstore-webservice/src/main/resources/import.sql
+++ b/dockstore-webservice/src/main/resources/import.sql
@@ -24,6 +24,9 @@ CREATE UNIQUE INDEX full_workflow_name ON workflow USING btree (sourcecontrol, o
 CREATE UNIQUE INDEX full_tool_name ON tool USING btree (registry, namespace, name, toolname) WHERE toolname IS NOT NULL;
 CREATE UNIQUE INDEX partial_workflow_name ON workflow USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
 CREATE UNIQUE INDEX partial_tool_name ON tool USING btree (registry, namespace, name) WHERE toolname IS NULL;
+CREATE UNIQUE INDEX full_service_name ON service USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
+CREATE UNIQUE INDEX partial_service_name ON service USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
+
 -- unable to convert these to JPA properly
 ALTER TABLE token ADD CONSTRAINT fk_userid_with_enduser FOREIGN KEY (userid) REFERENCES public.enduser (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION;
 -- https://liquibase.jira.com/browse/CORE-2895

--- a/dockstore-webservice/src/main/resources/migrations.1.7.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.7.0.xml
@@ -252,4 +252,13 @@
             ALTER TABLE workflow_workflowversion DROP CONSTRAINT IF EXISTS fkl8yg13ahjhtn0notrlf3amwwi;
         </sql>
     </changeSet>
+
+    <changeSet id="add_path_constraint_to_service" author="aduncan">
+        <sql dbms="postgresql">
+            create unique index if not exists full_service_name on service (sourcecontrol, organization, repository, workflowname) where workflowname is not null
+        </sql>
+        <sql dbms="postgresql">
+            create unique index if not exists partial_service_name on service (sourcecontrol, organization, repository) where workflowname is null
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
There was previously no constraints on service path and full path, so you could add duplicate services (duplicate meaning same path).