### PR TITLE
hook up checksums to trs

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/Registry.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/Registry.java
@@ -102,7 +102,7 @@ public enum Registry {
 
         public RegistryBean(Registry registry) {
             this.value = registry.name();
-            this.dockerPath = registry.toString();
+            this.dockerPath = registry.getDockerPath();
             this.friendlyName = registry.getFriendlyName();
             this.url = registry.url;
             this.privateOnly = Boolean.toString(registry.isPrivateOnly());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1319,7 +1319,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                             checksums.add(new Checksum(SHA_TYPE_FOR_SOURCEFILES, sha.get()));
                             if (sourceFile.getChecksums() == null) {
                                 sourceFile.setChecksums(checksums);
-                            } else {
+                            } else if (sourceFile.getChecksums().isEmpty()) {
                                 sourceFile.getChecksums().addAll(checksums);
                             }
                         }

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -517,7 +517,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
                 if (potentialDockerfile.isPresent()) {
                     ExtendedFileWrapper dockerfile = new ExtendedFileWrapper();
                     //TODO: hook up file checksum here
-                    dockerfile.setChecksum(getFileDescriptorChecksumsForTrs(potentialDockerfile.get()));
+                    dockerfile.setChecksum(convertToTRSChecksums(potentialDockerfile.get()));
                     dockerfile.setContent(potentialDockerfile.get().getContent());
                     dockerfile.setUrl(urlBuilt + ((Tag)entryVersion.get()).getDockerfilePath());
                     dockerfile.setOriginalFile(potentialDockerfile.get());
@@ -569,7 +569,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         return Response.status(status).build();
     }
 
-    public static List<Checksum> getFileDescriptorChecksumsForTrs(final SourceFile sourceFile) {
+    public static List<Checksum> convertToTRSChecksums(final SourceFile sourceFile) {
         List<Checksum> trsChecksums = new ArrayList<>();
         if (sourceFile.getChecksums() != null && !sourceFile.getChecksums().isEmpty()) {
             sourceFile.getChecksums().stream().forEach(checksum -> {

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -63,6 +63,7 @@ import io.dockstore.webservice.jdbi.ToolDAO;
 import io.dockstore.webservice.jdbi.WorkflowDAO;
 import io.dockstore.webservice.resources.AuthenticatedResourceInterface;
 import io.openapi.api.ToolsApiService;
+import io.openapi.model.Checksum;
 import io.openapi.model.Error;
 import io.openapi.model.ExtendedFileWrapper;
 import io.openapi.model.FileWrapper;
@@ -89,6 +90,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
     private static final String BITBUCKET_PREFIX = "git@bitbucket.org:";
     private static final int SEGMENTS_IN_ID = 3;
     private static final int DEFAULT_PAGE_SIZE = 1000;
+    private static final String DESCRIPTOR_FILE_SHA_TYPE_FOR_TRS = "sha1";
     private static final Logger LOG = LoggerFactory.getLogger(ToolsApiServiceImpl.class);
 
     private static ToolDAO toolDAO = null;
@@ -515,7 +517,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
                 if (potentialDockerfile.isPresent()) {
                     ExtendedFileWrapper dockerfile = new ExtendedFileWrapper();
                     //TODO: hook up file checksum here
-                    dockerfile.setChecksum(Lists.newArrayList());
+                    dockerfile.setChecksum(getFileDescriptorChecksumsForTrs(potentialDockerfile.get()));
                     dockerfile.setContent(potentialDockerfile.get().getContent());
                     dockerfile.setUrl(urlBuilt + ((Tag)entryVersion.get()).getDockerfilePath());
                     dockerfile.setOriginalFile(potentialDockerfile.get());
@@ -565,6 +567,19 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         Response.StatusType status = getExtendedStatus(Status.NOT_FOUND,
             "version found, but file not found (bad filename, invalid file, etc.)");
         return Response.status(status).build();
+    }
+
+    public static List<Checksum> getFileDescriptorChecksumsForTrs(final SourceFile sourceFile) {
+        List<Checksum> trsChecksums = new ArrayList<>();
+        if (sourceFile.getChecksums() != null && !sourceFile.getChecksums().isEmpty()) {
+            sourceFile.getChecksums().stream().forEach(checksum -> {
+                Checksum trsChecksum = new Checksum();
+                trsChecksum.setType(DESCRIPTOR_FILE_SHA_TYPE_FOR_TRS);
+                trsChecksum.setChecksum(checksum.getChecksum());
+                trsChecksums.add(trsChecksum);
+            });
+        }
+        return trsChecksums;
     }
 
     private Response.StatusType getExtendedStatus(Status status, String additionalMessage) {

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ApiV2BetaVersionConverter.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ApiV2BetaVersionConverter.java
@@ -153,7 +153,7 @@ public final class ApiV2BetaVersionConverter {
                 toolVersion.getImages().stream().filter(Objects::nonNull).map(ImageData::getImageName).collect(Collectors.joining()));
             // this is a bit weird, but seems to be current behaviour, also need to get rid of the double lambda
             final Optional<Optional<String>> first = toolVersion.getImages().stream().filter(Objects::nonNull).map(
-                item -> item.getChecksum().stream().filter(check -> check.getType().equals(ToolsImplCommon.DOCKSTORE_IMAGEID))
+                item -> item.getChecksum().stream().filter(check -> check.getType().equals(ToolsImplCommon.DOCKER_IMAGE_SHA_TYPE_FOR_TRS))
                     .map(Checksum::getChecksum).findFirst()).findFirst();
             if (first.isPresent() && first.get().isPresent()) {
                 betaToolVersion.setImage(first.get().get());

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
@@ -269,12 +269,17 @@ public final class ToolsImplCommon {
     private static void processImageDataForToolVersion(io.dockstore.webservice.core.Tool castedContainer, Tag version,
         ToolVersion toolVersion) {
         ImageData data = new ImageData();
-        if (version.getImageId() != null) {
-            Checksum checksum = new Checksum();
-            checksum.setChecksum(version.getImageId());
-            checksum.setType(DOCKSTORE_IMAGEID);
-            //TODO: hook up snapshot and checksum behaviour here too for tools
-            data.setChecksum(Lists.newArrayList(checksum));
+        List<Checksum> trsChecksums = new ArrayList<>();
+        if (version.getImages() != null) {
+            version.getImages().forEach(image -> {
+                image.getChecksums().forEach(checksum -> {
+                    Checksum trsChecksum = new Checksum();
+                    trsChecksum.setType(DOCKER_IMAGE_SHA_TYPE_FOR_TRS);
+                    trsChecksum.setChecksum(checksum.getChecksum());
+                    trsChecksums.add(trsChecksum);
+                });
+            });
+            data.setChecksum(trsChecksums);
         } else {
             //TODO: hook up snapshot and checksum behaviour here too for workflows (or tools without images?)
             data.setChecksum(MoreObjects.firstNonNull(data.getChecksum(), Lists.newArrayList()));

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
@@ -79,8 +79,8 @@ public final class ToolsImplCommon {
      */
     public static ExtendedFileWrapper sourceFileToToolDescriptor(String url, SourceFile sourceFile) {
         ExtendedFileWrapper toolDescriptor = new ExtendedFileWrapper();
-        getChecksumsForTrs(sourceFile);
-        toolDescriptor.setChecksum(getChecksumsForTrs(sourceFile));
+        convertToTRSChecksums(sourceFile);
+        toolDescriptor.setChecksum(convertToTRSChecksums(sourceFile));
         toolDescriptor.setContent(sourceFile.getContent());
         toolDescriptor.setUrl(url);
         toolDescriptor.setOriginalFile(sourceFile);
@@ -471,7 +471,7 @@ public final class ToolsImplCommon {
             LOG.error("This source file is not a recognized test file.");
         }
         ExtendedFileWrapper toolTests = new ExtendedFileWrapper();
-        List<Checksum> trsChecksums = getChecksumsForTrs(sourceFile);
+        List<Checksum> trsChecksums = convertToTRSChecksums(sourceFile);
         toolTests.setChecksum(trsChecksums);
         toolTests.setUrl(urlWithWorkDirectory + sourceFile.getPath());
         toolTests.setContent(sourceFile.getContent());
@@ -479,8 +479,8 @@ public final class ToolsImplCommon {
         return toolTests;
     }
 
-    private static List<Checksum> getChecksumsForTrs(final SourceFile sourceFile) {
-        List<Checksum> trsChecksums = ToolsApiServiceImpl.getFileDescriptorChecksumsForTrs(sourceFile);
+    private static List<Checksum> convertToTRSChecksums(final SourceFile sourceFile) {
+        List<Checksum> trsChecksums = ToolsApiServiceImpl.convertToTRSChecksums(sourceFile);
         return trsChecksums;
     }
 

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
@@ -43,6 +43,7 @@ import io.dockstore.webservice.core.Tag;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowVersion;
+import io.openapi.api.impl.ToolsApiServiceImpl;
 import io.openapi.model.Checksum;
 import io.openapi.model.DescriptorType;
 import io.openapi.model.ExtendedFileWrapper;
@@ -62,7 +63,7 @@ import org.slf4j.LoggerFactory;
 public final class ToolsImplCommon {
     public static final String WORKFLOW_PREFIX = "#workflow";
     public static final String SERVICE_PREFIX = "#service";
-    public static final String DOCKSTORE_IMAGEID = "dockstore:imageid";
+    public static final String DOCKER_IMAGE_SHA_TYPE_FOR_TRS = "sha-256";
     private static final Logger LOG = LoggerFactory.getLogger(ToolsImplCommon.class);
 
     private ToolsImplCommon() { }
@@ -78,8 +79,8 @@ public final class ToolsImplCommon {
      */
     public static ExtendedFileWrapper sourceFileToToolDescriptor(String url, SourceFile sourceFile) {
         ExtendedFileWrapper toolDescriptor = new ExtendedFileWrapper();
-        //TODO: hook up file checksum here
-        toolDescriptor.setChecksum(Lists.newArrayList());
+        getChecksumsForTrs(sourceFile);
+        toolDescriptor.setChecksum(getChecksumsForTrs(sourceFile));
         toolDescriptor.setContent(sourceFile.getContent());
         toolDescriptor.setUrl(url);
         toolDescriptor.setOriginalFile(sourceFile);
@@ -250,7 +251,7 @@ public final class ToolsImplCommon {
 
             for (io.dockstore.webservice.core.Checksum checksum : checksumList) {
                 Checksum trsChecksum = new Checksum();
-                trsChecksum.setType(checksum.getType());
+                trsChecksum.setType(DOCKER_IMAGE_SHA_TYPE_FOR_TRS);
                 trsChecksum.setChecksum(checksum.getChecksum());
                 trsChecksums.add(trsChecksum);
             }
@@ -281,7 +282,7 @@ public final class ToolsImplCommon {
             });
             data.setChecksum(trsChecksums);
         } else {
-            //TODO: hook up snapshot and checksum behaviour here too for workflows (or tools without images?)
+            //tools without images?
             data.setChecksum(MoreObjects.firstNonNull(data.getChecksum(), Lists.newArrayList()));
         }
         //TODO: for now, all container images are Docker based
@@ -470,12 +471,17 @@ public final class ToolsImplCommon {
             LOG.error("This source file is not a recognized test file.");
         }
         ExtendedFileWrapper toolTests = new ExtendedFileWrapper();
-        //TODO: hook up file checksum here
-        toolTests.setChecksum(Lists.newArrayList());
+        List<Checksum> trsChecksums = getChecksumsForTrs(sourceFile);
+        toolTests.setChecksum(trsChecksums);
         toolTests.setUrl(urlWithWorkDirectory + sourceFile.getPath());
         toolTests.setContent(sourceFile.getContent());
         toolTests.setOriginalFile(sourceFile);
         return toolTests;
+    }
+
+    private static List<Checksum> getChecksumsForTrs(final SourceFile sourceFile) {
+        List<Checksum> trsChecksums = ToolsApiServiceImpl.getFileDescriptorChecksumsForTrs(sourceFile);
+        return trsChecksums;
     }
 
     /**

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1476,7 +1476,7 @@ info:
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
   termsOfService: TBD
   title: Dockstore API
-  version: 1.9.0-alpha.5-SNAPSHOT
+  version: 1.9.0-alpha.6-SNAPSHOT
 openapi: 3.0.1
 paths:
   /api/ga4gh/v1/tools:
@@ -2945,7 +2945,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/Organization'
           description: default response
       security:
       - bearer: []

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5,7 +5,7 @@ info:
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images. Explore swagger.json for a Swagger 2.0 description\
     \ of our API and explore openapi.yaml for OpenAPI 3.0 descriptions."
-  version: "1.9.0-alpha.5-SNAPSHOT"
+  version: "1.9.0-alpha.6-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
+++ b/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,6 +30,8 @@ import io.dockstore.common.Registry;
 import io.dockstore.common.SourceControl;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.Checksum;
+import io.dockstore.webservice.core.Image;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Tag;
 import io.dockstore.webservice.core.ToolMode;
@@ -123,6 +126,9 @@ public class ToolsImplCommonTest {
         tag.setAutomated(true);
         tag.setReference("sampleReference");
         tag.setValid(true);
+        List<Checksum> checksums = Collections.singletonList(new Checksum("SHA-1", "fakeChecksum"));
+        Set<Image> image = Collections.singleton(new Image(checksums, "sampleRepo", "sampleTag", "SampleImageId", Registry.QUAY_IO));
+        tag.setImages(image);
         Tag hiddenTag = new Tag();
         hiddenTag.setImageId("hiddenImageId");
         hiddenTag.setName("hiddenName");
@@ -187,7 +193,8 @@ public class ToolsImplCommonTest {
             expectedToolVersion.setUrl("http://localhost:8080/api/ga4gh/v2/tools/quay.io%2Ftest_org%2Ftest6/versions/sampleTag");
             expectedToolVersion.setId("quay.io/test_org/test6:sampleTag");
         }
-        expectedToolVersion.setImage("sampleImageId");
+        // Images are grabbed on refresh, so
+        expectedToolVersion.setImage("fakeChecksum");
         List<DescriptorType> descriptorTypeList = new ArrayList<>();
         descriptorTypeList.add(DescriptorType.CWL);
         expectedToolVersion.setDescriptorType(descriptorTypeList);


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-905
Hooked up checksums in the various TODOs that were left. I also got rid of `DOCKSTORE_IMAGEID`. That doesn't seem to be what checksums for images are intended for, but can change back if I'm misunderstanding something

I think this ticket https://github.com/dockstore/dockstore/issues/3329 is also addressed by changing the `toString` to `getDockerPath`. I tried it locally, and could register a tool.
Missed it in my previous PR.