### PR TITLE
create better error message for workflow or tool registration

### DIFF
--- a/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
+++ b/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
@@ -75,8 +75,7 @@ class WdlBridge {
     val executableCallable = convertFilePathToExecutableCallable(filePath, sourceFilePath)
     val numberOfTaskCalls = executableCallable.taskCallNodes.seq.size
 
-    // WDL tool with zero task calls are valid
-    if (numberOfTaskCalls != 0 && numberOfTaskCalls > 1) {
+    if (numberOfTaskCalls > 1) {
       throw new WdlParser.SyntaxError("A WDL tool can only call one task. This file calls more than one task. Did you mean to register a workflow?")
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
@@ -168,12 +168,12 @@ public class ValidationIT extends BaseIT {
         workflow = workflowsApi.refresh(workflow.getId());
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
-        // change to valid tool - should be valid
+        // change to valid tool - should be invalid
         workflow.setWorkflowPath("/validTool.wdl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
         workflow = workflowsApi.refresh(workflow.getId());
-        Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
+        Assert.assertFalse("Should be invalid", isWorkflowVersionValid(workflow, "master"));
 
         // change back to valid workflow - should be valid
         workflow.setWorkflowPath("/validWorkflow.wdl");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
@@ -168,12 +168,12 @@ public class ValidationIT extends BaseIT {
         workflow = workflowsApi.refresh(workflow.getId());
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
-        // change to valid tool - should be invalid
+        // change to valid tool - should be valid
         workflow.setWorkflowPath("/validTool.wdl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
         workflow = workflowsApi.refresh(workflow.getId());
-        Assert.assertFalse("Should be invalid", isWorkflowVersionValid(workflow, "master"));
+        Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
 
         // change back to valid workflow - should be valid
         workflow.setWorkflowPath("/validWorkflow.wdl");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -737,8 +737,8 @@ public class CWLHandler implements LanguageHandlerInterface {
             } else if (!content.contains("class: Workflow")) {
                 isValid = false;
                 validationMessage = "A CWL workflow requires class: Workflow.";
-                if (content.contains("class: CommandLineTool")) {
-                    validationMessage += " This file contains class: CommandLineTool. Did you mean to register a tool?";
+                if (content.contains("class: CommandLineTool") || content.contains("class: ExpressionTool")) {
+                    validationMessage += " This file contains class: CommandLineTool or ExpressionTool. Did you mean to register a tool?";
                 }
             } else if (!this.isValidCwl(content, yaml)) {
                 isValid = false;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -725,7 +725,7 @@ public class CWLHandler implements LanguageHandlerInterface {
         Optional<SourceFile> mainDescriptor = filteredSourcefiles.stream().filter((sourceFile -> Objects.equals(sourceFile.getPath(), primaryDescriptorFilePath))).findFirst();
 
         boolean isValid = true;
-        String validationMessage = null;
+        StringBuilder validationMessage = new StringBuilder();
         Map<String, String> validationMessageObject = new HashMap<>();
 
         if (mainDescriptor.isPresent()) {
@@ -733,25 +733,24 @@ public class CWLHandler implements LanguageHandlerInterface {
             String content = mainDescriptor.get().getContent();
             if (content == null || content.isEmpty()) {
                 isValid = false;
-                validationMessage = "Primary descriptor is empty.";
+                validationMessage.append("Primary descriptor is empty.");
             } else if (!content.contains("class: Workflow")) {
                 isValid = false;
-                validationMessage = "A CWL workflow requires class: Workflow.";
+                validationMessage.append("A CWL workflow requires 'class: Workflow'.");
                 if (content.contains("class: CommandLineTool") || content.contains("class: ExpressionTool")) {
-                    validationMessage += " This file contains class: ";
-                    validationMessage += (content.contains("class: CommandLineTool")) ? "CommandLineTool." : "ExpressionTool.";
-                    validationMessage += " Did you mean to register a tool?";
+                    String cwlClass = content.contains("class: CommandLineTool") ? "CommandLineTool" : "ExpressionTool";
+                    validationMessage.append(" This file contains 'class: ").append(cwlClass).append("'. Did you mean to register a tool?");
                 }
             } else if (!this.isValidCwl(content, yaml)) {
                 isValid = false;
-                validationMessage = "Invalid CWL version.";
+                validationMessage.append("Invalid CWL version.");
             }
         } else {
-            validationMessage = "Primary CWL descriptor is not present.";
+            validationMessage.append("Primary CWL descriptor is not present.");
             isValid = false;
         }
 
-        validationMessageObject.put(primaryDescriptorFilePath, validationMessage);
+        validationMessageObject.put(primaryDescriptorFilePath, validationMessage.toString());
         return new VersionTypeValidation(isValid, validationMessageObject);
     }
 
@@ -773,9 +772,9 @@ public class CWLHandler implements LanguageHandlerInterface {
                 validationMessage = "Primary CWL descriptor is empty.";
             } else if (!content.contains("class: CommandLineTool") && !content.contains("class: ExpressionTool")) {
                 isValid = false;
-                validationMessage = "A CWL tool requires class: CommandLineTool or ExpressionTool.";
+                validationMessage = "A CWL tool requires 'class: CommandLineTool' or 'class: ExpressionTool'.";
                 if (content.contains("class: Workflow")) {
-                    validationMessage += " This file contains class: Workflow. Did you mean to register a workflow?";
+                    validationMessage += " This file contains 'class: Workflow'. Did you mean to register a workflow?";
                 }
             } else if (!this.isValidCwl(content, yaml)) {
                 isValid = false;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -738,7 +738,9 @@ public class CWLHandler implements LanguageHandlerInterface {
                 isValid = false;
                 validationMessage = "A CWL workflow requires class: Workflow.";
                 if (content.contains("class: CommandLineTool") || content.contains("class: ExpressionTool")) {
-                    validationMessage += " This file contains class: CommandLineTool or ExpressionTool. Did you mean to register a tool?";
+                    validationMessage += " This file contains class: ";
+                    validationMessage += (content.contains("class: CommandLineTool")) ? "CommandLineTool." : "ExpressionTool.";
+                    validationMessage += " Did you mean to register a tool?";
                 }
             } else if (!this.isValidCwl(content, yaml)) {
                 isValid = false;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -753,7 +753,6 @@ public class CWLHandler implements LanguageHandlerInterface {
         return new VersionTypeValidation(isValid, validationMessageObject);
     }
 
-    @SuppressWarnings("checkstyle:EmptyBlock")
     @Override
     public VersionTypeValidation validateToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
         List<DescriptorLanguage.FileType> fileTypes = new ArrayList<>(Collections.singletonList(DescriptorLanguage.FileType.DOCKSTORE_CWL));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -736,7 +736,10 @@ public class CWLHandler implements LanguageHandlerInterface {
                 validationMessage = "Primary descriptor is empty.";
             } else if (!content.contains("class: Workflow")) {
                 isValid = false;
-                validationMessage = "Requires class: Workflow.";
+                validationMessage = "A CWL workflow requires class: Workflow.";
+                if (content.contains("class: CommandLineTool")) {
+                    validationMessage += " This file contains class: CommandLineTool. Did you mean to register a tool?";
+                }
             } else if (!this.isValidCwl(content, yaml)) {
                 isValid = false;
                 validationMessage = "Invalid CWL version.";
@@ -750,6 +753,7 @@ public class CWLHandler implements LanguageHandlerInterface {
         return new VersionTypeValidation(isValid, validationMessageObject);
     }
 
+    @SuppressWarnings("checkstyle:EmptyBlock")
     @Override
     public VersionTypeValidation validateToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
         List<DescriptorLanguage.FileType> fileTypes = new ArrayList<>(Collections.singletonList(DescriptorLanguage.FileType.DOCKSTORE_CWL));
@@ -768,7 +772,10 @@ public class CWLHandler implements LanguageHandlerInterface {
                 validationMessage = "Primary CWL descriptor is empty.";
             } else if (!content.contains("class: CommandLineTool") && !content.contains("class: ExpressionTool")) {
                 isValid = false;
-                validationMessage = "Requires class: CommandLineTool or ExpressionTool.";
+                validationMessage = "A CWL tool requires class: CommandLineTool or ExpressionTool.";
+                if (content.contains("class: Workflow")) {
+                    validationMessage += " This file contains class: Workflow. Did you mean to register a workflow?";
+                }
             } else if (!this.isValidCwl(content, yaml)) {
                 isValid = false;
                 validationMessage = "Invalid CWL version.";


### PR DESCRIPTION
For #1319 

Created a better error message if a workflow is registered as a tool and vice versa.

Cases where an error message is shown:
- Registering a CWL tool as a CWL workflow
- Registering a CWL workflow as a CWL tool
- Registering a WDL workflow that calls more than one task as a WDL tool

Note that a WDL tool with one task called can be successfully registered as a workflow.

**Registering CWL Tool as a CWL Workflow:**
CommandLineTool:
![CWL CommandLineTool Error Message](https://user-images.githubusercontent.com/25287123/73943464-c8519f80-48be-11ea-8cb9-599f1cde7e56.png)
ExpressionTool:
![CWL ExpressionTool Error Message](https://user-images.githubusercontent.com/25287123/73943467-cb4c9000-48be-11ea-89cb-03efb776c7ef.png)

**Registering CWL Workflow as a CWL Tool:**
![Register CWL Workflow as CWL Tool](https://user-images.githubusercontent.com/25287123/73944698-0354d280-48c1-11ea-8b43-1731af747eb1.png)

**Registering WDL Workflow that calls more than one task as a WDL Tool:**
![Register WDL Workflow With   1 Task as WDL Tool](https://user-images.githubusercontent.com/25287123/73944284-511d0b00-48c0-11ea-8b3c-a7349294a1ac.png)