### PR TITLE
feature/2707/fetch validation messages eagerly

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -145,7 +145,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @OrderBy("id")
     private SortedSet<FileFormat> outputFileFormats = new TreeSet<>();
 
-    @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.EAGER, orphanRemoval = true, cascade = CascadeType.ALL)
     @JoinTable(name = "version_validation", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "validationid", referencedColumnName = "id"))
     @ApiModelProperty(value = "Cached validations for each version.")
     @OrderBy("type")


### PR DESCRIPTION
validation messages weren't being grabbed for services or workflows if you navigated to a specific one in the "my-..." pages. Fetching them eagerly instead now, but not sure if that's okay?