### PR TITLE
Activate spotbugs for unit tests and default profile

### DIFF
--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.7.0-beta.1-SNAPSHOT
+  version: 1.7.0-beta.2-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.7.0-beta.1-SNAPSHOT"
+  version: "1.7.0-beta.2-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/pom.xml
+++ b/pom.xml
@@ -1200,6 +1200,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <skip>true</skip>
                     <threshold>High</threshold>
                     <excludeFilterFile>
                         ${project.basedir}/findbugs-exclude.xml
@@ -1269,6 +1270,25 @@
                     io.dockstore.common.BenchmarkTest,io.dockstore.common.ToilOnlyTest, io.dockstore.common.NonConfidentialTest
                 </excludeGroups>
             </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>toil-integration-tests</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1355,6 +1355,24 @@
                 <skipITs>true</skipITs>
                 <skipClientITs>true</skipClientITs>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>integration-tests</id>


### PR DESCRIPTION
#2660 

Look for messages like "Done SpotBugs Analysis...." in the unit tests, but not in the integration tests now
