### PR TITLE
Remove deprecated test

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -1022,50 +1022,6 @@ public class BasicIT extends BaseIT {
     }
 
     /**
-     * This tests that you can verify and unverify a tool
-     */
-    @Ignore("Deprecated. CLI needs to be changed to use new Extended TRS verification endpoint")
-    @Test
-    public void testVerify() {
-        // Versions should be unverified
-        final long count = testingPostgres
-            .runSelectStatement("select count(*) from tag t, version_metadata vm where vm.verified='true' and t.id = vm.id", long.class);
-
-        Assert.assertEquals("there should be no verified tags, there are " + count, 0, count);
-
-        // Verify tag
-        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "verify", "--entry",
-            "quay.io/dockstoretestuser/quayandbitbucket", "--verified-source", "Docker testing group", "--version", "master", "--script" });
-
-        // Tag should be verified
-        final long count2 = testingPostgres.runSelectStatement(
-            "select count(*) from tag t, version_metadata vm where vm.verified='true' and vm.verifiedSource='Docker testing group' and t.id = vm.id",
-            long.class);
-
-        Assert.assertEquals("there should be one verified tag, there are " + count2, 1, count2);
-
-        // Update tag to have new verified source
-        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "verify", "--entry",
-            "quay.io/dockstoretestuser/quayandbitbucket", "--verified-source", "Docker testing group2", "--version", "master",
-            "--script" });
-
-        // Tag should have new verified source
-        final long count3 = testingPostgres.runSelectStatement(
-            "select count(*) from tag t, version_metadata vm where vm.verified='true' and vm.verifiedSource='Docker testing group2' and t.id = vm.id",
-            long.class);
-        Assert.assertEquals("there should be one verified tag, there are " + count3, 1, count3);
-
-        // Unverify tag
-        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file.txt"), "tool", "verify", "--entry",
-            "quay.io/dockstoretestuser/quayandbitbucket", "--unverify", "--version", "master", "--script" });
-
-        // Tag should be unverified
-        final long count5 = testingPostgres
-            .runSelectStatement("select count(*) from tag t, version_metadata vm where vm.verified='true' and t.id = vm.id", long.class);
-        Assert.assertEquals("there should be no verified tags, there are " + count5, 0, count5);
-    }
-
-    /**
      * This tests some cases for private tools
      */
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/VerifiedInformationMigrationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/VerifiedInformationMigrationIT.java
@@ -76,35 +76,4 @@ public class VerifiedInformationMigrationIT {
             .assertEquals("There should be 2 entries in sourcefile_verified after the migration but got: " + afterMigrationVerifiedCount, 5,
                 afterMigrationVerifiedCount);
     }
-
-    @Test
-    public void workflowVerifiedInformationMigrationTest() {
-        Application<DockstoreWebserviceConfiguration> application = SUPPORT.getApplication();
-        try {
-            application.run("db", "drop-all", "--confirm-delete-everything", CommonTestUtilities.CONFIDENTIAL_CONFIG_PATH);
-            List<String> migrationList = Arrays.asList("1.3.0.generated", "1.3.1.consistency", "1.4.0", "testworkflow");
-            CommonTestUtilities.runMigration(migrationList, application, CommonTestUtilities.CONFIDENTIAL_CONFIG_PATH);
-        } catch (Exception e) {
-            Assert.fail("Could not run migrations up to 1.4.0");
-        }
-
-        testingPostgres.runUpdateStatement("UPDATE workflowversion SET verified='t' where name='master'");
-
-        Client.main(new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "verify", "--entry",
-            SourceControl.GITHUB.toString() + "/testWorkflow/testWorkflow", "--verified-source", "Docker testing group", "--version",
-            "master", "--script" });
-
-        // Run full 1.5.0 migration
-        try {
-            List<String> migrationList = Arrays.asList("1.5.0");
-            CommonTestUtilities.runMigration(migrationList, application, CommonTestUtilities.CONFIDENTIAL_CONFIG_PATH);
-        } catch (Exception e) {
-            Assert.fail("Could not run 1.5.0 migration");
-        }
-
-        final long afterMigrationVerifiedCount = testingPostgres.runSelectStatement("select count(*) from sourcefile_verified", long.class);
-        Assert
-            .assertEquals("There should be 2 entries in sourcefile_verified after the migration but got: " + afterMigrationVerifiedCount, 2,
-                afterMigrationVerifiedCount);
-    }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/VerifiedInformationMigrationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/VerifiedInformationMigrationIT.java
@@ -4,13 +4,11 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.dockstore.common.CommonTestUtilities;
-import io.dockstore.common.SourceControl;
 import io.dockstore.common.TestingPostgres;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dropwizard.Application;
 import io.dropwizard.testing.DropwizardTestSupport;
-import io.dropwizard.testing.ResourceHelpers;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;


### PR DESCRIPTION
Removing some deprecated tests after https://github.com/dockstore/dockstore-cli/pull/6 is merged.

The migration test removal is odd because the CLI command has changed and would not affect the 1.5.0 migration the same way (verifying a source file will verify the source file, it won't verify all source files).