### PR TITLE
Add Dockerfile to web service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ before_install:
 # codacy hookup
 - sudo apt-get install jq
 - wget --no-verbose -O ~/codacy-coverage-reporter-assembly-latest.jar https://github.com/codacy/codacy-coverage-reporter/releases/download/4.0.5/codacy-coverage-reporter-4.0.5-assembly.jar
-- pyenv global 3.6.7
+- pyenv global 3.6.9
 
 install:
 - docker version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM maven:3.6.2-jdk-11 AS maven
+
+ADD . /
+RUN mvn clean install -DskipTests
+
+FROM ubuntu:18.04
+
+# Update the APT cache
+# prepare for Java download
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
+    software-properties-common \
+    telnet \
+    vim \
+    wget \
+    locales \
+    && apt-get clean
+
+# install java
+RUN add-apt-repository ppa:openjdk-r/ppa
+RUN apt-get update \
+    && apt-get install openjdk-11-jdk -y \
+    && apt-get install curl -y \
+    && apt-get clean
+
+RUN locale-gen en_US.UTF-8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+COPY --from=maven /dockstore-webservice/target/d*SNAPSHOT.jar /
+
+# install dockerize
+ENV DOCKERIZE_VERSION v0.2.0
+
+RUN curl -L https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    | tar -C /usr/local/bin -xzv
+
+RUN mkdir /dockstore_logs && chmod a+rx /dockstore_logs
+
+# Waiting for postgres service
+CMD ["dockerize", "-wait", "tcp://postgres:5432", "-timeout", "60s", "./init_webservice.sh"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ FROM ubuntu:18.04
 # Update the APT cache
 # prepare for Java download
 RUN apt-get update \
-    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
     software-properties-common \
     telnet \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3.6.2-jdk-11 AS maven
 
-ADD . /
+COPY . /
 RUN mvn clean install -DskipTests
 
 FROM ubuntu:18.04
@@ -9,20 +9,22 @@ FROM ubuntu:18.04
 # prepare for Java download
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y \
+    && apt-get install -y --no-install-recommends \
     software-properties-common \
     telnet \
     vim \
     wget \
     locales \
-    && apt-get clean
+    curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # install java
 RUN add-apt-repository ppa:openjdk-r/ppa
 RUN apt-get update \
-    && apt-get install openjdk-11-jdk -y \
-    && apt-get install curl -y \
-    && apt-get clean
+    && apt-get install openjdk-11-jdk=11.0.4+11-1ubuntu2~18.04.3 -y --no-install-recommends \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN locale-gen en_US.UTF-8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'


### PR DESCRIPTION
#3065

A small step towards continuous deploys, where we can get
pre-built web service images from quay.io.

Took dockstore/compose_setup/templates/Dockerfile_webservice.template
and modified to make this file, with the main difference being
that the webservice JAR is built instead of being pulled from OICR
artifactory.

Arguably shouldn't have dockerize waiting on postgres in here; OTOH
the web service is useless without Postgres container. Also there
was a comment about not hard-coding the dockstore_logs directory, but
I left it hard-coded. We can revisit when we make the corresponding
compose_setup changes.

I have created
https://quay.io/repository/dockstore-testing/dockstore-webservice and
it images have been made against this branch.
