### PR TITLE
migrate messages for wdl 1.0 validations

### DIFF
--- a/dockstore-webservice/src/main/resources/migrations.1.7.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.7.0.xml
@@ -315,7 +315,7 @@
     
     <changeSet id="wdlValidationMessageAppend" author="agduncan">
         <sql dbms="postgresql">
-            UPDATE validation SET message = REPLACE(message, 'Unknown methods were found', 'NOTE: WDL 1.0 is now supported by Dockstore. Please refresh to fix validation. Unknown methods were found')
+            UPDATE validation SET message = REPLACE(message, 'Unknown methods were found', 'NOTE: WDL 1.0 is now supported by Dockstore. If you have access, please refresh to fix validation errors. Unknown methods were found')
         </sql>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Issue that existing WDL 1.0 workflows will have a validation message saying that since it is WDL 1.0 we don't know if it is valid or not.

This will update the validation message to suggest refreshing.

Open to edits to the message, currently it is
`NOTE: WDL 1.0 is now supported by Dockstore. Please refresh to fix validation.`