### PR TITLE
Allow services and workflows with the same path

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -249,6 +249,31 @@ public class ServiceIT extends BaseIT {
         Assert.assertEquals("there should be one matching service", 1, count);
     }
 
+//    /**
+//     * Ensures that a service and a workflow can have the same path
+//     * @throws Exception
+//     */
+//    @Test
+//    public void createServiceWithSamePathAsWorkflow() throws Exception {
+//        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+//        final ApiClient webClient = getWebClient("admin@admin.com", testingPostgres);
+//        WorkflowsApi client = new WorkflowsApi(webClient);
+//
+//        String serviceRepo = "DockstoreTestUser2/test-service";
+//        String installationId = "1179416";
+//
+//        // Add service
+//        io.swagger.client.model.Workflow service = client.addService(serviceRepo, "admin@admin.com", installationId);
+//        assertNotNull(service);
+//
+//        final long count = testingPostgres
+//                .runSelectStatement("select count(*) from service where sourcecontrol = 'github.com' and organization = 'DockstoreTestUser2' and repository = 'test-service'", long.class);
+//        Assert.assertEquals("there should be one matching service", 1, count);
+//
+//        client.manualRegister("github", "DockstoreTestUser2/test-service", "/Dockstore.cwl",
+//                "", "cwl", "/test.json");
+//    }
+
     /**
      * This tests that you can't add a version that doesn't exist
      */

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -249,30 +249,33 @@ public class ServiceIT extends BaseIT {
         Assert.assertEquals("there should be one matching service", 1, count);
     }
 
-//    /**
-//     * Ensures that a service and a workflow can have the same path
-//     * @throws Exception
-//     */
-//    @Test
-//    public void createServiceWithSamePathAsWorkflow() throws Exception {
-//        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
-//        final ApiClient webClient = getWebClient("admin@admin.com", testingPostgres);
-//        WorkflowsApi client = new WorkflowsApi(webClient);
-//
-//        String serviceRepo = "DockstoreTestUser2/test-service";
-//        String installationId = "1179416";
-//
-//        // Add service
-//        io.swagger.client.model.Workflow service = client.addService(serviceRepo, "admin@admin.com", installationId);
-//        assertNotNull(service);
-//
-//        final long count = testingPostgres
-//                .runSelectStatement("select count(*) from service where sourcecontrol = 'github.com' and organization = 'DockstoreTestUser2' and repository = 'test-service'", long.class);
-//        Assert.assertEquals("there should be one matching service", 1, count);
-//
-//        client.manualRegister("github", "DockstoreTestUser2/test-service", "/Dockstore.cwl",
-//                "", "cwl", "/test.json");
-//    }
+    /**
+     * Ensures that a service and workflow can have the same path
+     * @throws Exception
+     */
+    @Test
+    public void testServiceWithSamePathAsWorkflow() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+        final ApiClient webClient = getWebClient("admin@admin.com", testingPostgres);
+        WorkflowsApi client = new WorkflowsApi(webClient);
+
+        String serviceRepo = "DockstoreTestUser2/test-service";
+        String installationId = "1179416";
+
+        // Add service
+        io.swagger.client.model.Workflow service = client.addService(serviceRepo, "admin@admin.com", installationId);
+        assertNotNull(service);
+        try {
+            client.addService(serviceRepo, "admin@admin.com", installationId);
+        } catch (ApiException ex) {
+            assertEquals("Should have error code 418", LAMBDA_FAILURE, ex.getCode());
+        }
+
+        final io.swagger.client.model.Workflow workflow = client
+                .manualRegister("github", serviceRepo, "/Dockstore.cwl", "", "cwl", "/test.json");
+        assertNotNull(workflow);
+
+    }
 
     /**
      * This tests that you can't add a version that doesn't exist

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.dockstore.client.cli.BaseIT;
+import io.dockstore.client.cli.BasicIT;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.DescriptorLanguage;
@@ -256,21 +257,17 @@ public class ServiceIT extends BaseIT {
     @Test
     public void testServiceWithSamePathAsWorkflow() throws Exception {
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
-        final ApiClient webClient = getWebClient("admin@admin.com", testingPostgres);
+        final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
         WorkflowsApi client = new WorkflowsApi(webClient);
 
         String serviceRepo = "DockstoreTestUser2/test-service";
         String installationId = "1179416";
 
         // Add service
-        io.swagger.client.model.Workflow service = client.addService(serviceRepo, "admin@admin.com", installationId);
+        io.swagger.client.model.Workflow service = client.addService(serviceRepo, BasicIT.USER_2_USERNAME, installationId);
         assertNotNull(service);
-        try {
-            client.addService(serviceRepo, "admin@admin.com", installationId);
-        } catch (ApiException ex) {
-            assertEquals("Should have error code 418", LAMBDA_FAILURE, ex.getCode());
-        }
 
+        // Add workflow with same path as service
         final io.swagger.client.model.Workflow workflow = client
                 .manualRegister("github", serviceRepo, "/Dockstore.cwl", "", "cwl", "/test.json");
         assertNotNull(workflow);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -266,6 +266,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         final WorkflowResource workflowResource = new WorkflowResource(httpClient, hibernate.getSessionFactory(), authorizer, entryResource, configuration);
         environment.jersey().register(workflowResource);
         final ServiceResource serviceResource = new ServiceResource(httpClient, hibernate.getSessionFactory(), configuration);
+        environment.jersey().register(serviceResource);
 
         // Note workflow resource must be passed to the docker repo resource, as the workflow resource refresh must be called for checker workflows
         final DockerRepoResource dockerRepoResource = new DockerRepoResource(environment.getObjectMapper(), httpClient, hibernate.getSessionFactory(), configuration.getBitbucketClientID(), configuration.getBitbucketClientSecret(), workflowResource, entryResource);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -71,6 +71,7 @@ import io.dockstore.webservice.resources.HostedToolResource;
 import io.dockstore.webservice.resources.HostedWorkflowResource;
 import io.dockstore.webservice.resources.MetadataResource;
 import io.dockstore.webservice.resources.OrganizationResource;
+import io.dockstore.webservice.resources.ServiceResource;
 import io.dockstore.webservice.resources.TemplateHealthCheck;
 import io.dockstore.webservice.resources.TokenResource;
 import io.dockstore.webservice.resources.ToolTesterResource;
@@ -262,8 +263,9 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         final EntryResource entryResource = new EntryResource(toolDAO, configuration);
         environment.jersey().register(entryResource);
 
-        final WorkflowResource workflowResource = new WorkflowResource(httpClient, hibernate.getSessionFactory(), configuration.getBitbucketClientID(), configuration.getBitbucketClientSecret(), authorizer, entryResource, configuration);
+        final WorkflowResource workflowResource = new WorkflowResource(httpClient, hibernate.getSessionFactory(), authorizer, entryResource, configuration);
         environment.jersey().register(workflowResource);
+        final ServiceResource serviceResource = new ServiceResource(httpClient, hibernate.getSessionFactory(), configuration);
 
         // Note workflow resource must be passed to the docker repo resource, as the workflow resource refresh must be called for checker workflows
         final DockerRepoResource dockerRepoResource = new DockerRepoResource(environment.getObjectMapper(), httpClient, hibernate.getSessionFactory(), configuration.getBitbucketClientID(), configuration.getBitbucketClientSecret(), workflowResource, entryResource);
@@ -271,7 +273,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         environment.jersey().register(new DockerRepoTagResource(toolDAO, tagDAO));
         environment.jersey().register(new TokenResource(tokenDAO, userDAO, httpClient, cachingAuthenticator, configuration));
 
-        environment.jersey().register(new UserResource(getHibernate().getSessionFactory(), workflowResource, dockerRepoResource, cachingAuthenticator, authorizer));
+        environment.jersey().register(new UserResource(getHibernate().getSessionFactory(), workflowResource, serviceResource, dockerRepoResource, cachingAuthenticator, authorizer));
         environment.jersey().register(new MetadataResource(getHibernate().getSessionFactory(), configuration));
         environment.jersey().register(new HostedToolResource(getHibernate().getSessionFactory(), authorizer, configuration.getLimitConfig()));
         environment.jersey().register(new HostedWorkflowResource(getHibernate().getSessionFactory(), authorizer, configuration.getLimitConfig()));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
@@ -16,7 +16,6 @@
 package io.dockstore.webservice.core;
 
 import javax.persistence.Column;
-import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.OneToOne;
@@ -32,7 +31,6 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @ApiModel(value = "BioWorkflow", description = "This describes one workflow in the dockstore")
 @Entity
-@DiscriminatorValue("bioworkflow")
 @Table(name = "workflow")
 @SuppressWarnings("checkstyle:magicnumber")
 public class BioWorkflow extends Workflow {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Service.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Service.java
@@ -15,7 +15,6 @@
  */
 package io.dockstore.webservice.core;
 
-import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
@@ -23,7 +22,6 @@ import io.swagger.annotations.ApiModel;
 
 @ApiModel(value = "Service", description = "This describes one service in the dockstore as a special degenerate case of a workflow")
 @Entity
-@DiscriminatorValue("service")
 @Table(name = "service")
 public class Service extends Workflow {
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -20,7 +20,6 @@ import java.util.Date;
 import java.util.Objects;
 
 import javax.persistence.Column;
-import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.validation.constraints.NotNull;
 
@@ -41,7 +40,6 @@ import org.apache.commons.io.FilenameUtils;
  */
 @ApiModel(value = "Tag", description = "This describes one tag associated with a container.")
 @Entity
-@DiscriminatorValue("tool")
 @SuppressWarnings("checkstyle:magicnumber")
 public class Tag extends Version<Tag> implements Comparable<Tag> {
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
@@ -259,7 +259,7 @@ public final class GitHubHelper {
     }
 
 
-    public static Collection<String> reposToCreateServicesFor(Collection<String> repositories, Optional<String> organization,
+    public static Collection<String> reposToCreateEntitiesFor(Collection<String> repositories, Optional<String> organization,
             Set<String> existingWorkflowPaths) {
         // Get all unique organizations
         final Set<String> myOrganizations = organization.map(o -> Collections.singleton(o))

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
@@ -48,12 +48,17 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
+import io.dockstore.webservice.core.Token;
+import io.dockstore.webservice.core.User;
+import io.dockstore.webservice.jdbi.TokenDAO;
+import io.dockstore.webservice.jdbi.UserDAO;
 import okhttp3.Request;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
 import static io.dockstore.webservice.resources.TokenResource.HTTP_TRANSPORT;
 import static io.dockstore.webservice.resources.TokenResource.JSON_FACTORY;
 
@@ -286,4 +291,37 @@ public final class GitHubHelper {
         return repos;
     }
 
+    /**
+     * Based on GitHub username, find the corresponding user
+     * @param tokenDAO
+     * @param userDAO
+     * @param username GitHub username
+     * @param allowFail If true, throw a failure if user cannot be found
+     * @return user with given GitHub username
+     */
+    public static User findUserByGitHubUsername(TokenDAO tokenDAO, UserDAO userDAO, String username, boolean allowFail) {
+        // Find user by github name
+        Token userGitHubToken = tokenDAO.findTokenByGitHubUsername(username);
+        if (userGitHubToken == null) {
+            String msg = "No user with GitHub username " + username + " exists on Dockstore.";
+            LOG.info(msg);
+            if (allowFail) {
+                throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
+            } else {
+                return null;
+            }
+        }
+
+        // Get user object for github token
+        User sendingUser = userDAO.findById(userGitHubToken.getUserId());
+        if (sendingUser == null) {
+            String msg = "No user with GitHub username " + username + " exists on Dockstore.";
+            LOG.info(msg);
+            if (allowFail) {
+                throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
+            }
+        }
+
+        return sendingUser;
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -25,6 +25,7 @@ import io.dockstore.webservice.jdbi.TokenDAO;
 import io.dockstore.webservice.jdbi.UserDAO;
 import io.dockstore.webservice.jdbi.WorkflowDAO;
 import io.dockstore.webservice.jdbi.WorkflowVersionDAO;
+import io.swagger.annotations.Api;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.hibernate.SessionFactory;
@@ -33,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import static io.dockstore.webservice.core.WorkflowMode.SERVICE;
 
+@Api("workflows")
 public class AbstractWorkflowResource implements SourceControlResourceInterface, AuthenticatedResourceInterface {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractWorkflowResource.class);
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -112,13 +112,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
 
     protected SourceCodeRepoInterface getSourceCodeRepoInterface(String gitUrl, User user) {
         List<Token> tokens = checkOnBitbucketToken(user);
-        Token bitbucketToken = Token.extractToken(tokens, TokenType.BITBUCKET_ORG);
-        Token githubToken = Token.extractToken(tokens, TokenType.GITHUB_COM);
-        Token gitlabToken = Token.extractToken(tokens, TokenType.GITLAB_COM);
 
-        final String bitbucketTokenContent = bitbucketToken == null ? null : bitbucketToken.getContent();
-        final String gitHubTokenContent = githubToken == null ? null : githubToken.getContent();
-        final String gitlabTokenContent = gitlabToken == null ? null : gitlabToken.getContent();
+        final String bitbucketTokenContent = getToken(tokens, TokenType.BITBUCKET_ORG);
+        final String gitHubTokenContent = getToken(tokens, TokenType.GITHUB_COM);
+        final String gitlabTokenContent = getToken(tokens, TokenType.GITLAB_COM);
 
         final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory
             .createSourceCodeRepo(gitUrl, client, bitbucketTokenContent, gitlabTokenContent, gitHubTokenContent);
@@ -126,6 +123,11 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             throw new CustomWebApplicationException("Git tokens invalid, please re-link your git accounts.", HttpStatus.SC_BAD_REQUEST);
         }
         return sourceCodeRepo;
+    }
+
+    private String getToken(List<Token> tokens, TokenType tokenType) {
+        final Token token = Token.extractToken(tokens, tokenType);
+        return token == null ? null : token.getContent();
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -1,0 +1,224 @@
+package io.dockstore.webservice.resources;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Sets;
+import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.DockstoreWebserviceConfiguration;
+import io.dockstore.webservice.core.SourceFile;
+import io.dockstore.webservice.core.Token;
+import io.dockstore.webservice.core.TokenType;
+import io.dockstore.webservice.core.User;
+import io.dockstore.webservice.core.Validation;
+import io.dockstore.webservice.core.Workflow;
+import io.dockstore.webservice.core.WorkflowMode;
+import io.dockstore.webservice.core.WorkflowVersion;
+import io.dockstore.webservice.helpers.GitHubSourceCodeRepo;
+import io.dockstore.webservice.helpers.SourceCodeRepoFactory;
+import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
+import io.dockstore.webservice.jdbi.FileDAO;
+import io.dockstore.webservice.jdbi.TokenDAO;
+import io.dockstore.webservice.jdbi.UserDAO;
+import io.dockstore.webservice.jdbi.WorkflowDAO;
+import io.dockstore.webservice.jdbi.WorkflowVersionDAO;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.hibernate.SessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.dockstore.webservice.core.WorkflowMode.SERVICE;
+
+public class AbstractWorkflowResource implements SourceControlResourceInterface, AuthenticatedResourceInterface {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractWorkflowResource.class);
+
+    protected final HttpClient client;
+    protected final TokenDAO tokenDAO;
+    protected final WorkflowDAO workflowDAO;
+    protected final UserDAO userDAO;
+    protected final WorkflowVersionDAO workflowVersionDAO;
+    protected final FileDAO fileDAO;
+
+    private final String bitbucketClientSecret;
+    private final String bitbucketClientID;
+
+    public AbstractWorkflowResource(HttpClient client, SessionFactory sessionFactory, DockstoreWebserviceConfiguration configuration) {
+        this.client = client;
+        this.tokenDAO = new TokenDAO(sessionFactory);
+        this.workflowDAO = new WorkflowDAO(sessionFactory);
+        this.userDAO = new UserDAO(sessionFactory);
+        this.fileDAO = new FileDAO(sessionFactory);
+        this.workflowVersionDAO = new WorkflowVersionDAO(sessionFactory);
+
+        this.bitbucketClientID = configuration.getBitbucketClientID();
+        this.bitbucketClientSecret = configuration.getBitbucketClientSecret();
+    }
+
+    protected List<Token> checkOnBitbucketToken(User user) {
+        List<Token> tokens = tokenDAO.findBitbucketByUserId(user.getId());
+
+        if (!tokens.isEmpty()) {
+            Token bitbucketToken = tokens.get(0);
+            String refreshUrl = BITBUCKET_URL + "site/oauth2/access_token";
+            String payload = "grant_type=refresh_token&refresh_token=" + bitbucketToken.getRefreshToken();
+            refreshToken(refreshUrl, bitbucketToken, client, tokenDAO, bitbucketClientID, bitbucketClientSecret, payload);
+        }
+
+        return tokenDAO.findByUserId(user.getId());
+    }
+
+    /**
+     * Finds all workflows from a general Dockstore path that are of type FULL
+     * @param dockstoreWorkflowPath Dockstore path (ex. github.com/dockstore/dockstore-ui2)
+     * @return List of FULL workflows with the given Dockstore path
+     */
+    protected List<Workflow> findAllWorkflowsByPath(String dockstoreWorkflowPath, WorkflowMode workflowMode) {
+        return workflowDAO.findAllByPath(dockstoreWorkflowPath, false)
+                .stream()
+                .filter(workflow ->
+                        workflow.getMode() == workflowMode)
+                .collect(Collectors.toList());
+    }
+
+    protected SourceCodeRepoInterface getSourceCodeRepoInterface(String gitUrl, User user) {
+        List<Token> tokens = checkOnBitbucketToken(user);
+        Token bitbucketToken = Token.extractToken(tokens, TokenType.BITBUCKET_ORG);
+        Token githubToken = Token.extractToken(tokens, TokenType.GITHUB_COM);
+        Token gitlabToken = Token.extractToken(tokens, TokenType.GITLAB_COM);
+
+        final String bitbucketTokenContent = bitbucketToken == null ? null : bitbucketToken.getContent();
+        final String gitHubTokenContent = githubToken == null ? null : githubToken.getContent();
+        final String gitlabTokenContent = gitlabToken == null ? null : gitlabToken.getContent();
+
+        final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory
+            .createSourceCodeRepo(gitUrl, client, bitbucketTokenContent, gitlabTokenContent, gitHubTokenContent);
+        if (sourceCodeRepo == null) {
+            throw new CustomWebApplicationException("Git tokens invalid, please re-link your git accounts.", HttpStatus.SC_BAD_REQUEST);
+        }
+        return sourceCodeRepo;
+    }
+
+    /**
+     * Common code for upserting a version to a workflow/service
+     * @param repository Repository path (ex. dockstore/dockstore-ui2)
+     * @param gitReference Git reference (ex. master)
+     * @param user User calling endpoint
+     * @param workflowMode Mode of workflows to filter by
+     * @return Shared dockstore path to workflow/service
+     */
+    protected String upsertVersionHelper(String repository, String gitReference, User user, WorkflowMode workflowMode,
+            String installationAccessToken) {
+        // Create path on Dockstore (not unique across workflows)
+        String dockstoreWorkflowPath = String.join("/", TokenType.GITHUB_COM.toString(), repository);
+
+        // Find all workflows with the given path that are full
+        List<Workflow> workflows = findAllWorkflowsByPath(dockstoreWorkflowPath, workflowMode);
+
+        if (workflows.size() > 0) {
+            // All workflows with the same path have the same Git Url
+            String sharedGitUrl = workflows.get(0).getGitUrl();
+
+            // Set up source code interface and ensure token is set up
+            GitHubSourceCodeRepo sourceCodeRepo;
+            if (user != null) {
+                User updatedUser = userDAO.findById(user.getId());
+                sourceCodeRepo = (GitHubSourceCodeRepo)getSourceCodeRepoInterface(sharedGitUrl, updatedUser);
+            } else {
+                sourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createGitHubAppRepo(installationAccessToken);
+            }
+
+            // Pull new version information from GitHub and update the versions
+            workflows = sourceCodeRepo.upsertVersionForWorkflows(repository, gitReference, workflows, workflowMode);
+
+            // Update each workflow with reference types
+            for (Workflow workflow : workflows) {
+                Set<WorkflowVersion> versions = workflow.getWorkflowVersions();
+                versions.forEach(version -> sourceCodeRepo.updateReferenceType(repository, version));
+            }
+        } else {
+            if (workflowMode == SERVICE) {
+                String msg = "No service with path " + dockstoreWorkflowPath + " exists on Dockstore.";
+                LOG.error(msg);
+                throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+            }
+        }
+
+        return dockstoreWorkflowPath;
+    }
+
+    /**
+     * Updates the existing workflow in the database with new information from newWorkflow, including new, updated, and removed
+     * workflow verions.
+     * @param workflow    workflow to be updated
+     * @param newWorkflow workflow to grab new content from
+     */
+    protected void updateDBWorkflowWithSourceControlWorkflow(Workflow workflow, Workflow newWorkflow) {
+        // update root workflow
+        workflow.update(newWorkflow);
+        // update workflow versions
+        Map<String, WorkflowVersion> existingVersionMap = new HashMap<>();
+        workflow.getWorkflowVersions().forEach(version -> existingVersionMap.put(version.getName(), version));
+
+        // delete versions that exist in old workflow but do not exist in newWorkflow
+        Map<String, WorkflowVersion> newVersionMap = new HashMap<>();
+        newWorkflow.getWorkflowVersions().forEach(version -> newVersionMap.put(version.getName(), version));
+        Sets.SetView<String> removedVersions = Sets.difference(existingVersionMap.keySet(), newVersionMap.keySet());
+        for (String version : removedVersions) {
+            workflow.removeWorkflowVersion(existingVersionMap.get(version));
+        }
+
+        // Then copy over content that changed
+        for (WorkflowVersion version : newWorkflow.getWorkflowVersions()) {
+            // skip frozen versions
+            WorkflowVersion workflowVersionFromDB = existingVersionMap.get(version.getName());
+            if (existingVersionMap.containsKey(version.getName())) {
+                if (workflowVersionFromDB.isFrozen()) {
+                    continue;
+                }
+                workflowVersionFromDB.update(version);
+            } else {
+                // create a new one and replace the old one
+                final long workflowVersionId = workflowVersionDAO.create(version);
+                workflowVersionFromDB = workflowVersionDAO.findById(workflowVersionId);
+                workflow.getWorkflowVersions().add(workflowVersionFromDB);
+                existingVersionMap.put(workflowVersionFromDB.getName(), workflowVersionFromDB);
+            }
+
+            // Update source files for each version
+            Map<String, SourceFile> existingFileMap = new HashMap<>();
+            workflowVersionFromDB.getSourceFiles().forEach(file -> existingFileMap.put(file.getType().toString() + file.getAbsolutePath(), file));
+
+            for (SourceFile file : version.getSourceFiles()) {
+                if (existingFileMap.containsKey(file.getType().toString() + file.getAbsolutePath())) {
+                    existingFileMap.get(file.getType().toString() + file.getAbsolutePath()).setContent(file.getContent());
+                } else {
+                    final long fileID = fileDAO.create(file);
+                    final SourceFile fileFromDB = fileDAO.findById(fileID);
+                    workflowVersionFromDB.getSourceFiles().add(fileFromDB);
+                }
+            }
+
+            // Remove existing files that are no longer present on remote
+            for (Map.Entry<String, SourceFile> entry : existingFileMap.entrySet()) {
+                boolean toDelete = true;
+                for (SourceFile file : version.getSourceFiles()) {
+                    if (entry.getKey().equals(file.getType().toString() + file.getAbsolutePath())) {
+                        toDelete = false;
+                    }
+                }
+                if (toDelete) {
+                    workflowVersionFromDB.getSourceFiles().remove(entry.getValue());
+                }
+            }
+
+            // Update the validations
+            for (Validation versionValidation : version.getValidations()) {
+                workflowVersionFromDB.addOrUpdateValidation(versionValidation);
+            }
+        }
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ServiceResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ServiceResource.java
@@ -21,8 +21,6 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
 import org.apache.http.client.HttpClient;
 import org.hibernate.SessionFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
 import static io.dockstore.webservice.core.WorkflowMode.SERVICE;
@@ -31,8 +29,6 @@ import static io.dockstore.webservice.core.WorkflowMode.SERVICE;
 @Path("/workflows")
 @Produces(MediaType.APPLICATION_JSON)
 public class ServiceResource extends AbstractWorkflowResource<Service> {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ServiceResource.class);
 
     public ServiceResource(HttpClient client, SessionFactory sessionFactory, DockstoreWebserviceConfiguration configuration) {
         super(client, sessionFactory, configuration, Service.class);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ServiceResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ServiceResource.java
@@ -1,13 +1,5 @@
 package io.dockstore.webservice.resources;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
@@ -17,53 +9,38 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import com.codahale.metrics.annotation.Timed;
-import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.core.Service;
-import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
-import io.dockstore.webservice.helpers.CacheConfigManager;
-import io.dockstore.webservice.helpers.GitHubHelper;
 import io.dockstore.webservice.helpers.GitHubSourceCodeRepo;
-import io.dockstore.webservice.helpers.SourceCodeRepoFactory;
-import io.dockstore.webservice.jdbi.TokenDAO;
-import io.dockstore.webservice.jdbi.UserDAO;
-import io.dockstore.webservice.jdbi.WorkflowDAO;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
-import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
-import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
 import static io.dockstore.webservice.core.WorkflowMode.SERVICE;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Path("/workflows")
 @Produces(MediaType.APPLICATION_JSON)
-public class ServiceResource extends AbstractWorkflowResource {
+public class ServiceResource extends AbstractWorkflowResource<Service> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ServiceResource.class);
-    private final WorkflowDAO workflowDAO;
-    private final UserDAO userDAO;
-    private final TokenDAO tokenDAO;
-    private final String gitHubPrivateKeyFile;
-    private final String gitHubAppId;
 
     public ServiceResource(HttpClient client, SessionFactory sessionFactory, DockstoreWebserviceConfiguration configuration) {
-        super(client, sessionFactory, configuration);
-        this.workflowDAO = new WorkflowDAO(sessionFactory);
-        this.userDAO = new UserDAO(sessionFactory);
-        this.tokenDAO = new TokenDAO(sessionFactory);
-        gitHubAppId = configuration.getGitHubAppId();
-        gitHubPrivateKeyFile = configuration.getGitHubAppPrivateKeyFile();
+        super(client, sessionFactory, configuration, Service.class);
+    }
+
+    @Override
+    protected Service initializeEntity(String repository, GitHubSourceCodeRepo sourceCodeRepo) {
+        return sourceCodeRepo.initializeService(repository);
     }
 
     @POST
@@ -74,28 +51,13 @@ public class ServiceResource extends AbstractWorkflowResource {
     @RolesAllowed({ "curator", "admin" })
     @ApiOperation(value = "Add or update a service version for a given GitHub tag for a service with the given repository (ex. dockstore/dockstore-ui2).", notes = "To be called by a lambda function. Error code 418 is returned to tell lambda not to retry.", authorizations = {
             @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class)
-    public Workflow upsertServiceVersion(@ApiParam(hidden = true) @Auth User user,
+    public Service upsertServiceVersion(@ApiParam(hidden = true) @Auth User user,
             @ApiParam(value = "Repository path", required = true) @FormParam("repository") String repository,
             @ApiParam(value = "Name of user on GitHub", required = true) @FormParam("username") String username,
             @ApiParam(value = "Git reference for new GitHub tag", required = true) @FormParam("gitReference") String gitReference,
             @ApiParam(value = "GitHub installation ID", required = true) @FormParam("installationId") String installationId) {
+        return upsertVersion(repository, username, gitReference, installationId, SERVICE);
 
-        // Retrieve the user who triggered the call (may not exist on Dockstore)
-        User sendingUser = GitHubHelper.findUserByGitHubUsername(this.tokenDAO, this.userDAO, username, false);
-
-        // Get Installation Access Token
-        String installationAccessToken = gitHubAppSetup(installationId);
-
-        // Call common upsert code
-        String dockstoreServicePath = upsertVersionHelper(repository, gitReference, null, SERVICE, installationAccessToken);
-
-        // Add user to service if necessary
-        Workflow service = workflowDAO.findByPath(dockstoreServicePath, false, Service.class).get();
-        if (sendingUser != null && !service.getUsers().contains(sendingUser)) {
-            service.getUsers().add(sendingUser);
-        }
-
-        return service;
     }
 
     @POST
@@ -110,118 +72,7 @@ public class ServiceResource extends AbstractWorkflowResource {
             @ApiParam(value = "Repository path", required = true) @FormParam("repository") String repository,
             @ApiParam(value = "Name of user on GitHub", required = true) @FormParam("username") String username,
             @ApiParam(value = "GitHub installation ID", required = true) @FormParam("installationId") String installationId) {
-        // Check for duplicates (currently workflows and services share paths)
-        String servicePath = "github.com/" + repository;
-
-        // Retrieve the user who triggered the call
-        User sendingUser = GitHubHelper.findUserByGitHubUsername(tokenDAO, userDAO, username, true);
-
-        // Determine if service is already in Dockstore
-        workflowDAO.findByPath(servicePath, false, Service.class).ifPresent((service) -> {
-            String msg = "A service already exists for GitHub repository " + repository;
-            LOG.info(msg);
-            throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
-        });
-
-        // Get Installation Access Token
-        String installationAccessToken = GitHubHelper.gitHubAppSetup(gitHubAppId, gitHubPrivateKeyFile, installationId);
-
-        // Create a service object
-        final GitHubSourceCodeRepo sourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createGitHubAppRepo(installationAccessToken);
-
-        // Check that repository exists on GitHub
-        try {
-            sourceCodeRepo.getRepository(repository);
-        } catch (CustomWebApplicationException ex) {
-            String msg = "Repository " + repository + " does not exist on GitHub";
-            LOG.error(msg);
-            throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
-        }
-
-        Service service = sourceCodeRepo.initializeService(repository);
-        service.getUsers().add(sendingUser);
-        long serviceId = workflowDAO.create(service);
-
-        return workflowDAO.findById(serviceId);
+        return addEntityFromGitHubRepository(repository, username, installationId);
     }
-
-    /**
-     * Does the following:
-     * 1) Add user to any existing Dockstore services they should own
-     *
-     * 2) For all of the users organizations that have the GitHub App installed on all repositories in those organizations,
-     * add any services that should be on Dockstore but are not
-     *
-     * 3) For all of the repositories which have the GitHub App installed, add them to Dockstore if they are missing
-     * @param user
-     * @param organization
-     */
-    void syncServicesForUser(User user, Optional<String> organization) {
-        List<Token> githubByUserId = tokenDAO.findGithubByUserId(user.getId());
-
-        if (githubByUserId.isEmpty()) {
-            String msg = "The user does not have a GitHub token, please create one";
-            LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
-        } else {
-            syncServices(user, organization, githubByUserId.get(0));
-        }
-    }
-
-
-
-    /**
-     * Setup tokens required for GitHub apps
-     * @param installationId App installation ID (per repository)
-     * @return Installation access token for the given repository
-     */
-    private String gitHubAppSetup(String installationId) {
-        GitHubHelper.checkJWT(gitHubAppId, gitHubPrivateKeyFile);
-        String installationAccessToken = CacheConfigManager.getInstance().getInstallationAccessTokenFromCache(installationId);
-        if (installationAccessToken == null) {
-            String msg = "Could not get an installation access token for install with id " + installationId;
-            LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        }
-        return installationAccessToken;
-    }
-
-    private void syncServices(User user, Optional<String> organization, Token gitHubToken) {
-        GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(gitHubToken, client);
-
-        // Get all GitHub repositories for the user
-        final Map<String, String> workflowGitUrl2Name = gitHubSourceCodeRepo.getWorkflowGitUrl2RepositoryId();
-
-        // Filter by organization if necessary
-        final Collection<String> repositories = GitHubHelper.filterReposByOrg(workflowGitUrl2Name.values(), organization);
-
-        // Add user to any services they should have access to that already exist on Dockstore
-        final List<Workflow> existingWorkflows = findDockstoreWorkflowsForGitHubRepos(repositories);
-        existingWorkflows.stream()
-                .filter(workflow -> !workflow.getUsers().contains(user))
-                .forEach(workflow -> workflow.getUsers().add(user));
-        final Set<String> existingWorkflowPaths = existingWorkflows.stream()
-                .map(workflow -> workflow.getWorkflowPath()).collect(Collectors.toSet());
-
-        GitHubHelper.checkJWT(gitHubAppId, gitHubPrivateKeyFile);
-
-        GitHubHelper.reposToCreateServicesFor(repositories, organization, existingWorkflowPaths).stream()
-                .forEach(repositoryName -> {
-                    final Service service = gitHubSourceCodeRepo.initializeService(repositoryName);
-                    service.addUser(user);
-                    final long serviceId = workflowDAO.create(service);
-                    final Workflow createdService = workflowDAO.findById(serviceId);
-                    final Workflow updatedService = gitHubSourceCodeRepo.getWorkflow(repositoryName, Optional.of(createdService));
-                    updateDBWorkflowWithSourceControlWorkflow(createdService, updatedService);
-                });
-    }
-
-    private List<Workflow> findDockstoreWorkflowsForGitHubRepos(Collection<String> repositories) {
-        final List<String> workflowPaths = repositories.stream().map(repositoryName -> "github.com/" + repositoryName)
-                .collect(Collectors.toList());
-        return workflowDAO.findByPaths(workflowPaths, false).stream()
-                .filter(workflow -> Objects.equals(workflow.getMode(), SERVICE)).collect(Collectors.toList());
-    }
-
 
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ServiceResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ServiceResource.java
@@ -23,7 +23,6 @@ import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
-import io.dockstore.webservice.core.WorkflowMode;
 import io.dockstore.webservice.helpers.CacheConfigManager;
 import io.dockstore.webservice.helpers.GitHubHelper;
 import io.dockstore.webservice.helpers.GitHubSourceCodeRepo;
@@ -88,7 +87,7 @@ public class ServiceResource extends AbstractWorkflowResource {
         String installationAccessToken = gitHubAppSetup(installationId);
 
         // Call common upsert code
-        String dockstoreServicePath = upsertVersionHelper(repository, gitReference, null, WorkflowMode.SERVICE, installationAccessToken);
+        String dockstoreServicePath = upsertVersionHelper(repository, gitReference, null, SERVICE, installationAccessToken);
 
         // Add user to service if necessary
         Workflow service = workflowDAO.findByPath(dockstoreServicePath, false, Service.class).get();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ServiceResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ServiceResource.java
@@ -33,7 +33,6 @@ import io.dockstore.webservice.jdbi.UserDAO;
 import io.dockstore.webservice.jdbi.WorkflowDAO;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.hibernate.UnitOfWork;
-import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
@@ -49,7 +48,6 @@ import static io.dockstore.webservice.core.WorkflowMode.SERVICE;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Path("/workflows")
-@Api("workflows")
 @Produces(MediaType.APPLICATION_JSON)
 public class ServiceResource extends AbstractWorkflowResource {
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ServiceResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ServiceResource.java
@@ -1,0 +1,230 @@
+package io.dockstore.webservice.resources;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.codahale.metrics.annotation.Timed;
+import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.DockstoreWebserviceConfiguration;
+import io.dockstore.webservice.core.Service;
+import io.dockstore.webservice.core.Token;
+import io.dockstore.webservice.core.User;
+import io.dockstore.webservice.core.Workflow;
+import io.dockstore.webservice.core.WorkflowMode;
+import io.dockstore.webservice.helpers.CacheConfigManager;
+import io.dockstore.webservice.helpers.GitHubHelper;
+import io.dockstore.webservice.helpers.GitHubSourceCodeRepo;
+import io.dockstore.webservice.helpers.SourceCodeRepoFactory;
+import io.dockstore.webservice.jdbi.TokenDAO;
+import io.dockstore.webservice.jdbi.UserDAO;
+import io.dockstore.webservice.jdbi.WorkflowDAO;
+import io.dropwizard.auth.Auth;
+import io.dropwizard.hibernate.UnitOfWork;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.Authorization;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.hibernate.SessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
+import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
+import static io.dockstore.webservice.core.WorkflowMode.SERVICE;
+
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+@Path("/workflows")
+@Api("workflows")
+@Produces(MediaType.APPLICATION_JSON)
+public class ServiceResource extends AbstractWorkflowResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceResource.class);
+    private final WorkflowDAO workflowDAO;
+    private final UserDAO userDAO;
+    private final TokenDAO tokenDAO;
+    private final String gitHubPrivateKeyFile;
+    private final String gitHubAppId;
+
+    public ServiceResource(HttpClient client, SessionFactory sessionFactory, DockstoreWebserviceConfiguration configuration) {
+        super(client, sessionFactory, configuration);
+        this.workflowDAO = new WorkflowDAO(sessionFactory);
+        this.userDAO = new UserDAO(sessionFactory);
+        this.tokenDAO = new TokenDAO(sessionFactory);
+        gitHubAppId = configuration.getGitHubAppId();
+        gitHubPrivateKeyFile = configuration.getGitHubAppPrivateKeyFile();
+    }
+
+    @POST
+    @Path("/path/service/upsertVersion/")
+    @Timed
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @UnitOfWork
+    @RolesAllowed({ "curator", "admin" })
+    @ApiOperation(value = "Add or update a service version for a given GitHub tag for a service with the given repository (ex. dockstore/dockstore-ui2).", notes = "To be called by a lambda function. Error code 418 is returned to tell lambda not to retry.", authorizations = {
+            @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class)
+    public Workflow upsertServiceVersion(@ApiParam(hidden = true) @Auth User user,
+            @ApiParam(value = "Repository path", required = true) @FormParam("repository") String repository,
+            @ApiParam(value = "Name of user on GitHub", required = true) @FormParam("username") String username,
+            @ApiParam(value = "Git reference for new GitHub tag", required = true) @FormParam("gitReference") String gitReference,
+            @ApiParam(value = "GitHub installation ID", required = true) @FormParam("installationId") String installationId) {
+
+        // Retrieve the user who triggered the call (may not exist on Dockstore)
+        User sendingUser = GitHubHelper.findUserByGitHubUsername(this.tokenDAO, this.userDAO, username, false);
+
+        // Get Installation Access Token
+        String installationAccessToken = gitHubAppSetup(installationId);
+
+        // Call common upsert code
+        String dockstoreServicePath = upsertVersionHelper(repository, gitReference, null, WorkflowMode.SERVICE, installationAccessToken);
+
+        // Add user to service if necessary
+        Workflow service = workflowDAO.findByPath(dockstoreServicePath, false, Service.class).get();
+        if (sendingUser != null && !service.getUsers().contains(sendingUser)) {
+            service.getUsers().add(sendingUser);
+        }
+
+        return service;
+    }
+
+    @POST
+    @Path("/path/service/")
+    @Timed
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @UnitOfWork
+    @RolesAllowed({ "curator", "admin" })
+    @ApiOperation(value = "Create a service for the given repository (ex. dockstore/dockstore-ui2).", notes = "To be called by a lambda function. Error code 418 is returned to tell lambda not to retry.", authorizations = {
+            @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class)
+    public Workflow addService(@ApiParam(hidden = true) @Auth User user,
+            @ApiParam(value = "Repository path", required = true) @FormParam("repository") String repository,
+            @ApiParam(value = "Name of user on GitHub", required = true) @FormParam("username") String username,
+            @ApiParam(value = "GitHub installation ID", required = true) @FormParam("installationId") String installationId) {
+        // Check for duplicates (currently workflows and services share paths)
+        String servicePath = "github.com/" + repository;
+
+        // Retrieve the user who triggered the call
+        User sendingUser = GitHubHelper.findUserByGitHubUsername(tokenDAO, userDAO, username, true);
+
+        // Determine if service is already in Dockstore
+        workflowDAO.findByPath(servicePath, false, Service.class).ifPresent((service) -> {
+            String msg = "A service already exists for GitHub repository " + repository;
+            LOG.info(msg);
+            throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
+        });
+
+        // Get Installation Access Token
+        String installationAccessToken = GitHubHelper.gitHubAppSetup(gitHubAppId, gitHubPrivateKeyFile, installationId);
+
+        // Create a service object
+        final GitHubSourceCodeRepo sourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createGitHubAppRepo(installationAccessToken);
+
+        // Check that repository exists on GitHub
+        try {
+            sourceCodeRepo.getRepository(repository);
+        } catch (CustomWebApplicationException ex) {
+            String msg = "Repository " + repository + " does not exist on GitHub";
+            LOG.error(msg);
+            throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
+        }
+
+        Service service = sourceCodeRepo.initializeService(repository);
+        service.getUsers().add(sendingUser);
+        long serviceId = workflowDAO.create(service);
+
+        return workflowDAO.findById(serviceId);
+    }
+
+    /**
+     * Does the following:
+     * 1) Add user to any existing Dockstore services they should own
+     *
+     * 2) For all of the users organizations that have the GitHub App installed on all repositories in those organizations,
+     * add any services that should be on Dockstore but are not
+     *
+     * 3) For all of the repositories which have the GitHub App installed, add them to Dockstore if they are missing
+     * @param user
+     * @param organization
+     */
+    void syncServicesForUser(User user, Optional<String> organization) {
+        List<Token> githubByUserId = tokenDAO.findGithubByUserId(user.getId());
+
+        if (githubByUserId.isEmpty()) {
+            String msg = "The user does not have a GitHub token, please create one";
+            LOG.info(msg);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+        } else {
+            syncServices(user, organization, githubByUserId.get(0));
+        }
+    }
+
+
+
+    /**
+     * Setup tokens required for GitHub apps
+     * @param installationId App installation ID (per repository)
+     * @return Installation access token for the given repository
+     */
+    private String gitHubAppSetup(String installationId) {
+        GitHubHelper.checkJWT(gitHubAppId, gitHubPrivateKeyFile);
+        String installationAccessToken = CacheConfigManager.getInstance().getInstallationAccessTokenFromCache(installationId);
+        if (installationAccessToken == null) {
+            String msg = "Could not get an installation access token for install with id " + installationId;
+            LOG.info(msg);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        }
+        return installationAccessToken;
+    }
+
+    private void syncServices(User user, Optional<String> organization, Token gitHubToken) {
+        GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(gitHubToken, client);
+
+        // Get all GitHub repositories for the user
+        final Map<String, String> workflowGitUrl2Name = gitHubSourceCodeRepo.getWorkflowGitUrl2RepositoryId();
+
+        // Filter by organization if necessary
+        final Collection<String> repositories = GitHubHelper.filterReposByOrg(workflowGitUrl2Name.values(), organization);
+
+        // Add user to any services they should have access to that already exist on Dockstore
+        final List<Workflow> existingWorkflows = findDockstoreWorkflowsForGitHubRepos(repositories);
+        existingWorkflows.stream()
+                .filter(workflow -> !workflow.getUsers().contains(user))
+                .forEach(workflow -> workflow.getUsers().add(user));
+        final Set<String> existingWorkflowPaths = existingWorkflows.stream()
+                .map(workflow -> workflow.getWorkflowPath()).collect(Collectors.toSet());
+
+        GitHubHelper.checkJWT(gitHubAppId, gitHubPrivateKeyFile);
+
+        GitHubHelper.reposToCreateServicesFor(repositories, organization, existingWorkflowPaths).stream()
+                .forEach(repositoryName -> {
+                    final Service service = gitHubSourceCodeRepo.initializeService(repositoryName);
+                    service.addUser(user);
+                    final long serviceId = workflowDAO.create(service);
+                    final Workflow createdService = workflowDAO.findById(serviceId);
+                    final Workflow updatedService = gitHubSourceCodeRepo.getWorkflow(repositoryName, Optional.of(createdService));
+                    updateDBWorkflowWithSourceControlWorkflow(createdService, updatedService);
+                });
+    }
+
+    private List<Workflow> findDockstoreWorkflowsForGitHubRepos(Collection<String> repositories) {
+        final List<String> workflowPaths = repositories.stream().map(repositoryName -> "github.com/" + repositoryName)
+                .collect(Collectors.toList());
+        return workflowDAO.findByPaths(workflowPaths, false).stream()
+                .filter(workflow -> Objects.equals(workflow.getMode(), SERVICE)).collect(Collectors.toList());
+    }
+
+
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -714,7 +714,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     }
 
     private List<Workflow> syncAndGetServices(User user, Optional<String> organization2) {
-        serviceResource.syncServicesForUser(user, organization2);
+        serviceResource.syncEntitiesForUser(user, organization2);
         userDAO.clearCache();
         return getStrippedServices(userDAO.findById(user.getId()));
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -91,19 +91,21 @@ public class UserResource implements AuthenticatedResourceInterface {
     private final TokenDAO tokenDAO;
 
     private final WorkflowResource workflowResource;
+    private final ServiceResource serviceResource;
     private final DockerRepoResource dockerRepoResource;
     private final WorkflowDAO workflowDAO;
     private final ToolDAO toolDAO;
     private PermissionsInterface authorizer;
     private final CachingAuthenticator cachingAuthenticator;
 
-    public UserResource(SessionFactory sessionFactory, WorkflowResource workflowResource, DockerRepoResource dockerRepoResource,
-            CachingAuthenticator cachingAuthenticator, PermissionsInterface authorizer) {
+    public UserResource(SessionFactory sessionFactory, WorkflowResource workflowResource, ServiceResource serviceResource,
+            DockerRepoResource dockerRepoResource, CachingAuthenticator cachingAuthenticator, PermissionsInterface authorizer) {
         this.userDAO = new UserDAO(sessionFactory);
         this.tokenDAO = new TokenDAO(sessionFactory);
         this.workflowDAO = new WorkflowDAO(sessionFactory);
         this.toolDAO = new ToolDAO(sessionFactory);
         this.workflowResource = workflowResource;
+        this.serviceResource = serviceResource;
         this.dockerRepoResource = dockerRepoResource;
         this.authorizer = authorizer;
         elasticManager = new ElasticManager();
@@ -712,7 +714,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     }
 
     private List<Workflow> syncAndGetServices(User user, Optional<String> organization2) {
-        workflowResource.syncServicesForUser(user, organization2);
+        serviceResource.syncServicesForUser(user, organization2);
         userDAO.clearCache();
         return getStrippedServices(userDAO.findById(user.getId()));
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -492,13 +492,11 @@ public class WorkflowResource
         User sendingUser = findUserByGitHubUsername(username, true);
 
         // Determine if service is already in Dockstore
-        Optional<Service> existingService = workflowDAO.findByPath(servicePath, false, Service.class);
-
-        if (!existingService.isPresent()) {
+        workflowDAO.findByPath(servicePath, false, Service.class).ifPresent((service) -> {
             String msg = "A service already exists for GitHub repository " + repository;
             LOG.info(msg);
             throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
-        }
+        });
 
         // Get Installation Access Token
         String installationAccessToken = GitHubHelper.gitHubAppSetup(gitHubAppId, gitHubPrivateKeyFile, installationId);
@@ -1530,7 +1528,7 @@ public class WorkflowResource
     public Workflow getWorkflowByPath(@ApiParam(hidden = true) @Auth User user,
         @ApiParam(value = "repository path", required = true) @PathParam("repository") String path, @ApiParam(value = "Comma-delimited list of fields to include: validations") @QueryParam("include") String include) {
 
-        Workflow workflow = workflowDAO.findByPath(path, false, Workflow.class).orElse(null);
+        BioWorkflow workflow = workflowDAO.findByPath(path, false, BioWorkflow.class).orElse(null);
         checkEntry(workflow);
         checkCanRead(user, workflow);
 
@@ -1942,7 +1940,7 @@ public class WorkflowResource
                     + " and has the file extension " + descriptorType, HttpStatus.SC_BAD_REQUEST);
         }
 
-        Workflow duplicate = workflowDAO.findByPath(sourceControlEnum.toString() + '/' + completeWorkflowPath, false, BioWorkflow.class).orElseGet(() -> null);
+        Workflow duplicate = workflowDAO.findByPath(sourceControlEnum.toString() + '/' + completeWorkflowPath, false, BioWorkflow.class).orElse(null);
         if (duplicate != null) {
             throw new CustomWebApplicationException("A workflow with the same path and name already exists.", HttpStatus.SC_BAD_REQUEST);
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -103,7 +103,6 @@ import io.dockstore.webservice.permissions.Role;
 import io.dockstore.webservice.permissions.SharedWorkflows;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.hibernate.UnitOfWork;
-import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
@@ -143,7 +142,6 @@ import static io.dockstore.webservice.core.WorkflowMode.SERVICE;
  */
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Path("/workflows")
-@Api("workflows")
 @Produces(MediaType.APPLICATION_JSON)
 public class WorkflowResource extends AbstractWorkflowResource
     implements EntryVersionHelper<Workflow, WorkflowVersion, WorkflowDAO>, StarrableResourceInterface,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -89,6 +89,7 @@ import io.dockstore.webservice.helpers.ElasticManager;
 import io.dockstore.webservice.helpers.ElasticMode;
 import io.dockstore.webservice.helpers.EntryVersionHelper;
 import io.dockstore.webservice.helpers.FileFormatHelper;
+import io.dockstore.webservice.helpers.GitHubSourceCodeRepo;
 import io.dockstore.webservice.helpers.SourceCodeRepoFactory;
 import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
 import io.dockstore.webservice.jdbi.FileFormatDAO;
@@ -143,7 +144,7 @@ import static io.dockstore.webservice.core.WorkflowMode.SERVICE;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Path("/workflows")
 @Produces(MediaType.APPLICATION_JSON)
-public class WorkflowResource extends AbstractWorkflowResource
+public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     implements EntryVersionHelper<Workflow, WorkflowVersion, WorkflowDAO>, StarrableResourceInterface,
     SourceControlResourceInterface {
     private static final String CWL_CHECKER = "_cwl_checker";
@@ -165,7 +166,7 @@ public class WorkflowResource extends AbstractWorkflowResource
 
     public WorkflowResource(HttpClient client, SessionFactory sessionFactory, PermissionsInterface permissionsInterface,
             EntryResource entryResource, DockstoreWebserviceConfiguration configuration) {
-        super(client, sessionFactory, configuration);
+        super(client, sessionFactory, configuration, Workflow.class);
         this.toolDAO = new ToolDAO(sessionFactory);
         this.labelDAO = new LabelDAO(sessionFactory);
         this.fileFormatDAO = new FileFormatDAO(sessionFactory);
@@ -180,6 +181,12 @@ public class WorkflowResource extends AbstractWorkflowResource
         zenodoClientID = configuration.getZenodoClientID();
         zenodoClientSecret = configuration.getZenodoClientSecret();
     }
+
+    @Override
+    protected Workflow initializeEntity(String repository, GitHubSourceCodeRepo sourceCodeRepo) {
+        return sourceCodeRepo.initializeWorkflow(repository, new BioWorkflow());
+    }
+
 
     /**
      * TODO: this should not be a GET either

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -28,7 +28,6 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,10 +44,8 @@ import java.util.stream.Collectors;
 
 import javax.annotation.security.RolesAllowed;
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
-import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -66,7 +63,6 @@ import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.Beta;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
-import com.google.common.collect.Sets;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.DescriptorLanguage.FileType;
 import io.dockstore.common.SourceControl;
@@ -85,7 +81,6 @@ import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.User;
-import io.dockstore.webservice.core.Validation;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowMode;
@@ -94,18 +89,12 @@ import io.dockstore.webservice.helpers.ElasticManager;
 import io.dockstore.webservice.helpers.ElasticMode;
 import io.dockstore.webservice.helpers.EntryVersionHelper;
 import io.dockstore.webservice.helpers.FileFormatHelper;
-import io.dockstore.webservice.helpers.GitHubHelper;
-import io.dockstore.webservice.helpers.GitHubSourceCodeRepo;
 import io.dockstore.webservice.helpers.SourceCodeRepoFactory;
 import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
-import io.dockstore.webservice.jdbi.FileDAO;
 import io.dockstore.webservice.jdbi.FileFormatDAO;
 import io.dockstore.webservice.jdbi.LabelDAO;
-import io.dockstore.webservice.jdbi.TokenDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
-import io.dockstore.webservice.jdbi.UserDAO;
 import io.dockstore.webservice.jdbi.WorkflowDAO;
-import io.dockstore.webservice.jdbi.WorkflowVersionDAO;
 import io.dockstore.webservice.languages.LanguageHandlerFactory;
 import io.dockstore.webservice.languages.LanguageHandlerInterface;
 import io.dockstore.webservice.permissions.Permission;
@@ -145,7 +134,6 @@ import org.slf4j.LoggerFactory;
 import static io.dockstore.common.DescriptorLanguage.CWL;
 import static io.dockstore.common.DescriptorLanguage.WDL;
 import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
-import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
 import static io.dockstore.webservice.core.WorkflowMode.SERVICE;
 
 /**
@@ -157,8 +145,8 @@ import static io.dockstore.webservice.core.WorkflowMode.SERVICE;
 @Path("/workflows")
 @Api("workflows")
 @Produces(MediaType.APPLICATION_JSON)
-public class WorkflowResource
-    implements AuthenticatedResourceInterface, EntryVersionHelper<Workflow, WorkflowVersion, WorkflowDAO>, StarrableResourceInterface,
+public class WorkflowResource extends AbstractWorkflowResource
+    implements EntryVersionHelper<Workflow, WorkflowVersion, WorkflowDAO>, StarrableResourceInterface,
     SourceControlResourceInterface {
     private static final String CWL_CHECKER = "_cwl_checker";
     private static final String WDL_CHECKER = "_wdl_checker";
@@ -167,49 +155,28 @@ public class WorkflowResource
     private static final String OPTIONAL_AUTH_MESSAGE = "Does not require authentication for published workflows, authentication can be provided for restricted workflows";
 
     private final ElasticManager elasticManager;
-    private final UserDAO userDAO;
-    private final TokenDAO tokenDAO;
-    private final WorkflowDAO workflowDAO;
     private final ToolDAO toolDAO;
-    private final WorkflowVersionDAO workflowVersionDAO;
     private final LabelDAO labelDAO;
-    private final FileDAO fileDAO;
     private final FileFormatDAO fileFormatDAO;
-    private final HttpClient client;
     private final EntryResource entryResource;
 
-    private final String bitbucketClientID;
-    private final String bitbucketClientSecret;
     private final PermissionsInterface permissionsInterface;
-    private final String gitHubPrivateKeyFile;
-    private final String gitHubAppId;
     private final String zenodoUrl;
     private final String zenodoClientID;
     private final String zenodoClientSecret;
 
-    public WorkflowResource(HttpClient client, SessionFactory sessionFactory, String bitbucketClientID, String bitbucketClientSecret,
-        PermissionsInterface permissionsInterface, EntryResource entryResource, DockstoreWebserviceConfiguration configuration) {
-        this.userDAO = new UserDAO(sessionFactory);
-        this.tokenDAO = new TokenDAO(sessionFactory);
-        this.workflowVersionDAO = new WorkflowVersionDAO(sessionFactory);
+    public WorkflowResource(HttpClient client, SessionFactory sessionFactory, PermissionsInterface permissionsInterface,
+            EntryResource entryResource, DockstoreWebserviceConfiguration configuration) {
+        super(client, sessionFactory, configuration);
         this.toolDAO = new ToolDAO(sessionFactory);
         this.labelDAO = new LabelDAO(sessionFactory);
-        this.fileDAO = new FileDAO(sessionFactory);
-        this.client = client;
         this.fileFormatDAO = new FileFormatDAO(sessionFactory);
-
-        this.bitbucketClientID = bitbucketClientID;
-        this.bitbucketClientSecret = bitbucketClientSecret;
 
         this.permissionsInterface = permissionsInterface;
 
         this.entryResource = entryResource;
 
-        this.workflowDAO = new WorkflowDAO(sessionFactory);
         elasticManager = new ElasticManager();
-
-        gitHubAppId = configuration.getGitHubAppId();
-        gitHubPrivateKeyFile = configuration.getGitHubAppPrivateKeyFile();
 
         zenodoUrl = configuration.getZenodoUrl();
         zenodoClientID = configuration.getZenodoClientID();
@@ -375,19 +342,6 @@ public class WorkflowResource
         }
     }
 
-    private List<Token> checkOnBitbucketToken(User user) {
-        List<Token> tokens = tokenDAO.findBitbucketByUserId(user.getId());
-
-        if (!tokens.isEmpty()) {
-            Token bitbucketToken = tokens.get(0);
-            String refreshUrl = BITBUCKET_URL + "site/oauth2/access_token";
-            String payload = "grant_type=refresh_token&refresh_token=" + bitbucketToken.getRefreshToken();
-            refreshToken(refreshUrl, bitbucketToken, client, tokenDAO, bitbucketClientID, bitbucketClientSecret, payload);
-        }
-
-        return tokenDAO.findByUserId(user.getId());
-    }
-
     @GET
     @Path("/{workflowId}/refresh")
     @Timed
@@ -458,309 +412,6 @@ public class WorkflowResource
         String dockstoreWorkflowPath = upsertVersionHelper(repository, gitReference, user, WorkflowMode.FULL, null);
 
         return findAllWorkflowsByPath(dockstoreWorkflowPath, WorkflowMode.FULL);
-    }
-
-    /**
-     * Finds all workflows from a general Dockstore path that are of type FULL
-     * @param dockstoreWorkflowPath Dockstore path (ex. github.com/dockstore/dockstore-ui2)
-     * @return List of FULL workflows with the given Dockstore path
-     */
-    private List<Workflow> findAllWorkflowsByPath(String dockstoreWorkflowPath, WorkflowMode workflowMode) {
-        return workflowDAO.findAllByPath(dockstoreWorkflowPath, false)
-                .stream()
-                .filter(workflow ->
-                        workflow.getMode() == workflowMode)
-                .collect(Collectors.toList());
-    }
-
-    @POST
-    @Path("/path/service/")
-    @Timed
-    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    @UnitOfWork
-    @RolesAllowed({ "curator", "admin" })
-    @ApiOperation(value = "Create a service for the given repository (ex. dockstore/dockstore-ui2).", notes = "To be called by a lambda function. Error code 418 is returned to tell lambda not to retry.", authorizations = {
-            @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class)
-    public Workflow addService(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Repository path", required = true) @FormParam("repository") String repository,
-            @ApiParam(value = "Name of user on GitHub", required = true) @FormParam("username") String username,
-            @ApiParam(value = "GitHub installation ID", required = true) @FormParam("installationId") String installationId) {
-        // Check for duplicates (currently workflows and services share paths)
-        String servicePath = "github.com/" + repository;
-
-        // Retrieve the user who triggered the call
-        User sendingUser = findUserByGitHubUsername(username, true);
-
-        // Determine if service is already in Dockstore
-        workflowDAO.findByPath(servicePath, false, Service.class).ifPresent((service) -> {
-            String msg = "A service already exists for GitHub repository " + repository;
-            LOG.info(msg);
-            throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
-        });
-
-        // Get Installation Access Token
-        String installationAccessToken = GitHubHelper.gitHubAppSetup(gitHubAppId, gitHubPrivateKeyFile, installationId);
-
-        // Create a service object
-        final GitHubSourceCodeRepo sourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createGitHubAppRepo(installationAccessToken);
-
-        // Check that repository exists on GitHub
-        try {
-            sourceCodeRepo.getRepository(repository);
-        } catch (CustomWebApplicationException ex) {
-            String msg = "Repository " + repository + " does not exist on GitHub";
-            LOG.error(msg);
-            throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
-        }
-
-        Service service = sourceCodeRepo.initializeService(repository);
-        service.getUsers().add(sendingUser);
-        long serviceId = workflowDAO.create(service);
-
-        return workflowDAO.findById(serviceId);
-    }
-
-    @POST
-    @Path("/path/service/upsertVersion/")
-    @Timed
-    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    @UnitOfWork
-    @RolesAllowed({ "curator", "admin" })
-    @ApiOperation(value = "Add or update a service version for a given GitHub tag for a service with the given repository (ex. dockstore/dockstore-ui2).", notes = "To be called by a lambda function. Error code 418 is returned to tell lambda not to retry.", authorizations = {
-            @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class)
-    public Workflow upsertServiceVersion(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "Repository path", required = true) @FormParam("repository") String repository,
-            @ApiParam(value = "Name of user on GitHub", required = true) @FormParam("username") String username,
-            @ApiParam(value = "Git reference for new GitHub tag", required = true) @FormParam("gitReference") String gitReference,
-            @ApiParam(value = "GitHub installation ID", required = true) @FormParam("installationId") String installationId) {
-
-        // Retrieve the user who triggered the call (may not exist on Dockstore)
-        User sendingUser = findUserByGitHubUsername(username, false);
-
-        // Get Installation Access Token
-        String installationAccessToken = GitHubHelper.gitHubAppSetup(gitHubAppId, gitHubPrivateKeyFile, installationId);
-
-        // Call common upsert code
-        String dockstoreServicePath = upsertVersionHelper(repository, gitReference, null, SERVICE, installationAccessToken);
-
-        // Add user to service if necessary
-        Workflow service = workflowDAO.findByPath(dockstoreServicePath, false, Service.class).get();
-        if (sendingUser != null && !service.getUsers().contains(sendingUser)) {
-            service.getUsers().add(sendingUser);
-        }
-
-        return service;
-    }
-
-    /**
-     * Does the following:
-     * 1) Add user to any existing Dockstore services they should own
-     *
-     * 2) For all of the users organizations that have the GitHub App installed on all repositories in those organizations,
-     * add any services that should be on Dockstore but are not
-     *
-     * 3) For all of the repositories which have the GitHub App installed, add them to Dockstore if they are missing
-     * @param user
-     * @param organization
-     */
-    void syncServicesForUser(User user, Optional<String> organization) {
-        List<Token> githubByUserId = tokenDAO.findGithubByUserId(user.getId());
-
-        if (githubByUserId.isEmpty()) {
-            String msg = "The user does not have a GitHub token, please create one";
-            LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
-        } else {
-            syncServices(user, organization, githubByUserId.get(0));
-        }
-    }
-
-    private void syncServices(User user, Optional<String> organization, Token gitHubToken) {
-        GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(gitHubToken, client);
-
-        // Get all GitHub repositories for the user
-        final Map<String, String> workflowGitUrl2Name = gitHubSourceCodeRepo.getWorkflowGitUrl2RepositoryId();
-
-        // Filter by organization if necessary
-        final Collection<String> repositories = GitHubHelper.filterReposByOrg(workflowGitUrl2Name.values(), organization);
-
-        // Add user to any services they should have access to that already exist on Dockstore
-        final List<Workflow> existingWorkflows = findDockstoreWorkflowsForGitHubRepos(repositories);
-        existingWorkflows.stream()
-                .filter(workflow -> !workflow.getUsers().contains(user))
-                .forEach(workflow -> workflow.getUsers().add(user));
-        final Set<String> existingWorkflowPaths = existingWorkflows.stream()
-                .map(workflow -> workflow.getWorkflowPath()).collect(Collectors.toSet());
-
-        GitHubHelper.checkJWT(gitHubAppId, gitHubPrivateKeyFile);
-
-        GitHubHelper.reposToCreateServicesFor(repositories, organization, existingWorkflowPaths).stream()
-                .forEach(repositoryName -> {
-                    final Service service = gitHubSourceCodeRepo.initializeService(repositoryName);
-                    service.addUser(user);
-                    final long serviceId = workflowDAO.create(service);
-                    final Workflow createdService = workflowDAO.findById(serviceId);
-                    final Workflow updatedService = gitHubSourceCodeRepo.getWorkflow(repositoryName, Optional.of(createdService));
-                    updateDBWorkflowWithSourceControlWorkflow(createdService, updatedService);
-                });
-    }
-
-    private List<Workflow> findDockstoreWorkflowsForGitHubRepos(Collection<String> repositories) {
-        final List<String> workflowPaths = repositories.stream().map(repositoryName -> "github.com/" + repositoryName)
-                .collect(Collectors.toList());
-        return workflowDAO.findByPaths(workflowPaths, false).stream()
-                .filter(workflow -> Objects.equals(workflow.getMode(), SERVICE)).collect(Collectors.toList());
-    }
-
-    /**
-     * Common code for upserting a version to a workflow/service
-     * @param repository Repository path (ex. dockstore/dockstore-ui2)
-     * @param gitReference Git reference (ex. master)
-     * @param user User calling endpoint
-     * @param workflowMode Mode of workflows to filter by
-     * @return Shared dockstore path to workflow/service
-     */
-    private String upsertVersionHelper(String repository, String gitReference, User user, WorkflowMode workflowMode, String installationAccessToken) {
-        // Create path on Dockstore (not unique across workflows)
-        String dockstoreWorkflowPath = String.join("/", TokenType.GITHUB_COM.toString(), repository);
-
-        // Find all workflows with the given path that are full
-        List<Workflow> workflows = findAllWorkflowsByPath(dockstoreWorkflowPath, workflowMode);
-
-        if (workflows.size() > 0) {
-            // All workflows with the same path have the same Git Url
-            String sharedGitUrl = workflows.get(0).getGitUrl();
-
-            // Set up source code interface and ensure token is set up
-            GitHubSourceCodeRepo sourceCodeRepo;
-            if (user != null) {
-                User updatedUser = userDAO.findById(user.getId());
-                sourceCodeRepo = (GitHubSourceCodeRepo)getSourceCodeRepoInterface(sharedGitUrl, updatedUser);
-            } else {
-                sourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createGitHubAppRepo(installationAccessToken);
-            }
-
-            // Pull new version information from GitHub and update the versions
-            workflows = sourceCodeRepo.upsertVersionForWorkflows(repository, gitReference, workflows, workflowMode);
-
-            // Update each workflow with reference types
-            for (Workflow workflow : workflows) {
-                Set<WorkflowVersion> versions = workflow.getWorkflowVersions();
-                versions.forEach(version -> sourceCodeRepo.updateReferenceType(repository, version));
-            }
-        } else {
-            if (workflowMode == SERVICE) {
-                String msg = "No service with path " + dockstoreWorkflowPath + " exists on Dockstore.";
-                LOG.error(msg);
-                throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
-            }
-        }
-
-        return dockstoreWorkflowPath;
-    }
-
-    /**
-     * Based on GitHub username, find the corresponding user
-     * @param username GitHub username
-     * @param allowFail If true, throw a failure if user cannot be found
-     * @return user with given GitHub username
-     */
-    private User findUserByGitHubUsername(String username, boolean allowFail) {
-        // Find user by github name
-        Token userGitHubToken = tokenDAO.findTokenByGitHubUsername(username);
-        if (userGitHubToken == null) {
-            String msg = "No user with GitHub username " + username + " exists on Dockstore.";
-            LOG.info(msg);
-            if (allowFail) {
-                throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
-            } else {
-                return null;
-            }
-        }
-
-        // Get user object for github token
-        User sendingUser = userDAO.findById(userGitHubToken.getUserId());
-        if (sendingUser == null) {
-            String msg = "No user with GitHub username " + username + " exists on Dockstore.";
-            LOG.info(msg);
-            if (allowFail) {
-                throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
-            }
-        }
-
-        return sendingUser;
-    }
-
-    /**
-     * Updates the existing workflow in the database with new information from newWorkflow, including new, updated, and removed
-     * workflow verions.
-     * @param workflow    workflow to be updated
-     * @param newWorkflow workflow to grab new content from
-     */
-    private void updateDBWorkflowWithSourceControlWorkflow(Workflow workflow, Workflow newWorkflow) {
-        // update root workflow
-        workflow.update(newWorkflow);
-        // update workflow versions
-        Map<String, WorkflowVersion> existingVersionMap = new HashMap<>();
-        workflow.getWorkflowVersions().forEach(version -> existingVersionMap.put(version.getName(), version));
-
-        // delete versions that exist in old workflow but do not exist in newWorkflow
-        Map<String, WorkflowVersion> newVersionMap = new HashMap<>();
-        newWorkflow.getWorkflowVersions().forEach(version -> newVersionMap.put(version.getName(), version));
-        Sets.SetView<String> removedVersions = Sets.difference(existingVersionMap.keySet(), newVersionMap.keySet());
-        for (String version : removedVersions) {
-            workflow.removeWorkflowVersion(existingVersionMap.get(version));
-        }
-
-        // Then copy over content that changed
-        for (WorkflowVersion version : newWorkflow.getWorkflowVersions()) {
-            // skip frozen versions
-            WorkflowVersion workflowVersionFromDB = existingVersionMap.get(version.getName());
-            if (existingVersionMap.containsKey(version.getName())) {
-                if (workflowVersionFromDB.isFrozen()) {
-                    continue;
-                }
-                workflowVersionFromDB.update(version);
-            } else {
-                // create a new one and replace the old one
-                final long workflowVersionId = workflowVersionDAO.create(version);
-                workflowVersionFromDB = workflowVersionDAO.findById(workflowVersionId);
-                workflow.getWorkflowVersions().add(workflowVersionFromDB);
-                existingVersionMap.put(workflowVersionFromDB.getName(), workflowVersionFromDB);
-            }
-
-            // Update source files for each version
-            Map<String, SourceFile> existingFileMap = new HashMap<>();
-            workflowVersionFromDB.getSourceFiles().forEach(file -> existingFileMap.put(file.getType().toString() + file.getAbsolutePath(), file));
-
-            for (SourceFile file : version.getSourceFiles()) {
-                if (existingFileMap.containsKey(file.getType().toString() + file.getAbsolutePath())) {
-                    existingFileMap.get(file.getType().toString() + file.getAbsolutePath()).setContent(file.getContent());
-                } else {
-                    final long fileID = fileDAO.create(file);
-                    final SourceFile fileFromDB = fileDAO.findById(fileID);
-                    workflowVersionFromDB.getSourceFiles().add(fileFromDB);
-                }
-            }
-
-            // Remove existing files that are no longer present on remote
-            for (Map.Entry<String, SourceFile> entry : existingFileMap.entrySet()) {
-                boolean toDelete = true;
-                for (SourceFile file : version.getSourceFiles()) {
-                    if (entry.getKey().equals(file.getType().toString() + file.getAbsolutePath())) {
-                        toDelete = false;
-                    }
-                }
-                if (toDelete) {
-                    workflowVersionFromDB.getSourceFiles().remove(entry.getValue());
-                }
-            }
-
-            // Update the validations
-            for (Validation versionValidation : version.getValidations()) {
-                workflowVersionFromDB.addOrUpdateValidation(versionValidation);
-            }
-        }
     }
 
     @GET
@@ -1967,24 +1618,6 @@ public class WorkflowResource
         updateDBWorkflowWithSourceControlWorkflow(workflowFromDB, newWorkflow);
         return workflowDAO.findById(workflowID);
 
-    }
-
-    private SourceCodeRepoInterface getSourceCodeRepoInterface(String gitUrl, User user) {
-        List<Token> tokens = checkOnBitbucketToken(user);
-        Token bitbucketToken = Token.extractToken(tokens, TokenType.BITBUCKET_ORG);
-        Token githubToken = Token.extractToken(tokens, TokenType.GITHUB_COM);
-        Token gitlabToken = Token.extractToken(tokens, TokenType.GITLAB_COM);
-
-        final String bitbucketTokenContent = bitbucketToken == null ? null : bitbucketToken.getContent();
-        final String gitHubTokenContent = githubToken == null ? null : githubToken.getContent();
-        final String gitlabTokenContent = gitlabToken == null ? null : gitlabToken.getContent();
-
-        final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory
-            .createSourceCodeRepo(gitUrl, client, bitbucketTokenContent, gitlabTokenContent, gitHubTokenContent);
-        if (sourceCodeRepo == null) {
-            throw new CustomWebApplicationException("Git tokens invalid, please re-link your git accounts.", HttpStatus.SC_BAD_REQUEST);
-        }
-        return sourceCodeRepo;
     }
 
     @PUT

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -421,7 +421,7 @@ public class WorkflowResource
             || workflow.getDescriptorType() == WDL) {
             String workflowName = workflow.getWorkflowName() == null ? "" : workflow.getWorkflowName();
             String checkerWorkflowName = "/" + workflowName + (workflow.getDescriptorType() == CWL ? CWL_CHECKER : WDL_CHECKER);
-            BioWorkflow byPath = (BioWorkflow)workflowDAO.findByPath(workflow.getPath() + checkerWorkflowName, false);
+            BioWorkflow byPath = workflowDAO.findByPath(workflow.getPath() + checkerWorkflowName, false, BioWorkflow.class).orElse(null);
             if (byPath != null && workflow.getCheckerWorkflow() == null) {
                 workflow.setCheckerWorkflow(byPath);
             }
@@ -492,9 +492,9 @@ public class WorkflowResource
         User sendingUser = findUserByGitHubUsername(username, true);
 
         // Determine if service is already in Dockstore
-        Workflow existingService = workflowDAO.findByPath(servicePath, false);
+        Optional<Service> existingService = workflowDAO.findByPath(servicePath, false, Service.class);
 
-        if (existingService != null) {
+        if (!existingService.isPresent()) {
             String msg = "A service already exists for GitHub repository " + repository;
             LOG.info(msg);
             throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
@@ -546,7 +546,7 @@ public class WorkflowResource
         String dockstoreServicePath = upsertVersionHelper(repository, gitReference, null, SERVICE, installationAccessToken);
 
         // Add user to service if necessary
-        Workflow service = workflowDAO.findByPath(dockstoreServicePath, false);
+        Workflow service = workflowDAO.findByPath(dockstoreServicePath, false, Service.class).get();
         if (sendingUser != null && !service.getUsers().contains(sendingUser)) {
             service.getUsers().add(sendingUser);
         }
@@ -811,7 +811,7 @@ public class WorkflowResource
         checkNotHosted(wf);
         checkCanWriteWorkflow(user, wf);
 
-        Workflow duplicate = workflowDAO.findByPath(workflow.getWorkflowPath(), false);
+        Workflow duplicate = workflowDAO.findByPath(workflow.getWorkflowPath(), false, BioWorkflow.class).orElse(null);
 
         if (duplicate != null && duplicate.getId() != workflowId) {
             LOG.info(user.getUsername() + ": " + "duplicate workflow found: {}" + workflow.getWorkflowPath());
@@ -1530,7 +1530,7 @@ public class WorkflowResource
     public Workflow getWorkflowByPath(@ApiParam(hidden = true) @Auth User user,
         @ApiParam(value = "repository path", required = true) @PathParam("repository") String path, @ApiParam(value = "Comma-delimited list of fields to include: validations") @QueryParam("include") String include) {
 
-        Workflow workflow = workflowDAO.findByPath(path, false);
+        Workflow workflow = workflowDAO.findByPath(path, false, Workflow.class).orElse(null);
         checkEntry(workflow);
         checkCanRead(user, workflow);
 
@@ -1598,7 +1598,7 @@ public class WorkflowResource
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "The user must be the workflow owner.", response = Permission.class, responseContainer = "List")
     public List<Permission> getWorkflowPermissions(@ApiParam(hidden = true) @Auth User user,
         @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
-        Workflow workflow = workflowDAO.findByPath(path, false);
+        Workflow workflow = workflowDAO.findByPath(path, false, BioWorkflow.class).orElse(null);
         checkEntry(workflow);
         return this.permissionsInterface.getPermissionsForWorkflow(user, workflow);
     }
@@ -1611,7 +1611,7 @@ public class WorkflowResource
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Role.Action.class, responseContainer = "List")
     public List<Role.Action> getWorkflowActions(@ApiParam(hidden = true) @Auth User user,
         @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
-        Workflow workflow = workflowDAO.findByPath(path, false);
+        Workflow workflow = workflowDAO.findByPath(path, false, BioWorkflow.class).orElse(null);
         checkEntry(workflow);
         return this.permissionsInterface.getActionsForWorkflow(user, workflow);
     }
@@ -1625,7 +1625,7 @@ public class WorkflowResource
     public List<Permission> addWorkflowPermission(@ApiParam(hidden = true) @Auth User user,
         @ApiParam(value = "repository path", required = true) @PathParam("repository") String path,
         @ApiParam(value = "user permission", required = true) Permission permission) {
-        Workflow workflow = workflowDAO.findByPath(path, false);
+        Workflow workflow = workflowDAO.findByPath(path, false, BioWorkflow.class).orElse(null);
         checkEntry(workflow);
         // TODO: Remove this guard when ready to expand sharing to non-hosted workflows. https://github.com/dockstore/dockstore/issues/1593
         if (workflow.getMode() != WorkflowMode.HOSTED) {
@@ -1644,7 +1644,7 @@ public class WorkflowResource
         @ApiParam(value = "repository path", required = true) @PathParam("repository") String path,
         @ApiParam(value = "user email", required = true) @QueryParam("email") String email,
         @ApiParam(value = "role", required = true) @QueryParam("role") Role role) {
-        Workflow workflow = workflowDAO.findByPath(path, false);
+        Workflow workflow = workflowDAO.findByPath(path, false, BioWorkflow.class).orElse(null);
         checkEntry(workflow);
         this.permissionsInterface.removePermission(user, workflow, email, role);
         return this.permissionsInterface.getPermissionsForWorkflow(user, workflow);
@@ -1707,7 +1707,7 @@ public class WorkflowResource
     @Path("/path/workflow/{repository}/published")
     @ApiOperation(value = "Get a published workflow by path", notes = "Does not require workflow name.", response = Workflow.class)
     public Workflow getPublishedWorkflowByPath(@ApiParam(value = "repository path", required = true) @PathParam("repository") String path, @ApiParam(value = "Comma-delimited list of fields to include: validations") @QueryParam("include") String include) {
-        Workflow workflow = workflowDAO.findByPath(path, true);
+        Workflow workflow = workflowDAO.findByPath(path, true, BioWorkflow.class).orElse(null);
         checkEntry(workflow);
 
         initializeValidations(include, workflow);
@@ -1942,7 +1942,7 @@ public class WorkflowResource
                     + " and has the file extension " + descriptorType, HttpStatus.SC_BAD_REQUEST);
         }
 
-        Workflow duplicate = workflowDAO.findByPath(sourceControlEnum.toString() + '/' + completeWorkflowPath, false);
+        Workflow duplicate = workflowDAO.findByPath(sourceControlEnum.toString() + '/' + completeWorkflowPath, false, BioWorkflow.class).orElseGet(() -> null);
         if (duplicate != null) {
             throw new CustomWebApplicationException("A workflow with the same path and name already exists.", HttpStatus.SC_BAD_REQUEST);
         }

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
@@ -48,6 +48,7 @@ import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
+import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Tag;
@@ -175,7 +176,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         if (parsedID.isTool()) {
             entry = toolDAO.findByPath(entryPath, user.isEmpty());
         } else {
-            entry = workflowDAO.findByPath(entryPath, user.isEmpty());
+            entry = workflowDAO.findByPath(entryPath, user.isEmpty(), BioWorkflow.class).orElseGet(null);
         }
         if (entry != null && entry.getIsPublished()) {
             return entry;

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -6458,6 +6458,10 @@ components:
         custom_docker_registry_path:
           type: string
           readOnly: true
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6473,10 +6477,6 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -6664,6 +6664,10 @@ components:
           items:
             $ref: "#/components/schemas/Base_class_for_versions_of_entries_in_the_D\
               ockstore"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6679,10 +6683,6 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -7699,6 +7699,10 @@ components:
           type: boolean
         parentEntry:
           $ref: "#/components/schemas/Entry"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -7714,10 +7718,6 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -2989,7 +2989,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/Entry'
           description: default response
   /entries/{id}/collections:
     get:
@@ -5011,7 +5011,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Service'
           description: default response
   /workflows/path/workflow/{repository}:
     get:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1975,7 +1975,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tool'
+                $ref: '#/components/schemas/Entry'
           description: default response
   /containers/hostedEntry/{entryId}:
     delete:
@@ -4818,7 +4818,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
   /workflows/hostedEntry/{entryId}:
     delete:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -2989,7 +2989,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
   /entries/{id}/collections:
     get:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -6187,6 +6187,10 @@ definitions:
       custom_docker_registry_path:
         type: "string"
         readOnly: true
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6202,10 +6206,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       author:
         type: "string"
         position: 1
@@ -6418,6 +6418,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/Base class for versions of entries in the Dockstore"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6433,10 +6437,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       author:
         type: "string"
         position: 1
@@ -7539,6 +7539,10 @@ definitions:
         type: "boolean"
       parentEntry:
         $ref: "#/definitions/Entry"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -7554,10 +7558,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       author:
         type: "string"
         position: 1


### PR DESCRIPTION

#2643 

We were calling `WorkflowDAO.findByPath` in several locations to see if an entry already existed. For example, when creating a service, we would call that method, and if there was a workflow with that path, the duplicate check would fire, and hence the bug.

1. Changed the method to return a `List<Workflow>` instead of a `Workflow`. 
1. Then added a new `Workflow WorkflowDAO.findByPath` method that takes a class as a third parameter and only returns 1 result.
1. Replaced all compilation errors introduced by method 1 with calls to method 2.

Also separated out the service endpoints into ServiceResource.java. Made AbstractWorkfowResource as a base class for ServiceResource and WorkflowResource to hold shared functionality.