### PR TITLE
Feature/2384/workflow verification

### DIFF
--- a/dockstore-client/src/main/java/io/dockstore/client/cli/SwaggerUtility.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/SwaggerUtility.java
@@ -29,7 +29,6 @@ import com.google.gson.Gson;
 import io.swagger.client.ApiClient;
 import io.swagger.client.model.PublishRequest;
 import io.swagger.client.model.StarRequest;
-import io.swagger.client.model.VerifyRequest;
 import org.apache.commons.io.FileUtils;
 
 public final class SwaggerUtility {
@@ -81,15 +80,6 @@ public final class SwaggerUtility {
         Gson gson = new Gson();
         String s = gson.toJson(publishRequest);
         return gson.fromJson(s, PublishRequest.class);
-    }
-
-    public static VerifyRequest createVerifyRequest(Boolean bool, String verifiedSource) {
-        Map<String, Object> verifyRequest = new HashMap<>();
-        verifyRequest.put("verify", bool);
-        verifyRequest.put("verifiedSource", verifiedSource);
-        Gson gson = new Gson();
-        String s = gson.toJson(verifyRequest);
-        return gson.fromJson(s, VerifyRequest.class);
     }
 
     public static StarRequest createStarRequest(Boolean bool) {

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -391,6 +391,17 @@ public abstract class AbstractEntryClient<T> {
      * @param unstarRequest true to star, false to unstar
      */
     protected abstract void handleStarUnstar(String entryPath, boolean unstarRequest);
+    /**
+     * Verify/Unverify an entry
+     *
+     * @param entry           a unique identifier for an entry, called a path for workflows and tools
+     * @param versionName     the name of the version
+     * @param verifySource    source of entry verification
+     * @param unverifyRequest true to unverify, false to verify
+     * @param isScript        true if called by script, false otherwise
+     */
+    protected abstract void handleVerifyUnverify(String entry, String versionName, String verifySource, boolean unverifyRequest,
+            boolean isScript);
 
     /**
      * Adds/removes supplied test parameter paths for a given entry version
@@ -695,6 +706,15 @@ public abstract class AbstractEntryClient<T> {
             if (containsHelpRequest(args) || args.isEmpty()) {
                 verifyHelp();
             } else {
+                /*
+                String entry = reqVal(args, "--entry");
+                String version = reqVal(args, "--version");
+                String verifySource = optVal(args, "--verified-source", null);
+
+                final boolean unverifyRequest = args.contains("--unverify");
+                final boolean isScript = SCRIPT.get();
+                handleVerifyUnverify(entry, version, verifySource, unverifyRequest, isScript);
+                 */
                 out("This command is currently deprecated. Use the extended TRS webservice endpoint instead.");
             }
         } else {

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -692,7 +692,11 @@ public abstract class AbstractEntryClient<T> {
 
     private void verify(List<String> args) {
         if (isAdmin) {
-            out("This command is currently deprecated. Use the extended TRS webservice endpoint instead.");
+            if (containsHelpRequest(args) || args.isEmpty()) {
+                verifyHelp();
+            } else {
+                out("This command is currently deprecated. Use the extended TRS webservice endpoint instead.");
+            }
         } else {
             out("This command is only accessible to Admins.");
         }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/AbstractEntryClient.java
@@ -100,7 +100,6 @@ import static io.dockstore.client.cli.Client.API_ERROR;
 import static io.dockstore.client.cli.Client.CLIENT_ERROR;
 import static io.dockstore.client.cli.Client.ENTRY_NOT_FOUND;
 import static io.dockstore.client.cli.Client.IO_ERROR;
-import static io.dockstore.client.cli.Client.SCRIPT;
 import static io.dockstore.common.DescriptorLanguage.CWL;
 import static io.dockstore.common.DescriptorLanguage.NEXTFLOW;
 import static io.dockstore.common.DescriptorLanguage.WDL;
@@ -392,18 +391,6 @@ public abstract class AbstractEntryClient<T> {
      * @param unstarRequest true to star, false to unstar
      */
     protected abstract void handleStarUnstar(String entryPath, boolean unstarRequest);
-
-    /**
-     * Verify/Unverify an entry
-     *
-     * @param entry           a unique identifier for an entry, called a path for workflows and tools
-     * @param versionName     the name of the version
-     * @param verifySource    source of entry verification
-     * @param unverifyRequest true to unverify, false to verify
-     * @param isScript        true if called by script, false otherwise
-     */
-    protected abstract void handleVerifyUnverify(String entry, String versionName, String verifySource, boolean unverifyRequest,
-            boolean isScript);
 
     /**
      * Adds/removes supplied test parameter paths for a given entry version
@@ -705,17 +692,7 @@ public abstract class AbstractEntryClient<T> {
 
     private void verify(List<String> args) {
         if (isAdmin) {
-            if (containsHelpRequest(args) || args.isEmpty()) {
-                verifyHelp();
-            } else {
-                String entry = reqVal(args, "--entry");
-                String version = reqVal(args, "--version");
-                String verifySource = optVal(args, "--verified-source", null);
-
-                final boolean unverifyRequest = args.contains("--unverify");
-                final boolean isScript = SCRIPT.get();
-                handleVerifyUnverify(entry, version, verifySource, unverifyRequest, isScript);
-            }
+            out("This command is currently deprecated. Use the extended TRS webservice endpoint instead.");
         } else {
             out("This command is only accessible to Admins.");
         }

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/ToolClient.java
@@ -708,6 +708,55 @@ public class ToolClient extends AbstractEntryClient<DockstoreTool> {
     }
 
     @Override
+    protected void handleVerifyUnverify(String entry, String versionName, String verifySource, boolean unverifyRequest, boolean isScript) {
+        // TODO: Implement this with extended TRS endpoint
+        /*
+        boolean toOverwrite = true;
+        try {
+            DockstoreTool tool = containersApi.getContainerByToolPath(entry, null);
+            List<Tag> tags = Optional.ofNullable(tool.getWorkflowVersions()).orElse(new ArrayList<>());
+            final Optional<Tag> first = tags.stream().filter((Tag u) -> u.getName().equals(versionName)).findFirst();
+
+            if (first.isEmpty()) {
+                errorMessage(versionName + " is not a valid tag for " + entry, Client.CLIENT_ERROR);
+            }
+            Tag tagToUpdate = first.get();
+
+            VerifyRequest verifyRequest = new VerifyRequest();
+            if (unverifyRequest) {
+                verifyRequest = SwaggerUtility.createVerifyRequest(false, null);
+            } else {
+                // Check if already has been verified
+                if (tagToUpdate.isVerified() && !isScript) {
+                    Scanner scanner = new Scanner(System.in, "utf-8");
+                    out("The tag " + versionName + " has already been verified by \'" + tagToUpdate.getVerifiedSource() + "\'");
+                    out("Would you like to overwrite this with \'" + verifySource + "\'? (y/n)");
+                    String overwrite = scanner.nextLine();
+                    if ("y".equalsIgnoreCase(overwrite)) {
+                        verifyRequest = SwaggerUtility.createVerifyRequest(true, verifySource);
+                    } else {
+                        toOverwrite = false;
+                    }
+                } else {
+                    verifyRequest = SwaggerUtility.createVerifyRequest(true, verifySource);
+                }
+            }
+
+            if (toOverwrite) {
+                containerTagsApi.verifyToolTag(tool.getId(), tagToUpdate.getId(), verifyRequest);
+                if (unverifyRequest) {
+                    out("Tag " + versionName + " has been unverified.");
+                } else {
+                    out("Tag " + versionName + " has been verified by \'" + verifySource + "\'");
+                }
+            }
+        } catch (ApiException ex) {
+            exceptionMessage(ex, "Unable to " + (unverifyRequest ? "unverify" : "verify") + " tag " + versionName, Client.API_ERROR);
+        }
+        */
+    }
+
+    @Override
     public void handleInfo(String entryPath) {
         try {
             DockstoreTool container = containersApi.getPublishedContainerByToolPath(entryPath, null);

--- a/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
+++ b/dockstore-client/src/main/java/io/dockstore/client/cli/nested/WorkflowClient.java
@@ -675,6 +675,59 @@ public class WorkflowClient extends AbstractEntryClient<Workflow> {
     }
 
     @Override
+    protected void handleVerifyUnverify(String entry, String versionName, String verifySource, boolean unverifyRequest, boolean isScript) {
+        // TODO: Implement this with extended TRS endpoint
+        /*
+        boolean toOverwrite = true;
+        try {
+            Workflow workflow = workflowsApi.getWorkflowByPath(entry, null, false);
+            List<WorkflowVersion> versions = workflow.getWorkflowVersions();
+
+            final Optional<WorkflowVersion> first = versions.stream().filter((WorkflowVersion u) -> u.getName().equals(versionName))
+                    .findFirst();
+
+            WorkflowVersion versionToUpdate;
+            if (first.isEmpty()) {
+                errorMessage(versionName + " is not a valid version for " + entry, Client.CLIENT_ERROR);
+            }
+            versionToUpdate = first.get();
+
+            VerifyRequest verifyRequest = new VerifyRequest();
+            if (unverifyRequest) {
+                verifyRequest = SwaggerUtility.createVerifyRequest(false, null);
+            } else {
+                // Check if already has been verified
+                if (versionToUpdate.isVerified() && !isScript) {
+                    Scanner scanner = new Scanner(System.in, "utf-8");
+                    out("The version " + versionName + " has already been verified by \'" + versionToUpdate.getVerifiedSource() + "\'");
+                    out("Would you like to overwrite this with \'" + verifySource + "\'? (y/n)");
+                    String overwrite = scanner.nextLine();
+                    if ("y".equalsIgnoreCase(overwrite)) {
+                        verifyRequest = SwaggerUtility.createVerifyRequest(true, verifySource);
+                    } else {
+                        toOverwrite = false;
+                    }
+                } else {
+                    verifyRequest = SwaggerUtility.createVerifyRequest(true, verifySource);
+                }
+            }
+
+            if (toOverwrite) {
+                List<WorkflowVersion> result = workflowsApi.verifyWorkflowVersion(workflow.getId(), versionToUpdate.getId(), verifyRequest);
+
+                if (unverifyRequest) {
+                    out("Version " + versionName + " has been unverified.");
+                } else {
+                    out("Version " + versionName + " has been verified by \'" + verifySource + "\'");
+                }
+            }
+        } catch (ApiException ex) {
+            exceptionMessage(ex, "Unable to " + (unverifyRequest ? "unverify" : "verify") + " version " + versionName, Client.API_ERROR);
+        }
+         */
+    }
+
+    @Override
     protected void handleListNonpublishedEntries() {
         try {
             // check user info after usage so that users can get usage without live webservice

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -1224,6 +1224,7 @@ public class BasicIT extends BaseIT {
     /**
      * This tests that you can verify and unverify a tool
      */
+    @Ignore("Deprecated. CLI needs to be changed to use new Extended TRS verification endpoint")
     @Test
     public void testVerify() {
         // Setup DB

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -1109,6 +1109,7 @@ public class GeneralWorkflowIT extends BaseIT {
     /**
      * This tests that you can verify and unverify a workflow
      */
+    @Ignore("Deprecated. CLI needs to be changed to use new Extended TRS verification endpoint")
     @Test
     public void testVerify() {
         // Setup DB

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -440,12 +440,12 @@ public class SwaggerClientIT extends BaseIT {
         Tool tool = ga4GhApi.toolsIdGet(encodedID);
         // Verifying the tag does nothing because the TRS verification endpoint was not used
         Assert.assertFalse(tool.isVerified());
-        Assert.assertEquals("[]", tool.getVerifiedSource());
+        Assert.assertEquals(null, tool.getVerifiedSource());
 
         // hit up a specific version
         ToolVersion master = ga4GhApi.toolsIdVersionsVersionIdGet(encodedID, "master");
         Assert.assertFalse(master.isVerified());
-        Assert.assertEquals("[]", master.getVerifiedSource());
+        Assert.assertEquals(null, master.getVerifiedSource());
     }
 
     // Can't test publish repos that don't exist

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -440,12 +440,12 @@ public class SwaggerClientIT extends BaseIT {
         Tool tool = ga4GhApi.toolsIdGet(encodedID);
         // Verifying the tag does nothing because the TRS verification endpoint was not used
         Assert.assertFalse(tool.isVerified());
-        Assert.assertEquals(null, tool.getVerifiedSource());
+        Assert.assertEquals("[]", tool.getVerifiedSource());
 
         // hit up a specific version
         ToolVersion master = ga4GhApi.toolsIdVersionsVersionIdGet(encodedID, "master");
         Assert.assertFalse(master.isVerified());
-        Assert.assertEquals(null, master.getVerifiedSource());
+        Assert.assertEquals("[]", master.getVerifiedSource());
     }
 
     // Can't test publish repos that don't exist

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -71,7 +71,6 @@ import io.swagger.client.model.ToolDockerfile;
 import io.swagger.client.model.ToolVersion;
 import io.swagger.client.model.ToolVersionV1;
 import io.swagger.client.model.User;
-import io.swagger.client.model.VerifyRequest;
 import io.swagger.client.model.Workflow;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
@@ -92,7 +91,6 @@ import static io.dockstore.webservice.TokenResourceIT.GITHUB_ACCOUNT_USERNAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -374,37 +372,6 @@ public class SwaggerClientIT extends BaseIT {
         secondTag.setReference("funky_tag");
         thrown.expect(ApiException.class);
         containertagsApi.addTags(dockstoreTool.getId(), Lists.newArrayList(secondTag));
-    }
-
-    @Ignore("Deprecated. Need to use the new verification endpoint")
-    @Test
-    public void testGetVerifiedSpecificTool() throws ApiException {
-        ApiClient client = getAdminWebClient();
-        Ga4Ghv1Api toolApi = new Ga4Ghv1Api(client);
-        ContainersApi containersApi = new ContainersApi(client);
-        ContainertagsApi containertagsApi = new ContainertagsApi(client);
-        // register one more to give us something to look at
-        DockstoreTool c = getContainer();
-        final DockstoreTool dockstoreTool = containersApi.registerManual(c);
-
-        io.swagger.client.model.ToolV1 tool = toolApi.toolsIdGet(REGISTRY_HUB_DOCKER_COM_SEQWARE_SEQWARE);
-        assertNotNull(tool);
-        assertEquals(tool.getId(), REGISTRY_HUB_DOCKER_COM_SEQWARE_SEQWARE);
-        List<Tag> tags = containertagsApi.getTagsByPath(dockstoreTool.getId());
-        assertEquals(1, tags.size());
-        Tag tag = tags.get(0);
-
-        // verify master branch
-        assertFalse(tag.isVerified());
-        assertNull(tag.getVerifiedSource());
-        VerifyRequest request = SwaggerUtility.createVerifyRequest(true, "test-source");
-        containertagsApi.verifyToolTag(dockstoreTool.getId(), tag.getId(), request);
-
-        // check again
-        tags = containertagsApi.getTagsByPath(dockstoreTool.getId());
-        tag = tags.get(0);
-        assertTrue(tag.isVerified());
-        assertEquals("test-source", tag.getVerifiedSource());
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -46,6 +46,7 @@ import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.ContainersApi;
 import io.swagger.client.api.ContainertagsApi;
+import io.swagger.client.api.Ga4GhApi;
 import io.swagger.client.api.Ga4Ghv1Api;
 import io.swagger.client.api.HostedApi;
 import io.swagger.client.api.MetadataApi;
@@ -64,8 +65,10 @@ import io.swagger.client.model.SourceFile;
 import io.swagger.client.model.StarRequest;
 import io.swagger.client.model.Tag;
 import io.swagger.client.model.Token;
+import io.swagger.client.model.Tool;
 import io.swagger.client.model.ToolDescriptor;
 import io.swagger.client.model.ToolDockerfile;
+import io.swagger.client.model.ToolVersion;
 import io.swagger.client.model.ToolVersionV1;
 import io.swagger.client.model.User;
 import io.swagger.client.model.VerifyRequest;
@@ -373,6 +376,7 @@ public class SwaggerClientIT extends BaseIT {
         containertagsApi.addTags(dockstoreTool.getId(), Lists.newArrayList(secondTag));
     }
 
+    @Ignore("Deprecated. Need to use the new verification endpoint")
     @Test
     public void testGetVerifiedSpecificTool() throws ApiException {
         ApiClient client = getAdminWebClient();
@@ -446,10 +450,15 @@ public class SwaggerClientIT extends BaseIT {
         assertTrue(strings.get(1).contains("moretestparameterstuff"));
     }
 
+    /**
+     * This test should be removed once tag.setVerified is removed because verification should solely depend on the version's source files
+     * @throws ApiException
+     */
     @Test
-    public void testVerifiedToolsViaGA4GH() throws IOException, ApiException {
+    public void testVerifiedToolsViaGA4GH() throws ApiException {
         ApiClient client = getAdminWebClient();
         ContainersApi containersApi = new ContainersApi(client);
+        Ga4GhApi ga4GhApi = new Ga4GhApi(client);
         // register one more to give us something to look at
         DockstoreTool c = getContainer();
         c.setIsPublished(true);
@@ -461,28 +470,15 @@ public class SwaggerClientIT extends BaseIT {
         // hit up the plain text versions
         final String basePath = client.getBasePath();
         String encodedID = "registry.hub.docker.com%2Fseqware%2Fseqware%2Ftest5";
-        URL url = new URL(basePath + DockstoreWebserviceApplication.GA4GH_API_PATH + "/tools/" + encodedID);
-        List<String> strings = Resources.readLines(url, Charset.forName("UTF-8"));
-        // test root version
-        assertTrue(strings.size() == 1 && strings.get(0).contains("\"verified\":true") && strings.get(0).contains("\"verified_source\":\"[\\\"funky source\\\"]\""));
-
-        // TODO: really, we should be using deserialized versions, but this is not currently working
-        //        ObjectMapper mapper = new ObjectMapper();
-        //        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        //        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        //        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        //        mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
-        //        mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
-        //        mapper.registerModule(new JodaModule());
-        //        final DockstoreTool dockstoreTool = mapper.readValue(strings.get(0), DockstoreTool.class);
+        Tool tool = ga4GhApi.toolsIdGet(encodedID);
+        // Verifying the tag does nothing because the TRS verification endpoint was not used
+        Assert.assertFalse(tool.isVerified());
+        Assert.assertEquals("[]", tool.getVerifiedSource());
 
         // hit up a specific version
-        url = new URL(basePath + DockstoreWebserviceApplication.GA4GH_API_PATH + "/tools/" + encodedID + "/versions/master");
-        strings = Resources.readLines(url, Charset.forName("UTF-8"));
-        // test nested version
-        assertEquals(1, strings.size());
-        assertTrue(strings.get(0).contains("\"verified\":true"));
-        assertTrue(strings.get(0).contains("\"verified_source\":\"funky source\""));
+        ToolVersion master = ga4GhApi.toolsIdVersionsVersionIdGet(encodedID, "master");
+        Assert.assertFalse(master.isVerified());
+        Assert.assertEquals("[]", master.getVerifiedSource());
     }
 
     // Can't test publish repos that don't exist

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -292,7 +292,11 @@ public abstract class Version<T extends Version> implements Comparable<T> {
         });
         // How strange that we're returning an array-like string
         Gson gson = new Gson();
-        return Strings.nullToEmpty(gson.toJson(verifiedSources));
+        if (verifiedSources.isEmpty()) {
+            return null;
+        } else {
+            return Strings.nullToEmpty(gson.toJson(verifiedSources));
+        }
     }
 
     @JsonProperty

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -157,7 +157,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     @ApiModelProperty(value = "Whether this version has been verified or not", position = 8)
     public boolean isVerified() {
-        return getVersionMetadata().verified;
+        return this.getSourceFiles().stream().anyMatch(file -> file.getVerifiedBySource().values().stream().anyMatch(innerEntry -> innerEntry.verified));
     }
 
     public void setVerified(boolean verified) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
@@ -41,7 +41,7 @@ public class VersionMetadata {
     protected boolean verified;
 
     @Column()
-    protected String verifiedSource = "[]";
+    protected String verifiedSource;
 
     @Column()
     protected String doiURL;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
@@ -41,7 +41,7 @@ public class VersionMetadata {
     protected boolean verified;
 
     @Column()
-    protected String verifiedSource;
+    protected String verifiedSource = "[]";
 
     @Column()
     protected String doiURL;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -233,6 +233,7 @@ public class DockerRepoResource
         if (refreshedTool.getCheckerWorkflow() != null) {
             workflowResource.refresh(user, refreshedTool.getCheckerWorkflow().getId());
         }
+        refreshedTool.getWorkflowVersions().forEach(Version::updateVerified);
         elasticManager.handleIndexUpdate(refreshedTool, ElasticMode.UPDATE);
         return refreshedTool;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoTagResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoTagResource.java
@@ -249,7 +249,7 @@ public class DockerRepoTagResource implements AuthenticatedResourceInterface {
      * @param user User to authenticate
      * @return Tool
      */
-    public Tool findToolByIdAndCheckToolAndUser(Long toolId, User user) {
+    private Tool findToolByIdAndCheckToolAndUser(Long toolId, User user) {
         Tool tool = toolDAO.findById(toolId);
         checkEntry(tool);
         checkUser(user, tool);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1682,7 +1682,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
      * @param user User to authenticate
      * @return Tool
      */
-    public Workflow findWorkflowByIdAndCheckWorkflowAndUser(Long entryId, User user) {
+    private Workflow findWorkflowByIdAndCheckWorkflowAndUser(Long entryId, User user) {
         Workflow workflow = workflowDAO.findById(entryId);
         checkEntry(workflow);
         checkUser(user, workflow);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -257,7 +257,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
                 }
                 // denormalizes verification out to the version level for performance
                 // not sure why the cast is needed
-                version.setVerified(version.getSourceFiles().stream().anyMatch(file -> ((SourceFile)file).getVerifiedBySource().values().stream().anyMatch(innerEntry -> innerEntry.verified)));
+                version.updateVerified();
                 return Response.ok().entity(sourceFile.getVerifiedBySource()).build();
             }
         }

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
@@ -287,7 +287,11 @@ public final class ToolsImplCommon {
                 verifiedSources.addAll(stringList);
             }
         });
-        tool.setVerifiedSource(Strings.nullToEmpty(GSON.toJson(verifiedSources)));
+        if (verifiedSources.isEmpty()) {
+            tool.setVerifiedSource(null);
+        } else {
+            tool.setVerifiedSource(Strings.nullToEmpty(GSON.toJson(verifiedSources)));
+        }
         return tool;
     }
 
@@ -331,7 +335,12 @@ public final class ToolsImplCommon {
         toolVersion.setUrl(globalVersionId);
         toolVersion.setName(version.getName());
         toolVersion.setVerified(version.isVerified());
-        toolVersion.setVerifiedSource(Strings.nullToEmpty(version.getVerifiedSource()));
+        String verifiedSource = version.getVerifiedSource();
+        if (verifiedSource == null || verifiedSource.isBlank()) {
+            toolVersion.setVerifiedSource(null);
+        } else {
+            toolVersion.setVerifiedSource(Strings.nullToEmpty(version.getVerifiedSource()));
+        }
         toolVersion.setContainerfile(false);
 
         // Set image if it's a DockstoreTool, otherwise make it empty string (for now)

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
@@ -287,11 +287,7 @@ public final class ToolsImplCommon {
                 verifiedSources.addAll(stringList);
             }
         });
-        if (verifiedSources.isEmpty()) {
-            tool.setVerifiedSource(null);
-        } else {
-            tool.setVerifiedSource(Strings.nullToEmpty(GSON.toJson(verifiedSources)));
-        }
+        tool.setVerifiedSource(Strings.nullToEmpty(GSON.toJson(verifiedSources)));
         return tool;
     }
 
@@ -335,12 +331,9 @@ public final class ToolsImplCommon {
         toolVersion.setUrl(globalVersionId);
         toolVersion.setName(version.getName());
         toolVersion.setVerified(version.isVerified());
-        String verifiedSource = version.getVerifiedSource();
-        if (verifiedSource == null || verifiedSource.isBlank()) {
-            toolVersion.setVerifiedSource(null);
-        } else {
-            toolVersion.setVerifiedSource(Strings.nullToEmpty(version.getVerifiedSource()));
-        }
+        String toolVerifiedSource = version.getVerifiedSource();
+        String verifiedSource = toolVerifiedSource == null || toolVerifiedSource.isBlank() ? "[]" : version.getVerifiedSource();
+        toolVersion.setVerifiedSource(Strings.nullToEmpty(verifiedSource));
         toolVersion.setContainerfile(false);
 
         // Set image if it's a DockstoreTool, otherwise make it empty string (for now)

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
@@ -22,13 +22,12 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
+import java.util.TreeSet;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
@@ -60,6 +59,7 @@ public final class ToolsImplCommon {
     public static final String WORKFLOW_PREFIX = "#workflow";
     public static final String SERVICE_PREFIX = "#service";
     private static final Logger LOG = LoggerFactory.getLogger(ToolsImplCommon.class);
+    private static final Gson GSON = new Gson();
 
     private ToolsImplCommon() { }
 
@@ -279,12 +279,15 @@ public final class ToolsImplCommon {
      */
     private static Tool setVerified(Tool tool, Set<? extends Version> versions) {
         tool.setVerified(versions.stream().anyMatch(Version::isVerified));
-        final List<String> collect = versions.stream().filter(Version::isVerified)
-            .map(e -> e.getVerifiedSource() != null ? e.getVerifiedSource() : "")
-            .collect(Collectors.toList());
-        Gson gson = new Gson();
-        Collections.sort(collect);
-        tool.setVerifiedSource(Strings.nullToEmpty(gson.toJson(collect)));
+        Set<String> verifiedSources = new TreeSet<>();
+        versions.stream().filter(Version::isVerified).forEach(e -> {
+            if (e.getVerifiedSource() != null) {
+                String[] array = GSON.fromJson(e.getVerifiedSource(), String[].class);
+                List<String> stringList = Arrays.asList(array);
+                verifiedSources.addAll(stringList);
+            }
+        });
+        tool.setVerifiedSource(Strings.nullToEmpty(GSON.toJson(verifiedSources)));
         return tool;
     }
 

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.7.0-beta.7-SNAPSHOT
+  version: 1.7.0-beta.8-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:
@@ -2142,7 +2142,7 @@ paths:
             format: int64
         - name: tagId
           in: path
-          description: Tag to verify.
+          description: Tag to request DOI.
           required: true
           schema:
             type: integer
@@ -2575,29 +2575,27 @@ paths:
               schema:
                 type: string
   "/containers/{containerId}/verify/{tagId}":
-    put:
+    post:
       tags:
         - containertags
-      summary: Verify or unverify a version . ADMIN ONLY
+      summary: Updates the verification status of a version. ADMIN ONLY
       description: ""
       operationId: verifyToolTag
       parameters:
         - name: containerId
           in: path
-          description: Tool to modify.
+          description: ID of the tool to update.
           required: true
           schema:
             type: integer
             format: int64
         - name: tagId
           in: path
-          description: Tag to verify.
+          description: ID of the tag to update.
           required: true
           schema:
             type: integer
             format: int64
-      requestBody:
-        $ref: "#/components/requestBodies/VerifyRequest"
       responses:
         "200":
           description: successful operation
@@ -6142,29 +6140,27 @@ paths:
               schema:
                 type: string
   "/workflows/{workflowId}/verify/{workflowVersionId}":
-    put:
+    post:
       tags:
         - workflows
-      summary: Verify or unverify a workflow. ADMIN ONLY
+      summary: Updates the verification status of a version. ADMIN ONLY
       description: ""
       operationId: verifyWorkflowVersion
       parameters:
         - name: workflowId
           in: path
-          description: Workflow to modify.
+          description: ID of the workflow to update.
           required: true
           schema:
             type: integer
             format: int64
         - name: workflowVersionId
           in: path
-          description: workflowVersionId
+          description: Id of the version to update.
           required: true
           schema:
             type: integer
             format: int64
-      requestBody:
-        $ref: "#/components/requestBodies/VerifyRequest"
       responses:
         "200":
           description: successful operation
@@ -6295,13 +6291,6 @@ components:
           schema:
             $ref: "#/components/schemas/StarRequest"
       description: StarRequest to star a repo for a user
-      required: true
-    VerifyRequest:
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/VerifyRequest"
-      description: Object containing verification information.
       required: true
   securitySchemes:
     BEARER:
@@ -6502,10 +6491,6 @@ components:
         custom_docker_registry_path:
           type: string
           readOnly: true
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6521,6 +6506,10 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -6708,10 +6697,6 @@ components:
           items:
             $ref: "#/components/schemas/Base_class_for_versions_of_entries_in_the_D\
               ockstore"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6727,6 +6712,10 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -7700,15 +7689,6 @@ components:
           type: string
         platformVersion:
           type: string
-    VerifyRequest:
-      type: object
-      properties:
-        verify:
-          type: boolean
-          readOnly: true
-        verifiedSource:
-          type: string
-          readOnly: true
     Workflow:
       type: object
       required:
@@ -7746,10 +7726,6 @@ components:
           type: boolean
         parentEntry:
           $ref: "#/components/schemas/Entry"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -7765,6 +7741,10 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -825,13 +825,6 @@ components:
         verified:
           type: boolean
       type: object
-    VerifyRequest:
-      properties:
-        verifiedSource:
-          type: string
-        verify:
-          type: boolean
-      type: object
     Version:
       properties:
         commitID:
@@ -2896,7 +2889,7 @@ paths:
                 type: string
           description: default response
   /containers/{containerId}/verify/{tagId}:
-    put:
+    post:
       operationId: verifyToolTag
       parameters:
       - in: path
@@ -2998,7 +2991,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
   /entries/{id}/collections:
     get:
@@ -5979,7 +5972,7 @@ paths:
                 type: string
           description: default response
   /workflows/{workflowId}/verify/{workflowVersionId}:
-    put:
+    post:
       operationId: verifyWorkflowVersion
       parameters:
       - in: path

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.7.0-beta.7-SNAPSHOT"
+  version: "1.7.0-beta.8-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:
@@ -1929,7 +1929,7 @@ paths:
         format: "int64"
       - name: "tagId"
         in: "path"
-        description: "Tag to verify."
+        description: "Tag to request DOI."
         required: true
         type: "integer"
         format: "int64"
@@ -2352,10 +2352,10 @@ paths:
           schema:
             type: "string"
   /containers/{containerId}/verify/{tagId}:
-    put:
+    post:
       tags:
       - "containertags"
-      summary: "Verify or unverify a version . ADMIN ONLY"
+      summary: "Updates the verification status of a version. ADMIN ONLY"
       description: ""
       operationId: "verifyToolTag"
       produces:
@@ -2363,22 +2363,16 @@ paths:
       parameters:
       - name: "containerId"
         in: "path"
-        description: "Tool to modify."
+        description: "ID of the tool to update."
         required: true
         type: "integer"
         format: "int64"
       - name: "tagId"
         in: "path"
-        description: "Tag to verify."
+        description: "ID of the tag to update."
         required: true
         type: "integer"
         format: "int64"
-      - in: "body"
-        name: "body"
-        description: "Object containing verification information."
-        required: true
-        schema:
-          $ref: "#/definitions/VerifyRequest"
       responses:
         200:
           description: "successful operation"
@@ -5822,10 +5816,10 @@ paths:
           schema:
             type: "string"
   /workflows/{workflowId}/verify/{workflowVersionId}:
-    put:
+    post:
       tags:
       - "workflows"
-      summary: "Verify or unverify a workflow. ADMIN ONLY"
+      summary: "Updates the verification status of a version. ADMIN ONLY"
       description: ""
       operationId: "verifyWorkflowVersion"
       produces:
@@ -5833,22 +5827,16 @@ paths:
       parameters:
       - name: "workflowId"
         in: "path"
-        description: "Workflow to modify."
+        description: "ID of the workflow to update."
         required: true
         type: "integer"
         format: "int64"
       - name: "workflowVersionId"
         in: "path"
-        description: "workflowVersionId"
+        description: "Id of the version to update."
         required: true
         type: "integer"
         format: "int64"
-      - in: "body"
-        name: "body"
-        description: "Object containing verification information."
-        required: true
-        schema:
-          $ref: "#/definitions/VerifyRequest"
       responses:
         200:
           description: "successful operation"
@@ -6234,10 +6222,6 @@ definitions:
       custom_docker_registry_path:
         type: "string"
         readOnly: true
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6253,6 +6237,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1
@@ -6465,10 +6453,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/Base class for versions of entries in the Dockstore"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6484,6 +6468,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1
@@ -7544,15 +7532,6 @@ definitions:
         type: "string"
       platformVersion:
         type: "string"
-  VerifyRequest:
-    type: "object"
-    properties:
-      verify:
-        type: "boolean"
-        readOnly: true
-      verifiedSource:
-        type: "string"
-        readOnly: true
   Workflow:
     type: "object"
     required:
@@ -7589,10 +7568,6 @@ definitions:
         type: "boolean"
       parentEntry:
         $ref: "#/definitions/Entry"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -7608,6 +7583,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1

--- a/dockstore-webservice/src/test/java/core/ElasticManagerIT.java
+++ b/dockstore-webservice/src/test/java/core/ElasticManagerIT.java
@@ -93,7 +93,6 @@ public class ElasticManagerIT {
             verificationInformation.metadata = "Dockstore team";
             verifiedBySource.put("Dockstore CLI", verificationInformation);
             file.setVerifiedBySource(verifiedBySource);
-            tag.setVerified(true);
         }
         tag.addSourceFile(file);
         tag.setReference("master");

--- a/dockstore-webservice/src/test/java/core/ElasticManagerIT.java
+++ b/dockstore-webservice/src/test/java/core/ElasticManagerIT.java
@@ -96,6 +96,7 @@ public class ElasticManagerIT {
         }
         tag.addSourceFile(file);
         tag.setReference("master");
+        tag.updateVerified();
         tool.setRegistry("potato");
         tool.addWorkflowVersion(tag);
         tool.setDefaultVersion("master");

--- a/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
+++ b/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
@@ -165,7 +165,7 @@ public class ToolsImplCommonTest {
         expectedTool.setVerified(false);
         expectedTool.setSigned(false);
         expectedTool.setVersions(Collections.EMPTY_LIST);
-        expectedTool.setVerifiedSource(null);
+        expectedTool.setVerifiedSource("[]");
         ToolVersion expectedToolVersion = new ToolVersion();
         expectedToolVersion.setName("sampleTag");
         if (toolname != null) {
@@ -182,7 +182,7 @@ public class ToolsImplCommonTest {
         expectedToolVersion.setContainerfile(true);
         expectedToolVersion.setMetaVersion(null);
         expectedToolVersion.setVerified(false);
-        expectedToolVersion.setVerifiedSource(null);
+        expectedToolVersion.setVerifiedSource("[]");
         expectedToolVersion.setRegistryUrl("quay.io");
         expectedToolVersion.setImageName("quay.io/test_org/test6");
         List<ToolVersion> expectedToolVersions = new ArrayList<>();

--- a/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
+++ b/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
@@ -139,6 +139,7 @@ public class ToolsImplCommonTest {
         sourceFile2.setAbsolutePath("/Dockstore.cwl");
         tag.addSourceFile(sourceFile);
         tag.addSourceFile(sourceFile2);
+        tag.updateVerified();
         tool.addWorkflowVersion(tag);
         tool.setCheckerWorkflow(null);
         Tool expectedTool = new Tool();
@@ -275,6 +276,9 @@ public class ToolsImplCommonTest {
         actualWorkflowVersion3.setReference(REFERENCE3);
         SourceFile sourceFile3 = getFakeSourceFile("potatoTesterSource", isService, "/pcawg-cgp-somatic-workflow.wdl3");
         actualWorkflowVersion3.addSourceFile(sourceFile3);
+        actualWorkflowVersion1.updateVerified();
+        actualWorkflowVersion2.updateVerified();
+        actualWorkflowVersion3.updateVerified();
         // Check that Dockstore version is actually has the right verified source
         Assert.assertEquals("[\"chickenTesterSource\",\"potatoTesterSource\"]", actualWorkflowVersion3.getVerifiedSource());
         workflow.addWorkflowVersion(actualWorkflowVersion1);

--- a/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
+++ b/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
@@ -165,7 +165,7 @@ public class ToolsImplCommonTest {
         expectedTool.setVerified(false);
         expectedTool.setSigned(false);
         expectedTool.setVersions(Collections.EMPTY_LIST);
-        expectedTool.setVerifiedSource("[]");
+        expectedTool.setVerifiedSource(null);
         ToolVersion expectedToolVersion = new ToolVersion();
         expectedToolVersion.setName("sampleTag");
         if (toolname != null) {
@@ -182,7 +182,7 @@ public class ToolsImplCommonTest {
         expectedToolVersion.setContainerfile(true);
         expectedToolVersion.setMetaVersion(null);
         expectedToolVersion.setVerified(false);
-        expectedToolVersion.setVerifiedSource("[]");
+        expectedToolVersion.setVerifiedSource(null);
         expectedToolVersion.setRegistryUrl("quay.io");
         expectedToolVersion.setImageName("quay.io/test_org/test6");
         List<ToolVersion> expectedToolVersions = new ArrayList<>();

--- a/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
+++ b/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
@@ -18,7 +18,9 @@ package io.swagger.api.impl;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,6 +39,7 @@ import io.swagger.model.ExtendedFileWrapper;
 import io.swagger.model.FileWrapper;
 import io.swagger.model.Tool;
 import io.swagger.model.ToolVersion;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -178,7 +181,7 @@ public class ToolsImplCommonTest {
         expectedToolVersion.setContainerfile(true);
         expectedToolVersion.setMetaVersion(null);
         expectedToolVersion.setVerified(false);
-        expectedToolVersion.setVerifiedSource("");
+        expectedToolVersion.setVerifiedSource("[]");
         expectedToolVersion.setRegistryUrl("quay.io");
         expectedToolVersion.setImageName("quay.io/test_org/test6");
         List<ToolVersion> expectedToolVersions = new ArrayList<>();
@@ -209,6 +212,36 @@ public class ToolsImplCommonTest {
         convertDockstoreWorkflowToTool(null, true);
     }
 
+    /**
+     * Gets a fake source file to use for testing.  Only a few parameters
+     * @param verifiedSource    If verified, what the verified source is
+     * @param isService         Whether the entry that's going to add this file is a service or not
+     * @param path              The path of the sourcefile, must be unique if added to the same version
+     * @return
+     */
+    private SourceFile getFakeSourceFile(String verifiedSource, boolean isService, String path) {
+        SourceFile sourceFile = new SourceFile();
+        sourceFile.setId(461402);
+        sourceFile.setContent(PLACEHOLDER_CONTENT);
+        sourceFile.setPath(path);
+        sourceFile.setAbsolutePath(path);
+        if (verifiedSource != null) {
+            SourceFile.VerificationInformation verificationInformation1 = new SourceFile.VerificationInformation();
+            verificationInformation1.verified = true;
+            verificationInformation1.metadata = "Dockstore team";
+            verificationInformation1.platformVersion = "1.7.0";
+            Map<String, SourceFile.VerificationInformation> verificationInformationMap = new HashMap<>();
+            verificationInformationMap.put(verifiedSource, verificationInformation1);
+            sourceFile.setVerifiedBySource(verificationInformationMap);
+        }
+        if (isService) {
+            sourceFile.setType(DescriptorLanguage.FileType.DOCKSTORE_SERVICE_YML);
+        } else {
+            sourceFile.setType(DescriptorLanguage.FileType.DOCKSTORE_WDL);
+        }
+        return sourceFile;
+    }
+
     private void convertDockstoreWorkflowToTool(String toolname, boolean isService) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
@@ -217,16 +250,7 @@ public class ToolsImplCommonTest {
         final String REFERENCE2 = "bbb";
         final String REFERENCE3 = "ccc";
         String json;
-        SourceFile actualSourceFile1 = new SourceFile();
-        actualSourceFile1.setId(461402);
-        if (isService) {
-            actualSourceFile1.setType(DescriptorLanguage.FileType.DOCKSTORE_SERVICE_YML);
-        } else {
-            actualSourceFile1.setType(DescriptorLanguage.FileType.DOCKSTORE_WDL);
-        }
-        actualSourceFile1.setContent(PLACEHOLDER_CONTENT);
-        actualSourceFile1.setPath("/pcawg-cgp-somatic-workflow.wdl");
-        actualSourceFile1.setAbsolutePath("/pcawg-cgp-somatic-workflow.wdl");
+        SourceFile actualSourceFile1 = getFakeSourceFile(null, isService, "/pcawg-cgp-somatic-workflow.wdl");
         WorkflowVersion actualWorkflowVersion1 = new WorkflowVersion();
         actualWorkflowVersion1.setWorkflowPath("/pcawg-cgp-somatic-workflow.wdl");
         actualWorkflowVersion1.setLastModified(null);
@@ -237,20 +261,22 @@ public class ToolsImplCommonTest {
         actualWorkflowVersion1.setName(REFERENCE1);
         actualWorkflowVersion1.setDirtyBit(false);
         actualWorkflowVersion1.setValid(false);
-        actualWorkflowVersion1.setVerifiedSource(null);
         BioWorkflow workflow = new BioWorkflow();
         json = mapper.writeValueAsString(actualWorkflowVersion1);
         WorkflowVersion actualWorkflowVersion2 = mapper.readValue(json, WorkflowVersion.class);
         actualWorkflowVersion2.setName(REFERENCE2);
         actualWorkflowVersion2.setReference(REFERENCE2);
         actualWorkflowVersion2.setHidden(false);
-        actualWorkflowVersion2.setVerifiedSource("potatoTesterSource");
-        actualWorkflowVersion2.setVerified(true);
+        SourceFile sourceFile2 = getFakeSourceFile("chickenTesterSource", isService, "/pcawg-cgp-somatic-workflow2.wdl");
+        actualWorkflowVersion2.addSourceFile(sourceFile2);
         json = mapper.writeValueAsString(actualWorkflowVersion2);
         WorkflowVersion actualWorkflowVersion3 = mapper.readValue(json, WorkflowVersion.class);
         actualWorkflowVersion3.setName(REFERENCE3);
         actualWorkflowVersion3.setReference(REFERENCE3);
-        actualWorkflowVersion3.setVerifiedSource("chickenTesterSource");
+        SourceFile sourceFile3 = getFakeSourceFile("potatoTesterSource", isService, "/pcawg-cgp-somatic-workflow.wdl3");
+        actualWorkflowVersion3.addSourceFile(sourceFile3);
+        // Check that Dockstore version is actually has the right verified source
+        Assert.assertEquals("[\"chickenTesterSource\",\"potatoTesterSource\"]", actualWorkflowVersion3.getVerifiedSource());
         workflow.addWorkflowVersion(actualWorkflowVersion1);
         workflow.addWorkflowVersion(actualWorkflowVersion2);
         workflow.addWorkflowVersion(actualWorkflowVersion3);
@@ -315,13 +341,13 @@ public class ToolsImplCommonTest {
         // Meta-version dates are currently dependant on the environment, disabling for now
         expectedToolVersion1.setMetaVersion(null);
         expectedToolVersion1.setVerified(true);
-        expectedToolVersion1.setVerifiedSource("potatoTesterSource");
+        expectedToolVersion1.setVerifiedSource("[\"chickenTesterSource\"]");
         expectedToolVersion1.setImageName("");
         expectedToolVersion1.setRegistryUrl("");
         json = mapper.writeValueAsString(expectedToolVersion1);
         ToolVersion expectedToolVersion2 = mapper.readValue(json, ToolVersion.class);
         expectedToolVersion2.setName(REFERENCE3);
-        expectedToolVersion2.setVerifiedSource("chickenTesterSource");
+        expectedToolVersion2.setVerifiedSource("[\"chickenTesterSource\",\"potatoTesterSource\"]");
         expectedToolVersion2.setImageName("");
         expectedToolVersion2.setRegistryUrl("");
 


### PR DESCRIPTION
For dockstore/dockstore#2384

Major modifications to the verification feature.

Exclusively use the extended TRS verification endpoint for verifying.
Modify the existing tag and workflow verification endpoint to instead sync the verification status (if there happens to be sync problem).
Not using on-the-fly verification status calculation but hopefully there's no sync issue.
Use the updateVerified function to calculate verification status.  There is no direct setter.
Deprecate the verify command for 1.7.0 (no time to modify it to use the new verification endpoint instead).

Weird stuff:
- Verification source returned from TRS endpoints cannot return null, empty array (as a String) is returned instead
- The database still stores it as null though.