### PR TITLE
Feature/2330/checker workflow link

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
@@ -29,6 +29,7 @@ import io.swagger.client.model.DockstoreTool;
 import io.swagger.client.model.Entry;
 import io.swagger.client.model.PublishRequest;
 import io.swagger.client.model.Workflow;
+import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -172,9 +173,9 @@ public class CheckerWorkflowIT extends BaseIT {
         // Should not be able to directly publish the checker
         try {
             workflowApi.publish(refreshedEntry.getCheckerId(), publishRequest);
-            assertTrue("Should not reach this statement.", false);
+            Assert.fail("Should not reach this statement.");
         } catch (ApiException ex) {
-            assertEquals(ex.getCode(), 400);
+            assertEquals(ex.getCode(), HttpStatus.SC_BAD_REQUEST);
         }
     }
 
@@ -342,9 +343,9 @@ public class CheckerWorkflowIT extends BaseIT {
         // Should not be able to directly publish the checker
         try {
             workflowApi.publish(refreshedEntry.getCheckerId(), publishRequest);
-            assertTrue("Should not reach this statement.", false);
+            Assert.fail("Should not reach this statement.");
         } catch (ApiException ex) {
-            assertEquals(ex.getCode(), 400);
+            assertEquals(ex.getCode(), HttpStatus.SC_BAD_REQUEST);
         }
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
@@ -168,6 +168,14 @@ public class CheckerWorkflowIT extends BaseIT {
         final long count9 = testingPostgres
             .runSelectStatement("select count(*) from tool where ispublished = true", long.class);
         assertEquals("the tool should not be published, there are " + count9, 0, count9);
+
+        // Should not be able to directly publish the checker
+        try {
+            workflowApi.publish(refreshedEntry.getCheckerId(), publishRequest);
+            assertTrue("Should not reach this statement.", false);
+        } catch (ApiException ex) {
+            assertEquals(ex.getCode(), 400);
+        }
     }
 
     /**
@@ -330,6 +338,14 @@ public class CheckerWorkflowIT extends BaseIT {
         final long count8 = testingPostgres
             .runSelectStatement("select count(*) from workflow where ispublished = true", long.class);
         assertEquals("No workflows should be published, there are " + count8, 0, count8);
+
+        // Should not be able to directly publish the checker
+        try {
+            workflowApi.publish(refreshedEntry.getCheckerId(), publishRequest);
+            assertTrue("Should not reach this statement.", false);
+        } catch (ApiException ex) {
+            assertEquals(ex.getCode(), 400);
+        }
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1417,16 +1417,22 @@ public class WorkflowResource
     public Workflow publish(@ApiParam(hidden = true) @Auth User user,
         @ApiParam(value = "Workflow id to publish/unpublish", required = true) @PathParam("workflowId") Long workflowId,
         @ApiParam(value = "PublishRequest to refresh the list of repos for a user", required = true) PublishRequest request) {
-        Workflow c = workflowDAO.findById(workflowId);
-        checkEntry(c);
+        Workflow workflow = workflowDAO.findById(workflowId);
+        checkEntry(workflow);
 
-        checkCanShareWorkflow(user, c);
+        checkCanShareWorkflow(user, workflow);
 
-        Workflow checker = c.getCheckerWorkflow();
+        Workflow checker = workflow.getCheckerWorkflow();
+
+        if (workflow.isIsChecker()) {
+            String msg = "Cannot directly publish/unpublish a checker workflow.";
+            LOG.error(msg);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+        }
 
         if (request.getPublish()) {
             boolean validTag = false;
-            Set<WorkflowVersion> versions = c.getWorkflowVersions();
+            Set<WorkflowVersion> versions = workflow.getWorkflowVersions();
             for (WorkflowVersion workflowVersion : versions) {
                 if (workflowVersion.isValid()) {
                     validTag = true;
@@ -1434,8 +1440,8 @@ public class WorkflowResource
                 }
             }
 
-            if (validTag && (!c.getGitUrl().isEmpty() || Objects.equals(c.getMode(), WorkflowMode.HOSTED))) {
-                c.setIsPublished(true);
+            if (validTag && (!workflow.getGitUrl().isEmpty() || Objects.equals(workflow.getMode(), WorkflowMode.HOSTED))) {
+                workflow.setIsPublished(true);
                 if (checker != null) {
                     checker.setIsPublished(true);
                 }
@@ -1443,17 +1449,17 @@ public class WorkflowResource
                 throw new CustomWebApplicationException("Repository does not meet requirements to publish.", HttpStatus.SC_BAD_REQUEST);
             }
         } else {
-            c.setIsPublished(false);
+            workflow.setIsPublished(false);
             if (checker != null) {
                 checker.setIsPublished(false);
             }
         }
 
-        long id = workflowDAO.create(c);
-        c = workflowDAO.findById(id);
+        long id = workflowDAO.create(workflow);
+        workflow = workflowDAO.findById(id);
         if (request.getPublish()) {
-            elasticManager.handleIndexUpdate(c, ElasticMode.UPDATE);
-            if (c.getTopicId() == null) {
+            elasticManager.handleIndexUpdate(workflow, ElasticMode.UPDATE);
+            if (workflow.getTopicId() == null) {
                 try {
                     entryResource.createAndSetDiscourseTopic(id);
                 } catch (CustomWebApplicationException ex) {
@@ -1461,9 +1467,9 @@ public class WorkflowResource
                 }
             }
         } else {
-            elasticManager.handleIndexUpdate(c, ElasticMode.DELETE);
+            elasticManager.handleIndexUpdate(workflow, ElasticMode.DELETE);
         }
-        return c;
+        return workflow;
     }
 
     @GET

--- a/dockstore-webservice/src/main/resources/migrations.1.7.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.7.0.xml
@@ -288,4 +288,28 @@
             <column name="blacklistedversionnames" type="text"/>
         </createTable>
     </changeSet>
+
+    <changeSet id="fix_checker_workflow_publish_mismatch" author="aduncan">
+        <sql dbms="postgresql">
+            UPDATE workflow SET ispublished=false WHERE id IN (
+                SELECT c.id FROM tool t INNER JOIN workflow c ON t.checkerid=c.id WHERE t.ispublished != c.ispublished AND t.ispublished = false
+            )
+        </sql>
+        <sql dbms="postgresql">
+            UPDATE workflow SET ispublished=true WHERE id IN (
+                SELECT c.id FROM tool t INNER JOIN workflow c ON t.checkerid=c.id WHERE t.ispublished != c.ispublished AND t.ispublished = true
+            )
+        </sql>
+
+        <sql dbms="postgresql">
+            UPDATE workflow SET ispublished=false WHERE id IN (
+                SELECT c.id FROM workflow w INNER JOIN workflow c ON w.checkerid=c.id WHERE w.ispublished != c.ispublished AND w.ispublished = false
+            )
+        </sql>
+        <sql dbms="postgresql">
+            UPDATE workflow SET ispublished=true WHERE id IN (
+                SELECT c.id FROM workflow w INNER JOIN workflow c ON w.checkerid=c.id WHERE w.ispublished != c.ispublished AND w.ispublished = true
+            )
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Checker workflow publish state should match parent tool/workflow. Migrations added to fix, plus no longer able to directly publish a checker workflow, need to go through the parent.

https://github.com/dockstore/dockstore/issues/2330