### PR TITLE
a number of refresh issues

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -242,6 +242,7 @@ public abstract class SourceCodeRepoInterface {
     Entry updateEntryMetadata(final Entry entry, final DescriptorLanguage type) {
         // Determine which branch to use
         String repositoryId = getRepositoryId(entry);
+        Version version = null;
 
         if (repositoryId == null) {
             LOG.info("Could not find repository information.");
@@ -272,8 +273,10 @@ public abstract class SourceCodeRepoInterface {
                     sourceFiles = tag.getSourceFiles();
                     if (type == DescriptorLanguage.CWL) {
                         filePath = tag.getCwlPath();
+                        version = tag;
                     } else if (type == DescriptorLanguage.WDL) {
                         filePath = tag.getWdlPath();
+                        version = tag;
                     } else {
                         throw new UnsupportedOperationException("tool is not a CWL or WDL file");
                     }
@@ -289,6 +292,7 @@ public abstract class SourceCodeRepoInterface {
                 if (workflowVersion.getReference().equals(branch)) {
                     filePath = workflowVersion.getWorkflowPath();
                     sourceFiles = workflowVersion.getSourceFiles();
+                    version = workflowVersion;
                 }
             }
         }
@@ -314,7 +318,7 @@ public abstract class SourceCodeRepoInterface {
 
         // Parse file content and update
         LanguageHandlerInterface anInterface = LanguageHandlerFactory.getInterface(type);
-        return anInterface.parseWorkflowContent(entry, finalFilePath, firstFileContent, sourceFiles);
+        return anInterface.parseWorkflowContent(entry, finalFilePath, firstFileContent, sourceFiles, version);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -61,7 +61,7 @@ public interface LanguageHandlerInterface {
      * @param content  a cwl document
      * @return the updated entry
      */
-    Entry parseWorkflowContent(Entry entry, String filepath, String content, Set<SourceFile> sourceFiles);
+    Entry parseWorkflowContent(Entry entry, String filepath, String content, Set<SourceFile> sourceFiles, Version version);
 
     /**
      * Validates a workflow set for the workflow described by with primaryDescriptorFilePath

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -36,10 +36,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.dockstore.common.DescriptorLanguage.FileType.DOCKSTORE_CWL;
-import static io.dockstore.common.DescriptorLanguage.FileType.DOCKSTORE_WDL;
-import static io.dockstore.common.DescriptorLanguage.FileType.NEXTFLOW_CONFIG;
-
 public class LanguagePluginHandler implements LanguageHandlerInterface {
 
     public static final Logger LOG = LoggerFactory.getLogger(LanguagePluginHandler.class);
@@ -55,12 +51,13 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
     }
 
     @Override
-    public Entry parseWorkflowContent(Entry entry, String filepath, String content, Set<SourceFile> sourceFiles) {
+    public Entry parseWorkflowContent(Entry entry, String filepath, String content, Set<SourceFile> sourceFiles, Version version) {
         final MinimalLanguageInterface.WorkflowMetadata workflowMetadata = minimalLanguageInterface
             .parseWorkflowForMetadata(filepath, content, new HashMap<>());
         entry.setAuthor(workflowMetadata.getAuthor());
         entry.setEmail(workflowMetadata.getEmail());
         entry.setDescription(workflowMetadata.getDescription());
+        // TODO: hook up validation object to version for parsing metadata
         return entry;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
@@ -113,7 +113,7 @@ public class HostedToolResource extends AbstractHostedEntryResource<Tool, Tag, T
         for (SourceFile file : sourceFiles) {
             if (file.getPath().equals(tag.getCwlPath()) || file.getPath().equals(tag.getWdlPath())) {
                 LOG.info("refreshing metadata based on " + file.getPath() + " from " + tag.getName());
-                LanguageHandlerFactory.getInterface(file.getType()).parseWorkflowContent(entry, file.getPath(), file.getContent(), sourceFiles);
+                LanguageHandlerFactory.getInterface(file.getType()).parseWorkflowContent(entry, file.getPath(), file.getContent(), sourceFiles, tag);
             }
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
@@ -198,7 +198,7 @@ public class HostedWorkflowResource extends AbstractHostedEntryResource<Workflow
         LanguageHandlerInterface anInterface = LanguageHandlerFactory.getInterface(workflow.getFileType());
         Optional<SourceFile> first = sourceFiles.stream().filter(file -> file.getPath().equals(version.getWorkflowPath())).findFirst();
         first.ifPresent(sourceFile -> LOG.info("refreshing metadata based on " + sourceFile.getPath() + " from " + version.getName()));
-        first.ifPresent(sourceFile -> anInterface.parseWorkflowContent(workflow, sourceFile.getPath(), sourceFile.getContent(), sourceFiles));
+        first.ifPresent(sourceFile -> anInterface.parseWorkflowContent(workflow, sourceFile.getPath(), sourceFile.getContent(), sourceFiles, version));
     }
 
     @Override

--- a/dockstore-webservice/src/test/java/core/CWLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/CWLParseTest.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.core.Entry;
+import io.dockstore.webservice.core.Tag;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.languages.LanguageHandlerFactory;
 import io.dockstore.webservice.languages.LanguageHandlerInterface;
@@ -37,7 +38,7 @@ public class CWLParseTest {
     public void testOldMetadataExample() throws IOException {
         String filePath = ResourceHelpers.resourceFilePath("metadata_example0.cwl");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_CWL);
-        Entry entry = sInterface.parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+        Entry entry = sInterface.parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
         Assert.assertEquals("incorrect author", "Keiran Raine", entry.getAuthor());
         Assert.assertEquals("incorrect email", "keiranmraine@gmail.com", entry.getEmail());
     }
@@ -46,7 +47,7 @@ public class CWLParseTest {
     public void testNewMetadataExample() throws IOException {
         String filePath = ResourceHelpers.resourceFilePath("metadata_example2.cwl");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_CWL);
-        Entry entry = sInterface.parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+        Entry entry = sInterface.parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
         Assert.assertEquals("incorrect author", "Denis Yuen", entry.getAuthor());
         Assert.assertEquals("incorrect email", "dyuen@oicr.on.ca", entry.getEmail());
     }
@@ -60,7 +61,7 @@ public class CWLParseTest {
     public void testcwlVersion1_1_doc1() throws IOException {
         String filePath = ResourceHelpers.resourceFilePath("metadata_cwlVersion1_1_example1.cwl");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_CWL);
-        Entry entry = sInterface.parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+        Entry entry = sInterface.parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
         Assert.assertEquals("incorrect author", "Peter Amstutz", entry.getAuthor());
         Assert.assertEquals("incorrect email", "peter.amstutz@curoverse.com", entry.getEmail());
         Assert.assertEquals("incorrect description", "Print the contents of a file to stdout using 'cat' running in a docker container.", entry.getDescription());
@@ -74,7 +75,7 @@ public class CWLParseTest {
     public void testcwlVersion1_1_doc2() throws IOException {
         String filePath = ResourceHelpers.resourceFilePath("metadata_cwlVersion1_1_example2.cwl");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_CWL);
-        Entry entry = sInterface.parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+        Entry entry = sInterface.parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
         Assert.assertEquals("incorrect author", "Peter Amstutz", entry.getAuthor());
         Assert.assertEquals("incorrect email", "peter.amstutz@curoverse.com", entry.getEmail());
         Assert.assertEquals("incorrect description", "Print the contents of a file to stdout using 'cat' running in a docker container.", entry.getDescription());
@@ -88,7 +89,7 @@ public class CWLParseTest {
     public void testcwlVersion1_1_doc3() throws IOException {
         String filePath = ResourceHelpers.resourceFilePath("metadata_cwlVersion1_1_example3.cwl");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_CWL);
-        Entry entry = sInterface.parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+        Entry entry = sInterface.parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
         Assert.assertEquals("incorrect author", "Peter Amstutz", entry.getAuthor());
         Assert.assertEquals("incorrect email", "peter.amstutz@curoverse.com", entry.getEmail());
         Assert.assertEquals("incorrect description", "Print the contents of a file to stdout using 'cat' running in a docker container.\nNew line doc.", entry.getDescription());
@@ -98,7 +99,7 @@ public class CWLParseTest {
     public void testCombinedMetadataExample() throws IOException {
         String filePath = ResourceHelpers.resourceFilePath("metadata_example3.cwl");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_CWL);
-        Entry entry = sInterface.parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+        Entry entry = sInterface.parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
         Assert.assertEquals("incorrect author", "Denis Yuen", entry.getAuthor());
         Assert.assertEquals("incorrect email", "dyuen@oicr.on.ca", entry.getEmail());
     }

--- a/dockstore-webservice/src/test/java/core/NFLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/NFLParseTest.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Tool;
+import io.dockstore.webservice.core.WorkflowVersion;
 import io.dockstore.webservice.languages.LanguageHandlerFactory;
 import io.dockstore.webservice.languages.LanguageHandlerInterface;
 import io.dropwizard.testing.ResourceHelpers;
@@ -40,7 +41,7 @@ public class NFLParseTest {
         String filePath = ResourceHelpers.resourceFilePath("nfl-chipseq/nextflow.config");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.NEXTFLOW_CONFIG);
         Entry entry = sInterface
-            .parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+            .parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new WorkflowVersion());
         assertNull("incorrect author", entry.getAuthor());
         assertTrue("incorrect description", entry.getDescription().startsWith("Analysis pipeline used for ChIP-seq (chromatin immunoprecipitation sequencing) data"));
     }
@@ -50,7 +51,7 @@ public class NFLParseTest {
         String filePath = ResourceHelpers.resourceFilePath("nfl-rnaseq/nextflow.config");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.NEXTFLOW_CONFIG);
         Entry entry = sInterface
-            .parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+            .parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new WorkflowVersion());
         assertTrue("incorrect author", entry.getAuthor().split(",").length >= 2);
         assertTrue("incorrect description", entry.getDescription().startsWith("Nextflow RNA-Seq analysis pipeline, part of the nf-core community."));
     }
@@ -60,7 +61,7 @@ public class NFLParseTest {
         String filePath = ResourceHelpers.resourceFilePath("nfl-ampa/nextflow.config");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.NEXTFLOW_CONFIG);
         Entry entry = sInterface
-            .parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+            .parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new WorkflowVersion());
         assertEquals("incorrect description", "Fast automated prediction of protein antimicrobial regions", entry.getDescription());
     }
 }

--- a/dockstore-webservice/src/test/java/core/WDLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/WDLParseTest.java
@@ -26,7 +26,9 @@ import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.SourceFile;
+import io.dockstore.webservice.core.Tag;
 import io.dockstore.webservice.core.Tool;
+import io.dockstore.webservice.core.WorkflowVersion;
 import io.dockstore.webservice.languages.LanguageHandlerFactory;
 import io.dockstore.webservice.languages.LanguageHandlerInterface;
 import io.dockstore.webservice.languages.WDLHandler;
@@ -36,6 +38,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class WDLParseTest {
@@ -45,7 +48,7 @@ public class WDLParseTest {
         String filePath = ResourceHelpers.resourceFilePath("metadata_example0.wdl");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_WDL);
         Entry entry = sInterface
-            .parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+            .parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
         assertTrue("incorrect author", entry.getAuthor().contains("Chip Stewart"));
         assertTrue("incorrect email", entry.getEmail().contains("stewart@broadinstitute.org"));
     }
@@ -55,9 +58,9 @@ public class WDLParseTest {
         String filePath = ResourceHelpers.resourceFilePath("metadata_example1.wdl");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_WDL);
         Entry entry = sInterface
-            .parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+            .parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
         assertTrue("incorrect author", entry.getAuthor().split(",").length >= 2);
-        assertTrue("incorrect email", entry.getEmail() == null);
+        assertNull("incorrect email", entry.getEmail());
     }
 
     @Test
@@ -65,7 +68,7 @@ public class WDLParseTest {
         String filePath = ResourceHelpers.resourceFilePath("metadata_example2.wdl");
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_WDL);
         Entry entry = sInterface
-            .parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>());
+            .parseWorkflowContent(new Tool(), filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
         assertTrue("incorrect author", entry.getAuthor().split(",").length >= 2);
         assertEquals("incorrect email", "This is a cool workflow", entry.getDescription());
     }
@@ -130,8 +133,8 @@ public class WDLParseTest {
 
             LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_WDL);
             Entry entry = sInterface
-                    .parseWorkflowContent(new BioWorkflow(), primaryWDL.getAbsolutePath(), FileUtils.readFileToString(primaryWDL, StandardCharsets.UTF_8), sourceFileSet);
-            assertTrue("incorrect author", entry.getAuthor().split(",").length == 1);
+                    .parseWorkflowContent(new BioWorkflow(), primaryWDL.getAbsolutePath(), FileUtils.readFileToString(primaryWDL, StandardCharsets.UTF_8), sourceFileSet, new WorkflowVersion());
+            assertEquals("incorrect author", 1, entry.getAuthor().split(",").length);
             assertEquals("incorrect email", "foobar@foo.com", entry.getEmail());
             assertTrue("incorrect description", entry.getDescription().length() > 0);
         } catch (Exception e) {

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Workflow;
+import io.dockstore.webservice.core.WorkflowVersion;
 import io.dropwizard.testing.ResourceHelpers;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
@@ -38,7 +39,7 @@ public class WDLHandlerTest {
         final String goodWdl = FileUtils
                 .readFileToString(new File(validFilePath),
                         StandardCharsets.UTF_8);
-        wdlHandler.parseWorkflowContent(workflow, validFilePath, goodWdl, Collections.emptySet());
+        wdlHandler.parseWorkflowContent(workflow, validFilePath, goodWdl, Collections.emptySet(), new WorkflowVersion());
         Assert.assertEquals(workflow.getAuthor(), "Mr. Foo");
         Assert.assertEquals(workflow.getEmail(), "foo@foo.com");
         Assert.assertEquals(workflow.getDescription(),
@@ -49,11 +50,9 @@ public class WDLHandlerTest {
         final String invalidDescriptionWdl = FileUtils
                 .readFileToString(new File(invalidFilePath),
                         StandardCharsets.UTF_8);
-        wdlHandler.parseWorkflowContent(workflow, invalidFilePath, invalidDescriptionWdl, Collections.emptySet());
+        wdlHandler.parseWorkflowContent(workflow, invalidFilePath, invalidDescriptionWdl, Collections.emptySet(), new WorkflowVersion());
         Assert.assertNull(workflow.getAuthor());
         Assert.assertNull(workflow.getEmail());
-        Assert.assertEquals(WDLHandler.WDL_SYNTAX_ERROR, workflow.getDescription());
-
     }
 
     @Test


### PR DESCRIPTION
Working on #2708 

Couldn't quite reproduce the same issue, but improved refresh by
* not dying when refresh on empty repos (library api call legitimately dies with GHFileNotFoundException)
* not dying when .dockstore.yml is malformed  (NullPointerException)
* when we can't parse metadata, instead of dying, create a validation object reporting the issue to the user

