### PR TITLE
sort versions by last modified date

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -16,12 +16,6 @@
 
 package io.dockstore.webservice.core;
 
-import java.util.Date;
-import java.util.Objects;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
@@ -29,6 +23,11 @@ import com.google.common.collect.Ordering;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.apache.commons.io.FilenameUtils;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import java.util.Date;
+import java.util.Objects;
 
 /**
  * This implements version for a Workflow.
@@ -115,7 +114,9 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
 
     @Override
     public int compareTo(WorkflowVersion that) {
-        return ComparisonChain.start().compare(this.getName(), that.getName(), Ordering.natural().nullsLast())
+        return ComparisonChain.start()
+                .compare(this.getLastModified(), that.getLastModified(), Ordering.natural().reverse().nullsLast())
+                .compare(this.getName(), that.getName(), Ordering.natural().nullsLast())
                 .compare(this.getReference(), that.getReference(), Ordering.natural().nullsLast()).result();
     }
 


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/2415
Orders workflow versions by last modified date first. This ensures expected order for both hosted and remote workflow versions.