### PR TITLE
Add validation for missing file(s) in .dockstore.yml

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
@@ -389,6 +389,23 @@ public class ValidationIT extends BaseIT {
         tool = toolsApi.refresh(tool.getId());
     }
 
+    /**
+     * This tests that validation works as expected on services
+     * Requires GitHub Repo DockstoreTestUser2/test-service, missingFile branch
+     */
+    @Test
+    public void testService() {
+        WorkflowsApi client = setupWorkflowWebService();
+        String serviceRepo = "DockstoreTestUser2/test-service";
+        String installationId = "1179416";
+
+        // Add a service with a dockstore.yml that lists a file that is missing in the repository - should be invalid
+        List<Workflow> services = client.handleGitHubRelease(serviceRepo, "DockstoreTestUser2", "refs/heads/missingFile", installationId);
+        Assert.assertEquals("Should have added one service", 1, services.size());
+        Workflow service = services.get(0);
+        Assert.assertFalse("Should be invalid due to missing file in dockstore.yml", isWorkflowVersionValid(service, "missingFile"));
+    }
+
     @Test
     public void getThingy() {
         final List<String> readmePaths = new ArrayList<>(

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/ServicePrototypePlugin.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/ServicePrototypePlugin.java
@@ -15,11 +15,11 @@
  */
 package io.dockstore.webservice.languages;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.VersionTypeValidation;
@@ -66,15 +66,10 @@ public class ServicePrototypePlugin implements RecommendedLanguageInterface {
                     isValid = false;
                 } else {
                     // check that files in .dockstore.yml exist
-                    ArrayList<String> missingFiles = new ArrayList<String>();
-                    for (String file : files) {
-                        String absolutePath = "/" + file;
-                        if (indexedFiles.get(absolutePath) == null) {
-                            missingFiles.add(String.format("'%s'", file));
-                        }
-                    }
+                    String missingFiles = files.stream().filter(file -> indexedFiles.get("/" + file) == null).map(file -> String.format("'%s'", file))
+                        .collect(Collectors.joining(", "));
                     if (!missingFiles.isEmpty()) {
-                        validationMessageObject.put(initialPath, String.format("The following file(s) are missing: %s.", String.join(", ", missingFiles)));
+                        validationMessageObject.put(initialPath, String.format("The following file(s) are missing: %s.", missingFiles));
                         isValid = false;
                     }
                 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/ServicePrototypePlugin.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/ServicePrototypePlugin.java
@@ -15,6 +15,7 @@
  */
 package io.dockstore.webservice.languages;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,6 +64,19 @@ public class ServicePrototypePlugin implements RecommendedLanguageInterface {
                 if (files == null) {
                     validationMessageObject.put(initialPath, "The key 'files' does not exist.");
                     isValid = false;
+                } else {
+                    // check that files in .dockstore.yml exist
+                    ArrayList<String> missingFiles = new ArrayList<String>();
+                    for (String file : files) {
+                        String absolutePath = "/" + file;
+                        if (indexedFiles.get(absolutePath) == null) {
+                            missingFiles.add(String.format("'%s'", file));
+                        }
+                    }
+                    if (!missingFiles.isEmpty()) {
+                        validationMessageObject.put(initialPath, String.format("The following file(s) are missing: %s.", String.join(", ", missingFiles)));
+                        isValid = false;
+                    }
                 }
             }
         } catch (YAMLException | ClassCastException ex) {


### PR DESCRIPTION
For #3007 

If a file in .dockstore.yml doesn't exist in the GitHub repo, a validation warning will appear. This is what it looks like right now with the backend change:
![Screenshot from 2020-03-05 14-42-31](https://user-images.githubusercontent.com/25287123/76019721-28545980-5ef0-11ea-9127-73deecea6b79.png)

There are some changes that need to be made in the UI, but I'll do that after this PR.