### PR TITLE
Hosted amazon ecr and sbgenomics error

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -38,7 +38,6 @@ import com.codahale.metrics.annotation.Timed;
 import com.google.common.base.MoreObjects;
 import com.google.gson.Gson;
 import io.dockstore.common.DescriptorLanguage;
-import io.dockstore.common.Registry;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.core.Entry;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -135,7 +135,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
 
         // Only check type for workflows
         DescriptorLanguage convertedDescriptorType = checkType(descriptorType);
-        Registry convertedRegistry = checkRegistry(registry);
+        String convertedRegistry = checkRegistry(registry);
         T entry = getEntry(user, convertedRegistry, name, convertedDescriptorType, namespace, entryName);
         checkForDuplicatePath(entry);
         long l = getEntryDAO().create(entry);
@@ -156,7 +156,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
      * @param entryName Optional entry name
      * @return Newly created entry
      */
-    protected abstract T getEntry(User user, Registry registry, String name, DescriptorLanguage descriptorType, String namespace, String entryName);
+    protected abstract T getEntry(User user, String registry, String name, DescriptorLanguage descriptorType, String namespace, String entryName);
 
     @Override
     public void checkUserCanUpdate(User user, Entry entry) {
@@ -335,7 +335,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
      * @param registry
      * @return
      */
-    protected abstract Registry checkRegistry(String registry);
+    protected abstract String checkRegistry(String registry);
 
     /**
      * Create new version of a workflow or tag of a tool

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
@@ -88,9 +88,9 @@ public class HostedToolResource extends AbstractHostedEntryResource<Tool, Tag, T
     }
 
     @Override
-    protected Tool getEntry(User user, Registry registry, String name, DescriptorLanguage descriptorType, String namespace, String entryName) {
+    protected Tool getEntry(User user, String registry, String name, DescriptorLanguage descriptorType, String namespace, String entryName) {
         Tool tool = new Tool();
-        tool.setRegistry(registry.toString());
+        tool.setRegistry(registry);
         tool.setNamespace(namespace);
         tool.setName(name);
         tool.setMode(ToolMode.HOSTED);
@@ -229,12 +229,21 @@ public class HostedToolResource extends AbstractHostedEntryResource<Tool, Tag, T
     }
 
     @Override
-    protected Registry checkRegistry(String registry) {
+    protected String checkRegistry(String registry) {
         for (Registry registryObject : Registry.values()) {
             if (Objects.equals(registry.toLowerCase(), registryObject.toString())) {
-                return registryObject;
+                return registry;
+            } else if (Objects.equals(registryObject.name(), Registry.AMAZON_ECR.name())) {
+                if (registry.matches("^[a-zA-Z0-9]+\\.dkr\\.ecr\\.[a-zA-Z0-9]+\\.amazonaws\\.com")) {
+                    return registry;
+                }
+            } else if (Objects.equals(registryObject.name(), Registry.SEVEN_BRIDGES.name())) {
+                if (registry.matches("^([a-zA-Z0-9]+-)?images\\.sbgenomics\\.com")) {
+                    return registry;
+                }
             }
         }
+
         throw new CustomWebApplicationException(registry + " is not a valid registry type", HttpStatus.SC_BAD_REQUEST);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
@@ -145,7 +145,7 @@ public class HostedWorkflowResource extends AbstractHostedEntryResource<Workflow
     }
 
     @Override
-    protected Workflow getEntry(User user, Registry registry, String name, DescriptorLanguage descriptorType, String namespace, String entryName) {
+    protected Workflow getEntry(User user, String registry, String name, DescriptorLanguage descriptorType, String namespace, String entryName) {
         Workflow workflow = new BioWorkflow();
         workflow.setMode(WorkflowMode.HOSTED);
         // TODO: We set the organization to the username of the user creating it. However, for gmail accounts this is an
@@ -283,7 +283,7 @@ public class HostedWorkflowResource extends AbstractHostedEntryResource<Workflow
     }
 
     @Override
-    protected Registry checkRegistry(String registry) {
+    protected String checkRegistry(String registry) {
         // Registry does not matter for workflows
         return null;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
@@ -32,7 +32,6 @@ import javax.ws.rs.core.MediaType;
 
 import com.codahale.metrics.annotation.Timed;
 import io.dockstore.common.DescriptorLanguage;
-import io.dockstore.common.Registry;
 import io.dockstore.common.SourceControl;
 import io.dockstore.common.VersionTypeValidation;
 import io.dockstore.webservice.CustomWebApplicationException;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SourceControlResourceInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SourceControlResourceInterface.java
@@ -101,8 +101,6 @@ public interface SourceControlResourceInterface {
                     URI uri = new URI(refreshUrl);
                     domain = uri.getHost();
                 } catch (URISyntaxException e) {
-
-
                     domain = "web site";
                 }
                 throw new CustomWebApplicationException("Could not retrieve " + domain + " token based on code",

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SourceControlResourceInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SourceControlResourceInterface.java
@@ -101,6 +101,8 @@ public interface SourceControlResourceInterface {
                     URI uri = new URI(refreshUrl);
                     domain = uri.getHost();
                 } catch (URISyntaxException e) {
+
+
                     domain = "web site";
                 }
                 throw new CustomWebApplicationException("Could not retrieve " + domain + " token based on code",


### PR DESCRIPTION
Previously there was an error registering amazon ecr and sbgenomics hosted tools because for their associated registry objects the paths were null (since they are custom).