### PR TITLE
Add row level security policy to join table

### DIFF
--- a/dockstore-webservice/src/main/resources/migrations.1.8.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.8.0.xml
@@ -29,4 +29,21 @@
             <column name="conceptdoi" type="varchar(255)"/>
         </addColumn>
     </changeSet>
+    <changeSet id="frozen join table" author="coverbeck">
+        <sql dbms="postgresql">
+            alter table version_sourcefile enable row level security;
+            alter table version_sourcefile force row level security;
+            /* All users can read the table, but cannot update or delete if frozen */
+            create policy select_frozenfiles on version_sourcefile for select using (true)
+
+            create policy insert_frozenworkflowfiles on version_sourcefile for insert using (not (select wv.frozen from workflowversion wv where versionid = wv.id))
+            create policy insert_frozentagfiles on version_sourcefile for insert (not (select t.frozen from tag t where versionid = t.id))
+
+            create policy update_frozenworkflowfiles on version_sourcefile for update using (not (select wv.frozen from workflowversion wv where versionid = wv.id))
+            create policy update_frozentagfiles on version_sourcefile for update (not (select t.frozen from tag t where versionid = t.id))
+
+            create policy delete_frozenworkflowfiles on version_sourcefile for delete using (not (select wv.frozen from workflowversion wv where versionid = wv.id))
+            create policy delete_frozentagfiles on version_sourcefile for delete using (not (select t.frozen from tag t where versionid = t.id))
+        </sql>
+    </changeSet>
    </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.8.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.8.0.xml
@@ -34,16 +34,10 @@
             alter table version_sourcefile enable row level security;
             alter table version_sourcefile force row level security;
             /* All users can read the table, but cannot update or delete if frozen */
-            create policy select_frozenfiles on version_sourcefile for select using (true)
-
-            create policy insert_frozenworkflowfiles on version_sourcefile for insert using (not (select wv.frozen from workflowversion wv where versionid = wv.id))
-            create policy insert_frozentagfiles on version_sourcefile for insert (not (select t.frozen from tag t where versionid = t.id))
-
-            create policy update_frozenworkflowfiles on version_sourcefile for update using (not (select wv.frozen from workflowversion wv where versionid = wv.id))
-            create policy update_frozentagfiles on version_sourcefile for update (not (select t.frozen from tag t where versionid = t.id))
-
-            create policy delete_frozenworkflowfiles on version_sourcefile for delete using (not (select wv.frozen from workflowversion wv where versionid = wv.id))
-            create policy delete_frozentagfiles on version_sourcefile for delete using (not (select t.frozen from tag t where versionid = t.id))
+            create policy select_frozenfiles on version_sourcefile for select using(true);
+            create policy insert_frozenfiles on version_sourcefile for insert with check( (false = (select sf.frozen from sourcefile sf where sourcefileid = sf.id)));
+            create policy update_frozenfiles on version_sourcefile for update using (false = (select sf.frozen from sourcefile sf where sourcefileid = sf.id));
+            create policy delete_frozenfiles on version_sourcefile for delete using (false = (select sf.frozen from sourcefile sf where sourcefileid = sf.id));
         </sql>
     </changeSet>
    </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.8.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.8.0.xml
@@ -35,9 +35,11 @@
             alter table version_sourcefile force row level security;
             /* All users can read the table, but cannot update or delete if frozen */
             create policy select_frozenfiles on version_sourcefile for select using(true);
-            create policy insert_frozenfiles on version_sourcefile for insert with check( (false = (select sf.frozen from sourcefile sf where sourcefileid = sf.id)));
-            create policy update_frozenfiles on version_sourcefile for update using (false = (select sf.frozen from sourcefile sf where sourcefileid = sf.id));
-            create policy delete_frozenfiles on version_sourcefile for delete using (false = (select sf.frozen from sourcefile sf where sourcefileid = sf.id));
+            /* Don't allow new source files to be added to an a frozen version */
+            create policy insert_frozenfiles on version_sourcefile for insert with check( not(select v.frozen from workflowversion v where id = versionid union select t.frozen from tag t where t.id = versionid));
+            /* Don't allow a new file to be added to the version in the join table if any of the source files are already frozen (easier to query this way instead of querying two tables like above) */
+            create policy update_frozenfiles on version_sourcefile for update using (not (select sf.frozen from sourcefile sf where sourcefileid = sf.id));
+            create policy delete_frozenfiles on version_sourcefile for delete using (not (select sf.frozen from sourcefile sf where sourcefileid = sf.id));
         </sql>
     </changeSet>
    </databaseChangeLog>


### PR DESCRIPTION

#2849 

Extend row level security to version_sourcefile, so that if a version is frozen, the files associated with the version cannot be change.

Part of the ticket was to remove the application guards once database protection was implemented, but I decided against that -- Hibernate throws a 500 exception in that case. We would need to catch that exception and throw our own exception. The problem is the exception is thrown after the return statement code in the Java code for the resource endpoint -- the error happens because the `@UnitOfWork` annotation causes Hibernate to attempt to commit the transaction. We would  have to remove the annotation, manually start the transaction and commit it. Which is doable, but doesn't seem like it would offer much over the current application guards.