### PR TITLE
Feature/fix release process

### DIFF
--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.8.0-beta.4</version>
+        <version>1.8.0-beta.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-common</artifactId>

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.8.0-beta.3-SNAPSHOT</version>
+        <version>1.8.0-beta.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-common</artifactId>

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.8.0-beta.3</version>
+        <version>1.8.0-beta.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-common</artifactId>

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.8.0-beta.4-SNAPSHOT</version>
+        <version>1.8.0-beta.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-common</artifactId>

--- a/dockstore-event-consumer/pom.xml
+++ b/dockstore-event-consumer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.3-SNAPSHOT</version>
+        <version>1.8.0-beta.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -30,12 +30,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>

--- a/dockstore-event-consumer/pom.xml
+++ b/dockstore-event-consumer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.4-SNAPSHOT</version>
+        <version>1.8.0-beta.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -30,12 +30,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>

--- a/dockstore-event-consumer/pom.xml
+++ b/dockstore-event-consumer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.4</version>
+        <version>1.8.0-beta.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -30,12 +30,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>

--- a/dockstore-event-consumer/pom.xml
+++ b/dockstore-event-consumer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.3</version>
+        <version>1.8.0-beta.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -30,12 +30,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.8.0-beta.4</version>
+        <version>1.8.0-beta.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-integration-testing</artifactId>
@@ -60,30 +60,30 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-client</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
 
         <!-- testing -->
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.8.0-beta.4-SNAPSHOT</version>
+        <version>1.8.0-beta.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-integration-testing</artifactId>
@@ -60,30 +60,30 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
 
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-client</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
 
         <!-- testing -->
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.8.0-beta.3-SNAPSHOT</version>
+        <version>1.8.0-beta.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-integration-testing</artifactId>
@@ -60,30 +60,30 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
 
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-client</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
 
         <!-- testing -->
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.8.0-beta.3</version>
+        <version>1.8.0-beta.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-integration-testing</artifactId>
@@ -60,30 +60,30 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-client</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
 
         <!-- testing -->
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-language-plugin-parent/pom.xml
+++ b/dockstore-language-plugin-parent/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <version>1.8.0-beta.3-SNAPSHOT</version>
+        <version>1.8.0-beta.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
         <dependency>
             <groupId>ro.fortsoft.pf4j</groupId>

--- a/dockstore-language-plugin-parent/pom.xml
+++ b/dockstore-language-plugin-parent/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <version>1.8.0-beta.3</version>
+        <version>1.8.0-beta.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ro.fortsoft.pf4j</groupId>

--- a/dockstore-language-plugin-parent/pom.xml
+++ b/dockstore-language-plugin-parent/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <version>1.8.0-beta.4-SNAPSHOT</version>
+        <version>1.8.0-beta.4</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
         <dependency>
             <groupId>ro.fortsoft.pf4j</groupId>

--- a/dockstore-language-plugin-parent/pom.xml
+++ b/dockstore-language-plugin-parent/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <version>1.8.0-beta.4</version>
+        <version>1.8.0-beta.5-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ro.fortsoft.pf4j</groupId>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
 
     <parent>
-        <version>1.8.0-beta.4</version>
+        <version>1.8.0-beta.5-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -53,32 +53,32 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-quay-client</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-sam-client</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-bitbucket-client</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-discourse-client</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-language-plugin-parent</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
         <!-- DOCKSTORE-2428 - demo how to add new workflow language
         <dependency>
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-zenodo-client</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
@@ -571,7 +571,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
 
     <parent>
-        <version>1.8.0-beta.3-SNAPSHOT</version>
+        <version>1.8.0-beta.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -53,32 +53,32 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-quay-client</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-sam-client</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-bitbucket-client</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-discourse-client</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-language-plugin-parent</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
         <!-- DOCKSTORE-2428 - demo how to add new workflow language
         <dependency>
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-zenodo-client</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
@@ -571,7 +571,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
 
     <parent>
-        <version>1.8.0-beta.3</version>
+        <version>1.8.0-beta.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -53,32 +53,32 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-quay-client</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-sam-client</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-bitbucket-client</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-discourse-client</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-language-plugin-parent</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
         <!-- DOCKSTORE-2428 - demo how to add new workflow language
         <dependency>
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-zenodo-client</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
@@ -571,7 +571,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
 
     <parent>
-        <version>1.8.0-beta.4-SNAPSHOT</version>
+        <version>1.8.0-beta.4</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -53,32 +53,32 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-quay-client</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-sam-client</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-bitbucket-client</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-discourse-client</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-language-plugin-parent</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
         <!-- DOCKSTORE-2428 - demo how to add new workflow language
         <dependency>
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-zenodo-client</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
@@ -571,7 +571,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.8.0-beta.3"
+  version: "1.8.0-beta.4"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.8.0-beta.2-SNAPSHOT"
+  version: "1.8.0-beta.3"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/openapi-java-client/pom.xml
+++ b/openapi-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>openapi-java-client</name>
 
     <parent>
-        <version>1.8.0-beta.4-SNAPSHOT</version>
+        <version>1.8.0-beta.4</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -323,7 +323,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/openapi-java-client/pom.xml
+++ b/openapi-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>openapi-java-client</name>
 
     <parent>
-        <version>1.8.0-beta.4</version>
+        <version>1.8.0-beta.5-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -323,7 +323,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/openapi-java-client/pom.xml
+++ b/openapi-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>openapi-java-client</name>
 
     <parent>
-        <version>1.8.0-beta.3-SNAPSHOT</version>
+        <version>1.8.0-beta.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -323,7 +323,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/openapi-java-client/pom.xml
+++ b/openapi-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>openapi-java-client</name>
 
     <parent>
-        <version>1.8.0-beta.3</version>
+        <version>1.8.0-beta.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -323,7 +323,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>io.dockstore</groupId>
     <artifactId>dockstore</artifactId>
-    <version>1.8.0-beta.3</version>
+    <version>1.8.0-beta.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>dockstore</name>
@@ -73,7 +73,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-        <tag>1.8.0-beta.3</tag>
+        <tag>1.7.0</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>io.dockstore</groupId>
     <artifactId>dockstore</artifactId>
-    <version>1.8.0-beta.4</version>
+    <version>1.8.0-beta.5-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>dockstore</name>
@@ -73,7 +73,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-        <tag>1.8.0-beta.4</tag>
+        <tag>1.7.0</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1397,7 +1397,7 @@
             </build>
         </profile>
         <profile>
-            <id>skipTestsForReleasePerform-tests</id>
+            <id>skipForRelease</id>
             <properties>
                 <!-- skip swagger kongchen generation on release and rely on checked in yaml -->
                 <swagger.skip>true</swagger.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>io.dockstore</groupId>
     <artifactId>dockstore</artifactId>
-    <version>1.8.0-beta.3-SNAPSHOT</version>
+    <version>1.8.0-beta.3</version>
     <packaging>pom</packaging>
 
     <name>dockstore</name>
@@ -73,7 +73,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-        <tag>1.7.0</tag>
+        <tag>1.8.0-beta.3</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -998,6 +998,7 @@
                     <version>2.5.3</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <releaseProfiles>skipForRelease</releaseProfiles>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -1394,6 +1395,13 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>skipTestsForReleasePerform-tests</id>
+            <properties>
+                <!-- skip swagger kongchen generation on release and rely on checked in yaml -->
+                <swagger.skip>true</swagger.skip>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>io.dockstore</groupId>
     <artifactId>dockstore</artifactId>
-    <version>1.8.0-beta.4-SNAPSHOT</version>
+    <version>1.8.0-beta.4</version>
     <packaging>pom</packaging>
 
     <name>dockstore</name>
@@ -73,7 +73,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-        <tag>1.7.0</tag>
+        <tag>1.8.0-beta.4</tag>
     </scm>
 
     <repositories>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.4</version>
+        <version>1.8.0-beta.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,17 +29,17 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-integration-testing</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.3</version>
+        <version>1.8.0-beta.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,17 +29,17 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-integration-testing</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.4-SNAPSHOT</version>
+        <version>1.8.0-beta.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,17 +29,17 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-integration-testing</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
         </dependency>
     </dependencies>
 

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.3-SNAPSHOT</version>
+        <version>1.8.0-beta.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,17 +29,17 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-integration-testing</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
         </dependency>
     </dependencies>
 

--- a/swagger-java-bitbucket-client/pom.xml
+++ b/swagger-java-bitbucket-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.4</version>
+        <version>1.8.0-beta.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-bitbucket-client/pom.xml
+++ b/swagger-java-bitbucket-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.4-SNAPSHOT</version>
+        <version>1.8.0-beta.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-bitbucket-client/pom.xml
+++ b/swagger-java-bitbucket-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.3</version>
+        <version>1.8.0-beta.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-bitbucket-client/pom.xml
+++ b/swagger-java-bitbucket-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.3-SNAPSHOT</version>
+        <version>1.8.0-beta.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-client/pom.xml
+++ b/swagger-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-client</name>
 
     <parent>
-        <version>1.8.0-beta.4-SNAPSHOT</version>
+        <version>1.8.0-beta.4</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -260,7 +260,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.4-SNAPSHOT</version>
+            <version>1.8.0-beta.4</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/swagger-java-client/pom.xml
+++ b/swagger-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-client</name>
 
     <parent>
-        <version>1.8.0-beta.3-SNAPSHOT</version>
+        <version>1.8.0-beta.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -260,7 +260,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.3-SNAPSHOT</version>
+            <version>1.8.0-beta.3</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/swagger-java-client/pom.xml
+++ b/swagger-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-client</name>
 
     <parent>
-        <version>1.8.0-beta.4</version>
+        <version>1.8.0-beta.5-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -260,7 +260,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.4</version>
+            <version>1.8.0-beta.5-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/swagger-java-client/pom.xml
+++ b/swagger-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-client</name>
 
     <parent>
-        <version>1.8.0-beta.3</version>
+        <version>1.8.0-beta.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -260,7 +260,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.8.0-beta.3</version>
+            <version>1.8.0-beta.4-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/swagger-java-discourse-client/pom.xml
+++ b/swagger-java-discourse-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-discourse-client</name>
 
     <parent>
-        <version>1.8.0-beta.3</version>
+        <version>1.8.0-beta.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-discourse-client/pom.xml
+++ b/swagger-java-discourse-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-discourse-client</name>
 
     <parent>
-        <version>1.8.0-beta.4</version>
+        <version>1.8.0-beta.5-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-discourse-client/pom.xml
+++ b/swagger-java-discourse-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-discourse-client</name>
 
     <parent>
-        <version>1.8.0-beta.3-SNAPSHOT</version>
+        <version>1.8.0-beta.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-discourse-client/pom.xml
+++ b/swagger-java-discourse-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-discourse-client</name>
 
     <parent>
-        <version>1.8.0-beta.4-SNAPSHOT</version>
+        <version>1.8.0-beta.4</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-quay-client/pom.xml
+++ b/swagger-java-quay-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-quay-client</name>
 
     <parent>
-        <version>1.8.0-beta.4-SNAPSHOT</version>
+        <version>1.8.0-beta.4</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-quay-client/pom.xml
+++ b/swagger-java-quay-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-quay-client</name>
 
     <parent>
-        <version>1.8.0-beta.3-SNAPSHOT</version>
+        <version>1.8.0-beta.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-quay-client/pom.xml
+++ b/swagger-java-quay-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-quay-client</name>
 
     <parent>
-        <version>1.8.0-beta.4</version>
+        <version>1.8.0-beta.5-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-quay-client/pom.xml
+++ b/swagger-java-quay-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-quay-client</name>
 
     <parent>
-        <version>1.8.0-beta.3</version>
+        <version>1.8.0-beta.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-sam-client/pom.xml
+++ b/swagger-java-sam-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.4</version>
+        <version>1.8.0-beta.5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-sam-client/pom.xml
+++ b/swagger-java-sam-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.4-SNAPSHOT</version>
+        <version>1.8.0-beta.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-sam-client/pom.xml
+++ b/swagger-java-sam-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.3</version>
+        <version>1.8.0-beta.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-sam-client/pom.xml
+++ b/swagger-java-sam-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.8.0-beta.3-SNAPSHOT</version>
+        <version>1.8.0-beta.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-zenodo-client/pom.xml
+++ b/swagger-java-zenodo-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-zenodo-client</name>
 
     <parent>
-        <version>1.8.0-beta.4</version>
+        <version>1.8.0-beta.5-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-zenodo-client/pom.xml
+++ b/swagger-java-zenodo-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-zenodo-client</name>
 
     <parent>
-        <version>1.8.0-beta.3</version>
+        <version>1.8.0-beta.4-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-zenodo-client/pom.xml
+++ b/swagger-java-zenodo-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-zenodo-client</name>
 
     <parent>
-        <version>1.8.0-beta.4-SNAPSHOT</version>
+        <version>1.8.0-beta.4</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-zenodo-client/pom.xml
+++ b/swagger-java-zenodo-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-zenodo-client</name>
 
     <parent>
-        <version>1.8.0-beta.3-SNAPSHOT</version>
+        <version>1.8.0-beta.3</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>


### PR DESCRIPTION
PITA, the kongchen plugin was causing an issue when running inside the new checkout used for a Maven release. Somehow, the generated swagger always has an incorrect class hierarchy when running on a new checkout (doesn't know that BioWorkflow is a Workflow)

