### PR TITLE
Enforce proper annotations for dockstore-cli build

### DIFF
--- a/swagger-java-client/pom.xml
+++ b/swagger-java-client/pom.xml
@@ -103,17 +103,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemProperties>
-                        <property>
-                            <name>loggerPath</name>
-                            <value>conf/log4j.properties</value>
-                        </property>
-                    </systemProperties>
-                    <argLine>-Xms512m -Xmx1500m</argLine>
-                    <parallel>methods</parallel>
-                    <forkMode>pertest</forkMode>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -193,7 +182,13 @@
             </plugin>
         </plugins>
     </build>
+
     <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+        </dependency>
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>

--- a/swagger-java-client/src/test/java/io/dockstore/swagger/EnforceAnnotationsTest.java
+++ b/swagger-java-client/src/test/java/io/dockstore/swagger/EnforceAnnotationsTest.java
@@ -8,19 +8,19 @@ import org.junit.Test;
 
 public class EnforceAnnotationsTest {
 
-
     @Test
     public void checkAnnotations() {
-        // we had a bizarre issue where the Workflow would lose an annotation
+        // we had a bizarre issue where the Workflow would lose an annotation that was required for dockstore-cli to work properly
         Workflow workflow = new Workflow();
         Class<? extends Workflow> cls = workflow.getClass();
         final Annotation[] annotations = cls.getAnnotations();
         boolean hasJsonSubTypes = false;
         for (Annotation an : annotations) {
-            if (an.toString().startsWith("@com.fasterxml.jackson.annotation.JsonSubTypes(")) {
-                if (an.toString().contains("name=\"Service\", value=io.swagger.client.model.Service.class") && an.toString().contains("name=\"BioWorkflow\", value=io.swagger.client.model.BioWorkflow.class")) {
-                    hasJsonSubTypes = true;
-                }
+            final String toString = an.toString();
+            if (toString.startsWith("@com.fasterxml.jackson.annotation.JsonSubTypes(") && toString
+                .contains("name=\"Service\", value=io.swagger.client.model.Service.class") && toString
+                .contains("name=\"BioWorkflow\", value=io.swagger.client.model.BioWorkflow.class")) {
+                hasJsonSubTypes = true;
             }
         }
         Assert.assertTrue(hasJsonSubTypes);

--- a/swagger-java-client/src/test/java/io/dockstore/swagger/EnforceAnnotationsTest.java
+++ b/swagger-java-client/src/test/java/io/dockstore/swagger/EnforceAnnotationsTest.java
@@ -1,0 +1,29 @@
+package io.dockstore.swagger;
+
+import java.lang.annotation.Annotation;
+
+import io.swagger.client.model.Workflow;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EnforceAnnotationsTest {
+
+
+    @Test
+    public void checkAnnotations() {
+        // we had a bizarre issue where the Workflow would lose an annotation
+        Workflow workflow = new Workflow();
+        Class<? extends Workflow> cls = workflow.getClass();
+        final Annotation[] annotations = cls.getAnnotations();
+        boolean hasJsonSubTypes = false;
+        for (Annotation an : annotations) {
+            if (an.toString().startsWith("@com.fasterxml.jackson.annotation.JsonSubTypes(")) {
+                if (an.toString().contains("name=\"Service\", value=io.swagger.client.model.Service.class") && an.toString().contains("name=\"BioWorkflow\", value=io.swagger.client.model.BioWorkflow.class")) {
+                    hasJsonSubTypes = true;
+                }
+            }
+        }
+        Assert.assertTrue(hasJsonSubTypes);
+    }
+
+}


### PR DESCRIPTION
In the jar imported by dockstore-cli

Maven: io.dockstore:swagger-java-client:1.8.0-beta.0 (fails)
```
@JsonSubTypes({@Type(
    value = Service.class,
    name = "Service"
)})
public class Workflow {
```
Maven: Maven: io.dockstore:swagger-java-client:1.8.0-beta.5 (works)
```
@JsonSubTypes({@Type(
    value = Service.class,
    name = "Service"
), @Type(
    value = BioWorkflow.class,
    name = "BioWorkflow"
)})
public class Workflow {
```

This is what was partially addressed for swagger by https://github.com/dockstore/dockstore/commit/fc6d6b55251f75c51b67d4bdfa9c2045b4644d9c 

Note openapi3 https://github.com/dockstore/dockstore/blob/develop/dockstore-webservice/src/main/resources/openapi3/openapi.yaml seems to suffer from the same problem (but doesn't have obvious consequences (yet) yet maybe because we don't rely on it enough yet

Unfortunately, I can't enforce the same condition on openapi3 since it seems permanently broken.


