### PR TITLE
Feature/get org repos return object

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/Repository.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/Repository.java
@@ -7,14 +7,14 @@ package io.dockstore.common;
  */
 public class Repository {
     private String organization;
-    private String repository;
+    private String repositoryName;
     private SourceControl gitRegistry;
     private boolean isPresent;
     private boolean canDelete;
 
-    public Repository(String organization, String repository, SourceControl gitRegistry, boolean isPresent, boolean canDelete) {
+    public Repository(String organization, String repositoryName, SourceControl gitRegistry, boolean isPresent, boolean canDelete) {
         this.organization = organization;
-        this.repository = repository;
+        this.repositoryName = repositoryName;
         this.gitRegistry = gitRegistry;
         this.isPresent = isPresent;
         this.canDelete = canDelete;
@@ -28,12 +28,12 @@ public class Repository {
         this.organization = organization;
     }
 
-    public String getRepository() {
-        return repository;
+    public String getRepositoryName() {
+        return repositoryName;
     }
 
-    public void setRepository(String repository) {
-        this.repository = repository;
+    public void setRepositoryName(String repositoryName) {
+        this.repositoryName = repositoryName;
     }
 
     public SourceControl getGitRegistry() {
@@ -53,7 +53,7 @@ public class Repository {
     }
 
     public String getPath() {
-        return organization + "/" + repository;
+        return String.format("%s/%s", organization, repositoryName);
     }
 
     public boolean isCanDelete() {

--- a/dockstore-common/src/main/java/io/dockstore/common/Repository.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/Repository.java
@@ -1,0 +1,56 @@
+package io.dockstore.common;
+
+/**
+ * Class used by registration wizard to for toggle view
+ * @author aduncan
+ * @since 1.8.0
+ */
+public class Repository {
+    String organization;
+    String repository;
+    SourceControl gitRegistry;
+    boolean isPresent;
+
+    public Repository(String organization, String repository, SourceControl gitRegistry, boolean isPresent) {
+        this.organization = organization;
+        this.repository = repository;
+        this.gitRegistry = gitRegistry;
+        this.isPresent = isPresent;
+    }
+
+    public String getOrganization() {
+        return organization;
+    }
+
+    public void setOrganization(String organization) {
+        this.organization = organization;
+    }
+
+    public String getRepository() {
+        return repository;
+    }
+
+    public void setRepository(String repository) {
+        this.repository = repository;
+    }
+
+    public SourceControl getGitRegistry() {
+        return gitRegistry;
+    }
+
+    public void setGitRegistry(SourceControl gitRegistry) {
+        this.gitRegistry = gitRegistry;
+    }
+
+    public boolean isPresent() {
+        return isPresent;
+    }
+
+    public void setPresent(boolean present) {
+        isPresent = present;
+    }
+
+    public String getPath() {
+        return organization + "/" + repository;
+    }
+}

--- a/dockstore-common/src/main/java/io/dockstore/common/Repository.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/Repository.java
@@ -6,11 +6,11 @@ package io.dockstore.common;
  * @since 1.8.0
  */
 public class Repository {
-    String organization;
-    String repository;
-    SourceControl gitRegistry;
-    boolean isPresent;
-    boolean canDelete;
+    private String organization;
+    private String repository;
+    private SourceControl gitRegistry;
+    private boolean isPresent;
+    private boolean canDelete;
 
     public Repository(String organization, String repository, SourceControl gitRegistry, boolean isPresent, boolean canDelete) {
         this.organization = organization;

--- a/dockstore-common/src/main/java/io/dockstore/common/Repository.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/Repository.java
@@ -10,12 +10,14 @@ public class Repository {
     String repository;
     SourceControl gitRegistry;
     boolean isPresent;
+    boolean canDelete;
 
-    public Repository(String organization, String repository, SourceControl gitRegistry, boolean isPresent) {
+    public Repository(String organization, String repository, SourceControl gitRegistry, boolean isPresent, boolean canDelete) {
         this.organization = organization;
         this.repository = repository;
         this.gitRegistry = gitRegistry;
         this.isPresent = isPresent;
+        this.canDelete = canDelete;
     }
 
     public String getOrganization() {
@@ -52,5 +54,13 @@ public class Repository {
 
     public String getPath() {
         return organization + "/" + repository;
+    }
+
+    public boolean isCanDelete() {
+        return canDelete;
+    }
+
+    public void setCanDelete(boolean canDelete) {
+        this.canDelete = canDelete;
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -290,6 +290,13 @@ public class UserResourceIT extends BaseIT {
             assertNull("Workflow should be null", deletedWorkflow);
         }
 
+        // Try making a repo undeletable
+        ghWorkflow = workflowsApi.addWorkflow(SourceControl.GITHUB.name(), "dockstoretesting", "basic-workflow");
+        ghWorkflow = (BioWorkflow)workflowsApi.refresh(ghWorkflow.getId());
+        repositories = userApi.getUserOrganizationRepositories(SourceControl.GITHUB.name(), "dockstoretesting");
+        assertTrue(repositories.size() > 0);
+        assertTrue(repositories.stream().filter(repo -> Objects.equals(repo.getPath(), "dockstoretesting/basic-workflow") && repo.isPresent() && !repo.isCanDelete()).findAny().isPresent());
+
         // Test Gitlab
         orgs = userApi.getUserOrganizations(SourceControl.GITLAB.name());
         assertTrue(orgs.size() > 0);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -17,6 +17,7 @@
 package io.dockstore.webservice;
 
 import java.util.List;
+import java.util.Objects;
 
 import io.dockstore.client.cli.BaseIT;
 import io.dockstore.client.cli.SwaggerUtility;
@@ -33,6 +34,7 @@ import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.BioWorkflow;
 import io.swagger.client.model.Organization;
+import io.swagger.client.model.Repository;
 import io.swagger.client.model.User;
 import io.swagger.client.model.Workflow;
 import org.apache.http.HttpStatus;
@@ -262,15 +264,21 @@ public class UserResourceIT extends BaseIT {
         assertTrue(orgs.contains("DockstoreTestUser"));
         assertTrue(orgs.contains("DockstoreTestUser2"));
 
-        List<String> repositories = userApi.getUserOrganizationRepositories(SourceControl.GITHUB.name(), "dockstoretesting");
+        List<Repository> repositories = userApi.getUserOrganizationRepositories(SourceControl.GITHUB.name(), "dockstoretesting");
         assertTrue(repositories.size() > 0);
-        assertTrue(repositories.contains("dockstoretesting/basic-tool"));
-        assertTrue(repositories.contains("dockstoretesting/basic-workflow"));
+        assertTrue(repositories.stream().filter(repo -> Objects.equals(repo.getPath(), "dockstoretesting/basic-tool") && !repo.isPresent()).findAny().isPresent());
+        assertTrue(repositories.stream().filter(repo -> Objects.equals(repo.getPath(), "dockstoretesting/basic-workflow") && !repo.isPresent()).findAny().isPresent());
 
         // Register a workflow
         BioWorkflow ghWorkflow = workflowsApi.addWorkflow(SourceControl.GITHUB.name(), "dockstoretesting", "basic-workflow");
         assertNotNull("GitHub workflow should be added", ghWorkflow);
         assertEquals(ghWorkflow.getFullWorkflowPath(), "github.com/dockstoretesting/basic-workflow");
+
+        // dockstoretesting/basic-workflow should be present now
+        repositories = userApi.getUserOrganizationRepositories(SourceControl.GITHUB.name(), "dockstoretesting");
+        assertTrue(repositories.size() > 0);
+        assertTrue(repositories.stream().filter(repo -> Objects.equals(repo.getPath(), "dockstoretesting/basic-tool") && !repo.isPresent()).findAny().isPresent());
+        assertTrue(repositories.stream().filter(repo -> Objects.equals(repo.getPath(), "dockstoretesting/basic-workflow") && repo.isPresent()).findAny().isPresent());
 
         // Try deleting a workflow
         workflowsApi.deleteWorkflow(SourceControl.GITHUB.name(), "dockstoretesting", "basic-workflow");
@@ -289,12 +297,17 @@ public class UserResourceIT extends BaseIT {
 
         repositories = userApi.getUserOrganizationRepositories(SourceControl.GITLAB.name(), "dockstore.test.user2");
         assertTrue(repositories.size() > 0);
-        assertTrue(repositories.contains("dockstore.test.user2/dockstore-workflow-md5sum-unified"));
-        assertTrue(repositories.contains("dockstore.test.user2/dockstore-workflow-example"));
+        assertTrue(repositories.stream().filter(repo -> Objects.equals(repo.getPath(), "dockstore.test.user2/dockstore-workflow-md5sum-unified") && !repo.isPresent()).findAny().isPresent());
+        assertTrue(repositories.stream().filter(repo -> Objects.equals(repo.getPath(), "dockstore.test.user2/dockstore-workflow-example") && !repo.isPresent()).findAny().isPresent());
 
         // Register a workflow
         BioWorkflow glWorkflow = workflowsApi.addWorkflow(SourceControl.GITLAB.name(), "dockstore.test.user2", "dockstore-workflow-example");
         assertEquals(glWorkflow.getFullWorkflowPath(), "gitlab.com/dockstore.test.user2/dockstore-workflow-example");
+
+        // dockstore.test.user2/dockstore-workflow-example should be present now
+        repositories = userApi.getUserOrganizationRepositories(SourceControl.GITLAB.name(), "dockstore.test.user2");
+        assertTrue(repositories.size() > 0);
+        assertTrue(repositories.stream().filter(repo -> Objects.equals(repo.getPath(), "dockstore.test.user2/dockstore-workflow-example") && repo.isPresent()).findAny().isPresent());
 
         // Try registering the workflow again (duplicate) should fail
         try {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -292,7 +292,7 @@ public class UserResourceIT extends BaseIT {
 
         // Try making a repo undeletable
         ghWorkflow = workflowsApi.addWorkflow(SourceControl.GITHUB.name(), "dockstoretesting", "basic-workflow");
-        ghWorkflow = (BioWorkflow)workflowsApi.refresh(ghWorkflow.getId());
+        workflowsApi.refresh(ghWorkflow.getId());
         repositories = userApi.getUserOrganizationRepositories(SourceControl.GITHUB.name(), "dockstoretesting");
         assertTrue(repositories.size() > 0);
         assertTrue(repositories.stream().filter(repo -> Objects.equals(repo.getPath(), "dockstoretesting/basic-workflow") && repo.isPresent() && !repo.isCanDelete()).findAny().isPresent());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -770,7 +770,7 @@ public class UserResource implements AuthenticatedResourceInterface {
         return repositoryUrlToName.values().stream()
                 .filter(repository -> repository.startsWith(organization + "/"))
                 .map(repository -> new Repository(repository.split("/")[0], repository.split("/")[1], gitRegistry, workflowDAO.findByPath(gitRegistry + "/" + repository, false, BioWorkflow.class).isPresent(), canDeleteWorkflow(gitRegistry + "/" + repository)))
-                .sorted(Comparator.comparing(Repository::getRepository))
+                .sorted(Comparator.comparing(Repository::getRepositoryName))
                 .collect(Collectors.toList());
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -17,6 +17,7 @@
 package io.dockstore.webservice.resources;
 
 import java.text.MessageFormat;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -42,6 +43,7 @@ import javax.ws.rs.core.MediaType;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.Lists;
 import io.dockstore.common.Registry;
+import io.dockstore.common.Repository;
 import io.dockstore.common.SourceControl;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.api.Limits;
@@ -760,11 +762,15 @@ public class UserResource implements AuthenticatedResourceInterface {
     @Path("/registries/{gitRegistry}/organizations/{organization}")
     @Operation(operationId = "getUserOrganizationRepositories", description = "Get all of the repositories for an organization for a given git registry accessible to the logged in user.", security = @SecurityRequirement(name = "bearer"))
     @ApiOperation(value = "See OpenApi for details")
-    public Set<String> getUserOrganizationRepositories(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user", in = ParameterIn.HEADER) @Auth User authUser,
-                                            @Parameter(name = "gitRegistry", description = "Git registry", required = true, in = ParameterIn.PATH) @PathParam("gitRegistry") SourceControl gitRegistry,
-                                            @Parameter(name = "organization", description = "Git organization", required = true, in = ParameterIn.PATH) @PathParam("organization") String organization) {
+    public List<Repository> getUserOrganizationRepositories(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user", in = ParameterIn.HEADER) @Auth User authUser,
+                                                           @Parameter(name = "gitRegistry", description = "Git registry", required = true, in = ParameterIn.PATH) @PathParam("gitRegistry") SourceControl gitRegistry,
+                                                           @Parameter(name = "organization", description = "Git organization", required = true, in = ParameterIn.PATH) @PathParam("organization") String organization) {
         Map<String, String> repositoryUrlToName = getGitRepositoryMap(authUser, gitRegistry);
-        return repositoryUrlToName.values().stream().filter(repository -> repository.startsWith(organization + "/")).collect(Collectors.toSet());
+        return repositoryUrlToName.values().stream()
+                .filter(repository -> repository.startsWith(organization + "/"))
+                .map(repository -> new Repository(repository.split("/")[0], repository.split("/")[1], gitRegistry, workflowDAO.findByPath(gitRegistry + "/" + repository, false, BioWorkflow.class).isPresent()))
+                .sorted(Comparator.comparing(Repository::getRepository))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -783,10 +783,9 @@ public class UserResource implements AuthenticatedResourceInterface {
     private boolean canDeleteWorkflow(String path) {
         Optional<BioWorkflow> workflow = workflowDAO.findByPath(path, false, BioWorkflow.class);
         if (workflow.isPresent()) {
-            return Objects.equals(workflow.get().getMode(), WorkflowMode.STUB);
-        } else {
-            return false;
+            return workflow.get().getMode() == WorkflowMode.STUB;
         }
+        return false;
     }
 
     /**

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -2665,8 +2665,6 @@ paths:
           required: true
           schema:
             type: string
-      requestBody:
-        $ref: "#/components/requestBodies/updateLabelsBody"
       responses:
         "200":
           description: successful operation
@@ -3006,8 +3004,6 @@ paths:
           required: true
           schema:
             type: string
-      requestBody:
-        $ref: "#/components/requestBodies/updateLabelsBody"
       responses:
         "200":
           description: successful operation
@@ -3122,7 +3118,7 @@ paths:
     post:
       tags:
         - organizations
-      summary: Add aliases linked to an Organization in Dockstore.
+      summary: Add aliases linked to a listing in Dockstore.
       description: Aliases are alphanumerical (case-insensitive and may contain internal
         hyphens), given in a comma-delimited list.
       operationId: addOrganizationAliases
@@ -3140,8 +3136,6 @@ paths:
           required: true
           schema:
             type: string
-      requestBody:
-        $ref: "#/components/requestBodies/updateLabelsBody"
       responses:
         "200":
           description: successful operation
@@ -4003,8 +3997,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: string
-                uniqueItems: true
+                  $ref: "#/components/schemas/Repository"
   /users/services/sync:
     post:
       tags:
@@ -6596,10 +6589,6 @@ components:
         custom_docker_registry_path:
           type: string
           readOnly: true
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6615,6 +6604,10 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -6805,10 +6798,6 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/Version"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6824,6 +6813,10 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -7198,6 +7191,24 @@ components:
         customDockerPath:
           type: string
         enum:
+          type: string
+    Repository:
+      type: object
+      properties:
+        organization:
+          type: string
+        repository:
+          type: string
+        gitRegistry:
+          type: string
+          enum:
+            - dockstore.org
+            - github.com
+            - bitbucket.org
+            - gitlab.com
+        present:
+          type: boolean
+        path:
           type: string
     Service:
       allOf:
@@ -7951,10 +7962,6 @@ components:
           type: boolean
         parentEntry:
           $ref: "#/components/schemas/Entry"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -7970,6 +7977,10 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -7197,7 +7197,7 @@ components:
       properties:
         organization:
           type: string
-        repository:
+        repositoryName:
           type: string
         gitRegistry:
           type: string
@@ -7206,6 +7206,8 @@ components:
             - github.com
             - bitbucket.org
             - gitlab.com
+        canDelete:
+          type: boolean
         present:
           type: boolean
         path:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -888,7 +888,7 @@ components:
       properties:
         organization:
           type: string
-        repository:
+        repositoryName:
           type: string
         gitRegistry:
           type: string
@@ -897,6 +897,8 @@ components:
           - github.com
           - bitbucket.org
           - gitlab.com
+        canDelete:
+          type: boolean
         present:
           type: boolean
         path:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -41,20 +41,6 @@ paths:
                 $ref: '#/components/schemas/Entry'
       security:
       - bearer: []
-  /metadata/config.json:
-    get:
-      tags:
-      - metadata
-      summary: Configuration for UI clients of the API
-      description: Configuration, NO authentication
-      operationId: getConfig
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Config'
   /metadata/dockerRegistryList:
     get:
       tags:
@@ -209,6 +195,20 @@ paths:
           content:
             text/html: {}
             text/xml: {}
+  /metadata/config.json:
+    get:
+      tags:
+      - metadata
+      summary: Configuration for UI clients of the API
+      description: Configuration, NO authentication
+      operationId: getConfig
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Config'
   /toolTester/logs/search:
     get:
       tags:
@@ -406,10 +406,9 @@ paths:
           content:
             application/json:
               schema:
-                uniqueItems: true
                 type: array
                 items:
-                  type: string
+                  $ref: '#/components/schemas/Repository'
       security:
       - bearer: []
   /workflows/registries/{gitRegistry}/organizations/{organization}/repositories/{repositoryName}:
@@ -550,9 +549,6 @@ components:
         last_modified:
           type: integer
           format: int32
-        last_modified_date:
-          type: string
-          format: date-time
         checker_id:
           type: integer
           format: int64
@@ -568,6 +564,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
+        last_modified_date:
+          type: string
+          format: date-time
     FileFormat:
       type: object
       properties:
@@ -745,8 +744,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Validation'
-        workingDirectory:
-          type: string
         hidden:
           type: boolean
         verified:
@@ -765,6 +762,8 @@ components:
           - NOT_REQUESTED
           - REQUESTED
           - CREATED
+        workingDirectory:
+          type: string
         dbUpdateDate:
           type: string
           format: date-time
@@ -778,6 +777,35 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
+    RegistryBean:
+      type: object
+      properties:
+        dockerPath:
+          type: string
+        friendlyName:
+          type: string
+        url:
+          type: string
+        privateOnly:
+          type: string
+        customDockerPath:
+          type: string
+        enum:
+          type: string
+    SourceControlBean:
+      type: object
+      properties:
+        value:
+          type: string
+        friendlyName:
+          type: string
+    DescriptorLanguageBean:
+      type: object
+      properties:
+        value:
+          type: string
+        friendlyName:
+          type: string
     Config:
       type: object
       properties:
@@ -837,35 +865,6 @@ components:
           type: string
         discourseUrl:
           type: string
-    RegistryBean:
-      type: object
-      properties:
-        dockerPath:
-          type: string
-        friendlyName:
-          type: string
-        url:
-          type: string
-        privateOnly:
-          type: string
-        customDockerPath:
-          type: string
-        enum:
-          type: string
-    SourceControlBean:
-      type: object
-      properties:
-        value:
-          type: string
-        friendlyName:
-          type: string
-    DescriptorLanguageBean:
-      type: object
-      properties:
-        value:
-          type: string
-        friendlyName:
-          type: string
     ToolTesterLog:
       type: object
       properties:
@@ -883,6 +882,24 @@ components:
           - FULL
           - SUMMARY
         filename:
+          type: string
+    Repository:
+      type: object
+      properties:
+        organization:
+          type: string
+        repository:
+          type: string
+        gitRegistry:
+          type: string
+          enum:
+          - dockstore.org
+          - github.com
+          - bitbucket.org
+          - gitlab.com
+        present:
+          type: boolean
+        path:
           type: string
     BioWorkflow:
       type: object
@@ -940,6 +957,8 @@ components:
         topicId:
           type: integer
           format: int64
+        conceptDoi:
+          type: string
         mode:
           type: string
           enum:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -6864,7 +6864,7 @@ definitions:
     properties:
       organization:
         type: "string"
-      repository:
+      repositoryName:
         type: "string"
       gitRegistry:
         type: "string"
@@ -6873,6 +6873,8 @@ definitions:
         - "github.com"
         - "bitbucket.org"
         - "gitlab.com"
+      canDelete:
+        type: "boolean"
       present:
         type: "boolean"
       path:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -2439,13 +2439,6 @@ paths:
         description: "Comma-delimited list of aliases."
         required: true
         type: "string"
-      - in: "body"
-        name: "body"
-        description: "This is here to appease Swagger. It requires PUT methods to\
-          \ have a body, even if it is empty. Please leave it empty."
-        required: false
-        schema:
-          type: "string"
       responses:
         200:
           description: "successful operation"
@@ -2783,13 +2776,6 @@ paths:
         description: "Comma-delimited list of aliases."
         required: true
         type: "string"
-      - in: "body"
-        name: "body"
-        description: "This is here to appease Swagger. It requires PUT methods to\
-          \ have a body, even if it is empty. Please leave it empty."
-        required: false
-        schema:
-          type: "string"
       responses:
         200:
           description: "successful operation"
@@ -2897,7 +2883,7 @@ paths:
     post:
       tags:
       - "organizations"
-      summary: "Add aliases linked to an Organization in Dockstore."
+      summary: "Add aliases linked to a listing in Dockstore."
       description: "Aliases are alphanumerical (case-insensitive and may contain internal\
         \ hyphens), given in a comma-delimited list."
       operationId: "addOrganizationAliases"
@@ -2915,13 +2901,6 @@ paths:
         description: "Comma-delimited list of aliases."
         required: true
         type: "string"
-      - in: "body"
-        name: "body"
-        description: "This is here to appease Swagger. It requires PUT methods to\
-          \ have a body, even if it is empty. Please leave it empty."
-        required: false
-        schema:
-          type: "string"
       responses:
         200:
           description: "successful operation"
@@ -3744,8 +3723,7 @@ paths:
           schema:
             type: "array"
             items:
-              type: "string"
-            uniqueItems: true
+              $ref: "#/definitions/Repository"
   /users/services/sync:
     post:
       tags:
@@ -6211,10 +6189,6 @@ definitions:
       custom_docker_registry_path:
         type: "string"
         readOnly: true
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6230,6 +6204,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1
@@ -6447,10 +6425,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/Version"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6466,6 +6440,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1
@@ -6880,6 +6858,24 @@ definitions:
       customDockerPath:
         type: "string"
       enum:
+        type: "string"
+  Repository:
+    type: "object"
+    properties:
+      organization:
+        type: "string"
+      repository:
+        type: "string"
+      gitRegistry:
+        type: "string"
+        enum:
+        - "dockstore.org"
+        - "github.com"
+        - "bitbucket.org"
+        - "gitlab.com"
+      present:
+        type: "boolean"
+      path:
         type: "string"
   Service:
     allOf:
@@ -7708,10 +7704,6 @@ definitions:
         type: "boolean"
       parentEntry:
         $ref: "#/definitions/Entry"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -7727,6 +7719,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1


### PR DESCRIPTION
Previously the getOrganisationRepositoriesForUser was just returning a set of repository names (ex. dockstore/dockstore-ui2). I realized that the wizard GUI needs more information than this, so I now return a list of repository objects.

isPresent - is there an existing workflow in the database with the same repository org/name and same git registry
canDelete - can the workflow be deleted. For now only stubs can be deleted, this is open for discussion but I don't think is a blocker.