### PR TITLE
Feature/zenodo error fix

### DIFF
--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -88,6 +88,11 @@
         </dependency>
         -->
         <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.zafarkhaja</groupId>
             <artifactId>java-semver</artifactId>
         </dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -88,11 +88,6 @@
         </dependency>
         -->
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.10.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.github.zafarkhaja</groupId>
             <artifactId>java-semver</artifactId>
         </dependency>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
@@ -197,6 +197,16 @@ public class Token implements Comparable<Token> {
         this.userId = userId;
     }
 
+    @JsonProperty
+    public Timestamp getDbCreateDate() {
+        return dbCreateDate;
+    }
+
+    @JsonProperty
+    public Timestamp getDbUpdateDate() {
+        return dbUpdateDate;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -60,6 +60,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     protected final FileDAO fileDAO;
     protected final String gitHubPrivateKeyFile;
     protected final String gitHubAppId;
+    protected final SessionFactory sessionFactory;
 
     private final String bitbucketClientSecret;
     private final String bitbucketClientID;
@@ -67,6 +68,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
 
     public AbstractWorkflowResource(HttpClient client, SessionFactory sessionFactory, DockstoreWebserviceConfiguration configuration, Class<T> clazz) {
         this.client = client;
+        this.sessionFactory = sessionFactory;
 
         this.tokenDAO = new TokenDAO(sessionFactory);
         this.workflowDAO = new WorkflowDAO(sessionFactory);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SourceControlResourceInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SourceControlResourceInterface.java
@@ -102,6 +102,7 @@ public interface SourceControlResourceInterface {
                     domain = uri.getHost();
                 } catch (URISyntaxException e) {
                     domain = "web site";
+                    LOG.debug(e.getMessage(), e);
                 }
                 throw new CustomWebApplicationException("Could not retrieve " + domain + " token based on code",
                         HttpStatus.SC_INTERNAL_SERVER_ERROR);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -614,9 +614,9 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         // Update the zenodo token in case it changed. This handles the case where the token has been changed but an error occurred, so the token in the database was not updated
         if (zenodoToken != null) {
             tokenDAO.update(zenodoToken);
+            sessionFactory.getCurrentSession().getTransaction().commit();
+            sessionFactory.getCurrentSession().beginTransaction();
         }
-        sessionFactory.getCurrentSession().getTransaction().commit();
-        sessionFactory.getCurrentSession().beginTransaction();
 
         if (zenodoToken == null) {
             LOG.error(NO_ZENDO_USER_TOKEN + " " + user.getUsername());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -612,7 +612,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
         // Update the zenodo token in case it changed. This handles the case where the token has been changed but an error occurred, so the token in the database was not updated
         tokenDAO.update(zenodoToken);
-        sessionFactory.getCurrentSession().flush();
+        sessionFactory.getCurrentSession().getTransaction().commit();
+        sessionFactory.getCurrentSession().beginTransaction();
 
         if (zenodoToken == null) {
             LOG.error(NO_ZENDO_USER_TOKEN + " " + user.getUsername());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -18,6 +18,7 @@ package io.dockstore.webservice.resources;
 
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -108,7 +109,6 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.hibernate.Hibernate;
 import org.hibernate.SessionFactory;
-import org.joda.time.DateTime;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.slf4j.Logger;
@@ -566,8 +566,9 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             Token zenodoToken = tokens.get(0);
 
             // Check that token is an hour old
-            DateTime updateTime = new DateTime(zenodoToken.getDbUpdateDate());
-            if (updateTime.plusHours(1).isBeforeNow()) {
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime updateTime = zenodoToken.getDbUpdateDate().toLocalDateTime();
+            if (now.isAfter(updateTime.plusHours(1).minusMinutes(1))) {
                 LOG.info("Refreshing the Zenodo Token");
                 String refreshUrl = zenodoUrl + "/oauth/token";
                 String payload = "client_id=" + zenodoClientID + "&client_secret=" + zenodoClientSecret

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -573,8 +573,6 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                 String payload = "client_id=" + zenodoClientID + "&client_secret=" + zenodoClientSecret
                         + "&grant_type=refresh_token&refresh_token=" + zenodoToken.getRefreshToken();
                 refreshToken(refreshUrl, zenodoToken, client, tokenDAO, null, null, payload);
-            } else {
-                LOG.info("Zenodo Token is still valid");
             }
         }
         return tokenDAO.findByUserId(user.getId());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -611,7 +611,9 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         Token zenodoToken = Token.extractToken(tokens, TokenType.ZENODO_ORG);
 
         // Update the zenodo token in case it changed. This handles the case where the token has been changed but an error occurred, so the token in the database was not updated
-        tokenDAO.update(zenodoToken);
+        if (zenodoToken != null) {
+            tokenDAO.update(zenodoToken);
+        }
         sessionFactory.getCurrentSession().getTransaction().commit();
         sessionFactory.getCurrentSession().beginTransaction();
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -611,6 +611,11 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
         List<Token> tokens = checkOnZenodoToken(user);
         Token zenodoToken = Token.extractToken(tokens, TokenType.ZENODO_ORG);
+
+        // Update the zenodo token in case it changed. This handles the case where the token has been changed but an error occurred, so the token in the database was not updated
+        tokenDAO.update(zenodoToken);
+        sessionFactory.getCurrentSession().flush();
+
         if (zenodoToken == null) {
             LOG.error(NO_ZENDO_USER_TOKEN + " " + user.getUsername());
             throw new CustomWebApplicationException(NO_ZENDO_USER_TOKEN + " " + user.getUsername(), HttpStatus.SC_BAD_REQUEST);


### PR DESCRIPTION
I talk more about the solution in the issue linked, but the gist is that we generate the zenodo token on every call, though on error case we generated a new token but didn't store it. This means you have to relink the account to fix it.

This PR adds two things:
* on token generation, save to the db right away so that new token is saved even on error
* only regenerate token after 1 hour has passed (expiry time of token)

This is a draft because it has no tests yet. Waiting for Walt to implement basic zenodo testing so that I can build off that.

https://github.com/dockstore/dockstore/issues/2787