### PR TITLE
Fix broken elastic search and my workflows

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -74,7 +74,7 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
     @ApiModelProperty(value = "Remote: Last time version on GitHub repo was changed. Hosted: time version created.", position = 102)
     private Date lastModified;
 
-    @Column
+    @Column(nullable = false)
     @ApiModelProperty(value = "Whether or not the version was added using the legacy refresh process.", position = 104)
     private boolean isLegacyVersion = true;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -74,7 +74,7 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
     @ApiModelProperty(value = "Remote: Last time version on GitHub repo was changed. Hosted: time version created.", position = 102)
     private Date lastModified;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "boolean default true")
     @ApiModelProperty(value = "Whether or not the version was added using the legacy refresh process.", position = 104)
     private boolean isLegacyVersion = true;
 

--- a/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
@@ -50,11 +50,10 @@
 
     <changeSet author="aduncan (generated)" id="addLegacyVersionColumn">
         <addColumn tableName="workflowversion">
-            <column name="islegacyversion" type="bool" defaultValue="true">
-                <constraints nullable="false"/>
-            </column>
+            <column name="islegacyversion" type="bool"/>
         </addColumn>
         <sql dbms="postgresql">
+            UPDATE workflowversion SET islegacyversion=true;
             UPDATE workflowversion SET islegacyversion=false WHERE id IN (SELECT wv.id FROM workflowversion wv JOIN workflow_workflowversion wwv ON wv.id=wwv.workflowversionid WHERE wwv.workflowid IN (SELECT id FROM workflow WHERE mode='DOCKSTORE_YML'));
         </sql>
     </changeSet>
@@ -64,4 +63,24 @@
             <column name="imageregistry" type="varchar(255 BYTE)"/>
         </addColumn>
     </changeSet>
+
+    <changeSet author="Charles Overbeck" id="makeIsLegacyVersionNotNullable">
+        <comment>Frozen versions are protected by security</comment>
+        <sql dbms="postgresql">
+            alter table workflowversion disable row level security;
+        </sql>
+
+        <comment>Because of row-level security, line 57 left nulls in frozen versions</comment>
+        <sql dbms="postgresql">
+            UPDATE workflowversion SET islegacyversion=false WHERE islegacyversion is null;
+        </sql>
+
+        <sql dbms="postgresql">
+            alter table workflowversion enable row level security;
+        </sql>
+
+        <addDefaultValue tableName="workflowversion" columnName="islegacyversion" defaultValueBoolean="true"/>
+        <addNotNullConstraint tableName="workflowversion" columnName="islegacyversion"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
@@ -50,10 +50,11 @@
 
     <changeSet author="aduncan (generated)" id="addLegacyVersionColumn">
         <addColumn tableName="workflowversion">
-            <column name="islegacyversion" type="bool"/>
+            <column name="islegacyversion" type="bool" defaultValue="true">
+                <constraints nullable="false"/>
+            </column>
         </addColumn>
         <sql dbms="postgresql">
-            UPDATE workflowversion SET islegacyversion=true;
             UPDATE workflowversion SET islegacyversion=false WHERE id IN (SELECT wv.id FROM workflowversion wv JOIN workflow_workflowversion wwv ON wv.id=wwv.workflowversionid WHERE wwv.workflowid IN (SELECT id FROM workflow WHERE mode='DOCKSTORE_YML'));
         </sql>
     </changeSet>

--- a/scripts/check_migrations.sh
+++ b/scripts/check_migrations.sh
@@ -9,6 +9,10 @@ set -o xtrace
 
 if [ "${TESTING_PROFILE}" = "automated-review" ]; then
     bash propose_migration.sh
-    (! grep "changeSet" dockstore-webservice/target/detected-migrations.xml)
+    DETECTED_MIGRATIONS=dockstore-webservice/target/detected-migrations.xml
+    if test -f "$DETECTED_MIGRATIONS"; then
+      cat "$DETECTED_MIGRATIONS"
+    fi
+    (! grep "changeSet" "$DETECTED_MIGRATIONS")
     exit 0;
 fi


### PR DESCRIPTION
#3310 #3253

Attempts were being made to assign null to the Java primitive boolean
isLegacyVersion field in WorkflowVersion. This would happen when
fetching workflows, which would at least cause ES reindex
and My Workflows to fail.

Don't allow nulls in the table.

Also cat detected_migrations as part of this; was using to debug my 
initial failures.
