### PR TITLE
Quick fix for broken elastic search and my workflows

### DIFF
--- a/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
@@ -50,10 +50,11 @@
 
     <changeSet author="aduncan (generated)" id="addLegacyVersionColumn">
         <addColumn tableName="workflowversion">
-            <column name="islegacyversion" type="bool"/>
+            <column name="islegacyversion" type="bool" defaultValue="true">
+                <constraints nullable="false"/>
+            </column>
         </addColumn>
         <sql dbms="postgresql">
-            UPDATE workflowversion SET islegacyversion=true;
             UPDATE workflowversion SET islegacyversion=false WHERE id IN (SELECT wv.id FROM workflowversion wv JOIN workflow_workflowversion wwv ON wv.id=wwv.workflowversionid WHERE wwv.workflowid IN (SELECT id FROM workflow WHERE mode='DOCKSTORE_YML'));
         </sql>
     </changeSet>


### PR DESCRIPTION

#3310

Attempts were being made to assign null to the Java primitive boolean
isLegacyVersion field in WorkflowVersion. This would happen when
fetching workflows, which would at least cause ES reindex
and My Workflows to fail.

Don't allow nulls in the table.

Quick fix because I don't know how it got into the state where the value
is null. But it makes sense to not allow nulls in any case. Nor did I
add a test. But I would like to get dev.dockstore.net working again.