### PR TITLE
Feature/remove refresh all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ dockstore-integration-testing/src/test/resources/dockstoreTest.yml
 
 # The tarball of the above three confidential files
 dockstore-integration-testing/src/test/resources/secrets.tar
+
+
+dockstore-webservice/src/main/resources/openapi3/unsortedopenapi.yaml

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -279,6 +279,12 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -23,7 +23,10 @@ import java.util.Optional;
 
 import io.dropwizard.testing.FixtureHelpers;
 import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -33,6 +36,12 @@ public class DockstoreYamlTest {
     private static final String DOCKSTORE10_YAML = FixtureHelpers.fixture("fixtures/dockstore10.yml");
     private static final String DOCKSTORE11_YAML = FixtureHelpers.fixture("fixtures/dockstore11.yml");
     private static final String DOCKSTORE12_YAML = FixtureHelpers.fixture("fixtures/dockstore12.yml");
+
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
 
     @Test
     public void testFindVersion() {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -150,7 +150,8 @@ public class BasicIT extends BaseIT {
 
         final long startToolCount = testingPostgres.runSelectStatement("select count(*) from tool", long.class);
         // should have 0 tools to start with
-        usersApi.refresh((long)1);
+        usersApi.refreshToolsByOrganization((long)1, "DockstoreTestUser");
+        usersApi.refreshToolsByOrganization((long)1, "dockstore_testuser2");
         // should have a certain number of tools based on github contents
         final long secondToolCount = testingPostgres.runSelectStatement("select count(*) from tool", long.class);
         assertTrue(startToolCount <= secondToolCount && secondToolCount > 1);
@@ -160,7 +161,8 @@ public class BasicIT extends BaseIT {
 
         // refresh
         try {
-            usersApi.refresh((long)1);
+            usersApi.refreshToolsByOrganization((long)1, "DockstoreTestUser");
+            usersApi.refreshToolsByOrganization((long)1, "dockstore_testuser2");
             fail("Refresh should fail");
         } catch (ApiException e) {
             assertTrue("Should see error message since user has Quay tools but no Quay token.",
@@ -181,7 +183,8 @@ public class BasicIT extends BaseIT {
         WorkflowsApi workflowsApi = new WorkflowsApi(client);
 
         // Refresh all
-        usersApi.refreshWorkflows((long)1);
+        usersApi.refreshWorkflowsByOrganization((long)1, "DockstoreTestUser");
+        usersApi.refreshWorkflowsByOrganization((long)1, "dockstore_testuser2");
         // should have a certain number of workflows based on github contents
         final long secondWorkflowCount = testingPostgres.runSelectStatement("select count(*) from workflow", long.class);
         assertTrue("should find non-zero number of workflows", secondWorkflowCount > 0);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
@@ -245,7 +245,7 @@ public class CheckerWorkflowIT extends BaseIT {
         UsersApi usersApi = new UsersApi(webClient);
         final Long id = usersApi.getUser().getId();
         if (all) {
-            usersApi.refreshWorkflows(id);
+            usersApi.refreshWorkflowsByOrganization(id, "DockstoreTestUser2");
         } else {
             usersApi.refreshWorkflowsByOrganization(id, stubCheckerWorkflow.getOrganization());
         }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedNextflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedNextflowIT.java
@@ -64,7 +64,7 @@ public class ExtendedNextflowIT extends BaseIT {
         UsersApi usersApi = new UsersApi(webClient);
         User user = usersApi.getUser();
 
-        final List<Workflow> workflows = usersApi.refreshWorkflows(user.getId());
+        final List<Workflow> workflows = usersApi.refreshWorkflowsByOrganization(user.getId(), "DockstoreTestUser");
 
         for (Workflow workflow : workflows) {
             assertNotSame("", workflow.getWorkflowName());
@@ -102,7 +102,8 @@ public class ExtendedNextflowIT extends BaseIT {
         UsersApi usersApi = new UsersApi(webClient);
         User user = usersApi.getUser();
         // get workflow stubs
-        usersApi.refreshWorkflows(user.getId());
+        usersApi.refreshWorkflowsByOrganization(user.getId(), "DockstoreTestUser");
+        usersApi.refreshWorkflowsByOrganization(user.getId(), "dockstore_testuser2");
 
         // do targeted refresh, should promote workflow to fully-fleshed out workflow
         Workflow workflowByPathBitbucket = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_BITBUCKET_WORKFLOW, null, false);
@@ -169,7 +170,8 @@ public class ExtendedNextflowIT extends BaseIT {
         UsersApi usersApi = new UsersApi(webClient);
         User user = usersApi.getUser();
         // get workflow stubs
-        usersApi.refreshWorkflows(user.getId());
+        usersApi.refreshWorkflowsByOrganization(user.getId(), "DockstoreTestUser");
+        usersApi.refreshWorkflowsByOrganization(user.getId(), "dockstore_testuser2");
 
         // do targeted refresh, should promote workflow to fully-fleshed out workflow
         Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_BINARY_WORKFLOW, null, false);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -642,7 +642,7 @@ public class GeneralIT extends BaseIT {
 
         UsersApi usersApi = new UsersApi(containersApi.getApiClient());
         final Long userid = usersApi.getUser().getId();
-        usersApi.refresh(userid);
+        usersApi.refreshToolsByOrganization(userid, "dockstoretestuser2");
 
         testingPostgres.runUpdateStatement("update tag set imageid = 'silly old value'");
         int size = containersApi.getContainer(c.getId(), null).getWorkflowVersions().size();
@@ -658,7 +658,7 @@ public class GeneralIT extends BaseIT {
 
         // so should overall refresh
         testingPostgres.runUpdateStatement("update tag set imageid = 'silly old value'");
-        usersApi.refresh(userid);
+        usersApi.refreshToolsByOrganization(userid, "dockstoretestuser2");
         container = containersApi.getContainer(c.getId(), null);
         size = container.getWorkflowVersions().size();
         size2 = container.getWorkflowVersions().stream().filter(tag -> tag.getImageId().equals("silly old value")).count();
@@ -690,7 +690,7 @@ public class GeneralIT extends BaseIT {
 
         UsersApi usersApi = new UsersApi(containersApi.getApiClient());
         final Long userid = usersApi.getUser().getId();
-        usersApi.refresh(userid);
+        usersApi.refreshToolsByOrganization(userid, "dockstoretestuser2");
 
         // Check that the image information has been grabbed on refresh.
         List<Tag> tags = containersApi.getContainer(tool.getId(), null).getWorkflowVersions();
@@ -708,7 +708,7 @@ public class GeneralIT extends BaseIT {
         testingPostgres.runUpdateStatement("update image set image_id = 'dummyid'");
         assertEquals("dummyid",
             containersApi.getContainer(tool.getId(), null).getWorkflowVersions().get(0).getImages().get(0).getImageID());
-        usersApi.refresh(userid);
+        usersApi.refreshToolsByOrganization(userid, "dockstoretestuser2");
         final long count2 = testingPostgres.runSelectStatement("select count(*) from image", long.class);
         assertEquals(imageID, containersApi.getContainer(tool.getId(), null).getWorkflowVersions().get(0).getImages().get(0).getImageID());
         assertEquals(imageID2, containersApi.getContainer(tool.getId(), null).getWorkflowVersions().get(1).getImages().get(0).getImageID());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -31,7 +31,6 @@ import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
-import io.swagger.client.model.PublishRequest;
 import io.swagger.client.model.Workflow;
 import io.swagger.client.model.WorkflowVersion;
 import org.junit.Assert;
@@ -117,7 +116,7 @@ public class GeneralWorkflowIT extends BaseIT {
         UsersApi usersApi = new UsersApi(client);
 
         // refresh all
-        usersApi.refreshWorkflows((long)1);
+        usersApi.refreshWorkflowsByOrganization((long)1, "DockstoreTestUser2");
 
         // refresh individual that is valid
         Workflow workflow = workflowsApi.getWorkflowByPath("github.com/DockstoreTestUser2/hello-dockstore-workflow", "", false);
@@ -281,7 +280,6 @@ public class GeneralWorkflowIT extends BaseIT {
     public void testRestubError() {
         ApiClient client = getWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(client);
-        UsersApi usersApi = new UsersApi(client);
 
         // refresh all and individual
         Workflow workflow = manualRegisterAndPublish(workflowsApi, "DockstoreTestUser2/hello-dockstore-workflow", "testname", "cwl",
@@ -381,7 +379,7 @@ public class GeneralWorkflowIT extends BaseIT {
         UsersApi usersApi = new UsersApi(client);
 
         // refresh all
-        usersApi.refreshWorkflows((long)1);
+        usersApi.refreshWorkflowsByOrganization((long)1, "dockstore_testuser2");
 
         // refresh individual that is valid
         Workflow workflow = workflowsApi
@@ -408,10 +406,7 @@ public class GeneralWorkflowIT extends BaseIT {
         WorkflowsApi workflowsApi = new WorkflowsApi(webClient);
 
         UsersApi usersApi = new UsersApi(webClient);
-        final Long userId = usersApi.getUser().getId();
-
-        // Make publish request (true)
-        final PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        usersApi.getUser();
 
         Workflow githubWorkflow = workflowsApi
             .manualRegister("github", "DockstoreTestUser2/test_lastmodified", "/Dockstore.cwl", "test-update-workflow", "cwl",
@@ -1037,7 +1032,7 @@ public class GeneralWorkflowIT extends BaseIT {
         // Refresh all workflows
         ApiClient client = getWebClient(USER_2_USERNAME, testingPostgres);
         UsersApi usersApi = new UsersApi(client);
-        usersApi.refreshWorkflows((long)1);
+        usersApi.refreshWorkflowsByOrganization((long)1, "dockstore_testuser2");
 
         // Check that user has been updated
         // TODO: bizarrely, the new GitHub Java API library doesn't seem to handle bio

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -198,7 +198,7 @@ public class WorkflowIT extends BaseIT {
         if (toPublish) {
             workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
         }
-        assertTrue(workflow.isIsPublished() == toPublish);
+        assertEquals(workflow.isIsPublished(), toPublish);
         return workflow;
     }
 
@@ -208,7 +208,8 @@ public class WorkflowIT extends BaseIT {
         UsersApi usersApi = new UsersApi(webClient);
         User user = usersApi.getUser();
 
-        final List<Workflow> workflows = usersApi.refreshWorkflows(user.getId());
+        final List<Workflow> workflows = usersApi.refreshWorkflowsByOrganization(user.getId(), "DockstoreTestUser2");
+
         for (Workflow workflow : workflows) {
             assertNotSame("", workflow.getWorkflowName());
         }
@@ -231,7 +232,7 @@ public class WorkflowIT extends BaseIT {
         User user = usersApi.getUser();
         Assert.assertNotEquals("getUser() endpoint should actually return the user profile", null, user.getUserProfiles());
 
-        final List<Workflow> workflows = usersApi.refreshWorkflows(user.getId());
+        final List<Workflow> workflows = usersApi.refreshWorkflowsByOrganization(user.getId(), "DockstoreTestUser2");
 
         for (Workflow workflow : workflows) {
             assertNotSame("", workflow.getWorkflowName());
@@ -662,7 +663,7 @@ public class WorkflowIT extends BaseIT {
 
         final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
         UsersApi usersApi = new UsersApi(webClient);
-        final List<Workflow> workflows = usersApi.refreshWorkflows(userId);
+        final List<Workflow> workflows = usersApi.refreshWorkflowsByOrganization(userId, "DockstoreTestUser2");
 
         // Check that there are multiple workflows
         final long count = testingPostgres.runSelectStatement("select count(*) from workflow", long.class);
@@ -747,7 +748,8 @@ public class WorkflowIT extends BaseIT {
         // refresh just for the current user
         UsersApi usersApi = new UsersApi(webClient);
         final Long userId = usersApi.getUser().getId();
-        usersApi.refreshWorkflows(userId);
+        usersApi.refreshWorkflowsByOrganization(userId, "DockstoreTestUser2");
+
         assertTrue("should remain with nothing published ",
             workflowApi.allPublishedWorkflows(null, null, null, null, null, false).isEmpty());
         // ensure that sorting or filtering don't expose unpublished workflows
@@ -1164,7 +1166,7 @@ public class WorkflowIT extends BaseIT {
         final Long userId = usersApi.getUser().getId();
 
         // Get workflows
-        usersApi.refreshWorkflows(userId);
+        final List<Workflow> workflows = usersApi.refreshWorkflowsByOrganization(userId, "DockstoreTestUser2");
 
         // Manually register workflow
         boolean success = true;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -233,6 +233,7 @@ public class WorkflowIT extends BaseIT {
         Assert.assertNotEquals("getUser() endpoint should actually return the user profile", null, user.getUserProfiles());
 
         final List<Workflow> workflows = usersApi.refreshWorkflowsByOrganization(user.getId(), "DockstoreTestUser2");
+        workflows.addAll(usersApi.refreshWorkflowsByOrganization(user.getId(), "dockstore_testuser2"));
 
         for (Workflow workflow : workflows) {
             assertNotSame("", workflow.getWorkflowName());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -664,6 +664,8 @@ public class WorkflowIT extends BaseIT {
         final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
         UsersApi usersApi = new UsersApi(webClient);
         final List<Workflow> workflows = usersApi.refreshWorkflowsByOrganization(userId, "DockstoreTestUser2");
+        workflows.addAll(usersApi.refreshWorkflowsByOrganization(userId, "DockstoreTestUser"));
+        workflows.addAll(usersApi.refreshWorkflowsByOrganization(userId, "dockstoretesting"));
 
         // Check that there are multiple workflows
         final long count = testingPostgres.runSelectStatement("select count(*) from workflow", long.class);
@@ -725,8 +727,8 @@ public class WorkflowIT extends BaseIT {
                 .equalsIgnoreCase("dockstore-whalesay-2")));
 
         // Check that for a repo from my organization that I forked to DockstoreTestUser2, that it along with the original repo are present
-        assertEquals("Should have two repos with name basic-workflow, one from DockstoreTestUser2 and one from dockstoretesting.", 2,
-            workflows.stream().filter((Workflow workflow) ->
+        assertTrue("Should have two repos with name basic-workflow, one from DockstoreTestUser2 and one from dockstoretesting.",
+            2 <= workflows.stream().filter((Workflow workflow) ->
                 (workflow.getOrganization().equalsIgnoreCase("dockstoretesting") || workflow.getOrganization()
                     .equalsIgnoreCase("DockstoreTestUser2")) && workflow.getRepository().equalsIgnoreCase("basic-workflow")).count());
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -34,7 +34,6 @@ import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.BioWorkflow;
 import io.swagger.client.model.Collection;
-import io.swagger.client.model.DockstoreTool;
 import io.swagger.client.model.EntryUpdateTime;
 import io.swagger.client.model.Organization;
 import io.swagger.client.model.OrganizationUpdateTime;
@@ -209,7 +208,8 @@ public class UserResourceIT extends BaseIT {
         User user = userApi.getUser();
         assertNotNull(user);
         // try to delete with published workflows
-        userApi.refreshWorkflows(user.getId());
+        userApi.refreshWorkflowsByOrganization((long)1, "DockstoreTestUser");
+        userApi.refreshWorkflowsByOrganization((long)1, "dockstore_testuser2");
         final Workflow workflowByPath = workflowsApi
             .getWorkflowByPath(WorkflowIT.DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, null, false);
         // refresh targeted
@@ -378,7 +378,8 @@ public class UserResourceIT extends BaseIT {
 
         Workflow addedWorkflow = workflowsApi.manualRegister("gitlab", "dockstore.test.user2/dockstore-workflow-md5sum-unified", "/Dockstore.cwl", "", "cwl", "/test.json");
 
-        List<DockstoreTool> tools = userApi.refresh(user.getId());
+        userApi.refreshToolsByOrganization((long)1, "dockstore.test.user2");
+
         List<EntryUpdateTime> entries = userApi.getUserEntries(10, null);
         assertFalse(entries.isEmpty());
         assertEquals("gitlab.com/dockstore.test.user2/dockstore-workflow-md5sum-unified", entries.get(entries.size() - 1).getPath());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -209,7 +209,7 @@ public class UserResourceIT extends BaseIT {
         assertNotNull(user);
         // try to delete with published workflows
         userApi.refreshWorkflowsByOrganization((long)1, "DockstoreTestUser");
-        userApi.refreshWorkflowsByOrganization((long)1, "dockstore_testuser2");
+        userApi.refreshWorkflowsByOrganization((long)1, "DockstoreTestUser2");
         final Workflow workflowByPath = workflowsApi
             .getWorkflowByPath(WorkflowIT.DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, null, false);
         // refresh targeted
@@ -382,8 +382,8 @@ public class UserResourceIT extends BaseIT {
 
         List<EntryUpdateTime> entries = userApi.getUserEntries(10, null);
         assertFalse(entries.isEmpty());
-        assertEquals("gitlab.com/dockstore.test.user2/dockstore-workflow-md5sum-unified", entries.get(entries.size() - 1).getPath());
-        assertEquals("dockstore-workflow-md5sum-unified", entries.get(entries.size() - 1).getPrettyPath());
+        assertTrue(entries.stream().anyMatch(e -> e.getPath().contains("gitlab.com/dockstore.test.user2/dockstore-workflow-md5sum-unified")));
+        assertTrue(entries.stream().anyMatch(e -> e.getPath().contains("dockstore-workflow-md5sum-unified")));
 
         // Update an entry
         Workflow workflow = workflowsApi.getWorkflowByPath("gitlab.com/dockstore.test.user2/dockstore-workflow-md5sum-unified", null, false);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -475,31 +475,6 @@ public class UserResource implements AuthenticatedResourceInterface {
     @GET
     @Timed
     @UnitOfWork
-    @Path("/{userId}/containers/refresh")
-    @ApiOperation(nickname =  "refresh", value = "Refresh all tools owned by the authenticated user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class, responseContainer = "List")
-    public List<Tool> refresh(@ApiParam(hidden = true) @Auth User authUser,
-            @ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId) {
-
-        checkUser(authUser, userId);
-
-        // Checks if the user has the tokens for their current tools
-        checkToolTokens(authUser, userId, null);
-
-        dockerRepoResource.refreshToolsForUser(userId, null);
-        userDAO.clearCache();
-        // TODO: Only update the ones that have changed
-        authUser = userDAO.findById(authUser.getId());
-        // Update user data
-        authUser.updateUserMetadata(tokenDAO);
-
-        List<Tool> finalTools = getTools(authUser);
-        bulkUpsertTools(authUser);
-        return finalTools;
-    }
-
-    @GET
-    @Timed
-    @UnitOfWork
     @Path("/{userId}/workflows/{organization}/refresh")
     @ApiOperation(value = "Refresh all workflows owned by the authenticated user with specified organization.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, responseContainer = "List")
     public List<Workflow> refreshWorkflowsByOrganization(@ApiParam(hidden = true) @Auth User authUser,
@@ -516,27 +491,6 @@ public class UserResource implements AuthenticatedResourceInterface {
         // Update user data
         authUser.updateUserMetadata(tokenDAO);
 
-        List<Workflow> finalWorkflows = getWorkflows(authUser);
-        bulkUpsertWorkflows(authUser);
-        return finalWorkflows;
-    }
-
-    @GET
-    @Timed
-    @UnitOfWork
-    @Path("/{userId}/workflows/refresh")
-    @ApiOperation(value = "Refresh all workflows owned by the authenticated user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, responseContainer = "List")
-    public List<Workflow> refreshWorkflows(@ApiParam(hidden = true) @Auth User authUser,
-            @ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId) {
-
-        checkUser(authUser, userId);
-
-        // Refresh all workflows, including full workflows
-        workflowResource.refreshStubWorkflowsForUser(authUser, null, new HashSet<>());
-        // Refresh the user
-        authUser = userDAO.findById(authUser.getId());
-        // Update user data
-        authUser.updateUserMetadata(tokenDAO);
         List<Workflow> finalWorkflows = getWorkflows(authUser);
         bulkUpsertWorkflows(authUser);
         return finalWorkflows;

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1196,8 +1196,8 @@ components:
           - SWL
           - NFL
           - service
-          - cwl
-          - wdl
+          
+          
           type: string
         descriptorTypeSubclass:
           enum:
@@ -2683,7 +2683,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organization'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
       - bearer: []

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -24,9 +24,12 @@ components:
         type: object
       type: object
     Checksum:
-      description: 'A production (immutable) tool version is required to have a hashcode.
-        Not required otherwise, but might be useful to detect changes. '
-      example: '[{checksum=ea2a5db69bd20a42976838790bc29294df3af02b, type=sha1}]'
+      description: A production (immutable) tool version is required to have a hashcode.
+        Not required otherwise, but might be useful to detect changes.  This exposes
+        the hashcode for specific image versions to verify that the container version
+        pulled is actually the version that was indexed by the registry.
+      example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182,
+        type=sha256}]'
       properties:
         checksum:
           description: 'The hex-string encoded checksum for the data. '

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4410,31 +4410,6 @@ paths:
               $ref: "#/definitions/DockstoreTool"
       security:
       - BEARER: []
-  /users/{userId}/containers/refresh:
-    get:
-      tags:
-      - "users"
-      summary: "Refresh all tools owned by the authenticated user."
-      description: ""
-      operationId: "refresh"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "userId"
-        in: "path"
-        description: "User ID"
-        required: true
-        type: "integer"
-        format: "int64"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/DockstoreTool"
-      security:
-      - BEARER: []
   /users/{userId}/containers/{organization}/refresh:
     get:
       tags:
@@ -4647,31 +4622,6 @@ paths:
       summary: "List all published workflows from a user."
       description: ""
       operationId: "userPublishedWorkflows"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "userId"
-        in: "path"
-        description: "User ID"
-        required: true
-        type: "integer"
-        format: "int64"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Workflow"
-      security:
-      - BEARER: []
-  /users/{userId}/workflows/refresh:
-    get:
-      tags:
-      - "users"
-      summary: "Refresh all workflows owned by the authenticated user."
-      description: ""
-      operationId: "refreshWorkflows"
       produces:
       - "application/json"
       parameters:

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ConfigHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ConfigHelperTest.java
@@ -1,9 +1,18 @@
 package io.dockstore.webservice.helpers;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 
 public class ConfigHelperTest {
+
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
 
     /**
      * Tests that a mock git.properties file can be read to surface


### PR DESCRIPTION
Working on #3295 

In general, for integration tests, refresh all is replaced with more targeted refresh by organization calls. Will need to be followed with a UI PR to remove the general refresh by all ... plus a documentation PR. 