### PR TITLE
Enable aliases to show up for organizations and workflow versions in swagger output

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -251,7 +251,7 @@ public class OrganizationIT extends BaseIT {
         // Should now appear in approved list
         organizationList = organizationsApiUser2.getApprovedOrganizations();
         assertEquals("Should have one approved Organizations.", organizationList.size(), 1);
-        organizationList.forEach(approvedOrganization -> Assert.assertNull(approvedOrganization.getAliases()));
+        organizationList.forEach(approvedOrganization -> Assert.assertTrue(approvedOrganization.getAliases().isEmpty()));
 
         // Should not be able to request re-review
         canRequestReview = true;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -76,6 +76,7 @@ import io.swagger.client.model.Workflow;
 import io.swagger.client.model.Workflow.DescriptorTypeEnum;
 import io.swagger.client.model.WorkflowVersion;
 import io.swagger.model.DescriptorType;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.hibernate.Session;
@@ -1547,7 +1548,8 @@ public class WorkflowIT extends BaseIT {
     public void testWorkflowVersionAliasesAreReturned() throws ApiException {
         final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
-        workflowApi.manualRegister("github", "DockstoreTestUser2/dockstore_workflow_cnv", "/workflow/cnv.cwl", "", "cwl", "/test.json");
+        workflowApi.manualRegister("github", "DockstoreTestUser2/dockstore_workflow_cnv",
+                "/workflow/cnv.cwl", "", "cwl", "/test.json");
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
         final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId());
@@ -1567,12 +1569,14 @@ public class WorkflowIT extends BaseIT {
                 workflowVersionWithAliases.getAliases().containsKey("awesome workflowversion") && workflowVersionWithAliases.getAliases().containsKey("spam")
                         && workflowVersionWithAliases.getAliases().containsKey("test workflowversion"));
 
+        // Do not include the validation parameter that requests workflow version aliases be included in the returned object
+        // So the aliases portion of the returned object should be null
         Workflow workflowById = workflowApi.getWorkflow(workflow.getId(), null);
         Optional<WorkflowVersion> optionalWorkflowVersionById = workflowById.getWorkflowVersions().stream()
                 .filter(version -> "master".equalsIgnoreCase(version.getName())).findFirst();
         assertTrue(optionalWorkflowVersionById.isPresent());
         WorkflowVersion workflowVersionById = optionalWorkflowVersionById.get();
-        Assert.assertNotNull("Getting workflow version via workflow ID has null alias", workflowVersionById.getAliases());
+        Assert.assertNull("Getting workflow version via workflow ID has null alias", workflowVersionById.getAliases());
 
         final Workflow publishedWorkflow = workflowApi.getPublishedWorkflow(workflow.getId(), null);
         assertNotNull("did not get published workflow", publishedWorkflow);
@@ -1580,7 +1584,7 @@ public class WorkflowIT extends BaseIT {
                 .filter(version -> "master".equalsIgnoreCase(version.getName())).findFirst();
         assertTrue(optionalWorkflowVersionByPublished.isPresent());
         WorkflowVersion workflowVersionByPublshed = optionalWorkflowVersionByPublished.get();
-        Assert.assertNotNull("Getting workflow version via published workflow has null alias", workflowVersionByPublshed.getAliases());
+        Assert.assertNull("Getting workflow version via published workflow has null alias", workflowVersionByPublshed.getAliases());
 
         final Workflow workflowByPath = workflowApi
                 .getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
@@ -1589,8 +1593,7 @@ public class WorkflowIT extends BaseIT {
                 .filter(version -> "master".equalsIgnoreCase(version.getName())).findFirst();
         assertTrue(optionalWorkflowVersionByPath.isPresent());
         WorkflowVersion workflowVersionByPath = optionalWorkflowVersionByPath.get();
-        Assert.assertNotNull("Getting workflow version via workflow path has null alias", workflowVersionByPath.getAliases());
-
+        Assert.assertNull("Getting workflow version via workflow path has null alias", workflowVersionByPath.getAliases());
 
         final Workflow publishedWorkflowByPath = workflowApi
                 .getPublishedWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
@@ -1599,7 +1602,48 @@ public class WorkflowIT extends BaseIT {
                 .filter(version -> "master".equalsIgnoreCase(version.getName())).findFirst();
         assertTrue(optionalWorkflowVersionByPublishedByPath.isPresent());
         WorkflowVersion workflowVersionByPublshedByPath = optionalWorkflowVersionByPublishedByPath.get();
-        Assert.assertNotNull("Getting workflow version via published workflow has null alias", workflowVersionByPublshedByPath.getAliases());
+        Assert.assertNull("Getting workflow version via published workflow has null alias", workflowVersionByPublshedByPath.getAliases());
+
+
+
+        // Include the validation parameter that requests workflow version aliases be included in the returned object
+        Workflow workflowByIdValidation = workflowApi.getWorkflow(workflow.getId(), "aliases");
+        Optional<WorkflowVersion> optionalWorkflowVersionByIdValidation = workflowByIdValidation.getWorkflowVersions().stream()
+                .filter(version -> "master".equalsIgnoreCase(version.getName())).findFirst();
+        assertTrue(optionalWorkflowVersionByIdValidation.isPresent());
+        WorkflowVersion workflowVersionByIdValidation = optionalWorkflowVersionByIdValidation.get();
+        Assert.assertFalse("Getting workflow version via workflow ID has null or empty alias",
+                MapUtils.isEmpty(workflowVersionByIdValidation.getAliases()));
+
+        final Workflow publishedWorkflowValidation = workflowApi.getPublishedWorkflow(workflow.getId(), "aliases");
+        assertNotNull("did not get published workflow", publishedWorkflowValidation);
+        Optional<WorkflowVersion> optionalWorkflowVersionByPublishedValidation = publishedWorkflowValidation.getWorkflowVersions().stream()
+                .filter(version -> "master".equalsIgnoreCase(version.getName())).findFirst();
+        assertTrue(optionalWorkflowVersionByPublishedValidation.isPresent());
+        WorkflowVersion workflowVersionByPublshedValidation = optionalWorkflowVersionByPublishedValidation.get();
+        Assert.assertFalse("Getting workflow version via published workflow has null or empty alias",
+                MapUtils.isEmpty(workflowVersionByPublshedValidation.getAliases()));
+
+        final Workflow workflowByPathValidation = workflowApi
+                .getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, "aliases", false);
+        assertNotNull("did not get published workflow by path", workflowByPathValidation);
+        Optional<WorkflowVersion> optionalWorkflowVersionByPathValidation = workflowByPathValidation.getWorkflowVersions().stream()
+                .filter(version -> "master".equalsIgnoreCase(version.getName())).findFirst();
+        assertTrue(optionalWorkflowVersionByPathValidation.isPresent());
+        WorkflowVersion workflowVersionByPathValidation = optionalWorkflowVersionByPathValidation.get();
+        Assert.assertFalse("Getting workflow version via workflow path has null or empty alias",
+                MapUtils.isEmpty(workflowVersionByPathValidation.getAliases()));
+
+
+        final Workflow publishedWorkflowByPathValidation = workflowApi
+                .getPublishedWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, "aliases", false);
+        assertNotNull("did not get published workflow by path", publishedWorkflowByPathValidation);
+        Optional<WorkflowVersion> optionalWorkflowVersionByPublishedByPathValidation = publishedWorkflowByPathValidation.getWorkflowVersions().stream()
+                .filter(version -> "master".equalsIgnoreCase(version.getName())).findFirst();
+        assertTrue(optionalWorkflowVersionByPublishedByPathValidation.isPresent());
+        WorkflowVersion workflowVersionByPublshedByPathValidation = optionalWorkflowVersionByPublishedByPathValidation.get();
+        Assert.assertFalse("Getting workflow version via published workflow has null alias",
+                MapUtils.isEmpty(workflowVersionByPublshedByPathValidation.getAliases()));
 
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -184,6 +184,7 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
 
             Collection collection = collectionDAO.findByNameAndOrg(collectionName, organization.getId());
             Hibernate.initialize(collection.getEntries());
+            Hibernate.initialize(collection.getAliases());
             return collection;
         }
     }
@@ -587,6 +588,7 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
         }
 
         Hibernate.initialize(byAlias.getEntries());
+        Hibernate.initialize(byAlias.getAliases());
         return byAlias;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -454,6 +454,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         Hibernate.initialize(workflow.getUsers());
         initializeValidations(include, workflow);
         Hibernate.initialize(workflow.getAliases());
+        workflow.getWorkflowVersions().stream().forEach(wv -> Hibernate.initialize(wv.getAliases()));
         return workflow;
     }
 
@@ -707,6 +708,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         checkEntry(workflow);
         initializeValidations(include, workflow);
         Hibernate.initialize(workflow.getAliases());
+        workflow.getWorkflowVersions().stream().forEach(wv -> Hibernate.initialize(wv.getAliases()));
         return filterContainersForHiddenTags(workflow);
     }
 
@@ -858,6 +860,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
         initializeValidations(include, workflow);
         Hibernate.initialize(workflow.getAliases());
+        workflow.getWorkflowVersions().stream().forEach(wv -> Hibernate.initialize(wv.getAliases()));
         return workflow;
     }
 
@@ -1044,6 +1047,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
         initializeValidations(include, workflow);
         Hibernate.initialize(workflow.getAliases());
+        workflow.getWorkflowVersions().stream().forEach(wv -> Hibernate.initialize(wv.getAliases()));
         filterContainersForHiddenTags(workflow);
 
         // evil hack for backwards compatibility with 1.6.0 CLI, sorry

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -445,7 +445,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @ApiOperation(nickname = "getWorkflow", value = "Retrieve a workflow", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, notes = "This is one of the few endpoints that returns the user object with populated properties (minus the userProfiles property)")
     public Workflow getWorkflow(@ApiParam(hidden = true) @Auth User user,
-        @ApiParam(value = "workflow ID", required = true) @PathParam("workflowId") Long workflowId, @ApiParam(value = "Comma-delimited list of fields to include: validations") @QueryParam("include") String include) {
+        @ApiParam(value = "workflow ID", required = true) @PathParam("workflowId") Long workflowId, @ApiParam(value = "Comma-delimited list of fields to include: validations, aliases") @QueryParam("include") String include) {
         Workflow workflow = workflowDAO.findById(workflowId);
         checkEntry(workflow);
         checkCanRead(user, workflow);
@@ -702,7 +702,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @UnitOfWork(readOnly = true)
     @Path("/published/{workflowId}")
     @ApiOperation(value = "Get a published workflow.", notes = "Hidden versions will not be visible. NO authentication", response = Workflow.class)
-    public Workflow getPublishedWorkflow(@ApiParam(value = "Workflow ID", required = true) @PathParam("workflowId") Long workflowId, @ApiParam(value = "Comma-delimited list of fields to include: validations") @QueryParam("include") String include) {
+    public Workflow getPublishedWorkflow(@ApiParam(value = "Workflow ID", required = true) @PathParam("workflowId") Long workflowId, @ApiParam(value = "Comma-delimited list of fields to include: validations, aliases") @QueryParam("include") String include) {
         Workflow workflow = workflowDAO.findPublishedById(workflowId);
         checkEntry(workflow);
         initializeValidations(include, workflow);
@@ -849,7 +849,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @ApiOperation(value = "Get a workflow by path.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Requires full path (including workflow name if applicable).", response = Workflow.class)
     public Workflow getWorkflowByPath(@ApiParam(hidden = true) @Auth User user,
-        @ApiParam(value = "repository path", required = true) @PathParam("repository") String path, @ApiParam(value = "Comma-delimited list of fields to include: validations") @QueryParam("include") String include,
+        @ApiParam(value = "repository path", required = true) @PathParam("repository") String path, @ApiParam(value = "Comma-delimited list of fields to include: validations, aliases") @QueryParam("include") String include,
         @ApiParam(value = "services", defaultValue = "false") @DefaultValue("false") @QueryParam("services") boolean services) {
         final Class<? extends Workflow> targetClass = services ? Service.class : BioWorkflow.class;
         Workflow workflow = workflowDAO.findByPath(path, false, targetClass).orElse(null);
@@ -1036,7 +1036,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @UnitOfWork(readOnly = true)
     @Path("/path/workflow/{repository}/published")
     @ApiOperation(nickname = "getPublishedWorkflowByPath", value = "Get a published workflow by path", notes = "Does not require workflow name.", response = Workflow.class)
-    public Workflow getPublishedWorkflowByPath(@ApiParam(value = "repository path", required = true) @PathParam("repository") String path, @ApiParam(value = "Comma-delimited list of fields to include: validations") @QueryParam("include") String include,
+    public Workflow getPublishedWorkflowByPath(@ApiParam(value = "repository path", required = true) @PathParam("repository") String path, @ApiParam(value = "Comma-delimited list of fields to include: validations, aliases") @QueryParam("include") String include,
         @ApiParam(value = "services", defaultValue = "false") @DefaultValue("false") @QueryParam("services") boolean services, @Context ContainerRequestContext containerContext) {
         final Class<? extends Workflow> targetClass = services ? Service.class : BioWorkflow.class;
         Workflow workflow = workflowDAO.findByPath(path, true, targetClass).orElse(null);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -147,6 +147,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     private static final String WDL_CHECKER = "_wdl_checker";
     private static final Logger LOG = LoggerFactory.getLogger(WorkflowResource.class);
     private static final String PAGINATION_LIMIT = "100";
+    private static final String ALIASES = "aliases";
+    private static final String VALIDATIONS = "validations";
 
     private final ToolDAO toolDAO;
     private final LabelDAO labelDAO;
@@ -445,7 +447,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @ApiOperation(nickname = "getWorkflow", value = "Retrieve a workflow", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, notes = "This is one of the few endpoints that returns the user object with populated properties (minus the userProfiles property)")
     public Workflow getWorkflow(@ApiParam(hidden = true) @Auth User user,
-        @ApiParam(value = "workflow ID", required = true) @PathParam("workflowId") Long workflowId, @ApiParam(value = "Comma-delimited list of fields to include: validations, aliases") @QueryParam("include") String include) {
+        @ApiParam(value = "workflow ID", required = true) @PathParam("workflowId") Long workflowId, @ApiParam(value = "Comma-delimited list of fields to include: " + VALIDATIONS + ", " + ALIASES) @QueryParam("include") String include) {
         Workflow workflow = workflowDAO.findById(workflowId);
         checkEntry(workflow);
         checkCanRead(user, workflow);
@@ -702,7 +704,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @UnitOfWork(readOnly = true)
     @Path("/published/{workflowId}")
     @ApiOperation(value = "Get a published workflow.", notes = "Hidden versions will not be visible. NO authentication", response = Workflow.class)
-    public Workflow getPublishedWorkflow(@ApiParam(value = "Workflow ID", required = true) @PathParam("workflowId") Long workflowId, @ApiParam(value = "Comma-delimited list of fields to include: validations, aliases") @QueryParam("include") String include) {
+    public Workflow getPublishedWorkflow(@ApiParam(value = "Workflow ID", required = true) @PathParam("workflowId") Long workflowId, @ApiParam(value = "Comma-delimited list of fields to include: " + VALIDATIONS + ", " + ALIASES) @QueryParam("include") String include) {
         Workflow workflow = workflowDAO.findPublishedById(workflowId);
         checkEntry(workflow);
         initializeValidations(include, workflow);
@@ -849,7 +851,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @ApiOperation(value = "Get a workflow by path.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Requires full path (including workflow name if applicable).", response = Workflow.class)
     public Workflow getWorkflowByPath(@ApiParam(hidden = true) @Auth User user,
-        @ApiParam(value = "repository path", required = true) @PathParam("repository") String path, @ApiParam(value = "Comma-delimited list of fields to include: validations, aliases") @QueryParam("include") String include,
+        @ApiParam(value = "repository path", required = true) @PathParam("repository") String path, @ApiParam(value = "Comma-delimited list of fields to include: " + VALIDATIONS + ", " + ALIASES) @QueryParam("include") String include,
         @ApiParam(value = "services", defaultValue = "false") @DefaultValue("false") @QueryParam("services") boolean services) {
         final Class<? extends Workflow> targetClass = services ? Service.class : BioWorkflow.class;
         Workflow workflow = workflowDAO.findByPath(path, false, targetClass).orElse(null);
@@ -1036,7 +1038,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @UnitOfWork(readOnly = true)
     @Path("/path/workflow/{repository}/published")
     @ApiOperation(nickname = "getPublishedWorkflowByPath", value = "Get a published workflow by path", notes = "Does not require workflow name.", response = Workflow.class)
-    public Workflow getPublishedWorkflowByPath(@ApiParam(value = "repository path", required = true) @PathParam("repository") String path, @ApiParam(value = "Comma-delimited list of fields to include: validations, aliases") @QueryParam("include") String include,
+    public Workflow getPublishedWorkflowByPath(@ApiParam(value = "repository path", required = true) @PathParam("repository") String path, @ApiParam(value = "Comma-delimited list of fields to include: " + VALIDATIONS + ", " + ALIASES) @QueryParam("include") String include,
         @ApiParam(value = "services", defaultValue = "false") @DefaultValue("false") @QueryParam("services") boolean services, @Context ContainerRequestContext containerContext) {
         final Class<? extends Workflow> targetClass = services ? Service.class : BioWorkflow.class;
         Workflow workflow = workflowDAO.findByPath(path, true, targetClass).orElse(null);
@@ -1622,10 +1624,10 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
      * @param workflow
      */
     private void initializeValidations(String include, Workflow workflow) {
-        if (checkIncludes(include, "validations")) {
+        if (checkIncludes(include, VALIDATIONS)) {
             workflow.getWorkflowVersions().forEach(workflowVersion -> Hibernate.initialize(workflowVersion.getValidations()));
         }
-        if (checkIncludes(include, "aliases")) {
+        if (checkIncludes(include, ALIASES)) {
             workflow.getWorkflowVersions().forEach(workflowVersion -> Hibernate.initialize(workflowVersion.getAliases()));
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -454,7 +454,6 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         Hibernate.initialize(workflow.getUsers());
         initializeValidations(include, workflow);
         Hibernate.initialize(workflow.getAliases());
-        workflow.getWorkflowVersions().stream().forEach(wv -> Hibernate.initialize(wv.getAliases()));
         return workflow;
     }
 
@@ -708,7 +707,6 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         checkEntry(workflow);
         initializeValidations(include, workflow);
         Hibernate.initialize(workflow.getAliases());
-        workflow.getWorkflowVersions().stream().forEach(wv -> Hibernate.initialize(wv.getAliases()));
         return filterContainersForHiddenTags(workflow);
     }
 
@@ -860,7 +858,6 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
         initializeValidations(include, workflow);
         Hibernate.initialize(workflow.getAliases());
-        workflow.getWorkflowVersions().stream().forEach(wv -> Hibernate.initialize(wv.getAliases()));
         return workflow;
     }
 
@@ -1047,7 +1044,6 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
         initializeValidations(include, workflow);
         Hibernate.initialize(workflow.getAliases());
-        workflow.getWorkflowVersions().stream().forEach(wv -> Hibernate.initialize(wv.getAliases()));
         filterContainersForHiddenTags(workflow);
 
         // evil hack for backwards compatibility with 1.6.0 CLI, sorry
@@ -1621,12 +1617,16 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
     /**
      * If include contains validations field, initialize the workflows validations for all of its workflow versions
+     * If include contains aliases field, initialize the aliases for all of its workflow versions
      * @param include
      * @param workflow
      */
     private void initializeValidations(String include, Workflow workflow) {
         if (checkIncludes(include, "validations")) {
             workflow.getWorkflowVersions().forEach(workflowVersion -> Hibernate.initialize(workflowVersion.getValidations()));
+        }
+        if (checkIncludes(include, "aliases")) {
+            workflow.getWorkflowVersions().forEach(workflowVersion -> Hibernate.initialize(workflowVersion.getAliases()));
         }
     }
 


### PR DESCRIPTION
When using the swagger UI and executing APIs that return workflows and their workflow versions enable the workflow version aliases to be seen in the return JSON

When using the swagger UI and executing APIs that return organizations enable the organization aliases to be seen in the return JSON