### PR TITLE
Feature/2746/exit client

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/Client.java
@@ -50,6 +50,7 @@ import io.dockstore.client.cli.nested.ToolClient;
 import io.dockstore.client.cli.nested.WorkflowClient;
 import io.dockstore.common.GeneratedConstants;
 import io.dockstore.common.Utilities;
+import io.dockstore.common.WdlBridgeShutDown;
 import io.github.collaboratory.cwl.cwlrunner.CWLRunnerFactory;
 import io.github.collaboratory.cwl.cwlrunner.CWLRunnerInterface;
 import io.swagger.client.ApiClient;
@@ -610,6 +611,7 @@ public class Client {
     public static void main(String[] argv) {
         Client client = new Client();
         client.run(argv);
+        WdlBridgeShutDown.shutdownSTTP();
     }
 
     /*

--- a/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
+++ b/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
@@ -316,6 +316,7 @@ class WdlBridge {
       DirectoryResolver.localFilesystemResolvers(Some(filePathObj)) :+ HttpResolver(relativeTo = None) :+ mapResolver
 
     val bundle = factory.getWomBundle(content, "{}", importResolvers, List(factory))
+    HttpResolver.closeBackendIfNecessary()
     if (bundle.isRight) {
       bundle.getOrElse(null)
     } else {

--- a/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
+++ b/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
@@ -16,6 +16,7 @@ import cromwell.languages.util.ImportResolver.{DirectoryResolver, HttpResolver, 
 import languages.wdl.biscayne.WdlBiscayneLanguageFactory
 import languages.wdl.draft2.WdlDraft2LanguageFactory
 import languages.wdl.draft3.WdlDraft3LanguageFactory
+import org.slf4j.LoggerFactory
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 import wdl.draft3.parser.WdlParser
@@ -307,16 +308,12 @@ class WdlBridge {
   def getBundleFromContent(content: String, filePath: String): WomBundle = {
     val factory = getLanguageFactory(content)
     val filePathObj = DefaultPathBuilder.build(filePath).get
-
     // Resolve from mapping, local filesystem, or http import
     val mapResolver = MapResolver()
     mapResolver.setSecondaryFiles(secondaryWdlFiles)
-
     lazy val importResolvers: List[ImportResolver] =
       DirectoryResolver.localFilesystemResolvers(Some(filePathObj)) :+ HttpResolver(relativeTo = None) :+ mapResolver
-
     val bundle = factory.getWomBundle(content, "{}", importResolvers, List(factory))
-    HttpResolver.closeBackendIfNecessary()
     if (bundle.isRight) {
       bundle.getOrElse(null)
     } else {
@@ -371,4 +368,12 @@ case class MapResolver() extends ImportResolver {
   }
 
   override def cleanupIfNecessary(): ErrorOr[Unit] = ().validNel
+}
+
+object WdlBridgeShutDown {
+  private val logger = LoggerFactory.getLogger("WdlBridge")
+  def shutdownSTTP(): Unit = {
+    HttpResolver.closeBackendIfNecessary();
+    logger.info("WDL HTTP import resolver closed")
+  }
 }


### PR DESCRIPTION
For #2746 

Very strange way of making sure the HttpResolver is shutdown.  

Not very clear how to test this without tooltester because JUnit appears to shut it down regardless.  Which is why this problem wasn't detected until tooltester ran some workflows with http imports.

Ideas appreciated.

Note that the backend sttp should be opened and closed once: https://sttp.readthedocs.io/en/latest/backends/start_stop.html