### PR TITLE
alternate docker client

### DIFF
--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -259,13 +259,25 @@
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-multipart</artifactId>
-            <version>${jersey-version}</version>
         </dependency>
-
         <dependency>
-            <groupId>com.spotify</groupId>
-            <artifactId>docker-client</artifactId>
-            <version>8.16.0</version>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java</artifactId>
+            <exclusions>
+                <!-- this isn't quite right, but this uses 2.27 which causes a bunch of issues with our 2.25.1 -->
+                <exclusion>
+                    <groupId>org.glassfish.jersey.connectors</groupId>
+                    <artifactId>jersey-apache-connector</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -521,11 +521,7 @@ public class Client {
     }
 
     private static ObjectMapper getObjectMapper() {
-        if (objectMapper == null) {
-            return new ObjectMapper();
-        } else {
-            return objectMapper;
-        }
+        return Objects.requireNonNullElseGet(objectMapper, ObjectMapper::new);
     }
 
     static void setObjectMapper(ObjectMapper objectMapper) {

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -188,26 +188,6 @@
                     <groupId>org.typelevel</groupId>
                     <artifactId>cats-effect_2.12</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-resolver</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-buffer</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-common</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-transport</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-transport-native-epoll</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/dockstore-event-consumer/pom.xml
+++ b/dockstore-event-consumer/pom.xml
@@ -58,11 +58,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.spotify</groupId>
-            <artifactId>docker-client</artifactId>
-            <version>8.11.0</version>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-configuration2 -->
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/dockstore-event-consumer/src/main/java/io/dockstore/consumer/handler/DOIHandler.java
+++ b/dockstore-event-consumer/src/main/java/io/dockstore/consumer/handler/DOIHandler.java
@@ -25,10 +25,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import com.google.common.collect.Lists;
-import com.spotify.docker.client.DefaultDockerClient;
-import com.spotify.docker.client.DockerClient;
-import com.spotify.docker.client.exceptions.DockerCertificateException;
-import com.spotify.docker.client.exceptions.DockerException;
 import io.dockstore.common.model.DOIMessage;
 import io.dockstore.zenodo.client.ApiClient;
 import io.dockstore.zenodo.client.ApiException;
@@ -91,21 +87,6 @@ public class DOIHandler implements MessageHandler<DOIMessage> {
             } else {
                 LOG.error("tag does not exist, will not be transient");
                 return true;
-            }
-
-            // Pull an image
-            // Create a client based on DOCKER_HOST and DOCKER_CERT_PATH env vars
-            String image = publishedContainer.getPath() + ":" + tag.getName();
-            File dockerImageFile = new File(image);
-            try (DockerClient docker = DefaultDockerClient.fromEnv().build()) {
-                docker.pull(image);
-                FileUtils.copyInputStreamToFile(docker.save(image), dockerImageFile);
-            } catch (DockerException | DockerCertificateException | InterruptedException e) {
-                LOG.error("could not pull Docker image:" + image, e);
-                return false;
-            } catch (IOException e) {
-                LOG.error("could not save Docker image to file:" + dockerImageFile.getAbsolutePath(), e);
-                return false;
             }
 
             // send documents to zenodo

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -256,12 +256,10 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>${jersey-version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-multipart</artifactId>
-            <version>${jersey-version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/openapi-java-client/pom.xml
+++ b/openapi-java-client/pom.xml
@@ -228,17 +228,14 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>${jersey-version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-multipart</artifactId>
-            <version>${jersey-version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>${jersey-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -279,7 +276,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
-            <version>2.25.1</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/openapi-java-wes-client/pom.xml
+++ b/openapi-java-wes-client/pom.xml
@@ -242,12 +242,10 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>${jersey-version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>2.25.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <name>dockstore</name>
     <description>dockstore parent POM</description>
-    <url>https://github.com/CancerCollaboratory/dockstore</url>
+    <url>https://github.com/dockstore/dockstore</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -55,6 +55,7 @@
         <netty.version>4.1.33.Final</netty.version>
         <scala.version>2.12.8</scala.version>
         <cromwell.version>41</cromwell.version>
+        <hk2.version>2.5.0-b42</hk2.version>
 
         <skipTests>false</skipTests>
         <skipClientITs>true</skipClientITs>
@@ -224,27 +225,12 @@
                 <artifactId>aws-encryption-sdk-java</artifactId>
                 <version>1.3.6</version>
             </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-handler</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
+
             <dependency>
                 <groupId>org.reactivestreams</groupId>
                 <artifactId>reactive-streams</artifactId>
                 <version>1.0.2</version>
             </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-
 
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -352,10 +338,13 @@
                 <scope>import</scope>
             </dependency>
 
+            <!-- https://mvnrepository.com/artifact/org.glassfish.hk2/hk2-bom -->
             <dependency>
-                <groupId>org.glassfish.jersey.media</groupId>
-                <artifactId>jersey-media-json-jackson</artifactId>
-                <version>2.25.1</version>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-bom</artifactId>
+                <version>${hk2.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>
@@ -832,6 +821,19 @@
                 <groupId>com.github.zafarkhaja</groupId>
                 <artifactId>java-semver</artifactId>
                 <version>0.9.0</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/com.github.docker-java/docker-java -->
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java</artifactId>
+                <version>3.1.5</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/swagger-java-bitbucket-client/pom.xml
+++ b/swagger-java-bitbucket-client/pom.xml
@@ -190,12 +190,10 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>${jersey-version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>2.25.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/swagger-java-client/pom.xml
+++ b/swagger-java-client/pom.xml
@@ -204,17 +204,14 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>${jersey-version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-multipart</artifactId>
-            <version>${jersey-version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>${jersey-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -255,7 +252,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
-            <version>2.25.1</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/swagger-java-discourse-client/pom.xml
+++ b/swagger-java-discourse-client/pom.xml
@@ -244,12 +244,10 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>${jersey-version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>2.25.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/swagger-java-quay-client/pom.xml
+++ b/swagger-java-quay-client/pom.xml
@@ -244,12 +244,10 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>${jersey-version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>2.25.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/swagger-java-sam-client/pom.xml
+++ b/swagger-java-sam-client/pom.xml
@@ -230,12 +230,10 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>${jersey-version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>2.25.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/swagger-java-zenodo-client/pom.xml
+++ b/swagger-java-zenodo-client/pom.xml
@@ -207,17 +207,14 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>${jersey-version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-multipart</artifactId>
-            <version>${jersey-version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>${jersey-version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -258,7 +255,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
-            <version>2.25.1</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>


### PR DESCRIPTION
Do not review, will revisit

https://github.com/spotify/docker-client is now inactive

https://github.com/docker-java/docker-java is a possible alternative

But it uses jersey 2.27 which dropwizard punted to dropwizard 2
Note that the dropwizard bom includes the jersey-bom which is super confusing