### PR TITLE
Use DockstoreYaml class

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
@@ -24,7 +24,6 @@ import javax.validation.constraints.NotNull;
  * A workflow as described in a .dockstore.yml
  */
 public class YamlWorkflow {
-    @NotNull
     private String name;
     @NotNull
     private String subclass;

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -172,4 +172,13 @@ public class DockstoreYamlTest {
         }
     }
 
+    @Test
+    public void testDifferentCaseForWorkflowSubclass() throws DockstoreYamlHelper.DockstoreYamlException {
+        final DockstoreYaml12 dockstoreYaml12 = DockstoreYamlHelper.readAsDockstoreYaml12(DOCKSTORE12_YAML);
+        final List<YamlWorkflow> workflows = dockstoreYaml12.getWorkflows();
+        assertEquals(3, workflows.size());
+        assertEquals(1, workflows.stream().filter(w -> "CWL".equals(w.getSubclass())).count());
+        assertEquals(1, workflows.stream().filter(w -> "cwl".equals(w.getSubclass())).count());
+    }
+
 }

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -78,8 +78,8 @@ public class DockstoreYamlTest {
     public void testReadDockstoreYaml12() throws DockstoreYamlHelper.DockstoreYamlException {
         final DockstoreYaml12 dockstoreYaml = (DockstoreYaml12)DockstoreYamlHelper.readDockstoreYaml(DOCKSTORE12_YAML);
         final List<YamlWorkflow> workflows = dockstoreYaml.getWorkflows();
-        assertEquals(2, workflows.size());
-        final Optional<YamlWorkflow> workflowFoobar = workflows.stream().filter(w -> w.getName().equals("foobar")).findFirst();
+        assertEquals(3, workflows.size());
+        final Optional<YamlWorkflow> workflowFoobar = workflows.stream().filter(w -> "foobar".equals(w.getName())).findFirst();
         if (!workflowFoobar.isPresent()) {
             fail("Could not find workflow foobar");
         }
@@ -91,6 +91,15 @@ public class DockstoreYamlTest {
         assertEquals("/dockstore.wdl.json", testParameterFiles.get(0));
         final List<Service12> services = dockstoreYaml.getServices();
         assertEquals(1, services.size());
+    }
+
+    @Test
+    public void testOptionalName() throws DockstoreYamlHelper.DockstoreYamlException {
+        final DockstoreYaml12 dockstoreYaml12 = DockstoreYamlHelper.readAsDockstoreYaml12(DOCKSTORE12_YAML);
+        final List<YamlWorkflow> workflows = dockstoreYaml12.getWorkflows();
+        assertEquals(3, workflows.size());
+        assertEquals("Expecting two workflows with names", 2L, workflows.stream().filter(w -> w.getName() != null).count());
+        assertEquals("Expecting one workflow without a name", 1L, workflows.stream().filter(w -> w.getName() == null).count());
     }
 
     @Test

--- a/dockstore-common/src/test/resources/fixtures/dockstore12.yml
+++ b/dockstore-common/src/test/resources/fixtures/dockstore12.yml
@@ -10,6 +10,11 @@ workflows:
      primaryDescriptorPath: /Dockstore.cwl
      testParameterFiles:
        - /dockstore.cwl.json
+  # A workflow with no name:
+  -  subclass: cwl
+     primaryDescriptorPath: /Dockstore.cwl
+     testParameterFiles:
+       - /dockstore.cwl.json
 services:
   - subclass: DOCKER_COMPOSE
     name: UCSC Xena Browser

--- a/dockstore-common/src/test/resources/fixtures/dockstore12.yml
+++ b/dockstore-common/src/test/resources/fixtures/dockstore12.yml
@@ -11,7 +11,7 @@ workflows:
      testParameterFiles:
        - /dockstore.cwl.json
   # A workflow with no name:
-  -  subclass: cwl
+  -  subclass: CWL
      primaryDescriptorPath: /Dockstore.cwl
      testParameterFiles:
        - /dockstore.cwl.json

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -915,14 +915,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
         }
 
-        // Delete existing version if it exists
-        Optional<WorkflowVersion> existingVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> Objects.equals(workflowVersion.getReference(), gitBranchName)).findFirst();
-        if (existingVersion.isPresent()) {
-            workflow.removeWorkflowVersion(existingVersion.get());
-        }
-
         Map<String, WorkflowVersion> existingDefaults = new HashMap<>();
-        existingVersion.ifPresent(workflowVersion -> existingDefaults.put(gitReference, workflowVersion));
 
         // Create version with sourcefiles and validate
         return setupWorkflowVersionsHelper(ghRepository.getFullName(), workflow, ref, Optional.of(workflow), existingDefaults, ghRepository, dockstoreYml);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -83,9 +83,6 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     private final String bitbucketClientID;
     private final Class<T> entityClass;
 
-    private final double dockstoreYMLV11 = 1.1;
-    private final double dockstoreYMLV12 = 1.2;
-
     public AbstractWorkflowResource(HttpClient client, SessionFactory sessionFactory, DockstoreWebserviceConfiguration configuration, Class<T> clazz) {
         this.client = client;
         this.sessionFactory = sessionFactory;


### PR DESCRIPTION

#3237 #3344 

Use DockstoreYaml class for reading .dockstore.yml. As part of this,
made name field optional for workflows.

A merge of hotfix branch into develop led to an issue with the tests, where a
version was being duplicated. Unrelated to my initial changes, but 
Andrew ended up adding code to avoid that, copying source files
instead of deleting the version and adding it again.