### PR TITLE
Feature/3143/extendeduser

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ExtendedUserData.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ExtendedUserData.java
@@ -16,10 +16,10 @@
 package io.dockstore.webservice.core;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dockstore.webservice.jdbi.UserDAO;
 import io.dockstore.webservice.permissions.PermissionsInterface;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,10 +32,10 @@ public class ExtendedUserData {
     @ApiModelProperty(value = "Whether a user can change their username")
     private boolean canChangeUsername;
 
-    public ExtendedUserData(User user, PermissionsInterface authorizer) {
-        Hibernate.initialize(user.getEntries());
+    public ExtendedUserData(User user, PermissionsInterface authorizer, UserDAO userDAO) {
+        Long publishedEntries = userDAO.findPublishedEntries(user.getUsername());
         try {
-            this.canChangeUsername = user.getEntries().stream().noneMatch(Entry::getIsPublished) && !authorizer.isSharing(user)
+            this.canChangeUsername = publishedEntries == 0 && !authorizer.isSharing(user)
                     && user.getOrganizations().size() == 0;
         } catch (Exception e) {
             LOG.error("SAM is improperly configured.", e);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ExtendedUserData.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ExtendedUserData.java
@@ -33,7 +33,7 @@ public class ExtendedUserData {
     private boolean canChangeUsername;
 
     public ExtendedUserData(User user, PermissionsInterface authorizer, UserDAO userDAO) {
-        Long publishedEntries = userDAO.findPublishedEntries(user.getUsername());
+        long publishedEntries = userDAO.findPublishedEntries(user.getUsername());
         try {
             this.canChangeUsername = publishedEntries == 0 && !authorizer.isSharing(user)
                     && user.getOrganizations().size() == 0;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -80,6 +80,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 @NamedQueries({ @NamedQuery(name = "io.dockstore.webservice.core.User.findAll", query = "SELECT t FROM User t"),
     @NamedQuery(name = "io.dockstore.webservice.core.User.findByUsername", query = "SELECT t FROM User t WHERE t.username = :username"),
     @NamedQuery(name = "io.dockstore.webservice.core.User.findByGoogleEmail", query = "SELECT t FROM User t JOIN t.userProfiles p where( KEY(p) = 'google.com' AND p.email = :email)"),
+    @NamedQuery(name = "io.dockstore.webservice.core.User.countPublishedEntries", query = "SELECT count(e) FROM User u INNER JOIN u.entries e where e.isPublished=true and u.username = :username"),
     @NamedQuery(name = "io.dockstore.webservice.core.User.findByGitHubUsername", query = "SELECT t FROM User t JOIN t.userProfiles p where( KEY(p) = 'github.com' AND p.username = :username)") })
 @SuppressWarnings("checkstyle:magicnumber")
 public class User implements Principal, Comparable<User>, Serializable {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/UserDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/UserDAO.java
@@ -76,9 +76,9 @@ public class UserDAO extends AbstractDockstoreDAO<User> {
         return (User)query.uniqueResult();
     }
 
-    public Long findPublishedEntries(String username)  {
+    public long findPublishedEntries(String username)  {
         final Query query = namedQuery("io.dockstore.webservice.core.User.countPublishedEntries").setParameter("username", username);
-        return (Long)query.uniqueResult();
+        return (long)query.uniqueResult();
     }
 
     public boolean delete(User user) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/UserDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/UserDAO.java
@@ -18,7 +18,6 @@ package io.dockstore.webservice.jdbi;
 
 import java.util.List;
 
-import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.User;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/UserDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/UserDAO.java
@@ -18,6 +18,7 @@ package io.dockstore.webservice.jdbi;
 
 import java.util.List;
 
+import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.User;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
@@ -74,6 +75,11 @@ public class UserDAO extends AbstractDockstoreDAO<User> {
         final Query query = namedQuery("io.dockstore.webservice.core.User.findByGitHubUsername")
             .setParameter("username", username);
         return (User)query.uniqueResult();
+    }
+
+    public Long findPublishedEntries(String username)  {
+        final Query query = namedQuery("io.dockstore.webservice.core.User.countPublishedEntries").setParameter("username", username);
+        return (Long)query.uniqueResult();
     }
 
     public boolean delete(User user) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -196,7 +196,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     @ApiOperation(value = "Get additional information about the authenticated user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = ExtendedUserData.class)
     public ExtendedUserData getExtendedUserData(@ApiParam(hidden = true) @Auth User user) {
         User foundUser = userDAO.findById(user.getId());
-        return new ExtendedUserData(foundUser, this.authorizer);
+        return new ExtendedUserData(foundUser, this.authorizer, userDAO);
     }
 
     @POST
@@ -211,7 +211,7 @@ public class UserResource implements AuthenticatedResourceInterface {
             throw new CustomWebApplicationException("Username pattern invalid", HttpStatus.SC_BAD_REQUEST);
         }
         User user = userDAO.findById(authUser.getId());
-        if (!new ExtendedUserData(user, this.authorizer).canChangeUsername()) {
+        if (!new ExtendedUserData(user, this.authorizer, userDAO).canChangeUsername()) {
             throw new CustomWebApplicationException("Cannot change username, user not ready", HttpStatus.SC_BAD_REQUEST);
         }
         user.setUsername(username);
@@ -239,7 +239,7 @@ public class UserResource implements AuthenticatedResourceInterface {
             @ApiParam(hidden = true) @Auth User authUser) {
         checkUser(authUser, authUser.getId());
         User user = userDAO.findById(authUser.getId());
-        if (!new ExtendedUserData(user, this.authorizer).canChangeUsername()) {
+        if (!new ExtendedUserData(user, this.authorizer, userDAO).canChangeUsername()) {
             throw new CustomWebApplicationException("Cannot delete user, user not ready for deletion", HttpStatus.SC_BAD_REQUEST);
         }
         // Remove dangling sharing artifacts before getting rid of tokens


### PR DESCRIPTION
Partial #3143 to speed up the extended user endpoint.  Still could use more optimizations I believe.

Before:
```
    974458 nanoseconds spent acquiring 2 JDBC connections;
    83384 nanoseconds spent releasing 2 JDBC connections;
    40787339 nanoseconds spent preparing 2538 JDBC statements;
    685346097 nanoseconds spent executing 2538 JDBC statements;
    0 nanoseconds spent executing 0 JDBC batches;
    0 nanoseconds spent performing 0 L2C puts;
    0 nanoseconds spent performing 0 L2C hits;
    0 nanoseconds spent performing 0 L2C misses;
    54512291 nanoseconds spent executing 1 flushes (flushing a total of 1881 entities and 3818 collections);
    0 nanoseconds spent executing 0 partial-flushes (flushing a total of 0 entities and 0 collections)
```

After:
```
    2774782 nanoseconds spent acquiring 2 JDBC connections;
    169564 nanoseconds spent releasing 2 JDBC connections;
    2275580 nanoseconds spent preparing 2 JDBC statements;
    14760844 nanoseconds spent executing 2 JDBC statements;
    0 nanoseconds spent executing 0 JDBC batches;
    0 nanoseconds spent performing 0 L2C puts;
    0 nanoseconds spent performing 0 L2C hits;
    0 nanoseconds spent performing 0 L2C misses;
    892104 nanoseconds spent executing 1 flushes (flushing a total of 1 entities and 5 collections);
    394570 nanoseconds spent executing 1 partial-flushes (flushing a total of 1 entities and 1 collections)
```

There are two statements because there's another DAO function called to get the authenticated user entity from hibernate, not related to the extended user endpoint per se.  This is likely the optimal amount of statements.



