### PR TITLE
Use Python 3.6.7 and pip3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,7 @@ before_install:
 # codacy hookup
 - sudo apt-get install jq
 - wget --no-verbose -O ~/codacy-coverage-reporter-assembly-latest.jar https://github.com/codacy/codacy-coverage-reporter/releases/download/4.0.5/codacy-coverage-reporter-4.0.5-assembly.jar
+- pyenv global 3.6.7
 
 install:
 - docker version

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -14,7 +14,7 @@ fi
 if [ "${TESTING_PROFILE}" = "toil-integration-tests" ]; then
     pip3 install --user toil[cwl]==3.15.0
 elif [ "${TESTING_PROFILE}" = "regression-integration-tests" ]; then
-    pip3 install --user -r dockstore-webservice/src/main/resources/requirements/1.5.0/requirements3.txt
+    pip3 install --user -r dockstore-webservice/src/main/resources/requirements/1.6.0/requirements3.txt
 else
     pip3 install --user -r dockstore-webservice/src/main/resources/requirements/1.7.0/requirements3.txt
 fi

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -12,11 +12,11 @@ if [ "${TESTING_PROFILE}" = "unit-tests" ] || [ "${TESTING_PROFILE}" == "automat
 fi
 
 if [ "${TESTING_PROFILE}" = "toil-integration-tests" ]; then
-    pip2.7 install --user toil[cwl]==3.15.0
+    pip3 install --user toil[cwl]==3.15.0
 elif [ "${TESTING_PROFILE}" = "regression-integration-tests" ]; then
-    pip2.7 install --user -r dockstore-webservice/src/main/resources/requirements/1.5.0/requirements.txt
+    pip3 install --user -r dockstore-webservice/src/main/resources/requirements/1.5.0/requirements3.txt
 else
-    pip2.7 install --user -r dockstore-webservice/src/main/resources/requirements/1.7.0/requirements.txt
+    pip3 install --user -r dockstore-webservice/src/main/resources/requirements/1.7.0/requirements3.txt
 fi
 
 # hook up integration tests with elastic search


### PR DESCRIPTION
Using python 3 and pip3 for everything in CI

Travis uses pyenv to install python (and pip?).  It so happens it has the 3.6.7 version available