### PR TITLE
Don't update on hosted workflow creation

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -137,7 +137,6 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
         checkForDuplicatePath(entry);
         long l = getEntryDAO().create(entry);
         T byId = getEntryDAO().findById(l);
-        PublicStateManager.getInstance().handleIndexUpdate(byId, StateManagerMode.UPDATE);
         return byId;
     }
 


### PR DESCRIPTION
For dockstore/dockstore#2992 Don't update listeners when a new hosted workflow is created (because it's not published)

Simply removed the statement. Couldn't figure out an easy way to create a test.