### PR TITLE
Allow only one simultaneous invocation of Nextflow

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/NextflowUtilities.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/NextflowUtilities.java
@@ -99,7 +99,7 @@ public final class NextflowUtilities {
                 Arrays.asList("java", "-jar", getNextflowTargetFile().getAbsolutePath(), "config", "-properties");
             final String join = Joiner.on(" ").join(strings);
             LOG.info("running: " + join);
-            final ImmutablePair<String, String> execute = Utilities.executeCommand(join, content.getParentFile());
+            final ImmutablePair<String, String> execute = executeNextflowConfig(content, join);
             String stdout = execute.getLeft();
             Properties properties = new Properties();
             properties.load(new StringReader(stdout));
@@ -108,6 +108,17 @@ public final class NextflowUtilities {
             LOG.error("Problem running Nextflow: ", e);
             throw new NextflowParsingException("Could not run Nextflow", e);
         }
+    }
+
+    /**
+     * This is an expensive operation; a new Java VM is spun up for this, so only allow one at a time by
+     * synchronizing the method.
+     * @param content
+     * @param join
+     * @return
+     */
+    private synchronized static ImmutablePair<String, String> executeNextflowConfig(File content, String join) {
+        return Utilities.executeCommand(join, content.getParentFile());
     }
 
     /**

--- a/dockstore-common/src/main/java/io/dockstore/common/NextflowUtilities.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/NextflowUtilities.java
@@ -111,17 +111,6 @@ public final class NextflowUtilities {
     }
 
     /**
-     * This is an expensive operation; a new Java VM is spun up for this, so only allow one at a time by
-     * synchronizing the method.
-     * @param content
-     * @param join
-     * @return
-     */
-    private synchronized static ImmutablePair<String, String> executeNextflowConfig(File content, String join) {
-        return Utilities.executeCommand(join, content.getParentFile());
-    }
-
-    /**
      * @param content the content of the config file
      * @return a commons configuration file with the keys from the nextflow config file
      */
@@ -146,6 +135,17 @@ public final class NextflowUtilities {
                 FileUtils.deleteQuietly(nextflowDir.toFile());
             }
         }
+    }
+
+    /**
+     * This is an expensive operation; a new Java VM is spun up for this, so only allow one at a time by
+     * synchronizing the method.
+     * @param content
+     * @param join
+     * @return
+     */
+    private static synchronized ImmutablePair<String, String> executeNextflowConfig(File content, String join) {
+        return Utilities.executeCommand(join, content.getParentFile());
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -98,6 +98,7 @@ public class NextflowHandler implements LanguageHandlerInterface {
     @Override
     public Map<String, SourceFile> processImports(String repositoryId, String content, Version version,
         SourceCodeRepoInterface sourceCodeRepoInterface, String filepath) {
+        LOG.info("Processing import for repository {}, version {}, filepath {}", repositoryId, version.getName(), filepath);
         // FIXME: see{@link NextflowUtilities#grabConfig(String) grabConfig} method for comments on why
         // we have to look at imports in this crummy way
         final Matcher matcher = INCLUDE_CONFIG_PATTERN.matcher(content);


### PR DESCRIPTION
We run Nextflow JAR in a new VM. If multiple requests
come in simultaneously, this will lead to a big slowdown
in server responsiveness.
