### PR TITLE
Fix TRS list headers

### DIFF
--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ApiV2BetaVersionConverter.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ApiV2BetaVersionConverter.java
@@ -187,15 +187,10 @@ public final class ApiV2BetaVersionConverter {
     private static Response getResponse(Object object, MultivaluedMap<String, Object> headers) {
         Response.ResponseBuilder responseBuilder = Response.ok(object);
         if (!headers.isEmpty()) {
+            final List<String> relevantHeaders = List.of("next_page", "last_page", "current_offset", "current_limit");
             for (String str : headers.keySet()) {
-                switch (str) {
-                case "next_page":
-                case "last_page":
-                case "current_offset":
-                case "current_limit":
+                if (relevantHeaders.contains(str)) {
                     responseBuilder.header(str, headers.getFirst(str));
-                default:
-                    // Skipping all other headers
                 }
             }
         }


### PR DESCRIPTION
Fix for #2838 , headers for list endpoint was not hooked up properly when converting from v2 final responses to v2 beta responses (i.e. headers available for final api, but were not available for beta api)