### PR TITLE
Wombundle error handle

### DIFF
--- a/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
+++ b/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
@@ -318,7 +318,7 @@ class WdlBridge {
         throw new WdlParser.SyntaxError(bundle.left.get.head)
       }
     } catch {
-      case _: Throwable => throw new WdlParser.SyntaxError("There was an error creating a Wom Bundle for the workflow.")
+      case ex: Exception => throw new WdlParser.SyntaxError("There was an error creating a Wom Bundle for the workflow.\n" + ex.getMessage())
     }
   }
 

--- a/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
+++ b/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
@@ -310,11 +310,15 @@ class WdlBridge {
     mapResolver.setSecondaryFiles(secondaryWdlFiles)
     lazy val importResolvers: List[ImportResolver] =
       DirectoryResolver.localFilesystemResolvers(Some(filePathObj)) :+ HttpResolver(relativeTo = None) :+ mapResolver
-    val bundle = factory.getWomBundle(content, "{}", importResolvers, List(factory))
-    if (bundle.isRight) {
-      bundle.getOrElse(null)
-    } else {
-      throw new WdlParser.SyntaxError(bundle.left.get.head)
+    try {
+      val bundle = factory.getWomBundle(content, "{}", importResolvers, List(factory))
+      if (bundle.isRight) {
+        bundle.getOrElse(null)
+      } else {
+        throw new WdlParser.SyntaxError(bundle.left.get.head)
+      }
+    } catch {
+      case _: Throwable => throw new WdlParser.SyntaxError("There was an error creating a Wom Bundle for the workflow.")
     }
   }
 


### PR DESCRIPTION
When loading a WDL workflow into a WomBundle, we now catch any exception and throw as a general syntax error so that the exception doesn't halt refresh.