### PR TITLE
Remove old verification endpoints

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSIT.java
@@ -230,24 +230,6 @@ public class ExtendedTRSIT extends BaseIT {
             "2.0.0");
         Assert.assertEquals("CRUMMY_PLATFORM has the wrong version", ((Map)stringObjectMap.get(CRUMMY_PLATFORM)).get("platformVersion"),
             "1.0.0");
-
-        assertNotOutOfSync(toolId, toolApi, ga4GhApi);
-
-        // Purposely mess up the verification (no longer in sync with sourcefile verification)
-        testingPostgres.runUpdateStatement("UPDATE version_metadata set verified=false");
-        testingPostgres.runUpdateStatement("UPDATE version_metadata set verifiedsource=null");
-
-        assertOutOfSync(toolId, toolApi, ga4GhApi);
-
-        // Sync tool back
-        containertagsApi.verifyToolTag(toolId, tagId);
-
-        assertNotOutOfSync(toolId, toolApi, ga4GhApi);
-
-        // Sync again
-        containertagsApi.verifyToolTag(toolId, tagId);
-
-        assertNotOutOfSync(toolId, toolApi, ga4GhApi);
     }
 
     private Tag getSpecificVersion(DockstoreTool dockstoreTool) {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -380,38 +380,6 @@ public class SwaggerClientIT extends BaseIT {
     }
 
     @Test
-    public void testGetVerifiedSpecificTool() throws ApiException {
-        ApiClient client = getAdminWebClient();
-        Ga4Ghv1Api toolApi = new Ga4Ghv1Api(client);
-        ContainersApi containersApi = new ContainersApi(client);
-        ContainertagsApi containertagsApi = new ContainertagsApi(client);
-        // register one more to give us something to look at
-        DockstoreTool c = getContainer();
-        final DockstoreTool dockstoreTool = containersApi.registerManual(c);
-
-        io.swagger.client.model.ToolV1 tool = toolApi.toolsIdGet(REGISTRY_HUB_DOCKER_COM_SEQWARE_SEQWARE);
-        assertNotNull(tool);
-        assertEquals(tool.getId(), REGISTRY_HUB_DOCKER_COM_SEQWARE_SEQWARE);
-        List<Tag> tags = containertagsApi.getTagsByPath(dockstoreTool.getId());
-        assertEquals(1, tags.size());
-        Tag tag = tags.get(0);
-
-        // verify master branch
-        assertFalse(tag.isVerified());
-        assertEquals(new ArrayList<>(), tag.getVerifiedSources());
-
-        containertagsApi.verifyToolTag(dockstoreTool.getId(), tag.getId());
-
-        // check again
-        tags = containertagsApi.getTagsByPath(dockstoreTool.getId());
-        tag = tags.get(0);
-
-        // The tag verification endpoint does nothing unless the extended TRS endpoint was used to verify
-        assertFalse(tag.isVerified());
-        assertEquals(new ArrayList<>(), tag.getVerifiedSources());
-    }
-
-    @Test
     public void testGetFiles() throws IOException, ApiException {
         ApiClient client = getAdminWebClient();
         Ga4Ghv1Api toolApi = new Ga4Ghv1Api(client);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoTagResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoTagResource.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -196,29 +195,6 @@ public class DockerRepoTagResource implements AuthenticatedResourceInterface {
             LOG.error(user.getUsername() + ": could not find tag: " + tagId + " in " + tool.getToolPath());
             throw new CustomWebApplicationException("Tag not found.", HttpStatus.SC_BAD_REQUEST);
         }
-    }
-
-    @POST
-    @Timed
-    @UnitOfWork
-    @Path("/{containerId}/verify/{tagId}")
-    @RolesAllowed("admin")
-    @ApiOperation(value = "Updates the verification status of a version. ADMIN ONLY", authorizations = {
-            @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tag.class, responseContainer = "List")
-    public Set<Tag> verifyToolTag(@ApiParam(hidden = true) @Auth User user,
-            @ApiParam(value = "ID of the tool to update.", required = true) @PathParam("containerId") Long containerId,
-            @ApiParam(value = "ID of the tag to update.", required = true) @PathParam("tagId") Long tagId) {
-        Tool tool = findToolByIdAndCheckToolAndUser(containerId, user);
-        Tag tag = tagDAO.findById(tagId);
-        if (tag == null) {
-            LOG.error(user.getUsername() + ": could not find tag: " + tool.getToolPath());
-            throw new CustomWebApplicationException("Tag not found.", HttpStatus.SC_BAD_REQUEST);
-        }
-        tag.updateVerified();
-        Tool result = toolDAO.findById(containerId);
-        checkEntry(result);
-        PublicStateManager.getInstance().handleIndexUpdate(result, StateManagerMode.UPDATE);
-        return result.getWorkflowVersions();
     }
 
     @POST

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -531,30 +531,6 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         }
     }
 
-    @POST
-    @Timed
-    @UnitOfWork
-    @Path("/{workflowId}/verify/{workflowVersionId}")
-    @RolesAllowed("admin")
-    @ApiOperation(value = "Updates the verification status of a version. ADMIN ONLY", authorizations = {
-        @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = WorkflowVersion.class, responseContainer = "List")
-    public Set<WorkflowVersion> verifyWorkflowVersion(@ApiParam(hidden = true) @Auth User user,
-        @ApiParam(value = "ID of the workflow to update.", required = true) @PathParam("workflowId") Long workflowId,
-        @ApiParam(value = "Id of the version to update.", required = true) @PathParam("workflowVersionId") Long workflowVersionId) {
-        Workflow workflow = findWorkflowByIdAndCheckWorkflowAndUser(workflowId, user);
-        WorkflowVersion workflowVersion = workflowVersionDAO.findById(workflowVersionId);
-        if (workflowVersion == null) {
-            LOG.error(user.getUsername() + ": could not find version: " + workflow.getWorkflowPath());
-            throw new CustomWebApplicationException("Version not found.", HttpStatus.SC_BAD_REQUEST);
-        }
-        workflowVersion.updateVerified();
-        Workflow result = workflowDAO.findById(workflowId);
-        checkEntry(result);
-        PublicStateManager.getInstance().handleIndexUpdate(result, StateManagerMode.UPDATE);
-        return result.getWorkflowVersions();
-    }
-
-
     /**
      * Get the Zenodo access token and refresh it if necessary
      * @param user Dockstore with Zenodo account

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.8.0-alpha.2-SNAPSHOT
+  version: 1.8.0-alpha.3-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:
@@ -2555,6 +2555,7 @@ paths:
           description: successful operation
       security:
         - BEARER: []
+      deprecated: true
   "/containers/{containerId}/updateTagPaths":
     put:
       tags:
@@ -2606,39 +2607,6 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/User"
-      security:
-        - BEARER: []
-  "/containers/{containerId}/verify/{tagId}":
-    post:
-      tags:
-        - containertags
-      summary: Updates the verification status of a version. ADMIN ONLY
-      description: ""
-      operationId: verifyToolTag
-      parameters:
-        - name: containerId
-          in: path
-          description: ID of the tool to update.
-          required: true
-          schema:
-            type: integer
-            format: int64
-        - name: tagId
-          in: path
-          description: ID of the tag to update.
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        "200":
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Tag"
       security:
         - BEARER: []
   "/containers/{toolId}/defaultVersion":
@@ -6321,6 +6289,7 @@ paths:
           description: successful operation
       security:
         - BEARER: []
+      deprecated: true
   "/workflows/{workflowId}/users":
     get:
       tags:
@@ -6345,39 +6314,6 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/User"
-      security:
-        - BEARER: []
-  "/workflows/{workflowId}/verify/{workflowVersionId}":
-    post:
-      tags:
-        - workflows
-      summary: Updates the verification status of a version. ADMIN ONLY
-      description: ""
-      operationId: verifyWorkflowVersion
-      parameters:
-        - name: workflowId
-          in: path
-          description: ID of the workflow to update.
-          required: true
-          schema:
-            type: integer
-            format: int64
-        - name: workflowVersionId
-          in: path
-          description: Id of the version to update.
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        "200":
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/WorkflowVersion"
       security:
         - BEARER: []
   "/workflows/{workflowId}/workflowVersions":
@@ -6512,184 +6448,17 @@ components:
         content:
           type: string
     BioWorkflow:
-      type: object
-      required:
-        - defaultTestParameterFilePath
-        - descriptorType
-        - gitUrl
-        - mode
-        - organization
-        - repository
-        - sourceControl
-        - workflow_path
-      properties:
-        id:
-          type: integer
-          format: int64
-          description: Implementation specific ID for the container in this web service
-        aliases:
-          type: object
-          description: aliases can be used as an alternate unique id for entries
-          additionalProperties:
-            $ref: "#/components/schemas/Alias"
-        dbCreateDate:
-          type: string
-          format: date-time
-        dbUpdateDate:
-          type: string
-          format: date-time
-        topicId:
-          type: integer
-          format: int64
-          description: The Id of the corresponding topic on Dockstore Discuss
-        parent_id:
-          type: integer
-          format: int64
-          readOnly: true
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
-        has_checker:
-          type: boolean
-          readOnly: true
-        input_file_formats:
-          type: array
-          readOnly: true
-          uniqueItems: true
-          items:
-            $ref: "#/components/schemas/FileFormat"
-        output_file_formats:
-          type: array
-          readOnly: true
-          uniqueItems: true
-          items:
-            $ref: "#/components/schemas/FileFormat"
-        author:
-          type: string
-          description: This is the name of the author stated in the Dockstore.cwl
-        description:
-          type: string
-          description: This is a human-readable description of this container and what it
-            is trying to accomplish, required GA4GH
-        labels:
-          type: array
-          description: Labels (i.e. meta tags) for describing the purpose and contents of
-            containers
-          uniqueItems: true
-          items:
-            $ref: "#/components/schemas/Label"
-        users:
-          type: array
-          description: This indicates the users that have control over this entry,
-            dockstore specific
-          uniqueItems: true
-          items:
-            $ref: "#/components/schemas/User"
-        starredUsers:
-          type: array
-          description: This indicates the users that have starred this entry, dockstore
-            specific
-          uniqueItems: true
-          items:
-            $ref: "#/components/schemas/User"
-        email:
-          type: string
-          description: This is the email of the git organization
-        defaultVersion:
-          type: string
-          description: This is the default version of the entry
-        is_published:
-          type: boolean
-          description: Implementation specific visibility in this web service
-        last_modified:
-          type: integer
-          format: int32
-          description: "Implementation specific timestamp for last modified. Tools-> For
-            automated/manual builds: N/A. For hosted: Last time a file was
-            updated/created (new version created). Workflows-> For remote: When
-            refresh is hit, last time GitHub repo was changed. Hosted: Last time
-            a new version was made."
-        lastUpdated:
-          type: string
-          format: date-time
-          description: "Implementation specific timestamp for last updated on webservice.
-            Tools-> For automated builds: last time tool/namespace was refreshed
-            Dockstore, tool info (like changing dockerfile path) updated, or
-            default version selected. For hosted tools: when you created the
-            tool. Workflows-> For remote: When refresh all is hit for first
-            time. Hosted: Seems to be time created."
-        gitUrl:
-          type: string
-          description: This is a link to the associated repo with a descriptor, required
-            GA4GH
-        checker_id:
-          type: integer
-          format: int64
-          description: The id of the associated checker workflow
-          readOnly: true
-        conceptDoi:
-          type: string
-          description: The Digital Object Identifier (DOI) representing all of the versions
-            of your workflow
-        mode:
-          type: string
-          description: This indicates what mode this is in which informs how we do things
-            like refresh, dockstore specific
-          enum:
-            - FULL
-            - STUB
-            - HOSTED
-            - SERVICE
-        workflowName:
-          type: string
-          description: This is the name of the workflow, not needed when only one workflow
-            in a repo
-        organization:
-          type: string
-          description: This is a git organization for the workflow
-        repository:
-          type: string
-          description: This is a git repository name
-        sourceControl:
-          type: string
-          description: "This is a specific source control provider like github or bitbucket
-            or n/a?, required: GA4GH"
-        descriptorType:
-          type: string
-          description: This is a descriptor type for the workflow, either CWL, WDL, or
-            Nextflow (Defaults to CWL)
-          enum:
-            - CWL
-            - WDL
-            - NFL
-            - service
-        workflow_path:
-          type: string
-          description: This indicates for the associated git repository, the default path
-            to the primary descriptor document
-        defaultTestParameterFilePath:
-          type: string
-          description: This indicates for the associated git repository, the default path
-            to the test parameter file
-        workflowVersions:
-          type: array
-          description: Implementation specific tracking of valid build workflowVersions for
-            the docker container
-          uniqueItems: true
-          items:
-            $ref: "#/components/schemas/WorkflowVersion"
-        is_checker:
-          type: boolean
-        full_workflow_path:
-          type: string
-          readOnly: true
-        path:
-          type: string
-        source_control_provider:
-          type: string
-          readOnly: true
-      description: This describes one workflow in the dockstore
+      allOf:
+        - $ref: "#/components/schemas/Workflow"
+        - type: object
+          properties:
+            parent_id:
+              type: integer
+              format: int64
+              readOnly: true
+            is_checker:
+              type: boolean
+          description: This describes one workflow in the dockstore
     Checksum:
       type: object
       properties:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -41,6 +41,55 @@ paths:
                 $ref: '#/components/schemas/Entry'
       security:
       - bearer: []
+  /metadata/config.json:
+    get:
+      tags:
+      - metadata
+      summary: Configuration for UI clients of the API
+      description: Configuration, NO authentication
+      operationId: getConfig
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Config'
+  /metadata/sitemap:
+    get:
+      tags:
+      - metadata
+      summary: List all available workflow, tool, organization, and collection paths.
+      description: List all available workflow, tool, organization, and collection
+        paths. Available means published for tools/workflows, and approved for organizations
+        and their respective collections. NO authentication
+      operationId: sitemap
+      responses:
+        default:
+          description: default response
+          content:
+            text/html:
+              schema:
+                type: string
+            text/xml:
+              schema:
+                type: string
+  /metadata/sourceControlList:
+    get:
+      tags:
+      - metadata
+      summary: Get the list of source controls supported on Dockstore
+      description: Get the list of source controls supported on Dockstore, NO authentication
+      operationId: getSourceControlList
+      responses:
+        default:
+          description: List of source control repositories
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SourceControlBean'
   /metadata/descriptorLanguageList:
     get:
       tags:
@@ -144,22 +193,6 @@ paths:
             application/json:
               schema:
                 type: string
-  /metadata/sourceControlList:
-    get:
-      tags:
-      - metadata
-      summary: Get the list of source controls supported on Dockstore
-      description: Get the list of source controls supported on Dockstore, NO authentication
-      operationId: getSourceControlList
-      responses:
-        default:
-          description: List of source control repositories
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/SourceControlBean'
   /metadata/dockerRegistryList:
     get:
       tags:
@@ -176,39 +209,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/RegistryBean'
-  /metadata/config.json:
-    get:
-      tags:
-      - metadata
-      summary: Configuration for UI clients of the API
-      description: Configuration, NO authentication
-      operationId: getConfig
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Config'
-  /metadata/sitemap:
-    get:
-      tags:
-      - metadata
-      summary: List all available workflow, tool, organization, and collection paths.
-      description: List all available workflow, tool, organization, and collection
-        paths. Available means published for tools/workflows, and approved for organizations
-        and their respective collections. NO authentication
-      operationId: sitemap
-      responses:
-        default:
-          description: default response
-          content:
-            text/html:
-              schema:
-                type: string
-            text/xml:
-              schema:
-                type: string
   /toolTester/logs/search:
     get:
       tags:
@@ -328,6 +328,61 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+  /users/users/organizations:
+    get:
+      description: Get all of the Dockstore organizations for a user, sorted by most
+        recently updated.
+      operationId: getUserDockstoreOrganizations
+      parameters:
+      - name: count
+        in: query
+        description: Maximum number of organizations to return
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        description: Filter paths with matching text
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OrganizationUpdateTime'
+      security:
+      - bearer: []
+  /users/users/entries:
+    get:
+      description: Get all of the entries for a user, sorted by most recently updated.
+      operationId: getUserEntries
+      parameters:
+      - name: count
+        in: query
+        description: Maximum number of entries to return
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        description: Filter paths with matching text
+        schema:
+          type: string
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EntryUpdateTime'
+      security:
+      - bearer: []
   /users/registries:
     get:
       description: Get all of the git registries accessible to the logged in user.
@@ -409,61 +464,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Repository'
-      security:
-      - bearer: []
-  /users/users/organizations:
-    get:
-      description: Get all of the Dockstore organizations for a user, sorted by most
-        recently updated.
-      operationId: getUserDockstoreOrganizations
-      parameters:
-      - name: count
-        in: query
-        description: Maximum number of organizations to return
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        description: Filter paths with matching text
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/OrganizationUpdateTime'
-      security:
-      - bearer: []
-  /users/users/entries:
-    get:
-      description: Get all of the entries for a user, sorted by most recently updated.
-      operationId: getUserEntries
-      parameters:
-      - name: count
-        in: query
-        description: Maximum number of entries to return
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        description: Filter paths with matching text
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/EntryUpdateTime'
       security:
       - bearer: []
   /workflows/registries/{gitRegistry}/organizations/{organization}/repositories/{repositoryName}:
@@ -740,6 +740,9 @@ components:
           format: date-time
         name:
           type: string
+        tosacceptanceDate:
+          type: string
+          format: date-time
         tosversion:
           type: string
           enum:
@@ -749,9 +752,6 @@ components:
           type: string
           format: date-time
           writeOnly: true
-        tosacceptanceDate:
-          type: string
-          format: date-time
     Validation:
       type: object
       properties:
@@ -837,8 +837,6 @@ components:
           type: string
         email:
           type: string
-        doiURL:
-          type: string
         verified:
           type: boolean
         verifiedSource:
@@ -847,6 +845,8 @@ components:
           type: array
           items:
             type: string
+        doiURL:
+          type: string
         doiStatus:
           type: string
           enum:
@@ -873,35 +873,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
-    DescriptorLanguageBean:
-      type: object
-      properties:
-        value:
-          type: string
-        friendlyName:
-          type: string
-    SourceControlBean:
-      type: object
-      properties:
-        value:
-          type: string
-        friendlyName:
-          type: string
-    RegistryBean:
-      type: object
-      properties:
-        dockerPath:
-          type: string
-        friendlyName:
-          type: string
-        url:
-          type: string
-        privateOnly:
-          type: string
-        customDockerPath:
-          type: string
-        enum:
-          type: string
     Config:
       type: object
       properties:
@@ -963,6 +934,35 @@ components:
           type: string
         discourseUrl:
           type: string
+    SourceControlBean:
+      type: object
+      properties:
+        value:
+          type: string
+        friendlyName:
+          type: string
+    DescriptorLanguageBean:
+      type: object
+      properties:
+        value:
+          type: string
+        friendlyName:
+          type: string
+    RegistryBean:
+      type: object
+      properties:
+        dockerPath:
+          type: string
+        friendlyName:
+          type: string
+        url:
+          type: string
+        privateOnly:
+          type: string
+        customDockerPath:
+          type: string
+        enum:
+          type: string
     ToolTesterLog:
       type: object
       properties:
@@ -980,26 +980,6 @@ components:
           - FULL
           - SUMMARY
         filename:
-          type: string
-    Repository:
-      type: object
-      properties:
-        organization:
-          type: string
-        repositoryName:
-          type: string
-        gitRegistry:
-          type: string
-          enum:
-          - dockstore.org
-          - github.com
-          - bitbucket.org
-          - gitlab.com
-        canDelete:
-          type: boolean
-        present:
-          type: boolean
-        path:
           type: string
     OrganizationUpdateTime:
       type: object
@@ -1025,6 +1005,26 @@ components:
         lastUpdateDate:
           type: string
           format: date-time
+    Repository:
+      type: object
+      properties:
+        organization:
+          type: string
+        repositoryName:
+          type: string
+        gitRegistry:
+          type: string
+          enum:
+          - dockstore.org
+          - github.com
+          - bitbucket.org
+          - gitlab.com
+        canDelete:
+          type: boolean
+        present:
+          type: boolean
+        path:
+          type: string
     BioWorkflow:
       type: object
       properties:
@@ -1124,13 +1124,13 @@ components:
         parent_id:
           type: integer
           format: int64
-        workflow_path:
-          type: string
         full_workflow_path:
           type: string
-        defaultTestParameterFilePath:
-          type: string
         source_control_provider:
+          type: string
+        workflow_path:
+          type: string
+        defaultTestParameterFilePath:
           type: string
         last_modified_date:
           type: string
@@ -1241,10 +1241,10 @@ components:
             $ref: '#/components/schemas/WorkflowVersion'
         path:
           type: string
-        isChecker:
-          type: boolean
         parentEntry:
           $ref: '#/components/schemas/Entry'
+        isChecker:
+          type: boolean
         metadataFromEntry:
           $ref: '#/components/schemas/Workflow'
         metadataFromVersion:
@@ -1254,13 +1254,13 @@ components:
         last_modified:
           type: integer
           format: int32
-        workflow_path:
-          type: string
         full_workflow_path:
           type: string
-        defaultTestParameterFilePath:
-          type: string
         source_control_provider:
+          type: string
+        workflow_path:
+          type: string
+        defaultTestParameterFilePath:
           type: string
         last_modified_date:
           type: string
@@ -1328,6 +1328,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Image'
+        aliases:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Alias'
         subClass:
           type: string
           enum:
@@ -1343,8 +1347,6 @@ components:
           type: string
         email:
           type: string
-        doiURL:
-          type: string
         verified:
           type: boolean
         verifiedSource:
@@ -1353,6 +1355,8 @@ components:
           type: array
           items:
             type: string
+        doiURL:
+          type: string
         doiStatus:
           type: string
           enum:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.8.0-alpha.2-SNAPSHOT"
+  version: "1.8.0-alpha.3-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:
@@ -2328,6 +2328,7 @@ paths:
           description: "successful operation"
       security:
       - BEARER: []
+      deprecated: true
   /containers/{containerId}/updateTagPaths:
     put:
       tags:
@@ -2381,37 +2382,6 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/User"
-      security:
-      - BEARER: []
-  /containers/{containerId}/verify/{tagId}:
-    post:
-      tags:
-      - "containertags"
-      summary: "Updates the verification status of a version. ADMIN ONLY"
-      description: ""
-      operationId: "verifyToolTag"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "containerId"
-        in: "path"
-        description: "ID of the tool to update."
-        required: true
-        type: "integer"
-        format: "int64"
-      - name: "tagId"
-        in: "path"
-        description: "ID of the tag to update."
-        required: true
-        type: "integer"
-        format: "int64"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Tag"
       security:
       - BEARER: []
   /containers/{toolId}/defaultVersion:
@@ -5972,6 +5942,7 @@ paths:
           description: "successful operation"
       security:
       - BEARER: []
+      deprecated: true
   /workflows/{workflowId}/users:
     get:
       tags:
@@ -5995,37 +5966,6 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/User"
-      security:
-      - BEARER: []
-  /workflows/{workflowId}/verify/{workflowVersionId}:
-    post:
-      tags:
-      - "workflows"
-      summary: "Updates the verification status of a version. ADMIN ONLY"
-      description: ""
-      operationId: "verifyWorkflowVersion"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "workflowId"
-        in: "path"
-        description: "ID of the workflow to update."
-        required: true
-        type: "integer"
-        format: "int64"
-      - name: "workflowVersionId"
-        in: "path"
-        description: "Id of the version to update."
-        required: true
-        type: "integer"
-        format: "int64"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/WorkflowVersion"
       security:
       - BEARER: []
   /workflows/{workflowId}/workflowVersions:
@@ -6100,209 +6040,18 @@ definitions:
       content:
         type: "string"
   BioWorkflow:
-    type: "object"
-    required:
-    - "defaultTestParameterFilePath"
-    - "descriptorType"
-    - "gitUrl"
-    - "mode"
-    - "organization"
-    - "repository"
-    - "sourceControl"
-    - "workflow_path"
-    properties:
-      id:
-        type: "integer"
-        format: "int64"
-        description: "Implementation specific ID for the container in this web service"
-      aliases:
-        type: "object"
-        description: "aliases can be used as an alternate unique id for entries"
-        additionalProperties:
-          $ref: "#/definitions/Alias"
-      dbCreateDate:
-        type: "string"
-        format: "date-time"
-      dbUpdateDate:
-        type: "string"
-        format: "date-time"
-      topicId:
-        type: "integer"
-        format: "int64"
-        description: "The Id of the corresponding topic on Dockstore Discuss"
-      parent_id:
-        type: "integer"
-        format: "int64"
-        readOnly: true
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
-      has_checker:
-        type: "boolean"
-        readOnly: true
-      input_file_formats:
-        type: "array"
-        readOnly: true
-        uniqueItems: true
-        items:
-          $ref: "#/definitions/FileFormat"
-      output_file_formats:
-        type: "array"
-        readOnly: true
-        uniqueItems: true
-        items:
-          $ref: "#/definitions/FileFormat"
-      author:
-        type: "string"
-        position: 1
-        description: "This is the name of the author stated in the Dockstore.cwl"
-      description:
-        type: "string"
-        position: 2
-        description: "This is a human-readable description of this container and what\
-          \ it is trying to accomplish, required GA4GH"
-      labels:
-        type: "array"
-        position: 3
-        description: "Labels (i.e. meta tags) for describing the purpose and contents\
-          \ of containers"
-        uniqueItems: true
-        items:
-          $ref: "#/definitions/Label"
-      users:
-        type: "array"
-        position: 4
-        description: "This indicates the users that have control over this entry,\
-          \ dockstore specific"
-        uniqueItems: true
-        items:
-          $ref: "#/definitions/User"
-      starredUsers:
-        type: "array"
-        position: 5
-        description: "This indicates the users that have starred this entry, dockstore\
-          \ specific"
-        uniqueItems: true
-        items:
-          $ref: "#/definitions/User"
-      email:
-        type: "string"
-        position: 6
-        description: "This is the email of the git organization"
-      defaultVersion:
-        type: "string"
-        position: 7
-        description: "This is the default version of the entry"
-      is_published:
-        type: "boolean"
-        position: 8
-        description: "Implementation specific visibility in this web service"
-      last_modified:
-        type: "integer"
-        format: "int32"
-        position: 9
-        description: "Implementation specific timestamp for last modified. Tools->\
-          \ For automated/manual builds: N/A. For hosted: Last time a file was updated/created\
-          \ (new version created). Workflows-> For remote: When refresh is hit, last\
-          \ time GitHub repo was changed. Hosted: Last time a new version was made."
-      lastUpdated:
-        type: "string"
-        format: "date-time"
-        position: 10
-        description: "Implementation specific timestamp for last updated on webservice.\
-          \ Tools-> For automated builds: last time tool/namespace was refreshed Dockstore,\
-          \ tool info (like changing dockerfile path) updated, or default version\
-          \ selected. For hosted tools: when you created the tool. Workflows-> For\
-          \ remote: When refresh all is hit for first time. Hosted: Seems to be time\
-          \ created."
-      gitUrl:
-        type: "string"
-        position: 11
-        description: "This is a link to the associated repo with a descriptor, required\
-          \ GA4GH"
-      checker_id:
-        type: "integer"
-        format: "int64"
-        position: 12
-        description: "The id of the associated checker workflow"
-        readOnly: true
-      conceptDoi:
-        type: "string"
-        position: 13
-        description: "The Digital Object Identifier (DOI) representing all of the\
-          \ versions of your workflow"
-      mode:
-        type: "string"
-        position: 13
-        description: "This indicates what mode this is in which informs how we do\
-          \ things like refresh, dockstore specific"
-        enum:
-        - "FULL"
-        - "STUB"
-        - "HOSTED"
-        - "SERVICE"
-      workflowName:
-        type: "string"
-        position: 14
-        description: "This is the name of the workflow, not needed when only one workflow\
-          \ in a repo"
-      organization:
-        type: "string"
-        position: 15
-        description: "This is a git organization for the workflow"
-      repository:
-        type: "string"
-        position: 16
-        description: "This is a git repository name"
-      sourceControl:
-        type: "string"
-        position: 17
-        description: "This is a specific source control provider like github or bitbucket\
-          \ or n/a?, required: GA4GH"
-      descriptorType:
-        type: "string"
-        position: 18
-        description: "This is a descriptor type for the workflow, either CWL, WDL,\
-          \ or Nextflow (Defaults to CWL)"
-        enum:
-        - "CWL"
-        - "WDL"
-        - "NFL"
-        - "service"
-      workflow_path:
-        type: "string"
-        position: 19
-        description: "This indicates for the associated git repository, the default\
-          \ path to the primary descriptor document"
-      defaultTestParameterFilePath:
-        type: "string"
-        position: 20
-        description: "This indicates for the associated git repository, the default\
-          \ path to the test parameter file"
-      workflowVersions:
-        type: "array"
-        position: 21
-        description: "Implementation specific tracking of valid build workflowVersions\
-          \ for the docker container"
-        uniqueItems: true
-        items:
-          $ref: "#/definitions/WorkflowVersion"
-      is_checker:
-        type: "boolean"
-        position: 23
-      full_workflow_path:
-        type: "string"
-        position: 24
-        readOnly: true
-      path:
-        type: "string"
-        position: 25
-      source_control_provider:
-        type: "string"
-        position: 26
-        readOnly: true
-    description: "This describes one workflow in the dockstore"
+    allOf:
+    - $ref: "#/definitions/Workflow"
+    - type: "object"
+      properties:
+        parent_id:
+          type: "integer"
+          format: "int64"
+          readOnly: true
+        is_checker:
+          type: "boolean"
+          position: 23
+      description: "This describes one workflow in the dockstore"
   Checksum:
     type: "object"
     properties:


### PR DESCRIPTION
For dockstore/dockstore#2777

Remove old verification endpoints in favour of the new one.

This does remove some small functionality though.  Previously it was modified into an endpoint that kind of synchronizes the version verification status (in the event something caused it to go out of sync with the file verification status).