### PR TITLE
Feature/2384/workflow verification

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -1224,6 +1224,7 @@ public class BasicIT extends BaseIT {
     /**
      * This tests that you can verify and unverify a tool
      */
+    @Ignore("Deprecated. CLI needs to be changed to use new Extended TRS verification endpoint")
     @Test
     public void testVerify() {
         // Setup DB

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -1083,6 +1083,7 @@ public class GeneralWorkflowIT extends BaseIT {
     /**
      * This tests that you can verify and unverify a workflow
      */
+    @Ignore("Deprecated. CLI needs to be changed to use new Extended TRS verification endpoint")
     @Test
     public void testVerify() {
         // Setup DB

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -46,6 +46,7 @@ import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.ContainersApi;
 import io.swagger.client.api.ContainertagsApi;
+import io.swagger.client.api.Ga4GhApi;
 import io.swagger.client.api.Ga4Ghv1Api;
 import io.swagger.client.api.HostedApi;
 import io.swagger.client.api.MetadataApi;
@@ -64,8 +65,10 @@ import io.swagger.client.model.SourceFile;
 import io.swagger.client.model.StarRequest;
 import io.swagger.client.model.Tag;
 import io.swagger.client.model.Token;
+import io.swagger.client.model.Tool;
 import io.swagger.client.model.ToolDescriptor;
 import io.swagger.client.model.ToolDockerfile;
+import io.swagger.client.model.ToolVersion;
 import io.swagger.client.model.ToolVersionV1;
 import io.swagger.client.model.User;
 import io.swagger.client.model.VerifyRequest;
@@ -447,10 +450,15 @@ public class SwaggerClientIT extends BaseIT {
         assertTrue(strings.get(1).contains("moretestparameterstuff"));
     }
 
+    /**
+     * This test should be removed once tag.setVerified is removed because verification should solely depend on the version's source files
+     * @throws ApiException
+     */
     @Test
-    public void testVerifiedToolsViaGA4GH() throws IOException, ApiException {
+    public void testVerifiedToolsViaGA4GH() throws ApiException {
         ApiClient client = getAdminWebClient();
         ContainersApi containersApi = new ContainersApi(client);
+        Ga4GhApi ga4GhApi = new Ga4GhApi(client);
         // register one more to give us something to look at
         DockstoreTool c = getContainer();
         c.setIsPublished(true);
@@ -462,28 +470,15 @@ public class SwaggerClientIT extends BaseIT {
         // hit up the plain text versions
         final String basePath = client.getBasePath();
         String encodedID = "registry.hub.docker.com%2Fseqware%2Fseqware%2Ftest5";
-        URL url = new URL(basePath + DockstoreWebserviceApplication.GA4GH_API_PATH + "/tools/" + encodedID);
-        List<String> strings = Resources.readLines(url, Charset.forName("UTF-8"));
-        // test root version
-        assertTrue(strings.size() == 1 && strings.get(0).contains("\"verified\":true") && strings.get(0).contains("\"verified_source\":\"[\\\"funky source\\\"]\""));
-
-        // TODO: really, we should be using deserialized versions, but this is not currently working
-        //        ObjectMapper mapper = new ObjectMapper();
-        //        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        //        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        //        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        //        mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
-        //        mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
-        //        mapper.registerModule(new JodaModule());
-        //        final DockstoreTool dockstoreTool = mapper.readValue(strings.get(0), DockstoreTool.class);
+        Tool tool = ga4GhApi.toolsIdGet(encodedID);
+        // Verifying the tag does nothing because the TRS verification endpoint was not used
+        Assert.assertFalse(tool.isVerified());
+        Assert.assertEquals("[]", tool.getVerifiedSource());
 
         // hit up a specific version
-        url = new URL(basePath + DockstoreWebserviceApplication.GA4GH_API_PATH + "/tools/" + encodedID + "/versions/master");
-        strings = Resources.readLines(url, Charset.forName("UTF-8"));
-        // test nested version
-        assertEquals(1, strings.size());
-        assertTrue(strings.get(0).contains("\"verified\":true"));
-        assertTrue(strings.get(0).contains("\"verified_source\":\"funky source\""));
+        ToolVersion master = ga4GhApi.toolsIdVersionsVersionIdGet(encodedID, "master");
+        Assert.assertFalse(master.isVerified());
+        Assert.assertEquals("[]", master.getVerifiedSource());
     }
 
     // Can't test publish repos that don't exist

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -373,6 +373,7 @@ public class SwaggerClientIT extends BaseIT {
         containertagsApi.addTags(dockstoreTool.getId(), Lists.newArrayList(secondTag));
     }
 
+    @Ignore("Deprecated. Need to use the new verification endpoint")
     @Test
     public void testGetVerifiedSpecificTool() throws ApiException {
         ApiClient client = getAdminWebClient();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -17,6 +17,7 @@
 package io.dockstore.webservice.core;
 
 import java.sql.Timestamp;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -45,6 +46,8 @@ import javax.persistence.SequenceGenerator;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Strings;
+import com.google.gson.Gson;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.hibernate.annotations.Cascade;
@@ -163,7 +166,18 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     @ApiModelProperty(value = "Verified source for the version", position = 9)
     public String getVerifiedSource() {
-        return versionMetadata.verifiedSource;
+        Set<String> verifiedSources = new TreeSet<>();
+        this.getSourceFiles().forEach(sourceFile -> {
+            Map<String, SourceFile.VerificationInformation> verifiedBySource = sourceFile.getVerifiedBySource();
+            for (Map.Entry<String, SourceFile.VerificationInformation> thing : verifiedBySource.entrySet()) {
+                if (thing.getValue().verified) {
+                    verifiedSources.add(thing.getKey());
+                }
+            }
+        });
+        // How strange that we're returning an array-like string
+        Gson gson = new Gson();
+        return Strings.nullToEmpty(gson.toJson(verifiedSources));
     }
 
     public void setVerifiedSource(String verifiedSource) {
@@ -273,6 +287,9 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     public void updateVerified(boolean newVerified, String newVerifiedSource) {
         this.getVersionMetadata().verified = newVerified;
         this.getVersionMetadata().verifiedSource = newVerifiedSource;
+        // Alternate solution
+        this.getVersionMetadata().verified = this.getSourceFiles().stream().anyMatch(file -> file.getVerifiedBySource().values().stream().anyMatch(innerEntry -> innerEntry.verified));
+        this.getVersionMetadata().verifiedSource = this.getSourceFiles().stream().filter(file -> file.getVerifiedBySource().values().stream().anyMatch(innerEntry -> innerEntry.verified)).findFirst().map(file -> file.getVerifiedBySource().keySet().toString()).get();
     }
 
     @JsonProperty

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -154,7 +154,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     @ApiModelProperty(value = "Whether this version has been verified or not", position = 8)
     public boolean isVerified() {
-        return getVersionMetadata().verified;
+        return this.getSourceFiles().stream().anyMatch(file -> file.getVerifiedBySource().values().stream().anyMatch(innerEntry -> innerEntry.verified));
     }
 
     public void setVerified(boolean verified) {

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
@@ -22,13 +22,12 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
+import java.util.TreeSet;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
@@ -60,6 +59,7 @@ public final class ToolsImplCommon {
     public static final String WORKFLOW_PREFIX = "#workflow";
     public static final String SERVICE_PREFIX = "#service";
     private static final Logger LOG = LoggerFactory.getLogger(ToolsImplCommon.class);
+    private static final Gson GSON = new Gson();
 
     private ToolsImplCommon() { }
 
@@ -279,12 +279,15 @@ public final class ToolsImplCommon {
      */
     private static Tool setVerified(Tool tool, Set<? extends Version> versions) {
         tool.setVerified(versions.stream().anyMatch(Version::isVerified));
-        final List<String> collect = versions.stream().filter(Version::isVerified)
-            .map(e -> e.getVerifiedSource() != null ? e.getVerifiedSource() : "")
-            .collect(Collectors.toList());
-        Gson gson = new Gson();
-        Collections.sort(collect);
-        tool.setVerifiedSource(Strings.nullToEmpty(gson.toJson(collect)));
+        Set<String> verifiedSources = new TreeSet<>();
+        versions.stream().filter(Version::isVerified).forEach(e -> {
+            if (e.getVerifiedSource() != null) {
+                String[] array = GSON.fromJson(e.getVerifiedSource(), String[].class);
+                List<String> stringList = Arrays.asList(array);
+                verifiedSources.addAll(stringList);
+            }
+        });
+        tool.setVerifiedSource(Strings.nullToEmpty(GSON.toJson(verifiedSources)));
         return tool;
     }
 

--- a/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
+++ b/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
@@ -181,7 +181,7 @@ public class ToolsImplCommonTest {
         expectedToolVersion.setContainerfile(true);
         expectedToolVersion.setMetaVersion(null);
         expectedToolVersion.setVerified(false);
-        expectedToolVersion.setVerifiedSource("");
+        expectedToolVersion.setVerifiedSource("[]");
         expectedToolVersion.setRegistryUrl("quay.io");
         expectedToolVersion.setImageName("quay.io/test_org/test6");
         List<ToolVersion> expectedToolVersions = new ArrayList<>();


### PR DESCRIPTION
For #2384 

Verification (entry and version) is now completely dependant on the extended TRS verification endpoint.  

Setting it through other means should be disabled but I believe those have been separated other tickets.