### PR TITLE
Feature/3084/my entries db dates

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/RefreshByOrgIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/RefreshByOrgIT.java
@@ -117,7 +117,7 @@ public class RefreshByOrgIT {
         checkInitialDB();
         // insert a non-existent tool to be deleted during refresh
         testingPostgres.runUpdateStatement(
-            "insert into tool (id, giturl, mode, name, namespace, registry, ispublished) select 100, giturl, mode, 'newtool', namespace, registry, ispublished from tool where id = 2;");
+            "insert into tool (id, giturl, mode, name, namespace, registry, ispublished, dbupdatedate, dbcreatedate) select 100, giturl, mode, 'newtool', namespace, registry, ispublished, dbupdatedate, dbcreatedate from tool where id = 2;");
         testingPostgres.runUpdateStatement("insert into user_entry (userid, entryid) values (1, 100)");
         Long count = testingPostgres.runSelectStatement("select count(*) from tool where id = 100;", long.class);
         assertEquals(1, (long)count);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -174,11 +174,11 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     private Map<String, Alias> aliases = new HashMap<>();
 
     // database timestamps
-    @Column(updatable = false)
+    @Column(updatable = false, nullable = false)
     @CreationTimestamp
     private Timestamp dbCreateDate;
 
-    @Column()
+    @Column(nullable = false)
     @UpdateTimestamp
     private Timestamp dbUpdateDate;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -127,12 +127,12 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     private User versionEditor;
 
     // database timestamps
-    @Column(updatable = false)
+    @Column(updatable = false, nullable = false)
     @CreationTimestamp
     @ApiModelProperty(position = 10)
     private Timestamp dbCreateDate;
 
-    @Column()
+    @Column(nullable = false)
     @UpdateTimestamp
     @JsonProperty("dbUpdateDate")
     @ApiModelProperty(position = 11)

--- a/dockstore-webservice/src/main/resources/migrations.1.8.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.8.0.xml
@@ -168,4 +168,17 @@
             <where>dbupdatedate is null</where>
         </update>
     </changeSet>
+    <changeSet id="add-not-null-db-dates" author="aduncan">
+        <addNotNullConstraint tableName="workflow" columnName="dbcreatedate"/>
+        <addNotNullConstraint tableName="workflow" columnName="dbupdatedate"/>
+        <addNotNullConstraint tableName="service" columnName="dbcreatedate"/>
+        <addNotNullConstraint tableName="service" columnName="dbupdatedate"/>
+        <addNotNullConstraint tableName="tool" columnName="dbcreatedate"/>
+        <addNotNullConstraint tableName="tool" columnName="dbupdatedate"/>
+        
+        <addNotNullConstraint tableName="workflowversion" columnName="dbcreatedate"/>
+        <addNotNullConstraint tableName="workflowversion" columnName="dbupdatedate"/>
+        <addNotNullConstraint tableName="tag" columnName="dbcreatedate"/>
+        <addNotNullConstraint tableName="tag" columnName="dbupdatedate"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.8.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.8.0.xml
@@ -117,8 +117,8 @@
     </changeSet>
     <changeSet id="set_null_db_times" author="aduncan">
         <sql dbms="postgresql">
-            UPDATE tool SET dbcreatedate=lastupdated where dbcreatedate is null;
-            UPDATE tool SET dbupdatedate=lastupdated where dbupdatedate is null;
+            UPDATE tool SET dbcreatedate=lastupdated WHERE dbcreatedate IS NULL;
+            UPDATE tool SET dbupdatedate=lastupdated WHERE dbupdatedate IS NULL;
         </sql>
         <update tableName="tool">
             <column name="dbcreatedate" value="2015-04-03T21:34:05Z"/>
@@ -130,8 +130,8 @@
         </update>
 
         <sql dbms="postgresql">
-            UPDATE tag SET dbcreatedate=lastbuilt where dbcreatedate is null;
-            UPDATE tag SET dbupdatedate=lastbuilt where dbupdatedate is null;
+            UPDATE tag SET dbcreatedate=lastbuilt WHERE dbcreatedate IS NULL;
+            UPDATE tag SET dbupdatedate=lastbuilt WHERE dbupdatedate IS NULL;
         </sql>
         <update tableName="tag">
             <column name="dbcreatedate" value="2015-04-03T21:34:05Z"/>
@@ -143,8 +143,8 @@
         </update>
 
         <sql dbms="postgresql">
-            UPDATE workflow SET dbcreatedate=lastupdated where dbcreatedate is null;
-            UPDATE workflow SET dbupdatedate=lastupdated where dbupdatedate is null;
+            UPDATE workflow SET dbcreatedate=lastupdated WHERE dbcreatedate IS NULL;
+            UPDATE workflow SET dbupdatedate=lastupdated WHERE dbupdatedate IS NULL;
         </sql>
         <update tableName="workflow">
             <column name="dbcreatedate" value="2015-04-03T21:34:05Z"/>
@@ -156,8 +156,8 @@
         </update>
 
         <sql dbms="postgresql">
-            UPDATE workflowversion SET dbcreatedate=lastmodified where dbcreatedate is null;
-            UPDATE workflowversion SET dbupdatedate=lastmodified where dbupdatedate is null;
+            UPDATE workflowversion SET dbcreatedate=lastmodified WHERE dbcreatedate IS NULL;
+            UPDATE workflowversion SET dbupdatedate=lastmodified WHERE dbupdatedate IS NULL;
         </sql>
         <update tableName="workflowversion">
             <column name="dbcreatedate" value="2015-04-03T21:34:05Z"/>

--- a/dockstore-webservice/src/main/resources/migrations.1.8.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.8.0.xml
@@ -115,4 +115,57 @@
             <column name="dbupdatedate" type="timestamp"/>
         </createTable>
     </changeSet>
+    <changeSet id="set_null_db_times" author="aduncan">
+        <sql dbms="postgresql">
+            UPDATE tool SET dbcreatedate=lastupdated where dbcreatedate is null;
+            UPDATE tool SET dbupdatedate=lastupdated where dbupdatedate is null;
+        </sql>
+        <update tableName="tool">
+            <column name="dbcreatedate" value="2015-04-03T21:34:05Z"/>
+            <where>dbcreatedate is null</where>
+        </update>
+        <update tableName="tool">
+            <column name="dbupdatedate" value="2015-04-03T21:34:05Z"/>
+            <where>dbupdatedate is null</where>
+        </update>
+
+        <sql dbms="postgresql">
+            UPDATE tag SET dbcreatedate=lastbuilt where dbcreatedate is null;
+            UPDATE tag SET dbupdatedate=lastbuilt where dbupdatedate is null;
+        </sql>
+        <update tableName="tag">
+            <column name="dbcreatedate" value="2015-04-03T21:34:05Z"/>
+            <where>dbcreatedate is null</where>
+        </update>
+        <update tableName="tag">
+            <column name="dbupdatedate" value="2015-04-03T21:34:05Z"/>
+            <where>dbupdatedate is null</where>
+        </update>
+
+        <sql dbms="postgresql">
+            UPDATE workflow SET dbcreatedate=lastupdated where dbcreatedate is null;
+            UPDATE workflow SET dbupdatedate=lastupdated where dbupdatedate is null;
+        </sql>
+        <update tableName="workflow">
+            <column name="dbcreatedate" value="2015-04-03T21:34:05Z"/>
+            <where>dbcreatedate is null</where>
+        </update>
+        <update tableName="workflow">
+            <column name="dbupdatedate" value="2015-04-03T21:34:05Z"/>
+            <where>dbupdatedate is null</where>
+        </update>
+
+        <sql dbms="postgresql">
+            UPDATE workflowversion SET dbcreatedate=lastmodified where dbcreatedate is null;
+            UPDATE workflowversion SET dbupdatedate=lastmodified where dbupdatedate is null;
+        </sql>
+        <update tableName="workflowversion">
+            <column name="dbcreatedate" value="2015-04-03T21:34:05Z"/>
+            <where>dbcreatedate is null</where>
+        </update>
+        <update tableName="workflowversion">
+            <column name="dbupdatedate" value="2015-04-03T21:34:05Z"/>
+            <where>dbupdatedate is null</where>
+        </update>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.8.0-alpha.4-SNAPSHOT
+  version: 1.8.0-beta.1-SNAPSHOT
   title: Dockstore API
   termsOfService: TBD
   contact:
@@ -6761,10 +6761,6 @@ components:
         custom_docker_registry_path:
           type: string
           readOnly: true
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6780,6 +6776,10 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -6970,10 +6970,6 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/Version"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6989,6 +6985,10 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -8252,10 +8252,6 @@ components:
           type: boolean
         parentEntry:
           $ref: "#/components/schemas/Entry"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -8271,6 +8267,10 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -6559,17 +6559,184 @@ components:
         content:
           type: string
     BioWorkflow:
-      allOf:
-        - $ref: "#/components/schemas/Workflow"
-        - type: object
-          properties:
-            parent_id:
-              type: integer
-              format: int64
-              readOnly: true
-            is_checker:
-              type: boolean
-          description: This describes one workflow in the dockstore
+      type: object
+      required:
+        - defaultTestParameterFilePath
+        - descriptorType
+        - gitUrl
+        - mode
+        - organization
+        - repository
+        - sourceControl
+        - workflow_path
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Implementation specific ID for the container in this web service
+        aliases:
+          type: object
+          description: aliases can be used as an alternate unique id for entries
+          additionalProperties:
+            $ref: "#/components/schemas/Alias"
+        dbCreateDate:
+          type: string
+          format: date-time
+        dbUpdateDate:
+          type: string
+          format: date-time
+        topicId:
+          type: integer
+          format: int64
+          description: The Id of the corresponding topic on Dockstore Discuss
+        parent_id:
+          type: integer
+          format: int64
+          readOnly: true
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
+        has_checker:
+          type: boolean
+          readOnly: true
+        input_file_formats:
+          type: array
+          readOnly: true
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/FileFormat"
+        output_file_formats:
+          type: array
+          readOnly: true
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/FileFormat"
+        author:
+          type: string
+          description: This is the name of the author stated in the Dockstore.cwl
+        description:
+          type: string
+          description: This is a human-readable description of this container and what it
+            is trying to accomplish, required GA4GH
+        labels:
+          type: array
+          description: Labels (i.e. meta tags) for describing the purpose and contents of
+            containers
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/Label"
+        users:
+          type: array
+          description: This indicates the users that have control over this entry,
+            dockstore specific
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/User"
+        starredUsers:
+          type: array
+          description: This indicates the users that have starred this entry, dockstore
+            specific
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/User"
+        email:
+          type: string
+          description: This is the email of the git organization
+        defaultVersion:
+          type: string
+          description: This is the default version of the entry
+        is_published:
+          type: boolean
+          description: Implementation specific visibility in this web service
+        last_modified:
+          type: integer
+          format: int32
+          description: "Implementation specific timestamp for last modified. Tools-> For
+            automated/manual builds: N/A. For hosted: Last time a file was
+            updated/created (new version created). Workflows-> For remote: When
+            refresh is hit, last time GitHub repo was changed. Hosted: Last time
+            a new version was made."
+        lastUpdated:
+          type: string
+          format: date-time
+          description: "Implementation specific timestamp for last updated on webservice.
+            Tools-> For automated builds: last time tool/namespace was refreshed
+            Dockstore, tool info (like changing dockerfile path) updated, or
+            default version selected. For hosted tools: when you created the
+            tool. Workflows-> For remote: When refresh all is hit for first
+            time. Hosted: Seems to be time created."
+        gitUrl:
+          type: string
+          description: This is a link to the associated repo with a descriptor, required
+            GA4GH
+        checker_id:
+          type: integer
+          format: int64
+          description: The id of the associated checker workflow
+          readOnly: true
+        conceptDoi:
+          type: string
+          description: The Digital Object Identifier (DOI) representing all of the versions
+            of your workflow
+        mode:
+          type: string
+          description: This indicates what mode this is in which informs how we do things
+            like refresh, dockstore specific
+          enum:
+            - FULL
+            - STUB
+            - HOSTED
+            - SERVICE
+        workflowName:
+          type: string
+          description: This is the name of the workflow, not needed when only one workflow
+            in a repo
+        organization:
+          type: string
+          description: This is a git organization for the workflow
+        repository:
+          type: string
+          description: This is a git repository name
+        sourceControl:
+          type: string
+          description: "This is a specific source control provider like github or bitbucket
+            or n/a?, required: GA4GH"
+        descriptorType:
+          type: string
+          description: This is a descriptor type for the workflow, either CWL, WDL, or
+            Nextflow (Defaults to CWL)
+          enum:
+            - CWL
+            - WDL
+            - NFL
+            - service
+        workflow_path:
+          type: string
+          description: This indicates for the associated git repository, the default path
+            to the primary descriptor document
+        defaultTestParameterFilePath:
+          type: string
+          description: This indicates for the associated git repository, the default path
+            to the test parameter file
+        workflowVersions:
+          type: array
+          description: Implementation specific tracking of valid build workflowVersions for
+            the docker container
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/WorkflowVersion"
+        is_checker:
+          type: boolean
+        full_workflow_path:
+          type: string
+          readOnly: true
+        path:
+          type: string
+        source_control_provider:
+          type: string
+          readOnly: true
+      description: This describes one workflow in the dockstore
     Checksum:
       type: object
       properties:
@@ -6761,6 +6928,10 @@ components:
         custom_docker_registry_path:
           type: string
           readOnly: true
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6776,10 +6947,6 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -6970,6 +7137,10 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/Version"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -6985,10 +7156,6 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl
@@ -8252,6 +8419,10 @@ components:
           type: boolean
         parentEntry:
           $ref: "#/components/schemas/Entry"
+        last_modified_date:
+          type: string
+          format: date-time
+          readOnly: true
         has_checker:
           type: boolean
           readOnly: true
@@ -8267,10 +8438,6 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/FileFormat"
-        last_modified_date:
-          type: string
-          format: date-time
-          readOnly: true
         author:
           type: string
           description: This is the name of the author stated in the Dockstore.cwl

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -41,22 +41,20 @@ paths:
                 $ref: '#/components/schemas/Entry'
       security:
       - bearer: []
-  /metadata/dockerRegistryList:
+  /metadata/config.json:
     get:
       tags:
       - metadata
-      summary: Get the list of docker registries supported on Dockstore
-      description: Get the list of docker registries supported on Dockstore, NO authentication
-      operationId: getDockerRegistries
+      summary: Configuration for UI clients of the API
+      description: Configuration, NO authentication
+      operationId: getConfig
       responses:
         default:
-          description: List of Docker registries
+          description: default response
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RegistryBean'
+                $ref: '#/components/schemas/Config'
   /metadata/sitemap:
     get:
       tags:
@@ -76,63 +74,22 @@ paths:
             text/xml:
               schema:
                 type: string
-  /metadata/rss:
+  /metadata/dockerRegistryList:
     get:
       tags:
       - metadata
-      summary: List all published tools and workflows in creation order
-      description: List all published tools and workflows in creation order, NO authentication
-      operationId: rssFeed
+      summary: Get the list of docker registries supported on Dockstore
+      description: Get the list of docker registries supported on Dockstore, NO authentication
+      operationId: getDockerRegistries
       responses:
         default:
-          description: default response
-          content:
-            text/xml:
-              schema:
-                type: string
-  /metadata/runner_dependencies:
-    get:
-      tags:
-      - metadata
-      summary: Returns the file containing runner dependencies
-      description: Returns the file containing runner dependencies, NO authentication
-      operationId: getRunnerDependencies
-      parameters:
-      - name: client_version
-        in: query
-        description: The Dockstore client version
-        schema:
-          type: string
-      - name: python_version
-        in: query
-        description: Python version, only relevant for the cwltool runner
-        schema:
-          type: string
-          default: "2"
-      - name: runner
-        in: query
-        description: The tool runner
-        schema:
-          type: string
-          default: cwltool
-          enum:
-          - cwltool
-      - name: output
-        in: query
-        description: Response type
-        schema:
-          type: string
-          default: text
-          enum:
-          - json
-          - text
-      responses:
-        default:
-          description: The requirements.txt file
+          description: List of Docker registries
           content:
             application/json:
               schema:
-                type: string
+                type: array
+                items:
+                  $ref: '#/components/schemas/RegistryBean'
   /metadata/sourceControlList:
     get:
       tags:
@@ -195,20 +152,63 @@ paths:
           content:
             text/html: {}
             text/xml: {}
-  /metadata/config.json:
+  /metadata/rss:
     get:
       tags:
       - metadata
-      summary: Configuration for UI clients of the API
-      description: Configuration, NO authentication
-      operationId: getConfig
+      summary: List all published tools and workflows in creation order
+      description: List all published tools and workflows in creation order, NO authentication
+      operationId: rssFeed
       responses:
         default:
           description: default response
           content:
+            text/xml:
+              schema:
+                type: string
+  /metadata/runner_dependencies:
+    get:
+      tags:
+      - metadata
+      summary: Returns the file containing runner dependencies
+      description: Returns the file containing runner dependencies, NO authentication
+      operationId: getRunnerDependencies
+      parameters:
+      - name: client_version
+        in: query
+        description: The Dockstore client version
+        schema:
+          type: string
+      - name: python_version
+        in: query
+        description: Python version, only relevant for the cwltool runner
+        schema:
+          type: string
+          default: "2"
+      - name: runner
+        in: query
+        description: The tool runner
+        schema:
+          type: string
+          default: cwltool
+          enum:
+          - cwltool
+      - name: output
+        in: query
+        description: Response type
+        schema:
+          type: string
+          default: text
+          enum:
+          - json
+          - text
+      responses:
+        default:
+          description: The requirements.txt file
+          content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Config'
+                type: string
   /toolTester/logs/search:
     get:
       tags:
@@ -615,6 +615,9 @@ components:
         last_modified:
           type: integer
           format: int32
+        last_modified_date:
+          type: string
+          format: date-time
         checker_id:
           type: integer
           format: int64
@@ -630,9 +633,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
-        last_modified_date:
-          type: string
-          format: date-time
       writeOnly: true
     FileFormat:
       type: object
@@ -831,6 +831,12 @@ components:
             $ref: '#/components/schemas/Image'
         hidden:
           type: boolean
+        workingDirectory:
+          type: string
+        description:
+          type: string
+        email:
+          type: string
         doiURL:
           type: string
         author:
@@ -854,12 +860,6 @@ components:
           enum:
           - README
           - DESCRIPTOR
-        workingDirectory:
-          type: string
-        description:
-          type: string
-        email:
-          type: string
         dbUpdateDate:
           type: string
           format: date-time
@@ -873,35 +873,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
-    RegistryBean:
-      type: object
-      properties:
-        dockerPath:
-          type: string
-        friendlyName:
-          type: string
-        url:
-          type: string
-        privateOnly:
-          type: string
-        customDockerPath:
-          type: string
-        enum:
-          type: string
-    SourceControlBean:
-      type: object
-      properties:
-        value:
-          type: string
-        friendlyName:
-          type: string
-    DescriptorLanguageBean:
-      type: object
-      properties:
-        value:
-          type: string
-        friendlyName:
-          type: string
     Config:
       type: object
       properties:
@@ -962,6 +933,35 @@ components:
         googleClientId:
           type: string
         discourseUrl:
+          type: string
+    RegistryBean:
+      type: object
+      properties:
+        dockerPath:
+          type: string
+        friendlyName:
+          type: string
+        url:
+          type: string
+        privateOnly:
+          type: string
+        customDockerPath:
+          type: string
+        enum:
+          type: string
+    SourceControlBean:
+      type: object
+      properties:
+        value:
+          type: string
+        friendlyName:
+          type: string
+    DescriptorLanguageBean:
+      type: object
+      properties:
+        value:
+          type: string
+        friendlyName:
           type: string
     ToolTesterLog:
       type: object
@@ -1134,6 +1134,9 @@ components:
           type: string
         source_control_provider:
           type: string
+        last_modified_date:
+          type: string
+          format: date-time
         checker_id:
           type: integer
           format: int64
@@ -1149,9 +1152,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
-        last_modified_date:
-          type: string
-          format: date-time
     Service:
       type: object
       allOf:
@@ -1264,6 +1264,9 @@ components:
           type: string
         source_control_provider:
           type: string
+        last_modified_date:
+          type: string
+          format: date-time
         checker_id:
           type: integer
           format: int64
@@ -1279,9 +1282,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
-        last_modified_date:
-          type: string
-          format: date-time
         type:
           type: string
       writeOnly: true
@@ -1345,6 +1345,10 @@ components:
           type: string
         hidden:
           type: boolean
+        description:
+          type: string
+        email:
+          type: string
         doiURL:
           type: string
         author:
@@ -1368,10 +1372,6 @@ components:
           enum:
           - README
           - DESCRIPTOR
-        description:
-          type: string
-        email:
-          type: string
         dbUpdateDate:
           type: string
           format: date-time

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -41,20 +41,22 @@ paths:
                 $ref: '#/components/schemas/Entry'
       security:
       - bearer: []
-  /metadata/config.json:
+  /metadata/dockerRegistryList:
     get:
       tags:
       - metadata
-      summary: Configuration for UI clients of the API
-      description: Configuration, NO authentication
-      operationId: getConfig
+      summary: Get the list of docker registries supported on Dockstore
+      description: Get the list of docker registries supported on Dockstore, NO authentication
+      operationId: getDockerRegistries
       responses:
         default:
-          description: default response
+          description: List of Docker registries
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Config'
+                type: array
+                items:
+                  $ref: '#/components/schemas/RegistryBean'
   /metadata/sitemap:
     get:
       tags:
@@ -193,22 +195,20 @@ paths:
           content:
             text/html: {}
             text/xml: {}
-  /metadata/dockerRegistryList:
+  /metadata/config.json:
     get:
       tags:
       - metadata
-      summary: Get the list of docker registries supported on Dockstore
-      description: Get the list of docker registries supported on Dockstore, NO authentication
-      operationId: getDockerRegistries
+      summary: Configuration for UI clients of the API
+      description: Configuration, NO authentication
+      operationId: getConfig
       responses:
         default:
-          description: List of Docker registries
+          description: default response
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RegistryBean'
+                $ref: '#/components/schemas/Config'
   /toolTester/logs/search:
     get:
       tags:
@@ -291,55 +291,43 @@ paths:
             text/plain:
               schema:
                 type: string
-  /users/registries:
+  /users/{userId}:
     get:
-      description: Get all of the git registries accessible to the logged in user.
-      operationId: getUserRegistries
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: string
-                  enum:
-                  - dockstore.org
-                  - github.com
-                  - bitbucket.org
-                  - gitlab.com
-      security:
-      - bearer: []
-  /users/registries/{gitRegistry}/organizations:
-    get:
-      description: Get all of the organizations for a given git registry accessible
-        to the logged in user.
-      operationId: getUserOrganizations
+      operationId: getSpecificUser
       parameters:
-      - name: gitRegistry
+      - name: userId
         in: path
-        description: Git registry
         required: true
         schema:
-          type: string
-          enum:
-          - dockstore.org
-          - github.com
-          - bitbucket.org
-          - gitlab.com
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/User'
       responses:
         default:
           description: default response
           content:
             application/json:
               schema:
-                uniqueItems: true
-                type: array
-                items:
-                  type: string
-      security:
-      - bearer: []
+                $ref: '#/components/schemas/User'
+  /users/user:
+    get:
+      operationId: getUser
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
   /users/users/organizations:
     get:
       description: Get all of the Dockstore organizations for a user, sorted by most
@@ -395,43 +383,55 @@ paths:
                   $ref: '#/components/schemas/EntryUpdateTime'
       security:
       - bearer: []
-  /users/user:
+  /users/registries:
     get:
-      operationId: getUser
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/User'
+      description: Get all of the git registries accessible to the logged in user.
+      operationId: getUserRegistries
       responses:
         default:
           description: default response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
-  /users/{userId}:
+                type: array
+                items:
+                  type: string
+                  enum:
+                  - dockstore.org
+                  - github.com
+                  - bitbucket.org
+                  - gitlab.com
+      security:
+      - bearer: []
+  /users/registries/{gitRegistry}/organizations:
     get:
-      operationId: getSpecificUser
+      description: Get all of the organizations for a given git registry accessible
+        to the logged in user.
+      operationId: getUserOrganizations
       parameters:
-      - name: userId
+      - name: gitRegistry
         in: path
+        description: Git registry
         required: true
         schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/User'
+          type: string
+          enum:
+          - dockstore.org
+          - github.com
+          - bitbucket.org
+          - gitlab.com
       responses:
         default:
           description: default response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                uniqueItems: true
+                type: array
+                items:
+                  type: string
+      security:
+      - bearer: []
   /users/registries/{gitRegistry}/organizations/{organization}:
     get:
       description: Get all of the repositories for an organization for a given git
@@ -615,9 +615,9 @@ components:
         last_modified:
           type: integer
           format: int32
-        last_modified_date:
-          type: string
-          format: date-time
+        checker_id:
+          type: integer
+          format: int64
         has_checker:
           type: boolean
         input_file_formats:
@@ -630,9 +630,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
-        checker_id:
-          type: integer
-          format: int64
+        last_modified_date:
+          type: string
+          format: date-time
       writeOnly: true
     FileFormat:
       type: object
@@ -831,14 +831,18 @@ components:
             $ref: '#/components/schemas/Image'
         hidden:
           type: boolean
-        workingDirectory:
-          type: string
-        email:
-          type: string
-        description:
-          type: string
         doiURL:
           type: string
+        author:
+          type: string
+        verified:
+          type: boolean
+        verifiedSource:
+          type: string
+        verifiedSources:
+          type: array
+          items:
+            type: string
         doiStatus:
           type: string
           enum:
@@ -850,15 +854,11 @@ components:
           enum:
           - README
           - DESCRIPTOR
-        verified:
-          type: boolean
-        verifiedSource:
+        workingDirectory:
           type: string
-        verifiedSources:
-          type: array
-          items:
-            type: string
-        author:
+        description:
+          type: string
+        email:
           type: string
         dbUpdateDate:
           type: string
@@ -873,6 +873,35 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
+    RegistryBean:
+      type: object
+      properties:
+        dockerPath:
+          type: string
+        friendlyName:
+          type: string
+        url:
+          type: string
+        privateOnly:
+          type: string
+        customDockerPath:
+          type: string
+        enum:
+          type: string
+    SourceControlBean:
+      type: object
+      properties:
+        value:
+          type: string
+        friendlyName:
+          type: string
+    DescriptorLanguageBean:
+      type: object
+      properties:
+        value:
+          type: string
+        friendlyName:
+          type: string
     Config:
       type: object
       properties:
@@ -933,35 +962,6 @@ components:
         googleClientId:
           type: string
         discourseUrl:
-          type: string
-    SourceControlBean:
-      type: object
-      properties:
-        value:
-          type: string
-        friendlyName:
-          type: string
-    DescriptorLanguageBean:
-      type: object
-      properties:
-        value:
-          type: string
-        friendlyName:
-          type: string
-    RegistryBean:
-      type: object
-      properties:
-        dockerPath:
-          type: string
-        friendlyName:
-          type: string
-        url:
-          type: string
-        privateOnly:
-          type: string
-        customDockerPath:
-          type: string
-        enum:
           type: string
     ToolTesterLog:
       type: object
@@ -1134,9 +1134,9 @@ components:
           type: string
         source_control_provider:
           type: string
-        last_modified_date:
-          type: string
-          format: date-time
+        checker_id:
+          type: integer
+          format: int64
         has_checker:
           type: boolean
         input_file_formats:
@@ -1149,9 +1149,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
-        checker_id:
-          type: integer
-          format: int64
+        last_modified_date:
+          type: string
+          format: date-time
     Service:
       type: object
       allOf:
@@ -1264,9 +1264,9 @@ components:
           type: string
         source_control_provider:
           type: string
-        last_modified_date:
-          type: string
-          format: date-time
+        checker_id:
+          type: integer
+          format: int64
         has_checker:
           type: boolean
         input_file_formats:
@@ -1279,9 +1279,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
-        checker_id:
-          type: integer
-          format: int64
+        last_modified_date:
+          type: string
+          format: date-time
         type:
           type: string
       writeOnly: true
@@ -1345,12 +1345,18 @@ components:
           type: string
         hidden:
           type: boolean
-        email:
-          type: string
-        description:
-          type: string
         doiURL:
           type: string
+        author:
+          type: string
+        verified:
+          type: boolean
+        verifiedSource:
+          type: string
+        verifiedSources:
+          type: array
+          items:
+            type: string
         doiStatus:
           type: string
           enum:
@@ -1362,15 +1368,9 @@ components:
           enum:
           - README
           - DESCRIPTOR
-        verified:
-          type: boolean
-        verifiedSource:
+        description:
           type: string
-        verifiedSources:
-          type: array
-          items:
-            type: string
-        author:
+        email:
           type: string
         dbUpdateDate:
           type: string

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -6150,18 +6150,209 @@ definitions:
       content:
         type: "string"
   BioWorkflow:
-    allOf:
-    - $ref: "#/definitions/Workflow"
-    - type: "object"
-      properties:
-        parent_id:
-          type: "integer"
-          format: "int64"
-          readOnly: true
-        is_checker:
-          type: "boolean"
-          position: 23
-      description: "This describes one workflow in the dockstore"
+    type: "object"
+    required:
+    - "defaultTestParameterFilePath"
+    - "descriptorType"
+    - "gitUrl"
+    - "mode"
+    - "organization"
+    - "repository"
+    - "sourceControl"
+    - "workflow_path"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+        description: "Implementation specific ID for the container in this web service"
+      aliases:
+        type: "object"
+        description: "aliases can be used as an alternate unique id for entries"
+        additionalProperties:
+          $ref: "#/definitions/Alias"
+      dbCreateDate:
+        type: "string"
+        format: "date-time"
+      dbUpdateDate:
+        type: "string"
+        format: "date-time"
+      topicId:
+        type: "integer"
+        format: "int64"
+        description: "The Id of the corresponding topic on Dockstore Discuss"
+      parent_id:
+        type: "integer"
+        format: "int64"
+        readOnly: true
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
+      has_checker:
+        type: "boolean"
+        readOnly: true
+      input_file_formats:
+        type: "array"
+        readOnly: true
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/FileFormat"
+      output_file_formats:
+        type: "array"
+        readOnly: true
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/FileFormat"
+      author:
+        type: "string"
+        position: 1
+        description: "This is the name of the author stated in the Dockstore.cwl"
+      description:
+        type: "string"
+        position: 2
+        description: "This is a human-readable description of this container and what\
+          \ it is trying to accomplish, required GA4GH"
+      labels:
+        type: "array"
+        position: 3
+        description: "Labels (i.e. meta tags) for describing the purpose and contents\
+          \ of containers"
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/Label"
+      users:
+        type: "array"
+        position: 4
+        description: "This indicates the users that have control over this entry,\
+          \ dockstore specific"
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/User"
+      starredUsers:
+        type: "array"
+        position: 5
+        description: "This indicates the users that have starred this entry, dockstore\
+          \ specific"
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/User"
+      email:
+        type: "string"
+        position: 6
+        description: "This is the email of the git organization"
+      defaultVersion:
+        type: "string"
+        position: 7
+        description: "This is the default version of the entry"
+      is_published:
+        type: "boolean"
+        position: 8
+        description: "Implementation specific visibility in this web service"
+      last_modified:
+        type: "integer"
+        format: "int32"
+        position: 9
+        description: "Implementation specific timestamp for last modified. Tools->\
+          \ For automated/manual builds: N/A. For hosted: Last time a file was updated/created\
+          \ (new version created). Workflows-> For remote: When refresh is hit, last\
+          \ time GitHub repo was changed. Hosted: Last time a new version was made."
+      lastUpdated:
+        type: "string"
+        format: "date-time"
+        position: 10
+        description: "Implementation specific timestamp for last updated on webservice.\
+          \ Tools-> For automated builds: last time tool/namespace was refreshed Dockstore,\
+          \ tool info (like changing dockerfile path) updated, or default version\
+          \ selected. For hosted tools: when you created the tool. Workflows-> For\
+          \ remote: When refresh all is hit for first time. Hosted: Seems to be time\
+          \ created."
+      gitUrl:
+        type: "string"
+        position: 11
+        description: "This is a link to the associated repo with a descriptor, required\
+          \ GA4GH"
+      checker_id:
+        type: "integer"
+        format: "int64"
+        position: 12
+        description: "The id of the associated checker workflow"
+        readOnly: true
+      conceptDoi:
+        type: "string"
+        position: 13
+        description: "The Digital Object Identifier (DOI) representing all of the\
+          \ versions of your workflow"
+      mode:
+        type: "string"
+        position: 13
+        description: "This indicates what mode this is in which informs how we do\
+          \ things like refresh, dockstore specific"
+        enum:
+        - "FULL"
+        - "STUB"
+        - "HOSTED"
+        - "SERVICE"
+      workflowName:
+        type: "string"
+        position: 14
+        description: "This is the name of the workflow, not needed when only one workflow\
+          \ in a repo"
+      organization:
+        type: "string"
+        position: 15
+        description: "This is a git organization for the workflow"
+      repository:
+        type: "string"
+        position: 16
+        description: "This is a git repository name"
+      sourceControl:
+        type: "string"
+        position: 17
+        description: "This is a specific source control provider like github or bitbucket\
+          \ or n/a?, required: GA4GH"
+      descriptorType:
+        type: "string"
+        position: 18
+        description: "This is a descriptor type for the workflow, either CWL, WDL,\
+          \ or Nextflow (Defaults to CWL)"
+        enum:
+        - "CWL"
+        - "WDL"
+        - "NFL"
+        - "service"
+      workflow_path:
+        type: "string"
+        position: 19
+        description: "This indicates for the associated git repository, the default\
+          \ path to the primary descriptor document"
+      defaultTestParameterFilePath:
+        type: "string"
+        position: 20
+        description: "This indicates for the associated git repository, the default\
+          \ path to the test parameter file"
+      workflowVersions:
+        type: "array"
+        position: 21
+        description: "Implementation specific tracking of valid build workflowVersions\
+          \ for the docker container"
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/WorkflowVersion"
+      is_checker:
+        type: "boolean"
+        position: 23
+      full_workflow_path:
+        type: "string"
+        position: 24
+        readOnly: true
+      path:
+        type: "string"
+        position: 25
+      source_control_provider:
+        type: "string"
+        position: 26
+        readOnly: true
+    description: "This describes one workflow in the dockstore"
   Checksum:
     type: "object"
     properties:
@@ -6357,6 +6548,10 @@ definitions:
       custom_docker_registry_path:
         type: "string"
         readOnly: true
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6372,10 +6567,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       author:
         type: "string"
         position: 1
@@ -6593,6 +6784,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/Version"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6608,10 +6803,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       author:
         type: "string"
         position: 1
@@ -8010,6 +8201,10 @@ definitions:
         type: "boolean"
       parentEntry:
         $ref: "#/definitions/Entry"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -8025,10 +8220,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       author:
         type: "string"
         position: 1

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.8.0-alpha.4-SNAPSHOT"
+  version: "1.8.0-beta.1-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:
@@ -6357,10 +6357,6 @@ definitions:
       custom_docker_registry_path:
         type: "string"
         readOnly: true
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6376,6 +6372,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1
@@ -6593,10 +6593,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/Version"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -6612,6 +6608,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1
@@ -8010,10 +8010,6 @@ definitions:
         type: "boolean"
       parentEntry:
         $ref: "#/definitions/Entry"
-      last_modified_date:
-        type: "string"
-        format: "date-time"
-        readOnly: true
       has_checker:
         type: "boolean"
         readOnly: true
@@ -8029,6 +8025,10 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/FileFormat"
+      last_modified_date:
+        type: "string"
+        format: "date-time"
+        readOnly: true
       author:
         type: "string"
         position: 1


### PR DESCRIPTION
Entry and version dbcreatedate and dbupdatedate are not nullable.

Migrate existing entry and version dbcreatedate and dbupdatedate to be not null. Does this by first trying to set them to lastmodified/lastupdated/etc. columns if they are set, with a fallback to the date of the first commit of Dockstore (open to alternatives).

https://github.com/dockstore/dockstore/issues/3084
https://github.com/dockstore/dockstore/issues/3099