### PR TITLE
Consistent SearchResourceIT test

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -132,6 +132,7 @@ public class ElasticListener implements StateListenerInterface {
     private boolean checkValid(Entry entry, StateManagerMode command) {
         boolean published = entry.getIsPublished();
         switch (command) {
+        case PUBLISH:
         case UPDATE:
             if (published) {
                 return true;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -158,9 +158,8 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
 
     @Override
     public Response toolsIndexGet(SecurityContext securityContext) {
-        List<Entry> published = getPublished();
-        if (!config.getEsConfiguration().getHostname().isEmpty() && !published.isEmpty()) {
-
+        if (!config.getEsConfiguration().getHostname().isEmpty()) {
+            List<Entry> published = getPublished();
             try (RestClient restClient = RestClient
                     .builder(new HttpHost(config.getEsConfiguration().getHostname(), config.getEsConfiguration().getPort(), "http"))
                     .build()) {
@@ -181,8 +180,9 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
                 restClient.performRequest("PUT", "/entry", Collections.emptyMap(), mappingEntity);
 
                 // Populate index
-
-                publicStateManager.bulkUpsert(published);
+                if (!published.isEmpty()) {
+                    publicStateManager.bulkUpsert(published);
+                }
             } catch (IOException e) {
                 LOG.error("Could not create elastic search index", e);
                 throw new CustomWebApplicationException(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
This is the fix for my previous PR. Don't know how it managed to pass in the first place.

Functionality change for the indexing endpoint:

Previous: If there's nothing in the database, don't do anything
Now: If there's nothing in the database, destroy the index and create it, but don't attempt to bulk update

