### PR TITLE
Feature/store jar on circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - store_artifacts:
           path: ~/junit
       - store_artifacts:
-          path: dockstore-webservice/target/*.jar
+          path: dockstore-webservice/target
 
     branches:
       ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,9 +68,9 @@ jobs:
       - store_test_results:
           path: ~/junit
       - store_artifacts:
-          path: 
-           - ~/junit
-           - dockstore-webservice/target/*.jar
+          path: ~/junit
+      - store_artifacts:
+          path: dockstore-webservice/target/*.jar
 
     branches:
       ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,10 @@ jobs:
       - store_test_results:
           path: ~/junit
       - store_artifacts:
-          path: ~/junit
+          path: 
+           - ~/junit
+           - dockstore-webservice/target/*.jar
+
     branches:
       ignore:
         - gh-pages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,19 @@ jobs:
           path: ~/junit
       - store_artifacts:
           path: ~/junit
+      - run:
+          name: Make jar directory
+          command: mkdir /tmp/artifacts
+      - run:
+          name: Move jars
+          command: cp dockstore-webservice/target/dockstore*.jar /tmp/artifacts
+      - run:
+          name: Move swagger.yaml
+          command: |
+            cp dockstore-webservice/src/main/resources/swagger.yaml /tmp/artifacts
+            cp dockstore-webservice/src/main/resources/openapi3/openapi.yaml /tmp/artifacts
       - store_artifacts:
-          path: dockstore-webservice/target
-
+          path: /tmp/artifacts
     branches:
       ignore:
         - gh-pages


### PR DESCRIPTION
Draft PR, not to be merged.

When tests are successfully ran CircleCI, the built webservice jar, the swagger and openapi.yaml are uploaded the CircleCI as an artifact and can be downloaded publicly.

See https://circleci.com/gh/dockstore/dockstore/2602#artifacts/containers/0 artifact tab for example.  

TODO:
- The URL is not intuitive. https://2602-33383826-gh.circle-artifacts.com/0/tmp/artifacts/dockstore-webservice-1.8.0-alpha.3-SNAPSHOT.jar
- The URL should mention the release somewhere
- It should only be built and uploaded when merged to develop.
