### PR TITLE
Don't grab entire entity for sitemap performance

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
@@ -18,6 +18,7 @@ package io.dockstore.webservice.core;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.NamedQuery;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
@@ -32,6 +33,7 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(value = "BioWorkflow", description = "This describes one workflow in the dockstore")
 @Entity
 @Table(name = "workflow")
+@NamedQuery(name = "io.dockstore.webservice.core.BioWorkflow.findAllPublishedPaths", query = "SELECT new io.dockstore.webservice.core.WorkflowPath(c.sourceControl, c.organization, c.repository, c.workflowName) from BioWorkflow c where c.isPublished = true")
 @SuppressWarnings("checkstyle:magicnumber")
 public class BioWorkflow extends Workflow {
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Service.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Service.java
@@ -16,6 +16,7 @@
 package io.dockstore.webservice.core;
 
 import javax.persistence.Entity;
+import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 
 import io.swagger.annotations.ApiModel;
@@ -23,6 +24,7 @@ import io.swagger.annotations.ApiModel;
 @ApiModel(value = "Service", description = "This describes one service in the dockstore as a special degenerate case of a workflow")
 @Entity
 @Table(name = "service")
+@NamedQuery(name = "io.dockstore.webservice.core.Service.findAllPublishedPaths", query = "SELECT new io.dockstore.webservice.core.WorkflowPath(c.sourceControl, c.organization, c.repository, c.workflowName) from Service c where c.isPublished = true")
 public class Service extends Workflow {
 
     public enum SubClass { DOCKER_COMPOSE, SWARM, KUBERNETES, HELM }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -70,6 +70,7 @@ import org.hibernate.annotations.Check;
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.findPublishedById", query = "SELECT c FROM Tool c WHERE c.id = :id AND c.isPublished = true"),
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.countAllPublished", query = "SELECT COUNT(c.id)" + Tool.PUBLISHED_QUERY),
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.findAllPublished", query = "SELECT c" + Tool.PUBLISHED_QUERY + "ORDER BY size(c.starredUsers) DESC"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Tool.findAllPublishedPaths", query = "SELECT new io.dockstore.webservice.core.ToolPath(c.registry, c.namespace, c.name, c.toolname)" + Tool.PUBLISHED_QUERY),
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.findByMode", query = "SELECT c FROM Tool c WHERE c.mode = :mode"),
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.findPublishedByNamespace", query = "SELECT c FROM Tool c WHERE lower(c.namespace) = lower(:namespace) AND c.isPublished = true ORDER BY gitUrl"),
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.findByPath", query = "SELECT c FROM Tool c WHERE c.registry = :registry AND c.namespace = :namespace AND c.name = :name"),

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ToolPath.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ToolPath.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 OICR
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dockstore.webservice.core;
+
+/**
+ * This class is only used to get data from the database in a more type-safe way
+ * @author gluu
+ * @since 1.8.0
+ */
+public class ToolPath {
+    private String registry;
+    private String namespace;
+    private String name;
+    private String toolname;
+
+    public ToolPath(String registry, String namespace, String name, String toolname) {
+        this.registry = registry;
+        this.namespace = namespace;
+        this.name = name;
+        this.toolname = toolname;
+    }
+
+    public String getRegistry() {
+        return registry;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getToolname() {
+        return toolname;
+    }
+
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ToolPath.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ToolPath.java
@@ -15,6 +15,9 @@
 
 package io.dockstore.webservice.core;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * This class is only used to get data from the database in a more type-safe way
  * @author gluu
@@ -47,6 +50,17 @@ public class ToolPath {
 
     public String getToolname() {
         return toolname;
+    }
+
+    public String getEntryPath() {
+        List<String> segments = new ArrayList<>();
+        segments.add(registry);
+        segments.add(namespace);
+        segments.add(name);
+        if (toolname != null && !toolname.isEmpty()) {
+            segments.add(toolname);
+        }
+        return String.join("/", segments);
     }
 
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ToolPath.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ToolPath.java
@@ -24,10 +24,10 @@ import java.util.List;
  * @since 1.8.0
  */
 public class ToolPath {
-    private String registry;
-    private String namespace;
-    private String name;
-    private String toolname;
+    private final String registry;
+    private final String namespace;
+    private final String name;
+    private final String toolname;
 
     public ToolPath(String registry, String namespace, String name, String toolname) {
         this.registry = registry;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowPath.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowPath.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 OICR
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dockstore.webservice.core;
+
+import io.dockstore.common.SourceControl;
+
+/**
+ * This class is only used to get data from the database in a more type-safe way
+ * @author gluu
+ * @since 1.8.0
+ */
+public class WorkflowPath {
+    private SourceControl sourceControl;
+    private String organization;
+    private String repository;
+    private String workflowName;
+
+    public WorkflowPath(SourceControl sourceControl, String organization, String repository, String workflowName) {
+        this.sourceControl = sourceControl;
+        this.organization = organization;
+        this.repository = repository;
+        this.workflowName = workflowName;
+    }
+
+    public SourceControl getSourceControl() {
+        return sourceControl;
+    }
+
+    public String getOrganization() {
+        return organization;
+    }
+
+    public String getRepository() {
+        return repository;
+    }
+
+    public String getWorkflowName() {
+        return workflowName;
+    }
+
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowPath.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowPath.java
@@ -26,10 +26,10 @@ import io.dockstore.common.SourceControl;
  * @since 1.8.0
  */
 public class WorkflowPath {
-    private SourceControl sourceControl;
-    private String organization;
-    private String repository;
-    private String workflowName;
+    private final SourceControl sourceControl;
+    private final String organization;
+    private final String repository;
+    private final String workflowName;
 
     public WorkflowPath(SourceControl sourceControl, String organization, String repository, String workflowName) {
         this.sourceControl = sourceControl;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowPath.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowPath.java
@@ -15,6 +15,9 @@
 
 package io.dockstore.webservice.core;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import io.dockstore.common.SourceControl;
 
 /**
@@ -51,4 +54,14 @@ public class WorkflowPath {
         return workflowName;
     }
 
+    public String getEntryPath() {
+        List<String> segments = new ArrayList<>();
+        segments.add(sourceControl.toString());
+        segments.add(organization);
+        segments.add(repository);
+        if (workflowName != null && !workflowName.isEmpty()) {
+            segments.add(workflowName);
+        }
+        return String.join("/", segments);
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/MetadataResourceHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/MetadataResourceHelper.java
@@ -6,7 +6,9 @@ import io.dockstore.webservice.core.Collection;
 import io.dockstore.webservice.core.Organization;
 import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.Tool;
+import io.dockstore.webservice.core.ToolPath;
 import io.dockstore.webservice.core.Workflow;
+import io.dockstore.webservice.core.WorkflowPath;
 
 public final class MetadataResourceHelper {
 
@@ -26,6 +28,17 @@ public final class MetadataResourceHelper {
             return baseUrl + "/services/" + workflow.getWorkflowPath();
         }
         throw new UnsupportedOperationException("should be unreachable");
+    }
+
+    public static String createWorkflowURL(WorkflowPath workflow, String entryType) {
+        return String.format("%s/%ss/%s/%s/%s%s", baseUrl, entryType, workflow.getSourceControl(), workflow.getOrganization(),
+                workflow.getRepository(),
+                workflow.getWorkflowName() == null || workflow.getWorkflowName().isEmpty() ? "" : '/' + workflow.getWorkflowName());
+    }
+
+    public static String createToolURL2(ToolPath toolPath) {
+        return String.format("%s/containers/%s/%s/%s%s", baseUrl, toolPath.getRegistry(), toolPath.getNamespace(), toolPath.getName(),
+                toolPath.getToolname() == null || toolPath.getToolname().isEmpty() ? "" : '/' + toolPath.getToolname());
     }
 
     public static String createOrganizationURL(Organization organization) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/MetadataResourceHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/MetadataResourceHelper.java
@@ -31,14 +31,11 @@ public final class MetadataResourceHelper {
     }
 
     public static String createWorkflowURL(WorkflowPath workflow, String entryType) {
-        return String.format("%s/%ss/%s/%s/%s%s", baseUrl, entryType, workflow.getSourceControl(), workflow.getOrganization(),
-                workflow.getRepository(),
-                workflow.getWorkflowName() == null || workflow.getWorkflowName().isEmpty() ? "" : '/' + workflow.getWorkflowName());
+        return String.format("%s/%ss/%s", baseUrl, entryType, workflow.getEntryPath());
     }
 
     public static String createToolURL2(ToolPath toolPath) {
-        return String.format("%s/containers/%s/%s/%s%s", baseUrl, toolPath.getRegistry(), toolPath.getNamespace(), toolPath.getName(),
-                toolPath.getToolname() == null || toolPath.getToolname().isEmpty() ? "" : '/' + toolPath.getToolname());
+        return String.format("%s/containers/%s", baseUrl, toolPath.getEntryPath());
     }
 
     public static String createOrganizationURL(Organization organization) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/BioWorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/BioWorkflowDAO.java
@@ -15,6 +15,9 @@
 
 package io.dockstore.webservice.jdbi;
 
+import java.util.List;
+
+import io.dockstore.webservice.core.WorkflowPath;
 import io.dockstore.webservice.core.BioWorkflow;
 import org.hibernate.SessionFactory;
 
@@ -25,5 +28,9 @@ import org.hibernate.SessionFactory;
 public class BioWorkflowDAO extends EntryDAO<BioWorkflow> {
     public BioWorkflowDAO(SessionFactory factory) {
         super(factory);
+    }
+
+    public List<WorkflowPath> findAllPublishedPaths() {
+        return list(namedQuery("io.dockstore.webservice.core.BioWorkflow.findAllPublishedPaths"));
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ServiceDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ServiceDAO.java
@@ -16,7 +16,10 @@
 
 package io.dockstore.webservice.jdbi;
 
+import java.util.List;
+
 import io.dockstore.webservice.core.Service;
+import io.dockstore.webservice.core.WorkflowPath;
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.SessionFactory;
 
@@ -34,5 +37,9 @@ public class ServiceDAO extends AbstractDAO<Service> {
 
     public long create(Service file) {
         return persist(file).getId();
+    }
+
+    public List<WorkflowPath> findAllPublishedPaths() {
+        return list(namedQuery("io.dockstore.webservice.core.Service.findAllPublishedPaths"));
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ToolDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ToolDAO.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.ToolMode;
+import io.dockstore.webservice.core.ToolPath;
 import io.dockstore.webservice.helpers.JsonLdRetriever;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
@@ -34,6 +35,10 @@ public class ToolDAO extends EntryDAO<Tool> {
 
     public List<Tool> findByMode(final ToolMode mode) {
         return list(namedQuery("io.dockstore.webservice.core.Tool.findByMode").setParameter("mode", mode));
+    }
+
+    public List<ToolPath> findAllPublishedPaths() {
+        return list(namedQuery("io.dockstore.webservice.core.Tool.findAllPublishedPaths"));
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -134,7 +134,7 @@ public class MetadataResource {
         addToolPaths(urls);
         addBioWorkflowPaths(urls);
         // Do not append services yet
-        addServicePaths(urls);
+        // addServicePaths(urls);
         addOrganizationAndCollectionPaths(urls);
         Collections.sort(urls);
         return String.join(System.lineSeparator(), urls);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -131,11 +131,11 @@ public class MetadataResource {
     @ApiOperation(value = "List all available workflow, tool, organization, and collection paths.", notes = "List all available workflow, tool, organization, and collection paths. Available means published for tools/workflows, and approved for organizations and their respective collections.")
     public String sitemap() {
         List<String> urls = new ArrayList<>();
-        addToolPaths(urls);
-        addBioWorkflowPaths(urls);
+        urls.addAll(getToolPaths());
+        urls.addAll(getBioWorkflowPaths());
         // Do not append services yet
-        // addServicePaths(urls);
-        addOrganizationAndCollectionPaths(urls);
+        // urls.addAll(getServicePaths());
+        urls.addAll(getOrganizationAndCollectionPaths());
         Collections.sort(urls);
         return String.join(System.lineSeparator(), urls);
     }
@@ -143,35 +143,33 @@ public class MetadataResource {
     /**
      * Adds organization and collection URLs
      * //TODO needs to be more efficient via JPA query
-     * @param urls  Current list of all URLs for sitemap
      */
-    private void addOrganizationAndCollectionPaths(List<String> urls) {
+    private List<String> getOrganizationAndCollectionPaths() {
+        List<String> urls = new ArrayList<>();
         List<Organization> organizations = organizationDAO.findAllApproved();
         organizations.forEach(organization -> {
             urls.add(createOrganizationURL(organization));
             List<Collection> collections = collectionDAO.findAllByOrg(organization.getId());
             collections.stream().map(collection -> createCollectionURL(collection, organization)).forEach(urls::add);
         });
+        return urls;
     }
 
-    private void addToolPaths(List<String> urls) {
+    private List<String> getToolPaths() {
         List<ToolPath> toolPaths = toolDAO.findAllPublishedPaths();
-        List<String> entryURLs = toolPaths.stream().map(MetadataResourceHelper::createToolURL2).collect(Collectors.toList());
-        urls.addAll(entryURLs);
+        return toolPaths.stream().map(MetadataResourceHelper::createToolURL2).collect(Collectors.toList());
     }
 
-    private void addBioWorkflowPaths(List<String> urls) {
+    private List<String> getBioWorkflowPaths() {
         List<WorkflowPath> workflowPaths = bioWorkflowDAO.findAllPublishedPaths();
-        List<String> entryURLs = workflowPaths.stream().map(
+        return workflowPaths.stream().map(
             (WorkflowPath workflow) -> MetadataResourceHelper.createWorkflowURL(workflow, "workflow")).collect(Collectors.toList());
-        urls.addAll(entryURLs);
     }
 
-    private void addServicePaths(List<String> urls) {
+    private List<String> getServicePaths() {
         List<WorkflowPath> workflowPaths = serviceDAO.findAllPublishedPaths();
-        List<String> entryURLs = workflowPaths.stream().map(
+        return workflowPaths.stream().map(
             (WorkflowPath workflow) -> MetadataResourceHelper.createWorkflowURL(workflow, "service")).collect(Collectors.toList());
-        urls.addAll(entryURLs);
     }
 
     private String createOrganizationURL(Organization organization) {


### PR DESCRIPTION
The previous time for sitemap endpoint on my computer: ~22s
```
    131655220 nanoseconds spent preparing 21458 JDBC statements;
    23993594494 nanoseconds spent executing 21458 JDBC statements;
```
---
The current time for sitemap endpoint on my computer: 0.6s
Including `addOrganizationAndCollectionPaths`:
```
    14933820 nanoseconds spent preparing 16 JDBC statements;
    19391355 nanoseconds spent executing 16 JDBC statements;
```
Not including `addOrganizationAndCollectionPaths`:
```
    13138388 nanoseconds spent preparing 3 JDBC statements;
    10009398 nanoseconds spent executing 3 JDBC statements;
```

which is literally one statement for each of (tool, workflow, and service)

---
Simply don't grab the entire entity.

A weird way of doing it that retains some types.  Another way is to make a separate constructor. The benefit is it would remove the new workflow/tool path object and the extra path compute method.

I think a much better (type-safe) way is to just lazy load everything (results in 1.5s)  but that's probably going to break a lot of things.

Additionally:
- Removed the extra line separator at the end
- Sorted it (did it for testing purposes, can be reverted)
- Prepare to add services in there

Push cancelled