### PR TITLE
Feature/3233/paginated tags

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
@@ -111,32 +111,23 @@ public class QuayImageRegistry extends AbstractImageRegistry {
             final QuayRepo quayRepo = toolFromQuay.get();
             final Map<String, QuayTag> tagsFromRepo = quayRepo.getTags();
             final int maxQuayTagsReturnedByRepo = 500;
+            List<QuayTag> quayTags = new ArrayList<>(tagsFromRepo.values());
             if (tagsFromRepo.size() == maxQuayTagsReturnedByRepo) {
                 try {
-                    List<QuayTag> allQuayTags = getAllQuayTags(repo);
-                    for (QuayTag tagItem : allQuayTags) {
-                        try {
-                            final Tag tag = convertQuayTagToTag(tagItem, tool);
-                            tags.add(tag);
-                        } catch (IllegalAccessException | InvocationTargetException ex) {
-                            LOG.error(quayToken.getUsername() + " Exception: {}", ex);
-                        }
-                    }
+                quayTags = getAllQuayTags(repo);
                 } catch (ApiException e) {
                     throw new CustomWebApplicationException("Could not get QuayTag", HttpStatus.SC_INTERNAL_SERVER_ERROR);
                 }
-            } else {
-                for (QuayTag tagItem : tagsFromRepo.values()) {
-                    try {
-                        final Tag tag = convertQuayTagToTag(tagItem, tool);
-                        tags.add(tag);
-                    } catch (IllegalAccessException | InvocationTargetException ex) {
-                        LOG.error(quayToken.getUsername() + " Exception: {}", ex);
-                    }
+            }
+            for (QuayTag tagItem : quayTags) {
+                try {
+                    final Tag tag = convertQuayTagToTag(tagItem, tool);
+                    tags.add(tag);
+                } catch (IllegalAccessException | InvocationTargetException ex) {
+                    LOG.error(quayToken.getUsername() + " Exception: {}", ex);
                 }
             }
         }
-
         String repository = tool.getNamespace() + "/" + tool.getName();
         updateTagsWithBuildInformation(repository, tags, tool);
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
@@ -114,7 +114,7 @@ public class QuayImageRegistry extends AbstractImageRegistry {
             List<QuayTag> quayTags = new ArrayList<>(tagsFromRepo.values());
             if (tagsFromRepo.size() == maxQuayTagsReturnedByRepo) {
                 try {
-                quayTags = getAllQuayTags(repo);
+                    quayTags = getAllQuayTags(repo);
                 } catch (ApiException e) {
                     throw new CustomWebApplicationException("Could not get QuayTag", HttpStatus.SC_INTERNAL_SERVER_ERROR);
                 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
@@ -126,8 +126,7 @@ public class QuayImageRegistry extends AbstractImageRegistry {
                     throw new CustomWebApplicationException("Could not get QuayTag", HttpStatus.SC_INTERNAL_SERVER_ERROR);
                 }
             } else {
-                List<QuayTag> values = (List<QuayTag>)tagsFromRepo.values();
-                for (QuayTag tagItem : values) {
+                for (QuayTag tagItem : tagsFromRepo.values()) {
                     try {
                         final Tag tag = convertQuayTagToTag(tagItem, tool);
                         tags.add(tag);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
@@ -34,6 +34,7 @@ import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import io.dockstore.common.Registry;
+import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.Checksum;
 import io.dockstore.webservice.core.Image;
 import io.dockstore.webservice.core.Tag;
@@ -56,6 +57,7 @@ import io.swagger.quay.client.model.QuayTag;
 import io.swagger.quay.client.model.UserView;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
@@ -45,7 +45,9 @@ import io.swagger.quay.client.ApiException;
 import io.swagger.quay.client.Configuration;
 import io.swagger.quay.client.api.BuildApi;
 import io.swagger.quay.client.api.RepositoryApi;
+import io.swagger.quay.client.api.TagApi;
 import io.swagger.quay.client.api.UserApi;
+import io.swagger.quay.client.model.InlineResponse2002;
 import io.swagger.quay.client.model.QuayBuild;
 import io.swagger.quay.client.model.QuayBuildTriggerMetadata;
 import io.swagger.quay.client.model.QuayOrganization;
@@ -65,45 +67,73 @@ public class QuayImageRegistry extends AbstractImageRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(QuayImageRegistry.class);
 
     private final Token quayToken;
-    private final ApiClient apiClient;
     private final BuildApi buildApi;
     private final RepositoryApi repositoryApi;
     private final UserApi userApi;
+    private final TagApi tagApi;
 
     public QuayImageRegistry(final Token quayToken) {
         this.quayToken = quayToken;
-
-        apiClient = Configuration.getDefaultApiClient();
+        ApiClient apiClient = Configuration.getDefaultApiClient();
         apiClient.addDefaultHeader("Authorization", "Bearer " + quayToken.getContent());
         this.buildApi = new BuildApi(apiClient);
         this.repositoryApi = new RepositoryApi(apiClient);
         this.userApi = new UserApi(apiClient);
+        this.tagApi = new TagApi((apiClient));
+
     }
+
+    private List<QuayTag> getAllQuayTags(String repository) throws ApiException {
+        List<QuayTag> allQuayTags = new ArrayList<>();
+        // Completely arbitrary maxPageSize in the weird event that Quay.io's pagination results in an infinite loop or something
+        final int maxPageSize = 100;
+        for (int page = 1; page < Integer.MAX_VALUE; page++) {
+            InlineResponse2002 inlineResponse2002 = tagApi.listRepoTags(repository, page, maxPageSize, null, true);
+            List<QuayTag> quayTags = inlineResponse2002.getTags();
+            allQuayTags.addAll(quayTags);
+            if (!inlineResponse2002.isHasAdditional()) {
+                break;
+            }
+        }
+        return allQuayTags;
+    }
+
 
     @Override
     public List<Tag> getTags(Tool tool) {
         LOG.info(quayToken.getUsername() + " ======================= Getting tags for: {}================================", tool.getPath());
-
+        final String repo = tool.getNamespace() + '/' + tool.getName();
         final List<Tag> tags = new ArrayList<>();
         final Optional<QuayRepo> toolFromQuay = getToolFromQuay(tool);
         if (toolFromQuay.isPresent()) {
             final QuayRepo quayRepo = toolFromQuay.get();
             final Map<String, QuayTag> tagsFromRepo = quayRepo.getTags();
-            for (QuayTag tagItem : tagsFromRepo.values()) {
+            final int maxQuayTagsReturnedByRepo = 500;
+            if (tagsFromRepo.size() == maxQuayTagsReturnedByRepo) {
                 try {
-                    final Tag tag = new Tag();
-                    BeanUtils.copyProperties(tag, tagItem);
-                    Optional<Image> tagImage = getImageForTag(tool, tag, tagItem);
-                    if (tagImage.isPresent()) {
-                        tag.getImages().add(tagImage.get());
+                    List<QuayTag> allQuayTags = getAllQuayTags(repo);
+                    for (QuayTag tagItem : allQuayTags) {
+                        try {
+                            final Tag tag = convertQuayTagToTag(tagItem, tool);
+                            tags.add(tag);
+                        } catch (IllegalAccessException | InvocationTargetException ex) {
+                            LOG.error(quayToken.getUsername() + " Exception: {}", ex);
+                        }
                     }
-                    insertQuayLastModifiedIntoLastBuilt(tagItem, tag);
-                    tags.add(tag);
-                } catch (IllegalAccessException | InvocationTargetException ex) {
-                    LOG.error(quayToken.getUsername() + " Exception: {}", ex);
+                } catch (ApiException e) {
+                    throw new CustomWebApplicationException("Could not get QuayTag", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+                }
+            } else {
+                List<QuayTag> values = (List<QuayTag>)tagsFromRepo.values();
+                for (QuayTag tagItem : values) {
+                    try {
+                        final Tag tag = convertQuayTagToTag(tagItem, tool);
+                        tags.add(tag);
+                    } catch (IllegalAccessException | InvocationTargetException ex) {
+                        LOG.error(quayToken.getUsername() + " Exception: {}", ex);
+                    }
                 }
             }
-
         }
 
         String repository = tool.getNamespace() + "/" + tool.getName();
@@ -111,6 +141,16 @@ public class QuayImageRegistry extends AbstractImageRegistry {
 
         return tags;
     }
+
+    private Tag convertQuayTagToTag(QuayTag quayTag, Tool tool) throws InvocationTargetException, IllegalAccessException {
+        final Tag tag = new Tag();
+        BeanUtils.copyProperties(tag, quayTag);
+        Optional<Image> tagImage = getImageForTag(tool, tag, quayTag);
+        tagImage.ifPresent(image -> tag.getImages().add(image));
+        insertQuayLastModifiedIntoLastBuilt(quayTag, tag);
+        return tag;
+    }
+
 
     //TODO: If the repo has a lot of tags, then it needs to be paged through. Can get tag info individually, but then that's more API calls.
     private Optional<Image> getImageForTag(final Tool tool, final Tag tag, final QuayTag quayTag) {

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
@@ -1,0 +1,41 @@
+package io.dockstore.webservice.helpers;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.dockstore.webservice.core.Tag;
+import io.dockstore.webservice.core.Token;
+import io.dockstore.webservice.core.Tool;
+import io.dockstore.webservice.core.Version;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class QuayImageRegistryTest {
+
+    /**
+     * Normally, we are only able to get 500 tags without using the paginated endpoint.
+     * This tests that when there are over 500 tags, we can use the paginated endpoint to retrieve all of them instead.
+     * Using calico/node because it has over 3838 tags
+     */
+    @Test
+    public void getOver500TagsTest() {
+        Token token = new Token();
+        token.setContent("fakeQuayTokenBecauseWeDontReallyNeedOne");
+        QuayImageRegistry quayImageRegistry = new QuayImageRegistry(token);
+        Tool tool = new Tool();
+        tool.setRegistry("quay.io");
+        tool.setNamespace("calico");
+        tool.setName("node");
+        List<Tag> tags = quayImageRegistry.getTags(tool);
+        int size = tags.size();
+        Assert.assertTrue("Should be able to get more than the default 500 tags", size > 3838);
+        tags.forEach(tag -> {
+            Assert.assertNotEquals("Image ID should be populated", null, tag.getImageId());
+            Assert.assertTrue("Images should be populated", tag.getImages().size() > 0);
+        });
+        Set<String> collect = tags.parallelStream().map(Version::getName).collect(Collectors.toSet());
+        int distinctSize = collect.size();
+        Assert.assertEquals("There should be no tags with the same name", size, distinctSize);
+    }
+}

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
@@ -9,9 +9,17 @@ import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.Version;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 
 public class QuayImageRegistryTest {
+
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
 
     /**
      * Normally, we are only able to get 500 tags without using the paginated endpoint.

--- a/swagger-java-quay-client/discovery.formatted.yaml
+++ b/swagger-java-quay-client/discovery.formatted.yaml
@@ -4713,9 +4713,25 @@ paths:
           name: specificTag
           required: false
           type: string
+        - description: Filters the tags to the specific tag.
+          in: query
+          name: onlyActiveTags
+          required: false
+          type: boolean
       responses:
         '200':
           description: Successful invocation
+          schema:
+            type: object
+            properties:
+              tags:
+                type: array
+                items:
+                  $ref: '#/definitions/QuayTag'
+              has_additional:
+                type: boolean
+              page:
+                type: integer
         '400':
           description: Bad Request
           schema:


### PR DESCRIPTION
For #3233 

Getting builds is not paginated, you just specify an amount and it retrieves that amount (was not able to find max amount, only tried up to ~459 builds).

As for tags...Previously we used the get-repo endpoint, it returns up to 500 tags with it.  The get tags endpoint is paginated and can eventually get all tags.

This PR does not affect builds (since there's no pagination), but allows us to get all tags.