### PR TITLE
Known commands that break with 1.6.0 client

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralRegressionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralRegressionIT.java
@@ -37,6 +37,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
@@ -45,6 +46,7 @@ import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
+import static io.dockstore.client.cli.GeneralWorkflowRegressionIT.KNOWN_BREAKAGE_MOVING_TO_1_6_0;
 import static io.dockstore.common.CommonTestUtilities.OLD_DOCKSTORE_VERSION;
 import static io.dockstore.common.CommonTestUtilities.runOldDockstoreClient;
 import static org.junit.Assert.assertEquals;
@@ -194,6 +196,7 @@ public class GeneralRegressionIT extends BaseIT {
      * Tests altering the cwl and dockerfile paths to invalid locations (quick registered)
      */
     @Test
+    @Ignore(KNOWN_BREAKAGE_MOVING_TO_1_6_0)
     public void testVersionTagWDLCWLAndDockerfilePathsAlterationOldClient() {
         runOldDockstoreClient(dockstore,
                 new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "tool", "version_tag", "update", "--entry",
@@ -252,6 +255,7 @@ public class GeneralRegressionIT extends BaseIT {
      * Tests hiding and unhiding different versions of a container (quick registered)
      */
     @Test
+    @Ignore(KNOWN_BREAKAGE_MOVING_TO_1_6_0)
     public void testVersionTagHideOld() {
         runOldDockstoreClient(dockstore,
                 new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "tool", "version_tag", "update", "--entry",
@@ -273,6 +277,7 @@ public class GeneralRegressionIT extends BaseIT {
      * Test update tag with only WDL to invalid then valid
      */
     @Test
+    @Ignore(KNOWN_BREAKAGE_MOVING_TO_1_6_0)
     public void testVersionTagWDLOldClient() {
         runOldDockstoreClient(dockstore,
                 new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "tool", "version_tag", "update", "--entry",
@@ -402,6 +407,7 @@ public class GeneralRegressionIT extends BaseIT {
      * Tests that WDL and CWL files can be grabbed from the command line
      */
     @Test
+    @Ignore(KNOWN_BREAKAGE_MOVING_TO_1_6_0)
     public void testGetWdlAndCwlOld() {
         runOldDockstoreClient(dockstore,
                 new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "tool", "publish", "--entry",

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowRegressionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowRegressionIT.java
@@ -150,6 +150,7 @@ public class GeneralWorkflowRegressionIT extends BaseIT {
      * This test manually publishing a workflow and grabbing valid descriptor
      */
     @Test
+    @Ignore(KNOWN_BREAKAGE_MOVING_TO_1_6_0)
     public void testManualPublishAndGrabWDLOld() {
         runOldDockstoreClient(dockstore,
                 new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "manual_publish",

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowRegressionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowRegressionIT.java
@@ -61,6 +61,7 @@ import static org.junit.Assert.assertTrue;
  */
 @Category({ RegressionTest.class })
 public class GeneralWorkflowRegressionIT extends BaseIT {
+    public static final String KNOWN_BREAKAGE_MOVING_TO_1_6_0 = "Known breakage moving to 1.6.0";
     @ClassRule
     public static TemporaryFolder temporaryFolder = new TemporaryFolder();
     @Rule
@@ -195,6 +196,7 @@ public class GeneralWorkflowRegressionIT extends BaseIT {
      * This tests that a user can update a workflow version
      */
     @Test
+    @Ignore(KNOWN_BREAKAGE_MOVING_TO_1_6_0)
     public void testUpdateWorkflowVersionOld() {
         // Set up DB
 
@@ -242,6 +244,7 @@ public class GeneralWorkflowRegressionIT extends BaseIT {
      * Tests that convert with valid imports will work (for WDL)
      */
     @Test
+    @Ignore(KNOWN_BREAKAGE_MOVING_TO_1_6_0)
     public void testRefreshAndConvertWithImportsWDLOld() {
         runOldDockstoreClient(dockstore,
                 new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "refresh", "--script" });
@@ -322,6 +325,7 @@ public class GeneralWorkflowRegressionIT extends BaseIT {
      * This tests the dirty bit attribute for workflow versions with github
      */
     @Test
+    @Ignore(KNOWN_BREAKAGE_MOVING_TO_1_6_0)
     public void testGithubDirtyBitOld() {
         // Setup DB
 
@@ -369,6 +373,7 @@ public class GeneralWorkflowRegressionIT extends BaseIT {
      * This tests the dirty bit attribute for workflow versions with bitbucket
      */
     @Test
+    @Ignore(KNOWN_BREAKAGE_MOVING_TO_1_6_0)
     public void testBitbucketDirtyBitOld() {
         // Setup DB
 
@@ -417,6 +422,7 @@ public class GeneralWorkflowRegressionIT extends BaseIT {
      */
     @Test
     @Category(SlowTest.class)
+    @Ignore(KNOWN_BREAKAGE_MOVING_TO_1_6_0)
     public void testGitlab() {
         // Setup DB
 
@@ -505,6 +511,7 @@ public class GeneralWorkflowRegressionIT extends BaseIT {
      * This tests manually publishing a gitlab workflow
      */
     @Test
+    @Ignore(KNOWN_BREAKAGE_MOVING_TO_1_6_0)
     public void testManualPublishGitlabOld() {
         // Setup DB
 
@@ -532,6 +539,7 @@ public class GeneralWorkflowRegressionIT extends BaseIT {
      * This tests that WDL files are properly parsed for secondary WDL files
      */
     @Test
+    @Ignore(KNOWN_BREAKAGE_MOVING_TO_1_6_0)
     public void testWDLWithImportsOld() {
         // Setup DB
 
@@ -557,6 +565,7 @@ public class GeneralWorkflowRegressionIT extends BaseIT {
      * This tests basic concepts with workflow test parameter files
      */
     @Test
+    @Ignore(KNOWN_BREAKAGE_MOVING_TO_1_6_0)
     public void testTestParameterFileOld() {
         // Setup DB
 
@@ -633,6 +642,7 @@ public class GeneralWorkflowRegressionIT extends BaseIT {
      * This currently fails
      */
     @Test
+    @Ignore(KNOWN_BREAKAGE_MOVING_TO_1_6_0)
     public void testVerifyOld() {
         // Setup DB
 


### PR DESCRIPTION
These functions are known to break when using a 1.6.0 client with a 1.7.0 webservice.

In short, basic launching of tools and workflows should work. 
Editing of paths, metadata, etc. won't

Everything else is a bit of a toss-up, review tests in regression-integration-tests profile for details

