### PR TITLE
Fix NPE for non-existent workflow

### DIFF
--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsApiServiceImpl.java
@@ -176,7 +176,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         if (parsedID.isTool()) {
             entry = toolDAO.findByPath(entryPath, user.isEmpty());
         } else {
-            entry = workflowDAO.findByPath(entryPath, user.isEmpty(), BioWorkflow.class).orElseGet(null);
+            entry = workflowDAO.findByPath(entryPath, user.isEmpty(), BioWorkflow.class).orElse(null);
         }
         if (entry != null && entry.getIsPublished()) {
             return entry;


### PR DESCRIPTION
#2643 followup

Introduced this in my PR to allow workflows and services to have
the same path. Noticed the exception when refreshing services
locally.

