### PR TITLE
Recent Entries Pretty Path

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/EntryUpdateTime.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/EntryUpdateTime.java
@@ -10,11 +10,13 @@ import java.util.Date;
  */
 public class EntryUpdateTime {
     private String path;
+    private String prettyPath;
     private EntryType entryType;
     private Date lastUpdateDate;
 
-    public EntryUpdateTime(String path, EntryType entryType, Timestamp lastUpdateDate) {
+    public EntryUpdateTime(String path, String prettyPath, EntryType entryType, Timestamp lastUpdateDate) {
         this.path = path;
+        this.prettyPath = prettyPath;
         this.entryType = entryType;
         this.lastUpdateDate = lastUpdateDate;
     }
@@ -25,6 +27,14 @@ public class EntryUpdateTime {
 
     public void setPath(String path) {
         this.path = path;
+    }
+
+    public String getPrettyPath() {
+        return prettyPath;
+    }
+
+    public void setPrettyPath(String prettyPath) {
+        this.prettyPath = prettyPath;
     }
 
     public EntryType getEntryType() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -661,7 +661,7 @@ public class UserResource implements AuthenticatedResourceInterface {
                 timestamp = mostRecentTag.get().getDbUpdateDate();
             }
             List<String> pathElements = Arrays.asList(entry.getEntryPath().split("/"));
-            String prettyPath = pathElements.subList(1, pathElements.size()).stream().collect(Collectors.joining("/"));
+            String prettyPath = String.join("/", pathElements.subList(1, pathElements.size()));
             entryUpdateTimes.add(new EntryUpdateTime(entry.getEntryPath(), prettyPath, entry.getEntryType(), timestamp));
         });
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -19,6 +19,7 @@ package io.dockstore.webservice.resources;
 import java.sql.Timestamp;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -659,7 +660,9 @@ public class UserResource implements AuthenticatedResourceInterface {
             if (mostRecentTag.isPresent() && timestamp.before(mostRecentTag.get().getDbUpdateDate())) {
                 timestamp = mostRecentTag.get().getDbUpdateDate();
             }
-            entryUpdateTimes.add(new EntryUpdateTime(entry.getEntryPath(), entry.getEntryType(), timestamp));
+            List<String> pathElements = Arrays.asList(entry.getEntryPath().split("/"));
+            String prettyPath = pathElements.subList(1, pathElements.size()).stream().collect(Collectors.joining("/"));
+            entryUpdateTimes.add(new EntryUpdateTime(entry.getEntryPath(), prettyPath, entry.getEntryType(), timestamp));
         });
 
         // Sort all entryUpdateTimes by timestamp

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -6650,10 +6650,6 @@ components:
         custom_docker_registry_path:
           type: string
           readOnly: true
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6669,6 +6665,10 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -6859,10 +6859,6 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/Version"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6878,6 +6874,10 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -6949,6 +6949,8 @@ components:
       type: object
       properties:
         path:
+          type: string
+        prettyPath:
           type: string
         entryType:
           type: string
@@ -8101,10 +8103,6 @@ components:
           $ref: "#/components/schemas/Entry"
         isChecker:
           type: boolean
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -8120,6 +8118,10 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -74,6 +74,63 @@ paths:
             text/xml:
               schema:
                 type: string
+  /metadata/rss:
+    get:
+      tags:
+      - metadata
+      summary: List all published tools and workflows in creation order
+      description: List all published tools and workflows in creation order, NO authentication
+      operationId: rssFeed
+      responses:
+        default:
+          description: default response
+          content:
+            text/xml:
+              schema:
+                type: string
+  /metadata/runner_dependencies:
+    get:
+      tags:
+      - metadata
+      summary: Returns the file containing runner dependencies
+      description: Returns the file containing runner dependencies, NO authentication
+      operationId: getRunnerDependencies
+      parameters:
+      - name: client_version
+        in: query
+        description: The Dockstore client version
+        schema:
+          type: string
+      - name: python_version
+        in: query
+        description: Python version, only relevant for the cwltool runner
+        schema:
+          type: string
+          default: "2"
+      - name: runner
+        in: query
+        description: The tool runner
+        schema:
+          type: string
+          default: cwltool
+          enum:
+          - cwltool
+      - name: output
+        in: query
+        description: Response type
+        schema:
+          type: string
+          default: text
+          enum:
+          - json
+          - text
+      responses:
+        default:
+          description: The requirements.txt file
+          content:
+            application/json:
+              schema:
+                type: string
   /metadata/sourceControlList:
     get:
       tags:
@@ -136,63 +193,6 @@ paths:
           content:
             text/html: {}
             text/xml: {}
-  /metadata/rss:
-    get:
-      tags:
-      - metadata
-      summary: List all published tools and workflows in creation order
-      description: List all published tools and workflows in creation order, NO authentication
-      operationId: rssFeed
-      responses:
-        default:
-          description: default response
-          content:
-            text/xml:
-              schema:
-                type: string
-  /metadata/runner_dependencies:
-    get:
-      tags:
-      - metadata
-      summary: Returns the file containing runner dependencies
-      description: Returns the file containing runner dependencies, NO authentication
-      operationId: getRunnerDependencies
-      parameters:
-      - name: client_version
-        in: query
-        description: The Dockstore client version
-        schema:
-          type: string
-      - name: python_version
-        in: query
-        description: Python version, only relevant for the cwltool runner
-        schema:
-          type: string
-          default: "2"
-      - name: runner
-        in: query
-        description: The tool runner
-        schema:
-          type: string
-          default: cwltool
-          enum:
-          - cwltool
-      - name: output
-        in: query
-        description: Response type
-        schema:
-          type: string
-          default: text
-          enum:
-          - json
-          - text
-      responses:
-        default:
-          description: The requirements.txt file
-          content:
-            application/json:
-              schema:
-                type: string
   /metadata/dockerRegistryList:
     get:
       tags:
@@ -291,43 +291,6 @@ paths:
             text/plain:
               schema:
                 type: string
-  /users/{userId}:
-    get:
-      operationId: getSpecificUser
-      parameters:
-      - name: userId
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/User'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-  /users/user:
-    get:
-      operationId: getUser
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/User'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
   /users/users/organizations:
     get:
       description: Get all of the Dockstore organizations for a user, sorted by most
@@ -383,6 +346,43 @@ paths:
                   $ref: '#/components/schemas/EntryUpdateTime'
       security:
       - bearer: []
+  /users/{userId}:
+    get:
+      operationId: getSpecificUser
+      parameters:
+      - name: userId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  /users/user:
+    get:
+      operationId: getUser
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
   /users/registries:
     get:
       description: Get all of the git registries accessible to the logged in user.
@@ -601,23 +601,20 @@ components:
           format: int64
         conceptDoi:
           type: string
+        metadataFromEntry:
+          $ref: '#/components/schemas/Entry'
+        metadataFromVersion:
+          $ref: '#/components/schemas/Version'
         workflowVersions:
           uniqueItems: true
           type: array
           items:
             $ref: '#/components/schemas/Version'
-        metadataFromEntry:
-          $ref: '#/components/schemas/Entry'
-        metadataFromVersion:
-          $ref: '#/components/schemas/Version'
         is_published:
           type: boolean
         last_modified:
           type: integer
           format: int32
-        last_modified_date:
-          type: string
-          format: date-time
         checker_id:
           type: integer
           format: int64
@@ -633,6 +630,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
+        last_modified_date:
+          type: string
+          format: date-time
       writeOnly: true
     FileFormat:
       type: object
@@ -831,11 +831,7 @@ components:
             $ref: '#/components/schemas/Image'
         hidden:
           type: boolean
-        workingDirectory:
-          type: string
-        description:
-          type: string
-        email:
+        author:
           type: string
         verified:
           type: boolean
@@ -858,7 +854,11 @@ components:
           enum:
           - README
           - DESCRIPTOR
-        author:
+        workingDirectory:
+          type: string
+        description:
+          type: string
+        email:
           type: string
         dbUpdateDate:
           type: string
@@ -996,6 +996,8 @@ components:
       properties:
         path:
           type: string
+        prettyPath:
+          type: string
         entryType:
           type: string
           enum:
@@ -1124,17 +1126,14 @@ components:
         parent_id:
           type: integer
           format: int64
-        full_workflow_path:
-          type: string
         source_control_provider:
           type: string
         workflow_path:
           type: string
         defaultTestParameterFilePath:
           type: string
-        last_modified_date:
+        full_workflow_path:
           type: string
-          format: date-time
         checker_id:
           type: integer
           format: int64
@@ -1150,6 +1149,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
+        last_modified_date:
+          type: string
+          format: date-time
     Service:
       type: object
       allOf:
@@ -1254,17 +1256,14 @@ components:
         last_modified:
           type: integer
           format: int32
-        full_workflow_path:
-          type: string
         source_control_provider:
           type: string
         workflow_path:
           type: string
         defaultTestParameterFilePath:
           type: string
-        last_modified_date:
+        full_workflow_path:
           type: string
-          format: date-time
         checker_id:
           type: integer
           format: int64
@@ -1280,6 +1279,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
+        last_modified_date:
+          type: string
+          format: date-time
         type:
           type: string
       writeOnly: true
@@ -1343,9 +1345,7 @@ components:
           type: string
         hidden:
           type: boolean
-        description:
-          type: string
-        email:
+        author:
           type: string
         verified:
           type: boolean
@@ -1368,7 +1368,9 @@ components:
           enum:
           - README
           - DESCRIPTOR
-        author:
+        description:
+          type: string
+        email:
           type: string
         dbUpdateDate:
           type: string

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -6247,10 +6247,6 @@ definitions:
       custom_docker_registry_path:
         type: "string"
         readOnly: true
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6266,6 +6262,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1
@@ -6483,10 +6483,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/Version"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6502,6 +6498,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1
@@ -6585,6 +6585,8 @@ definitions:
     type: "object"
     properties:
       path:
+        type: "string"
+      prettyPath:
         type: "string"
       entryType:
         type: "string"
@@ -7854,10 +7856,6 @@ definitions:
         $ref: "#/definitions/Entry"
       isChecker:
         type: "boolean"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -7873,6 +7871,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1


### PR DESCRIPTION
The Recent Entries on the logged in homepage currently show the full path. This is not really needed as the chance of collision between paths is low, and the registry usually doesn't matter. Will show b/c/d instead of a/b/c/d. This will have an accompanying UI PR (requires release).

Note that this is already how we display entries on the search page. I think this is a more useful approach since the registry doesn't really matter much (can still see it when hovering over a link if browser shows the URL) and the home page will look cleaner.