### PR TITLE
Deprecate unstar, modify star to become restful

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -926,7 +926,11 @@ public class DockerRepoResource
         @ApiParam(value = "Tool to star.", required = true) @PathParam("containerId") Long containerId,
         @ApiParam(value = "StarRequest to star a repo for a user", required = true) StarRequest request) {
         Tool tool = toolDAO.findById(containerId);
-        starEntryHelper(tool, user, "tool", tool.getToolPath());
+        if (request.getStar()) {
+            starEntryHelper(tool, user, "tool", tool.getToolPath());
+        } else {
+            unstarEntryHelper(tool, user, "tool", tool.getToolPath());
+        }
         PublicStateManager.getInstance().handleIndexUpdate(tool, StateManagerMode.UPDATE);
     }
 
@@ -935,8 +939,9 @@ public class DockerRepoResource
     @UnitOfWork
     @Path("/{containerId}/unstar")
     @ApiOperation(value = "Unstar a tool.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
+    @Deprecated(since = "1.8.0")
     public void unstarEntry(@ApiParam(hidden = true) @Auth User user,
-        @ApiParam(value = "Tool to unstar.", required = true) @PathParam("containerId") Long containerId) {
+            @ApiParam(value = "Tool to unstar.", required = true) @PathParam("containerId") Long containerId) {
         Tool tool = toolDAO.findById(containerId);
         unstarEntryHelper(tool, user, "tool", tool.getToolPath());
         PublicStateManager.getInstance().handleIndexUpdate(tool, StateManagerMode.UPDATE);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1439,8 +1439,11 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         @ApiParam(value = "Tool to star.", required = true) @PathParam("workflowId") Long workflowId,
         @ApiParam(value = "StarRequest to star a repo for a user", required = true) StarRequest request) {
         Workflow workflow = workflowDAO.findById(workflowId);
-
-        starEntryHelper(workflow, user, "workflow", workflow.getWorkflowPath());
+        if (request.getStar()) {
+            starEntryHelper(workflow, user, "workflow", workflow.getWorkflowPath());
+        } else {
+            unstarEntryHelper(workflow, user, "workflow", workflow.getWorkflowPath());
+        }
         PublicStateManager.getInstance().handleIndexUpdate(workflow, StateManagerMode.UPDATE);
     }
 
@@ -1449,6 +1452,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @UnitOfWork
     @Path("/{workflowId}/unstar")
     @ApiOperation(nickname =  "unstarEntry", value = "Unstar a workflow.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
+    @Deprecated(since = "1.8.0")
     public void unstarEntry(@ApiParam(hidden = true) @Auth User user,
         @ApiParam(value = "Workflow to unstar.", required = true) @PathParam("workflowId") Long workflowId) {
         Workflow workflow = workflowDAO.findById(workflowId);


### PR DESCRIPTION
Can't outright remove them or else it'll break 1.7.0 starring through CLI

dockstore/dockstore#2395