### PR TITLE
Feature/2851/cleared metadata

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -44,6 +44,7 @@ import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Validation;
 import io.dockstore.webservice.core.Version;
+import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import org.apache.commons.io.FileUtils;
@@ -131,9 +132,11 @@ public class WDLHandler implements LanguageHandlerInterface {
     }
 
     private void clearMetadata(Entry entry) {
-        entry.setAuthor(null);
-        entry.setEmail(null);
-        entry.setDescription(null);
+        if (entry instanceof Workflow) {
+            entry.setAuthor(null);
+            entry.setEmail(null);
+            entry.setDescription(null);
+        }
     }
 
     /**

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowVersion;
 import io.dropwizard.testing.ResourceHelpers;
@@ -51,6 +52,28 @@ public class WDLHandlerTest {
         wdlHandler.parseWorkflowContent(workflow, invalidFilePath, invalidDescriptionWdl, Collections.emptySet(), new WorkflowVersion());
         Assert.assertNull(workflow.getAuthor());
         Assert.assertNull(workflow.getEmail());
+    }
+
+    @Test
+    public void getWorkflowContentOfTool() throws IOException {
+        final WDLHandler wdlHandler = new WDLHandler();
+        final Tool tool = new Tool();
+        tool.setAuthor("Jane Doe");
+        tool.setDescription("A good description");
+        tool.setEmail("janedoe@example.org");
+
+        Assert.assertEquals("Jane Doe", tool.getAuthor());
+        Assert.assertEquals("A good description", tool.getDescription());
+        Assert.assertEquals("janedoe@example.org", tool.getEmail());
+
+        final String invalidFilePath = ResourceHelpers.resourceFilePath("invalid_description_example.wdl");
+        final String invalidDescriptionWdl = FileUtils.readFileToString(new File(invalidFilePath), StandardCharsets.UTF_8);
+        wdlHandler.parseWorkflowContent(tool, invalidFilePath, invalidDescriptionWdl, Collections.emptySet(), new WorkflowVersion());
+
+        // Check that parsing an invalid WDL workflow does not corrupt the CWL metadata
+        Assert.assertEquals("Jane Doe", tool.getAuthor());
+        Assert.assertEquals("A good description", tool.getDescription());
+        Assert.assertEquals("janedoe@example.org", tool.getEmail());
     }
 
     @Test


### PR DESCRIPTION
Quick fix for the issue dockstore/dockstore#2851

Simply don't clear metadata for a tool even when WDL parsing has failed.  This is because CWL parsing may have assigned valid metadata already.