### PR TITLE
Use Dockstore user name for Zenodo token user name

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -663,6 +663,10 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
                 token.setContent(accessToken);
                 token.setRefreshToken(refreshToken);
                 token.setUserId(user.getId());
+                // Zenodo does not return a user name in the token response
+                // so set the token user name to the Dockstore user name
+                // otherwise we will get a DB error when trying to
+                // link another user's Zenodo credentials
                 token.setUsername(user.getUsername());
                 long create = tokenDAO.create(token);
                 LOG.info("Zenodo token created for {}", user.getUsername());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -663,7 +663,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
                 token.setContent(accessToken);
                 token.setRefreshToken(refreshToken);
                 token.setUserId(user.getId());
-                token.setUsername("");
+                token.setUsername(user.getUsername());
                 long create = tokenDAO.create(token);
                 LOG.info("Zenodo token created for {}", user.getUsername());
                 return tokenDAO.findById(create);


### PR DESCRIPTION
Addresses https://ucsc-cgl.atlassian.net/browse/DOCK-886
The Zenodo endpoint https://sandbox.zenodo.org/oauth/token does not return a user name in the response. We need to store a user name in the token when it is put into the Dockstore DB, otherwise when other users try to link their Zenodo credentials they will get a DB error. So we put the Dockstore user name in the token.