### PR TITLE
Feature/3045/starred organization events

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BaseIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BaseIT.java
@@ -91,10 +91,14 @@ public class BaseIT {
         SUPPORT.after();
     }
 
+
+    protected static io.dockstore.openapi.client.ApiClient getOpenAPIWebClient(String username, TestingPostgres testingPostgresParameter) {
+        return CommonTestUtilities.getOpenAPIWebClient(true, username, testingPostgresParameter);
+    }
+
     /**
      * the following were migrated from SwaggerClientIT and can be eventually merged. Note different config file used
      */
-
     protected static ApiClient getWebClient(String username, TestingPostgres testingPostgresParameter) {
         return CommonTestUtilities.getWebClient(true, username, testingPostgresParameter);
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -6,7 +6,9 @@ import java.util.List;
 
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
+import io.dockstore.openapi.client.api.EventsApi;
 import io.dockstore.webservice.core.OrganizationUser;
+import io.dockstore.webservice.resources.EventSearchType;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.ContainersApi;
@@ -331,6 +333,13 @@ public class OrganizationIT extends BaseIT {
         assertEquals("potato", organization.getDescription());
         String description = organizationsApiUser2.getOrganizationDescription(organization.getId());
         assertEquals("potato", description);
+
+        organizationsApiUser2.starOrganization(organization.getId(), SwaggerUtility.createStarRequest(true));
+        final io.dockstore.openapi.client.ApiClient openAPIWebClientUser2 = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        EventsApi eventsApi = new EventsApi(openAPIWebClientUser2);
+        List<io.dockstore.openapi.client.model.Event> events1 = eventsApi
+                .getEvents(EventSearchType.STARRED_ORGANIZATION.toString(), null, null);
+        Assert.assertEquals("Should have 1 create, 1 approve, 4 modify events", 6, events1.size());
     }
 
     @Test(expected = ApiException.class)

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -338,15 +338,23 @@ public class OrganizationIT extends BaseIT {
         testStarredOrganizationEvents(organizationsApiUser2, organization);
     }
 
+    /**
+     * This tests that:
+     * the pagination limit works
+     * the newest events are gotten
+     * @param organizationsApiUser2 Organization API for user 2 who will star the organization
+     * @param organization  An organization which is known to have 6 events (create > modify > approve > modify > modify > modify)
+     */
     private void testStarredOrganizationEvents(OrganizationsApi organizationsApiUser2, Organization organization) {
         organizationsApiUser2.starOrganization(organization.getId(), SwaggerUtility.createStarRequest(true));
         final io.dockstore.openapi.client.ApiClient openAPIWebClientUser2 = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         EventsApi eventsApi = new EventsApi(openAPIWebClientUser2);
         List<io.dockstore.openapi.client.model.Event> events = eventsApi
                 .getEvents(EventSearchType.STARRED_ORGANIZATION.toString(), null, null);
-        Assert.assertEquals("Should have 1 create, 1 approve, 4 modify events", 6, events.size());
+        Assert.assertEquals("Should have the correct amount of events", 6, events.size());
         events = eventsApi.getEvents(EventSearchType.STARRED_ORGANIZATION.toString(), 5, null);
-        Assert.assertEquals("Should have 1 create, 1 approve, 4 modify events", 5, events.size());
+        Assert.assertEquals("Should have the correct amount of events", 5, events.size());
+        Assert.assertFalse("The create org event is the oldest, it should not be returned", events.stream().anyMatch(event -> event.getType().equals(io.dockstore.openapi.client.model.Event.TypeEnum.CREATE_ORG)));
         try {
             eventsApi.getEvents(EventSearchType.STARRED_ORGANIZATION.toString(), EventDAO.MAX_LIMIT + 1, 0);
             Assert.fail("Should've failed because it's over the limit");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -121,38 +121,41 @@ public final class CommonTestUtilities {
 
     /**
      * Shared convenience method
-     *
+     * TODO: Somehow merge it with the method below, they are nearly identical
      * @return
      */
     public static ApiClient getWebClient(boolean authenticated, String username, TestingPostgres testingPostgres) {
-        File configFile = FileUtils.getFile("src", "test", "resources", "config2");
-        INIConfiguration parseConfig = Utilities.parseConfig(configFile.getAbsolutePath());
         ApiClient client = new ApiClient();
-        client.setBasePath(parseConfig.getString(Constants.WEBSERVICE_BASE_PATH));
+        client.setBasePath(getBasePath());
         if (authenticated) {
-            client.addDefaultHeader("Authorization", "Bearer " + (testingPostgres
-                .runSelectStatement("select content from token where tokensource='dockstore' and username= '" + username + "';",
-                    String.class)));
+            client.addDefaultHeader("Authorization", getDockstoreToken(testingPostgres, username));
         }
         return client;
     }
 
     /**
      * Shared convenience method
-     *
+     * TODO: Somehow merge it with the method above, they are nearly identical
      * @return
      */
     public static io.dockstore.openapi.client.ApiClient getOpenAPIWebClient(boolean authenticated, String username, TestingPostgres testingPostgres) {
-        File configFile = FileUtils.getFile("src", "test", "resources", "config2");
-        INIConfiguration parseConfig = Utilities.parseConfig(configFile.getAbsolutePath());
         io.dockstore.openapi.client.ApiClient client = new io.dockstore.openapi.client.ApiClient();
-        client.setBasePath(parseConfig.getString(Constants.WEBSERVICE_BASE_PATH));
+        client.setBasePath(getBasePath());
         if (authenticated) {
-            client.addDefaultHeader("Authorization", "Bearer " + (testingPostgres
-                    .runSelectStatement("select content from token where tokensource='dockstore' and username= '" + username + "';",
-                            String.class)));
+            client.addDefaultHeader("Authorization", getDockstoreToken(testingPostgres, username));
         }
         return client;
+    }
+
+    private static String getBasePath() {
+        File configFile = FileUtils.getFile("src", "test", "resources", "config2");
+        INIConfiguration parseConfig = Utilities.parseConfig(configFile.getAbsolutePath());
+        return parseConfig.getString(Constants.WEBSERVICE_BASE_PATH);
+    }
+
+    private static String getDockstoreToken(TestingPostgres testingPostgres, String username) {
+        return "Bearer " + (testingPostgres
+                .runSelectStatement("select content from token where tokensource='dockstore' and username= '" + username + "';", String.class));
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -138,6 +138,24 @@ public final class CommonTestUtilities {
     }
 
     /**
+     * Shared convenience method
+     *
+     * @return
+     */
+    public static io.dockstore.openapi.client.ApiClient getOpenAPIWebClient(boolean authenticated, String username, TestingPostgres testingPostgres) {
+        File configFile = FileUtils.getFile("src", "test", "resources", "config2");
+        INIConfiguration parseConfig = Utilities.parseConfig(configFile.getAbsolutePath());
+        io.dockstore.openapi.client.ApiClient client = new io.dockstore.openapi.client.ApiClient();
+        client.setBasePath(parseConfig.getString(Constants.WEBSERVICE_BASE_PATH));
+        if (authenticated) {
+            client.addDefaultHeader("Authorization", "Bearer " + (testingPostgres
+                    .runSelectStatement("select content from token where tokensource='dockstore' and username= '" + username + "';",
+                            String.class)));
+        }
+        return client;
+    }
+
+    /**
      * Wrapper for dropping and recreating database from migrations for test confidential 1
      *
      * @param support reference to testing instance of the dockstore web service

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -37,6 +37,7 @@ import org.hibernate.annotations.UpdateTimestamp;
         @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByEntryId", query = "SELECT e FROM Event e where e.workflow.id = :entryId OR e.tool.id = :entryId"),
         @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllForOrganization", query = "SELECT eve FROM Event eve WHERE eve.organization.id = :organizationId ORDER BY id DESC"),
         @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByOrganizationIds", query = "SELECT e FROM Event e WHERE e.organization.id in :organizationIDs ORDER BY id DESC"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByOrganizationIdsOrEntryIds", query = "SELECT e FROM Event e WHERE (e.organization.id in :organizationIDs) OR (e.tool.id in :entryIDs) OR (e.workflow.id in :entryIDs) ORDER BY id DESC"),
         @NamedQuery(name = "io.dockstore.webservice.core.Event.countAllForOrganization", query = "SELECT COUNT(*) FROM Event eve WHERE eve.organization.id = :organizationId")
 })
 public class Event {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -31,11 +31,12 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Table(name = "event")
 @SuppressWarnings({"checkstyle:magicnumber", "checkstyle:hiddenfield"})
 @NamedQueries({
-        @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByEntry", query = "SELECT e FROM Event e where (e.tool.id in :entryIDs) OR (e.workflow.id in :entryIDs)"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByEntryIds", query = "SELECT e FROM Event e where (e.tool.id in :entryIDs) OR (e.workflow.id in :entryIDs) ORDER by id desc"),
         @NamedQuery(name = "io.dockstore.webservice.core.Event.deleteByEntryId", query = "DELETE Event e where e.tool.id = :entryId OR e.workflow.id = :entryId"),
         @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByUserId", query = "SELECT e FROM Event e where e.user.id = :userId"),
         @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByEntryId", query = "SELECT e FROM Event e where e.workflow.id = :entryId OR e.tool.id = :entryId"),
         @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllForOrganization", query = "SELECT eve FROM Event eve WHERE eve.organization.id = :organizationId ORDER BY id DESC"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByOrganizationIds", query = "SELECT e FROM Event e WHERE e.organization.id in :organizationIDs ORDER BY id DESC"),
         @NamedQuery(name = "io.dockstore.webservice.core.Event.countAllForOrganization", query = "SELECT COUNT(*) FROM Event eve WHERE eve.organization.id = :organizationId")
 })
 public class Event {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
@@ -63,6 +63,17 @@ public class EventDAO extends AbstractDAO<Event> {
         return list(query);
     }
 
+    public List<Event> findAllByOrganizationIdsOrEntryIds(Set<Long> organizationIds, Set<Long> entryIds, Integer offset, int limit) {
+        int newLimit = Math.min(MAX_LIMIT, limit);
+        if (organizationIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Query<Event> query = namedQuery("io.dockstore.webservice.core.Event.findAllByOrganizationIdsOrEntryIds");
+        query.setParameterList("organizationIDs", organizationIds).setParameter("entryIDs", entryIds)
+                .setFirstResult(offset).setMaxResults(newLimit);
+        return list(query);
+    }
+
     public void delete(Event event) {
         Session session = currentSession();
         session.delete(event);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
@@ -48,8 +48,18 @@ public class EventDAO extends AbstractDAO<Event> {
         if (entryIds.isEmpty()) {
             return Collections.emptyList();
         }
-        Query<Event> query = namedQuery("io.dockstore.webservice.core.Event.findAllByEntry");
+        Query<Event> query = namedQuery("io.dockstore.webservice.core.Event.findAllByEntryIds");
         query.setParameterList("entryIDs", entryIds).setFirstResult(offset).setMaxResults(newLimit);
+        return list(query);
+    }
+
+    public List<Event> findAllByOrganizationIds(Set<Long> organizationIds, Integer offset, int limit) {
+        int newLimit = Math.min(MAX_LIMIT, limit);
+        if (organizationIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Query<Event> query = namedQuery("io.dockstore.webservice.core.Event.findAllByOrganizationIds");
+        query.setParameterList("organizationIDs", organizationIds).setFirstResult(offset).setMaxResults(newLimit);
         return list(query);
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
@@ -16,7 +16,7 @@
 package io.dockstore.webservice.resources;
 
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -79,25 +79,21 @@ public class EventResource {
     @Operation(description = DESCRIPTION, summary = SUMMARY, security = @SecurityRequirement(name = "bearer"))
     @ApiOperation(value = SUMMARY, authorizations = {
             @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = DESCRIPTION, responseContainer = "List", response = Event.class)
-    public Set<Event> getEvents(@Parameter(hidden = true) @ApiParam(hidden = true) @Auth User user, @QueryParam("event_search_type") EventSearchType eventSearchType, @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") int limit, @QueryParam("offset") @DefaultValue("0") Integer offset) {
+    public List<Event> getEvents(@Parameter(hidden = true) @ApiParam(hidden = true) @Auth User user, @QueryParam("event_search_type") EventSearchType eventSearchType, @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") int limit, @QueryParam("offset") @DefaultValue("0") Integer offset) {
         User userWithSession = this.userDAO.findById(user.getId());
-        Set<Event> events = new HashSet<>();
         switch (eventSearchType) {
         case STARRED_ENTRIES:
             Set<Long> entryIDs = userWithSession.getStarredEntries().stream().map(Entry::getId).collect(Collectors.toSet());
-            events.addAll(this.eventDAO.findEventsByEntryIDs(entryIDs, offset, limit));
-            return events;
+            return this.eventDAO.findEventsByEntryIDs(entryIDs, offset, limit);
         case STARRED_ORGANIZATION:
             Set<Long> organizationIDs = userWithSession.getStarredOrganizations().stream().map(Organization::getId).collect(Collectors.toSet());
-            events.addAll(this.eventDAO.findAllByOrganizationIds(organizationIDs, offset, limit));
-            return events;
+            return this.eventDAO.findAllByOrganizationIds(organizationIDs, offset, limit);
         case ALL_STARRED:
             Set<Long> organizationIDs2 = userWithSession.getStarredOrganizations().stream().map(Organization::getId).collect(Collectors.toSet());
             Set<Long> entryIDs2 = userWithSession.getStarredEntries().stream().map(Entry::getId).collect(Collectors.toSet());
-            events.addAll(this.eventDAO.findAllByOrganizationIdsOrEntryIds(organizationIDs2, entryIDs2, offset, limit));
-            return events;
+            return this.eventDAO.findAllByOrganizationIdsOrEntryIds(organizationIDs2, entryIDs2, offset, limit);
         default:
-            return Collections.emptySet();
+            return Collections.emptyList();
         }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
@@ -17,7 +17,6 @@ package io.dockstore.webservice.resources;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -33,6 +32,7 @@ import javax.ws.rs.core.MediaType;
 import com.codahale.metrics.annotation.Timed;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Event;
+import io.dockstore.webservice.core.Organization;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.jdbi.EventDAO;
 import io.dockstore.webservice.jdbi.UserDAO;
@@ -88,10 +88,8 @@ public class EventResource {
             events.addAll(this.eventDAO.findEventsByEntryIDs(entryIDs, offset, limit));
             return events;
         case STARRED_ORGANIZATION:
-            userWithSession.getStarredOrganizations().forEach(organization -> {
-                List<Event> eventsForOrganization = this.eventDAO.findEventsForOrganization(organization.getId(), offset, limit);
-                events.addAll(eventsForOrganization);
-            });
+            Set<Long> collect = userWithSession.getStarredOrganizations().stream().map(Organization::getId).collect(Collectors.toSet());
+            events.addAll(this.eventDAO.findAllByOrganizationIds(collect, offset, limit));
             return events;
         default:
             return Collections.emptySet();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
@@ -88,8 +88,13 @@ public class EventResource {
             events.addAll(this.eventDAO.findEventsByEntryIDs(entryIDs, offset, limit));
             return events;
         case STARRED_ORGANIZATION:
-            Set<Long> collect = userWithSession.getStarredOrganizations().stream().map(Organization::getId).collect(Collectors.toSet());
-            events.addAll(this.eventDAO.findAllByOrganizationIds(collect, offset, limit));
+            Set<Long> organizationIDs = userWithSession.getStarredOrganizations().stream().map(Organization::getId).collect(Collectors.toSet());
+            events.addAll(this.eventDAO.findAllByOrganizationIds(organizationIDs, offset, limit));
+            return events;
+        case ALL_STARRED:
+            Set<Long> organizationIDs2 = userWithSession.getStarredOrganizations().stream().map(Organization::getId).collect(Collectors.toSet());
+            Set<Long> entryIDs2 = userWithSession.getStarredEntries().stream().map(Entry::getId).collect(Collectors.toSet());
+            events.addAll(this.eventDAO.findAllByOrganizationIdsOrEntryIds(organizationIDs2, entryIDs2, offset, limit));
             return events;
         default:
             return Collections.emptySet();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
@@ -79,7 +79,7 @@ public class EventResource {
     @Operation(description = DESCRIPTION, summary = SUMMARY, security = @SecurityRequirement(name = "bearer"))
     @ApiOperation(value = SUMMARY, authorizations = {
             @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = DESCRIPTION, responseContainer = "List", response = Event.class)
-    public Set<Event> getEvents(@ApiParam(hidden = true) @Auth User user, @QueryParam("event_search_type") EventSearchType eventSearchType, @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") int limit, @QueryParam("offset") @DefaultValue("0") Integer offset) {
+    public Set<Event> getEvents(@Parameter(hidden = true) @ApiParam(hidden = true) @Auth User user, @QueryParam("event_search_type") EventSearchType eventSearchType, @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") int limit, @QueryParam("offset") @DefaultValue("0") Integer offset) {
         User userWithSession = this.userDAO.findById(user.getId());
         Set<Event> events = new HashSet<>();
         switch (eventSearchType) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventSearchType.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventSearchType.java
@@ -15,7 +15,11 @@
 
 package io.dockstore.webservice.resources;
 
+// STARRED_ENTRIES return events related to starred entries
+// STARRED_ORGANIZATION return events related to starred organization
+// STARRED returns events related to both starred entries AND starred organizations
 public enum EventSearchType  {
     STARRED_ENTRIES,
-    STARRED_ORGANIZATION
+    STARRED_ORGANIZATION,
+    ALL_STARRED
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventSearchType.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventSearchType.java
@@ -16,5 +16,6 @@
 package io.dockstore.webservice.resources;
 
 public enum EventSearchType  {
-    STARRED_ENTRIES
+    STARRED_ENTRIES,
+    STARRED_ORGANIZATION
 }


### PR DESCRIPTION
For partial #3045 , UI remains

Add query for events related to starred organization (unused)

Add query for events related to starred organization OR starred entries

The previous query for events related to starred entries is also unused

Also need to remove all swagger annotations from the eventresource