### PR TITLE
Re create 1.7.3

### DIFF
--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
     </parent>
     <artifactId>dockstore-client</artifactId>
     <packaging>jar</packaging>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.postgresql</groupId>
@@ -53,17 +53,17 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-wes-client</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-file-plugin-parent</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>

--- a/dockstore-client/pom.xml
+++ b/dockstore-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
     </parent>
     <artifactId>dockstore-client</artifactId>
     <packaging>jar</packaging>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.postgresql</groupId>
@@ -53,17 +53,17 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-wes-client</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-file-plugin-parent</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-common</artifactId>

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-common</artifactId>

--- a/dockstore-event-consumer/pom.xml
+++ b/dockstore-event-consumer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -30,12 +30,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>

--- a/dockstore-event-consumer/pom.xml
+++ b/dockstore-event-consumer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -30,12 +30,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>

--- a/dockstore-file-plugin-parent/pom.xml
+++ b/dockstore-file-plugin-parent/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/dockstore-file-plugin-parent/pom.xml
+++ b/dockstore-file-plugin-parent/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-integration-testing</artifactId>
@@ -45,30 +45,30 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-client</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
 
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-client</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
 
         <!-- testing -->
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-integration-testing</artifactId>
@@ -45,30 +45,30 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-client</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-client</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
 
         <!-- testing -->
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -30,6 +30,7 @@ import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.Organization;
 import io.swagger.client.model.User;
 import io.swagger.client.model.Workflow;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Before;
@@ -119,6 +120,12 @@ public class UserResourceIT extends BaseIT {
         } catch (ApiException e) {
             assertEquals(e.getCode(), HttpStatus.SC_UNAUTHORIZED);
         }
+    }
+
+    @Test
+    public void longAvatarUrlTest() {
+        String generatedString = RandomStringUtils.randomAlphanumeric(9001);
+        testingPostgres.runUpdateStatement(String.format("update enduser set avatarurl='%s'", generatedString));
     }
 
     /**

--- a/dockstore-language-plugin-parent/pom.xml
+++ b/dockstore-language-plugin-parent/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ro.fortsoft.pf4j</groupId>

--- a/dockstore-language-plugin-parent/pom.xml
+++ b/dockstore-language-plugin-parent/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>ro.fortsoft.pf4j</groupId>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
 
     <parent>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -53,32 +53,32 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-quay-client</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-sam-client</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-bitbucket-client</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-discourse-client</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-language-plugin-parent</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <!-- DOCKSTORE-2428 - demo how to add new workflow language
         <dependency>
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-zenodo-client</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
@@ -571,7 +571,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
 
     <parent>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -53,32 +53,32 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-quay-client</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-sam-client</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-bitbucket-client</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-discourse-client</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-language-plugin-parent</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <!-- DOCKSTORE-2428 - demo how to add new workflow language
         <dependency>
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-zenodo-client</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
@@ -571,7 +571,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -111,7 +111,7 @@ public class User implements Principal, Comparable<User>, Serializable {
     @OrderBy("id")
     private SortedMap<String, Profile> userProfiles = new TreeMap<>();
 
-    @Column
+    @Column(columnDefinition = "text")
     @ApiModelProperty(value = "URL of user avatar on GitHub/Google that can be selected by the user", position = 7)
     private String avatarUrl;
 

--- a/dockstore-webservice/src/main/resources/migrations.1.7.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.7.0.xml
@@ -318,4 +318,7 @@
             UPDATE validation SET message = REPLACE(message, 'Unknown methods were found', 'NOTE: WDL 1.0 is now supported by Dockstore. If you have access, please refresh to fix validation errors. Unknown methods were found')
         </sql>
     </changeSet>
+    <changeSet author="gluu (generated)" id="unlimitedAvatarUrlLength">
+        <modifyDataType columnName="avatarurl" newDataType="clob" tableName="enduser"/>
+    </changeSet>
 </databaseChangeLog>

--- a/openapi-java-client/pom.xml
+++ b/openapi-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>openapi-java-client</name>
 
     <parent>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -325,7 +325,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/openapi-java-client/pom.xml
+++ b/openapi-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>openapi-java-client</name>
 
     <parent>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -325,7 +325,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/openapi-java-wes-client/pom.xml
+++ b/openapi-java-wes-client/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/openapi-java-wes-client/pom.xml
+++ b/openapi-java-wes-client/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>io.dockstore</groupId>
     <artifactId>dockstore</artifactId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.3</version>
     <packaging>pom</packaging>
 
     <name>dockstore</name>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>io.dockstore</groupId>
     <artifactId>dockstore</artifactId>
-    <version>1.7.3</version>
+    <version>1.7.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>dockstore</name>
@@ -70,7 +70,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-        <tag>1.5.2</tag>
+        <tag>1.7.3</tag>
     </scm>
 
     <repositories>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,22 +29,22 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-client</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-integration-testing</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
         </dependency>
     </dependencies>
 

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,22 +29,22 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-client</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-integration-testing</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/swagger-java-bitbucket-client/pom.xml
+++ b/swagger-java-bitbucket-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-bitbucket-client/pom.xml
+++ b/swagger-java-bitbucket-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-client/pom.xml
+++ b/swagger-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-client</name>
 
     <parent>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -262,7 +262,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.7.3</version>
+            <version>1.7.4-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/swagger-java-client/pom.xml
+++ b/swagger-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-client</name>
 
     <parent>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -262,7 +262,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.7.3-SNAPSHOT</version>
+            <version>1.7.3</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/swagger-java-discourse-client/pom.xml
+++ b/swagger-java-discourse-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-discourse-client</name>
 
     <parent>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-discourse-client/pom.xml
+++ b/swagger-java-discourse-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-discourse-client</name>
 
     <parent>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-quay-client/pom.xml
+++ b/swagger-java-quay-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-quay-client</name>
 
     <parent>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-quay-client/pom.xml
+++ b/swagger-java-quay-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-quay-client</name>
 
     <parent>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-sam-client/pom.xml
+++ b/swagger-java-sam-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-sam-client/pom.xml
+++ b/swagger-java-sam-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-zenodo-client/pom.xml
+++ b/swagger-java-zenodo-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-zenodo-client</name>
 
     <parent>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-zenodo-client/pom.xml
+++ b/swagger-java-zenodo-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-zenodo-client</name>
 
     <parent>
-        <version>1.7.3</version>
+        <version>1.7.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>


### PR DESCRIPTION
Had to re-create the hotfix 
Short story: never create a hotfix while the previous hotfix hasn't been merged
Long story: this branch isn't technically what was tagged for 1.7.3, but does a close enough job for the purposes of merging to master and develop. A previous branch branched 1.7.3 before 1.7.2 was closed so its all messed up when merging

Will need to make sure that the avatar url gets merged to develop