### PR TITLE
OpenAPI Add GA4GHV1

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
@@ -313,7 +313,7 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
     @ApiOperation(value = "Retrieve all events for an organization.", notes = OPTIONAL_AUTH_MESSAGE, authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Event.class, responseContainer = "List")
     @Operation(operationId = "getOrganizationEvents", summary = "Retrieve all events for an organization.", description = "Retrieve all events for an organization. Supports optional authentication.", security = @SecurityRequirement(name = "bearer"))
-    public List<Event> getOrganizationEvents(@ApiParam(hidden = true) @Auth Optional<User> user,
+    public List<Event> getOrganizationEvents(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth Optional<User> user,
             @ApiParam(value = "Organization ID.", required = true) @Parameter(description = "Organization ID.", name = "organizationId", in = ParameterIn.PATH, required = true) @PathParam("organizationId") Long id,
             @ApiParam(value = "Start index of paging.  If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.", defaultValue = DEFAULT_OFFSET) @Parameter(description = "Start index of paging.  If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.", name = "offset", in = ParameterIn.QUERY, required = true) @DefaultValue(DEFAULT_OFFSET) @QueryParam("offset") Integer offset,
             @ApiParam(value = "Amount of records to return in a given page, limited to "

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -155,7 +155,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     @Path("/{userId}")
     @Operation(operationId = "getSpecificUser")
     @ApiOperation(nickname = "getSpecificUser", value = "Get user by id.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
-    public User getUser(@ApiParam(hidden = true) @Auth User authUser, @ApiParam("User to return") @PathParam("userId") long userId) {
+    public User getUser(@ApiParam(hidden = true) @Parameter(hidden = true) @Auth User authUser, @ApiParam("User to return") @PathParam("userId") long userId) {
         checkUser(authUser, userId);
         User user = userDAO.findById(userId);
         if (user == null) {
@@ -170,7 +170,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     @Path("/user")
     @Operation(operationId = "getUser")
     @ApiOperation(nickname = "getUser", value = "Get the logged-in user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
-    public User getUser(@ApiParam(hidden = true) @Auth User user) {
+    public User getUser(@ApiParam(hidden = true) @Parameter(hidden = true) @Auth User user) {
         User foundUser = userDAO.findById(user.getId());
         Hibernate.initialize(foundUser.getUserProfiles());
         return foundUser;

--- a/dockstore-webservice/src/main/java/io/swagger/api/ToolsApiV1.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/ToolsApiV1.java
@@ -53,41 +53,17 @@ import org.apache.http.HttpStatus;
 @javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJerseyServerCodegen", date = "2016-09-12T21:34:41.980Z")
 @io.swagger.v3.oas.annotations.tags.Tag(name = "GA4GHV1", description = ResourceConstants.GA4GHV1)
 public class ToolsApiV1 {
-    private static final String TOOLS_GET_SUMMARY = "List all tools";
-    private static final String TOOLS_GET_DESCRIPTION = "This endpoint returns all tools available or a filtered subset using metadata query parameters.";
-    private static final String TOOLS_GET_RESPONSE_DESCRIPTION = "An array of Tools that match the filter.";
-    private static final String TOOLS_ID_GET_SUMMARY = "List one specific tool, acts as an anchor for self references";
-    private static final String TOOLS_ID_GET_DESCRIPTION = "This endpoint returns one specific tool (which has ToolVersions nested inside it)";
-    private static final String TOOLS_ID_GET_RESPONSE_DESCRIPTION = "A tool.";
-    private static final String TOOLS_ID_VERSION_GET_SUMMARY = "List versions of a tool";
-    private static final String TOOLS_ID_VERSION_GET_DESCRIPTION = "Returns all versions of the specified tool";
-    private static final String TOOLS_ID_VERSION_GET_RESPONSE_DESCRIPTION = "An array of tool versions";
-    private static final String DOCKERFILE_GET_SUMMARY = "Get the dockerfile for the specified image.";
-    private static final String DOCKERFILE_GET_DESCRIPTION = "Returns the dockerfile for the specified image.";
-    private static final String DOCKERFILE_GET_RESPONSE_DESCRIPTION = "The tool payload.";
-    private static final String VERSION_ID_GET_SUMMARY = "List one specific tool version, acts as an anchor for self references";
-    private static final String VERSION_ID_GET_DESCRIPTION = "This endpoint returns one specific tool version";
-    private static final String VERSION_ID_GET_RESPONSE_DESCRIPTION = "A tool version.";
-    private static final String DESCRIPTOR_GET_SUMMARY = "Get the tool descriptor (CWL/WDL) for the specified tool.";
-    private static final String DESCRIPTOR_GET_DESCRIPTION = "Returns the CWL or WDL descriptor for the specified tool.";
-    private static final String DESCRIPTOR_GET_RESPONSE_DESCRIPTION = "The tool descriptor.";
-    private static final String RELATIVE_DESCRIPTOR_GET_SUMMARY = "Get additional tool descriptor files (CWL/WDL) relative to the main file";
-    private static final String RELATIVE_DESCRIPTOR_GET_DESCRIPTION = "Returns additional CWL or WDL descriptors for the specified tool in the same or subdirectories";
-    private static final String RELATIVE_DESCRIPTOR_GET_RESPONSE_DESCRIPTION = "The tool descriptor.";
-    private static final String TESTS_GET_SUMMARY = "Get an array of test JSONs suitable for use with this descriptor type.";
-    private static final String TESTS_GET_DESCRIPTION = "";
-    private static final String TESTS_GET_RESPONSE_DESCRIPTION = "The tool test JSON response.";
     private final ToolsApiService delegate = ToolsApiServiceFactory.getToolsApi();
     @SuppressWarnings("checkstyle:ParameterNumber")
     @GET
     @UnitOfWork(readOnly = true)
     @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsGet", value = TOOLS_GET_SUMMARY, notes = TOOLS_GET_DESCRIPTION, response = ToolV1.class, responseContainer = "List", tags = {
+    @io.swagger.annotations.ApiOperation(nickname = "toolsGet", value = ToolsGet.SUMMARY, notes = ToolsGet.DESCRIPTION, response = ToolV1.class, responseContainer = "List", tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = TOOLS_GET_RESPONSE_DESCRIPTION, response = ToolV1.class, responseContainer = "List") })
-    @Operation(operationId = "toolsGetV1", summary = TOOLS_GET_SUMMARY, description = TOOLS_GET_DESCRIPTION, responses = {
-            @ApiResponse(responseCode = "200", description = TOOLS_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = ToolV1.class))))
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = ToolsGet.OK_RESPONSE, response = ToolV1.class, responseContainer = "List") })
+    @Operation(operationId = "toolsGetV1", summary = ToolsGet.SUMMARY, description = ToolsGet.DESCRIPTION, responses = {
+            @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = ToolsGet.OK_RESPONSE, content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = ToolV1.class))))
     })
     public Response toolsGet(
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`") @QueryParam("id") String id,
@@ -109,12 +85,12 @@ public class ToolsApiV1 {
     @Path("/{id}")
     @UnitOfWork(readOnly = true)
     @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsIdGet", value = TOOLS_ID_GET_SUMMARY, notes = TOOLS_ID_GET_DESCRIPTION, response = ToolV1.class, tags = {
+    @io.swagger.annotations.ApiOperation(nickname = "toolsIdGet", value = ToolsIdGet.SUMMARY, notes = ToolsIdGet.DESCRIPTION, response = ToolV1.class, tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = TOOLS_ID_GET_RESPONSE_DESCRIPTION, response = ToolV1.class) })
-    @Operation(operationId = "toolsIdGetV1", summary = TOOLS_ID_GET_SUMMARY, description = TOOLS_ID_GET_DESCRIPTION, responses = {
-            @ApiResponse(responseCode = "200", description = TOOLS_ID_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolV1.class)))
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = ToolsIdGet.OK_RESPONSE, response = ToolV1.class) })
+    @Operation(operationId = "toolsIdGetV1", summary = ToolsIdGet.SUMMARY, description = ToolsIdGet.DESCRIPTION, responses = {
+            @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = ToolsIdGet.OK_RESPONSE, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolV1.class)))
     })
     public Response toolsIdGet(
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`", required = true) @PathParam("id") String id,
@@ -126,12 +102,12 @@ public class ToolsApiV1 {
     @Path("/{id}/versions")
     @UnitOfWork(readOnly = true)
     @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsGet", value = TOOLS_ID_VERSION_GET_SUMMARY, notes = TOOLS_ID_VERSION_GET_DESCRIPTION, response = ToolVersionV1.class, responseContainer = "List", tags = {
+    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsGet", value = ToolsIdVersionGet.SUMMARY, notes = ToolsIdVersionGet.DESCRIPTION, response = ToolVersionV1.class, responseContainer = "List", tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = TOOLS_ID_VERSION_GET_RESPONSE_DESCRIPTION, response = ToolVersionV1.class, responseContainer = "List") })
-    @Operation(operationId = "toolsIdVersionGetV1", summary = TOOLS_ID_VERSION_GET_SUMMARY, description = TOOLS_ID_VERSION_GET_DESCRIPTION, responses = {
-            @ApiResponse(responseCode = "200", description = TOOLS_ID_VERSION_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = ToolVersionV1.class))))
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = ToolsIdVersionGet.OK_RESPONSE, response = ToolVersionV1.class, responseContainer = "List") })
+    @Operation(operationId = "toolsIdVersionGetV1", summary = ToolsIdVersionGet.SUMMARY, description = ToolsIdVersionGet.DESCRIPTION, responses = {
+            @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = ToolsIdVersionGet.OK_RESPONSE, content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = ToolVersionV1.class))))
     })
     public Response toolsIdVersionsGet(
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`", required = true) @PathParam("id") String id,
@@ -143,14 +119,14 @@ public class ToolsApiV1 {
     @Path("/{id}/versions/{version_id}/dockerfile")
     @UnitOfWork(readOnly = true)
     @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdDockerfileGet", value = DOCKERFILE_GET_SUMMARY, notes = DOCKERFILE_GET_DESCRIPTION, response = ToolDockerfile.class, tags = {
+    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdDockerfileGet", value = DockerfileGet.SUMMARY, notes = DockerfileGet.DESCRIPTION, response = ToolDockerfile.class, tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = DOCKERFILE_GET_RESPONSE_DESCRIPTION, response = ToolDockerfile.class),
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = DockerfileGet.OK_RESPONSE, response = ToolDockerfile.class),
 
         @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "The tool payload is not present in the service.", response = ToolDockerfile.class) })
-    @Operation(operationId = "dockerfileGetV1", summary = DOCKERFILE_GET_SUMMARY, description = DOCKERFILE_GET_DESCRIPTION, responses = {
-            @ApiResponse(responseCode = "200", description = DOCKERFILE_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolDockerfile.class)))
+    @Operation(operationId = "dockerfileGetV1", summary = DockerfileGet.SUMMARY, description = DockerfileGet.DESCRIPTION, responses = {
+            @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = DockerfileGet.OK_RESPONSE, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolDockerfile.class)))
     })
     public Response toolsIdVersionsVersionIdDockerfileGet(
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`", required = true) @PathParam("id") String id,
@@ -164,12 +140,12 @@ public class ToolsApiV1 {
     @Path("/{id}/versions/{version_id}")
     @UnitOfWork(readOnly = true)
     @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdGet", value = VERSION_ID_GET_SUMMARY, notes = VERSION_ID_GET_DESCRIPTION, response = ToolVersionV1.class, tags = {
+    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdGet", value = VersionIdGet.SUMMARY, notes = VersionIdGet.DESCRIPTION, response = ToolVersionV1.class, tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = VERSION_ID_GET_RESPONSE_DESCRIPTION, response = ToolVersionV1.class) })
-    @Operation(operationId = "versionIdGetV1", summary = VERSION_ID_GET_SUMMARY, description = VERSION_ID_GET_DESCRIPTION, responses = {
-            @ApiResponse(responseCode = "200", description = VERSION_ID_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolVersionV1.class)))
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = VersionIdGet.OK_RESPONSE, response = ToolVersionV1.class) })
+    @Operation(operationId = "versionIdGetV1", summary = VersionIdGet.SUMMARY, description = VersionIdGet.DESCRIPTION, responses = {
+            @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = VersionIdGet.OK_RESPONSE, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolVersionV1.class)))
     })
     public Response toolsIdVersionsVersionIdGet(
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`", required = true) @PathParam("id") String id,
@@ -183,13 +159,14 @@ public class ToolsApiV1 {
     @Path("/{id}/versions/{version_id}/{type}/descriptor")
     @UnitOfWork(readOnly = true)
     @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdTypeDescriptorGet", value = DESCRIPTOR_GET_SUMMARY, notes = DESCRIPTOR_GET_DESCRIPTION, response = ToolDescriptor.class, tags = {
+    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdTypeDescriptorGet", value = DescriptorGet.SUMMARY, notes = DescriptorGet.DESCRIPTION, response = ToolDescriptor.class, tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = DESCRIPTOR_GET_RESPONSE_DESCRIPTION, response = ToolDescriptor.class),
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "The tool can not be output in the specified type.", response = ToolDescriptor.class) })
-    @Operation(operationId = "descriptorGetV1", summary = DESCRIPTOR_GET_SUMMARY, description = DESCRIPTOR_GET_DESCRIPTION, responses = {
-            @ApiResponse(responseCode = "200", description = DESCRIPTOR_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolDescriptor.class)))
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = DescriptorGet.OK_RESPONSE, response = ToolDescriptor.class),
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = DescriptorGet.NOT_FOUND_RESPONSE, response = ToolDescriptor.class) })
+    @Operation(operationId = "descriptorGetV1", summary = DescriptorGet.SUMMARY, description = DescriptorGet.DESCRIPTION, responses = {
+            @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = DescriptorGet.OK_RESPONSE, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolDescriptor.class))),
+            @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = DescriptorGet.NOT_FOUND_RESPONSE, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolDescriptor.class)))
     })
     public Response toolsIdVersionsVersionIdTypeDescriptorGet(
         @ApiParam(value = "The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the \"non-plain\" types return a descriptor wrapped with metadata", required = true, allowableValues = "CWL, WDL, PLAIN_CWL, PLAIN_WDL") @PathParam("type") String type,
@@ -204,14 +181,15 @@ public class ToolsApiV1 {
     @Path("/{id}/versions/{version_id}/{type}/descriptor/{relative_path}")
     @UnitOfWork(readOnly = true)
     @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdTypeDescriptorRelativePathGet", value = RELATIVE_DESCRIPTOR_GET_SUMMARY, notes = RELATIVE_DESCRIPTOR_GET_DESCRIPTION, response = ToolDescriptor.class, tags = {
+    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdTypeDescriptorRelativePathGet", value = RelativeDescriptorGet.SUMMARY, notes = RelativeDescriptorGet.DESCRIPTION, response = ToolDescriptor.class, tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = RELATIVE_DESCRIPTOR_GET_RESPONSE_DESCRIPTION, response = ToolDescriptor.class),
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = RelativeDescriptorGet.OK_RESPONSE, response = ToolDescriptor.class),
 
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "The tool can not be output in the specified type.", response = ToolDescriptor.class) })
-    @Operation(operationId = "relativeDescriptorGetV1", summary = RELATIVE_DESCRIPTOR_GET_SUMMARY, description = RELATIVE_DESCRIPTOR_GET_DESCRIPTION, responses = {
-            @ApiResponse(responseCode = "200", description = RELATIVE_DESCRIPTOR_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolDescriptor.class)))
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = RelativeDescriptorGet.NOT_FOUND_RESPONSE, response = ToolDescriptor.class) })
+    @Operation(operationId = "relativeDescriptorGetV1", summary = RelativeDescriptorGet.SUMMARY, description = RelativeDescriptorGet.DESCRIPTION, responses = {
+            @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = RelativeDescriptorGet.OK_RESPONSE, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolDescriptor.class))),
+            @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = RelativeDescriptorGet.NOT_FOUND_RESPONSE, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolDescriptor.class)))
     })
     public Response toolsIdVersionsVersionIdTypeDescriptorRelativePathGet(
         @ApiParam(value = "The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return.  Plain types return the bare descriptor while the \"non-plain\" types return a descriptor wrapped with metadata", required = true, allowableValues = "CWL, WDL, PLAIN_CWL, PLAIN_WDL") @PathParam("type") String type,
@@ -228,14 +206,15 @@ public class ToolsApiV1 {
     @Path("/{id}/versions/{version_id}/{type}/tests")
     @UnitOfWork(readOnly = true)
     @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdTypeTestsGet", value = TESTS_GET_SUMMARY, notes = TESTS_GET_DESCRIPTION, response = ToolTestsV1.class, responseContainer = "List", tags = {
+    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdTypeTestsGet", value = TestsGet.SUMMARY, notes = TestsGet.DESCRIPTION, response = ToolTestsV1.class, responseContainer = "List", tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = TESTS_GET_RESPONSE_DESCRIPTION, response = ToolTestsV1.class, responseContainer = "List"),
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = TestsGet.OK_RESPONSE, response = ToolTestsV1.class, responseContainer = "List"),
 
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "The tool can not be output in the specified type.", response = ToolTestsV1.class, responseContainer = "List") })
-    @Operation(operationId = "testsGetV1", summary = TESTS_GET_SUMMARY, description = TESTS_GET_DESCRIPTION, responses = {
-            @ApiResponse(responseCode = "200", description = TESTS_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = ToolTestsV1.class))))
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = TestsGet.NOT_FOUND_RESPONSE, response = ToolTestsV1.class, responseContainer = "List") })
+    @Operation(operationId = "testsGetV1", summary = TestsGet.SUMMARY, description = TestsGet.DESCRIPTION, responses = {
+            @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = TestsGet.OK_RESPONSE, content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = ToolTestsV1.class)))),
+            @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = TestsGet.NOT_FOUND_RESPONSE, content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = ToolTestsV1.class))))
     })
     public Response toolsIdVersionsVersionIdTypeTestsGet(
         @ApiParam(value = "The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the \"non-plain\" types return a descriptor wrapped with metadata", required = true, allowableValues = "CWL, WDL, PLAIN_CWL, PLAIN_WDL") @PathParam("type") String type,
@@ -244,5 +223,48 @@ public class ToolsApiV1 {
         @Context SecurityContext securityContext, @Context ContainerRequestContext value) throws NotFoundException {
         return ApiV1VersionConverter
             .convertToVersion(delegate.toolsIdVersionsVersionIdTypeTestsGet(type, id, versionId, securityContext, value, Optional.empty()));
+    }
+    private static final class ToolsGet {
+        public static final String SUMMARY = "List all tools";
+        public static final String DESCRIPTION = "This endpoint returns all tools available or a filtered subset using metadata query parameters.";
+        public static final String OK_RESPONSE = "An array of Tools that match the filter.";
+    }
+    private static final class ToolsIdGet {
+        public static final String SUMMARY = "List one specific tool, acts as an anchor for self references";
+        public static final String DESCRIPTION = "This endpoint returns one specific tool (which has ToolVersions nested inside it)";
+        public static final String OK_RESPONSE = "A tool.";
+    }
+    private static final class ToolsIdVersionGet {
+        public static final String SUMMARY = "List versions of a tool";
+        public static final String DESCRIPTION = "Returns all versions of the specified tool";
+        public static final String OK_RESPONSE = "An array of tool versions";
+    }
+    private static final class DockerfileGet {
+        public static final String SUMMARY = "Get the dockerfile for the specified image.";
+        public static final String DESCRIPTION = "Returns the dockerfile for the specified image.";
+        public static final String OK_RESPONSE = "The tool payload.";
+    }
+    private static final class VersionIdGet {
+        public static final String SUMMARY = "List one specific tool version, acts as an anchor for self references";
+        public static final String DESCRIPTION = "This endpoint returns one specific tool version";
+        public static final String OK_RESPONSE = "A tool version.";
+    }
+    private static final class DescriptorGet {
+        public static final String SUMMARY = "Get the tool descriptor (CWL/WDL) for the specified tool.";
+        public static final String DESCRIPTION = "Returns the CWL or WDL descriptor for the specified tool.";
+        public static final String OK_RESPONSE = "The tool descriptor.";
+        public static final String NOT_FOUND_RESPONSE = "The tool can not be output in the specified type.";
+    }
+    private static final class RelativeDescriptorGet {
+        public static final String SUMMARY = "Get additional tool descriptor files (CWL/WDL) relative to the main file";
+        public static final String DESCRIPTION = "Returns additional CWL or WDL descriptors for the specified tool in the same or subdirectories";
+        public static final String OK_RESPONSE = "The tool descriptor.";
+        public static final String NOT_FOUND_RESPONSE = "The tool can not be output in the specified type.";
+    }
+    private static final class TestsGet {
+        public static final String SUMMARY = "Get an array of test JSONs suitable for use with this descriptor type.";
+        public static final String DESCRIPTION = "";
+        public static final String OK_RESPONSE = "The tool test JSON response.";
+        public static final String NOT_FOUND_RESPONSE = "The tool can not be output in the specified type.";
     }
 }

--- a/dockstore-webservice/src/main/java/io/swagger/api/ToolsApiV1.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/ToolsApiV1.java
@@ -24,6 +24,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
@@ -38,6 +39,11 @@ import io.swagger.model.ToolDockerfile;
 import io.swagger.model.ToolTestsV1;
 import io.swagger.model.ToolV1;
 import io.swagger.model.ToolVersionV1;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.apache.http.HttpStatus;
 
 @Path(DockstoreWebserviceApplication.GA4GH_API_PATH_V1 + "/tools")
@@ -47,16 +53,42 @@ import org.apache.http.HttpStatus;
 @javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJerseyServerCodegen", date = "2016-09-12T21:34:41.980Z")
 @io.swagger.v3.oas.annotations.tags.Tag(name = "GA4GHV1", description = ResourceConstants.GA4GHV1)
 public class ToolsApiV1 {
+    private static final String TOOLS_GET_SUMMARY = "List all tools";
+    private static final String TOOLS_GET_DESCRIPTION = "This endpoint returns all tools available or a filtered subset using metadata query parameters.";
+    private static final String TOOLS_GET_RESPONSE_DESCRIPTION = "An array of Tools that match the filter.";
+    private static final String TOOLS_ID_GET_SUMMARY = "List one specific tool, acts as an anchor for self references";
+    private static final String TOOLS_ID_GET_DESCRIPTION = "This endpoint returns one specific tool (which has ToolVersions nested inside it)";
+    private static final String TOOLS_ID_GET_RESPONSE_DESCRIPTION = "A tool.";
+    private static final String TOOLS_ID_VERSION_GET_SUMMARY = "List versions of a tool";
+    private static final String TOOLS_ID_VERSION_GET_DESCRIPTION = "Returns all versions of the specified tool";
+    private static final String TOOLS_ID_VERSION_GET_RESPONSE_DESCRIPTION = "An array of tool versions";
+    private static final String DOCKERFILE_GET_SUMMARY = "Get the dockerfile for the specified image.";
+    private static final String DOCKERFILE_GET_DESCRIPTION = "Returns the dockerfile for the specified image.";
+    private static final String DOCKERFILE_GET_RESPONSE_DESCRIPTION = "The tool payload.";
+    private static final String VERSION_ID_GET_SUMMARY = "List one specific tool version, acts as an anchor for self references";
+    private static final String VERSION_ID_GET_DESCRIPTION = "This endpoint returns one specific tool version";
+    private static final String VERSION_ID_GET_RESPONSE_DESCRIPTION = "A tool version.";
+    private static final String DESCRIPTOR_GET_SUMMARY = "Get the tool descriptor (CWL/WDL) for the specified tool.";
+    private static final String DESCRIPTOR_GET_DESCRIPTION = "Returns the CWL or WDL descriptor for the specified tool.";
+    private static final String DESCRIPTOR_GET_RESPONSE_DESCRIPTION = "The tool descriptor.";
+    private static final String RELATIVE_DESCRIPTOR_GET_SUMMARY = "Get additional tool descriptor files (CWL/WDL) relative to the main file";
+    private static final String RELATIVE_DESCRIPTOR_GET_DESCRIPTION = "Returns additional CWL or WDL descriptors for the specified tool in the same or subdirectories";
+    private static final String RELATIVE_DESCRIPTOR_GET_RESPONSE_DESCRIPTION = "The tool descriptor.";
+    private static final String TESTS_GET_SUMMARY = "Get an array of test JSONs suitable for use with this descriptor type.";
+    private static final String TESTS_GET_DESCRIPTION = "";
+    private static final String TESTS_GET_RESPONSE_DESCRIPTION = "The tool test JSON response.";
     private final ToolsApiService delegate = ToolsApiServiceFactory.getToolsApi();
-
     @SuppressWarnings("checkstyle:ParameterNumber")
     @GET
     @UnitOfWork(readOnly = true)
-    @Produces({ "application/json", "text/plain" })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsGet", value = "List all tools", notes = "This endpoint returns all tools available or a filtered subset using metadata query parameters. ", response = ToolV1.class, responseContainer = "List", tags = {
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
+    @io.swagger.annotations.ApiOperation(nickname = "toolsGet", value = TOOLS_GET_SUMMARY, notes = TOOLS_GET_DESCRIPTION, response = ToolV1.class, responseContainer = "List", tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = "An array of Tools that match the filter.", response = ToolV1.class, responseContainer = "List") })
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = TOOLS_GET_RESPONSE_DESCRIPTION, response = ToolV1.class, responseContainer = "List") })
+    @Operation(operationId = "toolsGetV1", summary = TOOLS_GET_SUMMARY, description = TOOLS_GET_DESCRIPTION, responses = {
+            @ApiResponse(responseCode = "200", description = TOOLS_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = ToolV1.class))))
+    })
     public Response toolsGet(
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`") @QueryParam("id") String id,
         @ApiParam(value = "The image registry that contains the image.") @QueryParam("registry") String registry,
@@ -76,11 +108,14 @@ public class ToolsApiV1 {
     @GET
     @Path("/{id}")
     @UnitOfWork(readOnly = true)
-    @Produces({ "application/json", "text/plain" })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsIdGet", value = "List one specific tool, acts as an anchor for self references", notes = "This endpoint returns one specific tool (which has ToolVersions nested inside it)", response = ToolV1.class, tags = {
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
+    @io.swagger.annotations.ApiOperation(nickname = "toolsIdGet", value = TOOLS_ID_GET_SUMMARY, notes = TOOLS_ID_GET_DESCRIPTION, response = ToolV1.class, tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = "A tool.", response = ToolV1.class) })
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = TOOLS_ID_GET_RESPONSE_DESCRIPTION, response = ToolV1.class) })
+    @Operation(operationId = "toolsIdGetV1", summary = TOOLS_ID_GET_SUMMARY, description = TOOLS_ID_GET_DESCRIPTION, responses = {
+            @ApiResponse(responseCode = "200", description = TOOLS_ID_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolV1.class)))
+    })
     public Response toolsIdGet(
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`", required = true) @PathParam("id") String id,
         @Context SecurityContext securityContext, @Context ContainerRequestContext value) throws NotFoundException {
@@ -90,11 +125,14 @@ public class ToolsApiV1 {
     @GET
     @Path("/{id}/versions")
     @UnitOfWork(readOnly = true)
-    @Produces({ "application/json", "text/plain" })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsGet", value = "List versions of a tool", notes = "Returns all versions of the specified tool", response = ToolVersionV1.class, responseContainer = "List", tags = {
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
+    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsGet", value = TOOLS_ID_VERSION_GET_SUMMARY, notes = TOOLS_ID_VERSION_GET_DESCRIPTION, response = ToolVersionV1.class, responseContainer = "List", tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = "An array of tool versions", response = ToolVersionV1.class, responseContainer = "List") })
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = TOOLS_ID_VERSION_GET_RESPONSE_DESCRIPTION, response = ToolVersionV1.class, responseContainer = "List") })
+    @Operation(operationId = "toolsIdVersionGetV1", summary = TOOLS_ID_VERSION_GET_SUMMARY, description = TOOLS_ID_VERSION_GET_DESCRIPTION, responses = {
+            @ApiResponse(responseCode = "200", description = TOOLS_ID_VERSION_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = ToolVersionV1.class))))
+    })
     public Response toolsIdVersionsGet(
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`", required = true) @PathParam("id") String id,
         @Context SecurityContext securityContext, @Context ContainerRequestContext value) throws NotFoundException {
@@ -104,13 +142,16 @@ public class ToolsApiV1 {
     @GET
     @Path("/{id}/versions/{version_id}/dockerfile")
     @UnitOfWork(readOnly = true)
-    @Produces({ "application/json", "text/plain" })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdDockerfileGet", value = "Get the dockerfile for the specified image.", notes = "Returns the dockerfile for the specified image.", response = ToolDockerfile.class, tags = {
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
+    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdDockerfileGet", value = DOCKERFILE_GET_SUMMARY, notes = DOCKERFILE_GET_DESCRIPTION, response = ToolDockerfile.class, tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = "The tool payload.", response = ToolDockerfile.class),
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = DOCKERFILE_GET_RESPONSE_DESCRIPTION, response = ToolDockerfile.class),
 
         @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "The tool payload is not present in the service.", response = ToolDockerfile.class) })
+    @Operation(operationId = "dockerfileGetV1", summary = DOCKERFILE_GET_SUMMARY, description = DOCKERFILE_GET_DESCRIPTION, responses = {
+            @ApiResponse(responseCode = "200", description = DOCKERFILE_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolDockerfile.class)))
+    })
     public Response toolsIdVersionsVersionIdDockerfileGet(
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`", required = true) @PathParam("id") String id,
         @ApiParam(value = "An identifier of the tool version for this particular tool registry, for example `v1`", required = true) @PathParam("version_id") String versionId,
@@ -122,11 +163,14 @@ public class ToolsApiV1 {
     @GET
     @Path("/{id}/versions/{version_id}")
     @UnitOfWork(readOnly = true)
-    @Produces({ "application/json", "text/plain" })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdGet", value = "List one specific tool version, acts as an anchor for self references", notes = "This endpoint returns one specific tool version", response = ToolVersionV1.class, tags = {
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
+    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdGet", value = VERSION_ID_GET_SUMMARY, notes = VERSION_ID_GET_DESCRIPTION, response = ToolVersionV1.class, tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = "A tool version.", response = ToolVersionV1.class) })
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = VERSION_ID_GET_RESPONSE_DESCRIPTION, response = ToolVersionV1.class) })
+    @Operation(operationId = "versionIdGetV1", summary = VERSION_ID_GET_SUMMARY, description = VERSION_ID_GET_DESCRIPTION, responses = {
+            @ApiResponse(responseCode = "200", description = VERSION_ID_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolVersionV1.class)))
+    })
     public Response toolsIdVersionsVersionIdGet(
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`", required = true) @PathParam("id") String id,
         @ApiParam(value = "An identifier of the tool version, scoped to this registry, for example `v1`", required = true) @PathParam("version_id") String versionId,
@@ -138,13 +182,15 @@ public class ToolsApiV1 {
     @GET
     @Path("/{id}/versions/{version_id}/{type}/descriptor")
     @UnitOfWork(readOnly = true)
-    @Produces({ "application/json", "text/plain" })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdTypeDescriptorGet", value = "Get the tool descriptor (CWL/WDL) for the specified tool.", notes = "Returns the CWL or WDL descriptor for the specified tool.", response = ToolDescriptor.class, tags = {
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
+    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdTypeDescriptorGet", value = DESCRIPTOR_GET_SUMMARY, notes = DESCRIPTOR_GET_DESCRIPTION, response = ToolDescriptor.class, tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = "The tool descriptor.", response = ToolDescriptor.class),
-
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = DESCRIPTOR_GET_RESPONSE_DESCRIPTION, response = ToolDescriptor.class),
         @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "The tool can not be output in the specified type.", response = ToolDescriptor.class) })
+    @Operation(operationId = "descriptorGetV1", summary = DESCRIPTOR_GET_SUMMARY, description = DESCRIPTOR_GET_DESCRIPTION, responses = {
+            @ApiResponse(responseCode = "200", description = DESCRIPTOR_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolDescriptor.class)))
+    })
     public Response toolsIdVersionsVersionIdTypeDescriptorGet(
         @ApiParam(value = "The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the \"non-plain\" types return a descriptor wrapped with metadata", required = true, allowableValues = "CWL, WDL, PLAIN_CWL, PLAIN_WDL") @PathParam("type") String type,
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`", required = true) @PathParam("id") String id,
@@ -157,13 +203,16 @@ public class ToolsApiV1 {
     @GET
     @Path("/{id}/versions/{version_id}/{type}/descriptor/{relative_path}")
     @UnitOfWork(readOnly = true)
-    @Produces({ "application/json", "text/plain" })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdTypeDescriptorRelativePathGet", value = "Get additional tool descriptor files (CWL/WDL) relative to the main file", notes = "Returns additional CWL or WDL descriptors for the specified tool in the same or subdirectories", response = ToolDescriptor.class, tags = {
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
+    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdTypeDescriptorRelativePathGet", value = RELATIVE_DESCRIPTOR_GET_SUMMARY, notes = RELATIVE_DESCRIPTOR_GET_DESCRIPTION, response = ToolDescriptor.class, tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = "The tool descriptor.", response = ToolDescriptor.class),
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = RELATIVE_DESCRIPTOR_GET_RESPONSE_DESCRIPTION, response = ToolDescriptor.class),
 
         @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "The tool can not be output in the specified type.", response = ToolDescriptor.class) })
+    @Operation(operationId = "relativeDescriptorGetV1", summary = RELATIVE_DESCRIPTOR_GET_SUMMARY, description = RELATIVE_DESCRIPTOR_GET_DESCRIPTION, responses = {
+            @ApiResponse(responseCode = "200", description = RELATIVE_DESCRIPTOR_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ToolDescriptor.class)))
+    })
     public Response toolsIdVersionsVersionIdTypeDescriptorRelativePathGet(
         @ApiParam(value = "The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return.  Plain types return the bare descriptor while the \"non-plain\" types return a descriptor wrapped with metadata", required = true, allowableValues = "CWL, WDL, PLAIN_CWL, PLAIN_WDL") @PathParam("type") String type,
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`", required = true) @PathParam("id") String id,
@@ -178,13 +227,16 @@ public class ToolsApiV1 {
     @GET
     @Path("/{id}/versions/{version_id}/{type}/tests")
     @UnitOfWork(readOnly = true)
-    @Produces({ "application/json", "text/plain" })
-    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdTypeTestsGet", value = "Get an array of test JSONs suitable for use with this descriptor type.", notes = "", response = ToolTestsV1.class, responseContainer = "List", tags = {
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
+    @io.swagger.annotations.ApiOperation(nickname = "toolsIdVersionsVersionIdTypeTestsGet", value = TESTS_GET_SUMMARY, notes = TESTS_GET_DESCRIPTION, response = ToolTestsV1.class, responseContainer = "List", tags = {
         "GA4GHV1", })
     @io.swagger.annotations.ApiResponses(value = {
-        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = "The tool test JSON response.", response = ToolTestsV1.class, responseContainer = "List"),
+        @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_OK, message = TESTS_GET_RESPONSE_DESCRIPTION, response = ToolTestsV1.class, responseContainer = "List"),
 
         @io.swagger.annotations.ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "The tool can not be output in the specified type.", response = ToolTestsV1.class, responseContainer = "List") })
+    @Operation(operationId = "testsGetV1", summary = TESTS_GET_SUMMARY, description = TESTS_GET_DESCRIPTION, responses = {
+            @ApiResponse(responseCode = "200", description = TESTS_GET_RESPONSE_DESCRIPTION, content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = ToolTestsV1.class))))
+    })
     public Response toolsIdVersionsVersionIdTypeTestsGet(
         @ApiParam(value = "The output type of the descriptor. If not specified it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the \"non-plain\" types return a descriptor wrapped with metadata", required = true, allowableValues = "CWL, WDL, PLAIN_CWL, PLAIN_WDL") @PathParam("type") String type,
         @ApiParam(value = "A unique identifier of the tool, scoped to this registry, for example `123456`", required = true) @PathParam("id") String id,

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1193,8 +1193,8 @@ components:
           - SWL
           - NFL
           - service
-          
-          
+          - cwl
+          - wdl
           type: string
         descriptorTypeSubclass:
           enum:
@@ -1598,6 +1598,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ToolDescriptor'
           description: The tool descriptor.
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolDescriptor'
+          description: The tool can not be output in the specified type.
       summary: Get the tool descriptor (CWL/WDL) for the specified tool.
       tags:
       - GA4GHV1
@@ -1634,6 +1640,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ToolDescriptor'
           description: The tool descriptor.
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolDescriptor'
+          description: The tool can not be output in the specified type.
       summary: Get additional tool descriptor files (CWL/WDL) relative to the main
         file
       tags:
@@ -1666,6 +1678,14 @@ paths:
                   $ref: '#/components/schemas/ToolTestsV1'
                 type: array
           description: The tool test JSON response.
+        "404":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ToolTestsV1'
+                type: array
+          description: The tool can not be output in the specified type.
       summary: Get an array of test JSONs suitable for use with this descriptor type.
       tags:
       - GA4GHV1

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -776,18 +776,36 @@ components:
       - versions
       type: object
     ToolClass:
-      description: Describes a class (type) of tool allowing us to categorize workflows,
-        tasks, and maybe even other entities (such as services) separately.
       properties:
         description:
-          description: A longer explanation of what this class is and what it can
-            accomplish.
           type: string
         id:
-          description: The unique identifier for the class.
           type: string
         name:
-          description: A short friendly name for the class.
+          type: string
+      type: object
+    ToolDescriptor:
+      properties:
+        descriptor:
+          type: string
+        type:
+          enum:
+          - CWL
+          - WDL
+          - NFL
+          - SERVICE
+          - GXFORMAT2
+          type: string
+        url:
+          type: string
+      required:
+      - type
+      type: object
+    ToolDockerfile:
+      properties:
+        dockerfile:
+          type: string
+        url:
           type: string
       type: object
     ToolFile:
@@ -822,6 +840,46 @@ components:
           type: string
         toolVersionName:
           type: string
+      type: object
+    ToolTestsV1:
+      properties:
+        test:
+          type: string
+        url:
+          type: string
+      type: object
+    ToolV1:
+      properties:
+        author:
+          type: string
+        contains:
+          items:
+            type: string
+          type: array
+        description:
+          type: string
+        id:
+          type: string
+        meta-version:
+          type: string
+        organization:
+          type: string
+        signed:
+          type: boolean
+        toolclass:
+          $ref: '#/components/schemas/ToolClass'
+        toolname:
+          type: string
+        url:
+          type: string
+        verified:
+          type: boolean
+        verified-source:
+          type: string
+        versions:
+          items:
+            $ref: '#/components/schemas/ToolVersionV1'
+          type: array
       type: object
     ToolVersion:
       description: A tool version describes a particular iteration of a tool as described
@@ -909,6 +967,32 @@ components:
       required:
       - id
       - url
+      type: object
+    ToolVersionV1:
+      properties:
+        descriptor-type:
+          items:
+            enum:
+            - CWL
+            - WDL
+            type: string
+          type: array
+        dockerfile:
+          type: boolean
+        id:
+          type: string
+        image:
+          type: string
+        meta-version:
+          type: string
+        name:
+          type: string
+        url:
+          type: string
+        verified:
+          type: boolean
+        verified-source:
+          type: string
       type: object
     User:
       properties:
@@ -1112,8 +1196,8 @@ components:
           - SWL
           - NFL
           - service
-          
-          
+          - cwl
+          - wdl
           type: string
         descriptorTypeSubclass:
           enum:
@@ -1342,6 +1426,252 @@ info:
   version: 1.9.0-alpha.4-SNAPSHOT
 openapi: 3.0.1
 paths:
+  /api/ga4gh/v1/tools:
+    get:
+      description: This endpoint returns all tools available or a filtered subset
+        using metadata query parameters.
+      operationId: toolsGetV1
+      parameters:
+      - in: query
+        name: id
+        schema:
+          type: string
+      - in: query
+        name: registry
+        schema:
+          type: string
+      - in: query
+        name: organization
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: toolname
+        schema:
+          type: string
+      - in: query
+        name: description
+        schema:
+          type: string
+      - in: query
+        name: author
+        schema:
+          type: string
+      - in: query
+        name: offset
+        schema:
+          type: string
+      - in: query
+        name: limit
+        schema:
+          format: int32
+          type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ToolV1'
+                type: array
+          description: An array of Tools that match the filter.
+      summary: List all tools
+      tags:
+      - GA4GHV1
+  /api/ga4gh/v1/tools/{id}:
+    get:
+      description: This endpoint returns one specific tool (which has ToolVersions
+        nested inside it)
+      operationId: toolsIdGetV1
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolV1'
+          description: A tool.
+      summary: List one specific tool, acts as an anchor for self references
+      tags:
+      - GA4GHV1
+  /api/ga4gh/v1/tools/{id}/versions:
+    get:
+      description: Returns all versions of the specified tool
+      operationId: toolsIdVersionGetV1
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ToolVersionV1'
+                type: array
+          description: An array of tool versions
+      summary: List versions of a tool
+      tags:
+      - GA4GHV1
+  /api/ga4gh/v1/tools/{id}/versions/{version_id}:
+    get:
+      description: This endpoint returns one specific tool version
+      operationId: versionIdGetV1
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolVersionV1'
+          description: A tool version.
+      summary: List one specific tool version, acts as an anchor for self references
+      tags:
+      - GA4GHV1
+  /api/ga4gh/v1/tools/{id}/versions/{version_id}/dockerfile:
+    get:
+      description: Returns the dockerfile for the specified image.
+      operationId: dockerfileGetV1
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolDockerfile'
+          description: The tool payload.
+      summary: Get the dockerfile for the specified image.
+      tags:
+      - GA4GHV1
+  /api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/descriptor:
+    get:
+      description: Returns the CWL or WDL descriptor for the specified tool.
+      operationId: descriptorGetV1
+      parameters:
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolDescriptor'
+          description: The tool descriptor.
+      summary: Get the tool descriptor (CWL/WDL) for the specified tool.
+      tags:
+      - GA4GHV1
+  /api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}:
+    get:
+      description: Returns additional CWL or WDL descriptors for the specified tool
+        in the same or subdirectories
+      operationId: relativeDescriptorGetV1
+      parameters:
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: relative_path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolDescriptor'
+          description: The tool descriptor.
+      summary: Get additional tool descriptor files (CWL/WDL) relative to the main
+        file
+      tags:
+      - GA4GHV1
+  /api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/tests:
+    get:
+      operationId: testsGetV1
+      parameters:
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ToolTestsV1'
+                type: array
+          description: The tool test JSON response.
+      summary: Get an array of test JSONs suitable for use with this descriptor type.
+      tags:
+      - GA4GHV1
   /entries/{id}/topic:
     post:
       description: Create a discourse topic for an entry.
@@ -2202,7 +2532,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/Collection'
           description: default response
       security:
       - bearer: []

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -24,12 +24,9 @@ components:
         type: object
       type: object
     Checksum:
-      description: A production (immutable) tool version is required to have a hashcode.
-        Not required otherwise, but might be useful to detect changes.  This exposes
-        the hashcode for specific image versions to verify that the container version
-        pulled is actually the version that was indexed by the registry.
-      example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182,
-        type=sha256}]'
+      description: 'A production (immutable) tool version is required to have a hashcode.
+        Not required otherwise, but might be useful to detect changes. '
+      example: '[{checksum=ea2a5db69bd20a42976838790bc29294df3af02b, type=sha1}]'
       properties:
         checksum:
           description: 'The hex-string encoded checksum for the data. '
@@ -1196,8 +1193,8 @@ components:
           - SWL
           - NFL
           - service
-          - cwl
-          - wdl
+          
+          
           type: string
         descriptorTypeSubclass:
           enum:
@@ -2532,7 +2529,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Collection'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
       - bearer: []
@@ -2663,7 +2660,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/Organization'
           description: default response
       security:
       - bearer: []
@@ -3059,11 +3056,6 @@ paths:
           maximum: 100
           minimum: 1
           type: integer
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/User'
       responses:
         default:
           content:
@@ -3616,11 +3608,6 @@ paths:
   /users/user:
     get:
       operationId: getUser
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/User'
       responses:
         default:
           content:
@@ -3699,11 +3686,6 @@ paths:
         schema:
           format: int64
           type: integer
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/User'
       responses:
         default:
           content:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -155,7 +155,7 @@ paths:
       - "GA4GHV1"
       summary: "List all tools"
       description: "This endpoint returns all tools available or a filtered subset\
-        \ using metadata query parameters. "
+        \ using metadata query parameters."
       operationId: "toolsGet"
       produces:
       - "application/json"


### PR DESCRIPTION
For dockstore/dockstore#1444

There's 2 OpenAPIs.  One that gets served in swagger-ui during runtime and one that gets generated during `mvn clean install` and gets checked in.

The one in swagger-ui seems to be complete and not have any major validation issues.

As for the checked in openapi.yaml...

The openapi.yaml was already valid (because it's missing a lot of problematic content).  This PR adds the problematic GA4GH V1 endpoints back while explicitly defining unique operationIds so that it does not conflict like swagger.yaml does.  Also fixed the minor validation issues such as user object not being hidden in the schema.

The checked-in openapi.yaml now passes all swagger-editor validation.

There's another issue for the missing content.