### PR TITLE
Feature/3345/default version

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/statelisteners/PublicStateManagerIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/statelisteners/PublicStateManagerIT.java
@@ -106,7 +106,7 @@ public class PublicStateManagerIT {
         tag.updateVerified();
         tool.setRegistry("potato");
         tool.addWorkflowVersion(tag);
-        tool.setDefaultVersion("master");
+        tool.setActualDefaultVersion(tag);
         tool.setIsPublished(true);
         return tool;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -297,9 +297,7 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
         }
     }
 
-    public String getDefaultVersion() {
-        return defaultVersion;
-    }
+    public abstract String getDefaultVersion();
 
     public void setDefaultVersion(String defaultVersion) {
         this.defaultVersion = defaultVersion;
@@ -475,9 +473,6 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
      */
     @JsonProperty
     public abstract Set<T> getWorkflowVersions();
-
-    @JsonProperty("actualDefaultVersionName")
-    public abstract String getActualDefaultVersionName();
 
     @JsonProperty
     public void setWorkflowVersions(Set<T> set) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -287,18 +287,13 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
      * Currently unused because too many entries do not have a default version set
      */
     public void syncMetadataWithDefault() {
-        T realDefaultVersion = this.getRealDefaultVersion();
+        T realDefaultVersion = this.getActualDefaultVersion();
         if (realDefaultVersion != null) {
             this.setMetadataFromVersion(realDefaultVersion);
         }
     }
     @ApiModelProperty(value = "This is the name of the default version of the entry", position = 7)
     public abstract String getDefaultVersion();
-
-    @JsonIgnore
-    public T getRealDefaultVersion() {
-        return this.getWorkflowVersions().stream().filter(workflowVersion -> workflowVersion.getName().equals(this.getDefaultVersion())).findFirst().orElse(null);
-    }
 
     public void setAuthor(String newAuthor) {
         this.author = newAuthor;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -236,7 +236,6 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
         }
     }
 
-
     public void setConceptDoi(String conceptDoi) {
         this.conceptDoi = conceptDoi;
     }
@@ -476,6 +475,9 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
      */
     @JsonProperty
     public abstract Set<T> getWorkflowVersions();
+
+    @JsonProperty("actualDefaultVersionName")
+    public abstract String getActualDefaultVersionName();
 
     @JsonProperty
     public void setWorkflowVersions(Set<T> set) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -137,10 +137,6 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     private String email;
 
     @Column
-    @ApiModelProperty(value = "This is the default version of the entry", position = 7)
-    private String defaultVersion;
-
-    @Column
     @JsonProperty("is_published")
     @ApiModelProperty(value = "Implementation specific visibility in this web service", position = 8)
     private boolean isPublished;
@@ -296,16 +292,12 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
             this.setMetadataFromVersion(realDefaultVersion);
         }
     }
-
+    @ApiModelProperty(value = "This is the name of the default version of the entry", position = 7)
     public abstract String getDefaultVersion();
-
-    public void setDefaultVersion(String defaultVersion) {
-        this.defaultVersion = defaultVersion;
-    }
 
     @JsonIgnore
     public T getRealDefaultVersion() {
-        return this.getWorkflowVersions().stream().filter(workflowVersion -> workflowVersion.getName().equals(this.defaultVersion)).findFirst().orElse(null);
+        return this.getWorkflowVersions().stream().filter(workflowVersion -> workflowVersion.getName().equals(this.getDefaultVersion())).findFirst().orElse(null);
     }
 
     public void setAuthor(String newAuthor) {
@@ -490,14 +482,19 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
         return getWorkflowVersions().remove(workflowVersion);
     }
 
+    public abstract void setActualDefaultVersion(T version);
+
+    @JsonIgnore
+    public abstract T getActualDefaultVersion();
+
     /**
      * @param newDefaultVersion
      * @return true if defaultVersion is a valid Docker tag
      */
     public boolean checkAndSetDefaultVersion(String newDefaultVersion) {
-        for (Version version : this.getWorkflowVersions()) {
+        for (T version : this.getWorkflowVersions()) {
             if (Objects.equals(newDefaultVersion, version.getName())) {
-                this.setDefaultVersion(newDefaultVersion);
+                this.setActualDefaultVersion(version);
                 this.syncMetadataWithDefault();
                 return true;
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -293,7 +293,13 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
         }
     }
     @ApiModelProperty(value = "This is the name of the default version of the entry", position = 7)
-    public abstract String getDefaultVersion();
+    public String getDefaultVersion() {
+        if (this.getActualDefaultVersion() != null) {
+            return this.getActualDefaultVersion().getName();
+        } else {
+            return null;
+        }
+    }
 
     public void setAuthor(String newAuthor) {
         this.author = newAuthor;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -84,6 +84,11 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
         super();
     }
 
+    @Override
+    public Date getDate() {
+        return this.getLastBuilt();
+    }
+
     public Version createEmptyVersion() {
         return new Tag();
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -170,7 +170,7 @@ public class Tool extends Entry<Tool, Tag> {
     @Override
     public String getDefaultVersion() {
         if (actualDefaultVersion != null) {
-            return actualDefaultVersion.name;
+            return actualDefaultVersion.getName();
         } else {
             return null;
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -167,15 +167,6 @@ public class Tool extends Entry<Tool, Tag> {
     }
 
     @Override
-    public String getDefaultVersion() {
-        if (this.getActualDefaultVersion() != null) {
-            return this.getActualDefaultVersion().getName();
-        } else {
-            return null;
-        }
-    }
-
-    @Override
     public void setActualDefaultVersion(Tag version) {
         this.actualDefaultVersion = version;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -29,7 +29,6 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
-import javax.persistence.ForeignKey;
 import javax.persistence.JoinColumn;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
@@ -147,14 +146,14 @@ public class Tool extends Entry<Tool, Tag> {
     @Cascade(CascadeType.DETACH)
     private final SortedSet<Tag> workflowVersions;
 
+    @JsonIgnore
+    @OneToOne(targetEntity = Tag.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "actualDefaultVersion", referencedColumnName = "id")
+    private Tag actualDefaultVersion;
+
     @Transient
     @JsonProperty
     private Set<Tag> tags = null;
-
-    @JsonIgnore
-    @OneToOne(targetEntity = Tag.class, fetch = FetchType.LAZY)
-    @JoinColumn(name = "actualDefaultVersion", referencedColumnName = "id", foreignKey = @ForeignKey(name = "fk_tool_default_tag"))
-    private Tag actualDefaultVersion;
 
     public Tool() {
         workflowVersions = new TreeSet<>();
@@ -169,11 +168,21 @@ public class Tool extends Entry<Tool, Tag> {
 
     @Override
     public String getDefaultVersion() {
-        if (actualDefaultVersion != null) {
-            return actualDefaultVersion.getName();
+        if (this.getActualDefaultVersion() != null) {
+            return this.getActualDefaultVersion().getName();
         } else {
             return null;
         }
+    }
+
+    @Override
+    public void setActualDefaultVersion(Tag version) {
+        this.actualDefaultVersion = version;
+    }
+
+    @Override
+    public Tag getActualDefaultVersion() {
+        return this.actualDefaultVersion;
     }
 
     @JsonProperty

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -29,15 +29,19 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
+import javax.persistence.JoinColumn;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.persistence.UniqueConstraint;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.EntryType;
@@ -147,6 +151,11 @@ public class Tool extends Entry<Tool, Tag> {
     @JsonProperty
     private Set<Tag> tags = null;
 
+    @JsonIgnore
+    @OneToOne(targetEntity = Tag.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "actualDefaultVersion", referencedColumnName = "id", foreignKey = @ForeignKey(name = "fk_tool_default_tag"))
+    private Tag actualDefaultVersion;
+
     public Tool() {
         workflowVersions = new TreeSet<>();
     }
@@ -157,6 +166,16 @@ public class Tool extends Entry<Tool, Tag> {
         this.name = name;
         workflowVersions = new TreeSet<>();
     }
+
+    @JsonProperty("actualDefaultVersionName")
+    public String getActualDefaultVersionName() {
+        if (actualDefaultVersion != null) {
+            return actualDefaultVersion.name;
+        } else {
+            return null;
+        }
+    }
+
 
     @JsonProperty
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -167,15 +167,14 @@ public class Tool extends Entry<Tool, Tag> {
         workflowVersions = new TreeSet<>();
     }
 
-    @JsonProperty("actualDefaultVersionName")
-    public String getActualDefaultVersionName() {
+    @Override
+    public String getDefaultVersion() {
         if (actualDefaultVersion != null) {
             return actualDefaultVersion.name;
         } else {
             return null;
         }
     }
-
 
     @JsonProperty
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -17,6 +17,7 @@
 package io.dockstore.webservice.core;
 
 import java.sql.Timestamp;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -194,6 +195,9 @@ public abstract class Version<T extends Version> implements Comparable<T> {
             return GSON.fromJson(Strings.nullToEmpty(this.getVersionMetadata().verifiedSource), String[].class);
         }
     }
+
+    @JsonIgnore
+    public abstract Date getDate();
 
     public boolean isDirtyBit() {
         return dirtyBit;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -196,6 +196,10 @@ public abstract class Version<T extends Version> implements Comparable<T> {
         }
     }
 
+    /**
+     * Used to determine the "newer" version. WorkflowVersion relies on last_modified, Tag relies on last_built.
+     * @return  The date used to determine the "newer" version
+     */
     @JsonIgnore
     public abstract Date getDate();
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -183,12 +183,22 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
         targetWorkflow.setGitUrl(getGitUrl());
         targetWorkflow.setDescriptorType(getDescriptorType());
         targetWorkflow.setDescriptorTypeSubclass(getDescriptorTypeSubclass());
-        targetWorkflow.setDefaultVersion(getDefaultVersion());
+        targetWorkflow.setActualDefaultVersion(this.getActualDefaultVersion());
         targetWorkflow.setDefaultTestParameterFilePath(getDefaultTestParameterFilePath());
         targetWorkflow.setCheckerWorkflow(getCheckerWorkflow());
         targetWorkflow.setIsChecker(isIsChecker());
         targetWorkflow.setConceptDoi(getConceptDoi());
         targetWorkflow.setMode(getMode());
+    }
+
+    @Override
+    public void setActualDefaultVersion(WorkflowVersion version) {
+        this.actualDefaultVersion = version;
+    }
+
+    @Override
+    public WorkflowVersion getActualDefaultVersion() {
+        return this.actualDefaultVersion;
     }
 
     @JsonProperty
@@ -236,8 +246,8 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
 
     @Override
     public String getDefaultVersion() {
-        if (actualDefaultVersion != null) {
-            return actualDefaultVersion.getName();
+        if (this.getActualDefaultVersion() != null) {
+            return this.getActualDefaultVersion().getName();
         } else {
             return null;
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -244,15 +244,6 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
         getDefaultPaths().put(this.getDescriptorType().getFileType(), defaultWorkflowPath);
     }
 
-    @Override
-    public String getDefaultVersion() {
-        if (this.getActualDefaultVersion() != null) {
-            return this.getActualDefaultVersion().getName();
-        } else {
-            return null;
-        }
-    }
-
     @JsonProperty
     public String getOrganization() {
         return organization;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -234,8 +234,8 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
         getDefaultPaths().put(this.getDescriptorType().getFileType(), defaultWorkflowPath);
     }
 
-    @JsonProperty("actualDefaultVersionName")
-    public String getActualDefaultVersionName() {
+    @Override
+    public String getDefaultVersion() {
         if (actualDefaultVersion != null) {
             return actualDefaultVersion.name;
         } else {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -28,9 +28,11 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
 
@@ -125,6 +127,11 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
     @OrderBy("id")
     @Cascade({ CascadeType.DETACH, CascadeType.SAVE_UPDATE })
     private final SortedSet<WorkflowVersion> workflowVersions;
+
+    @JsonIgnore
+    @OneToOne(targetEntity = WorkflowVersion.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "actualDefaultVersion", referencedColumnName = "id")
+    private WorkflowVersion actualDefaultVersion;
 
     protected Workflow() {
         workflowVersions = new TreeSet<>();
@@ -225,6 +232,15 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
     //TODO: odd side effect, this means that if the descriptor language is set wrong, we will get or set the wrong the default paths
     public void setDefaultWorkflowPath(String defaultWorkflowPath) {
         getDefaultPaths().put(this.getDescriptorType().getFileType(), defaultWorkflowPath);
+    }
+
+    @JsonProperty("actualDefaultVersionName")
+    public String getActualDefaultVersionName() {
+        if (actualDefaultVersion != null) {
+            return actualDefaultVersion.name;
+        } else {
+            return null;
+        }
     }
 
     @JsonProperty

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -237,7 +237,7 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
     @Override
     public String getDefaultVersion() {
         if (actualDefaultVersion != null) {
-            return actualDefaultVersion.name;
+            return actualDefaultVersion.getName();
         } else {
             return null;
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -55,9 +55,6 @@ import org.apache.commons.io.FilenameUtils;
 
 @SuppressWarnings("checkstyle:magicnumber")
 public class WorkflowVersion extends Version<WorkflowVersion> implements Comparable<WorkflowVersion>, Aliasable {
-
-
-
     @ElementCollection(targetClass = Alias.class)
     @JoinTable(name = "workflowversion_alias", joinColumns = @JoinColumn(name = "id"), uniqueConstraints = @UniqueConstraint(name = "unique_workflowversion_aliases", columnNames = { "alias" }))
     @MapKeyColumn(name = "alias", columnDefinition = "text")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -88,6 +88,11 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
     }
 
     @Override
+    public Date getDate() {
+        return this.getLastModified();
+    }
+
+    @Override
     public String getWorkingDirectory() {
         if (workflowPath != null && !workflowPath.isEmpty()) {
             return FilenameUtils.getPathNoEndSeparator(workflowPath);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -364,7 +364,7 @@ public abstract class SourceCodeRepoInterface {
                             return branch.equals(reference);
                         }).findFirst();
                 firstWorkflowVersion.ifPresentOrElse(version -> entry.checkAndSetDefaultVersion(version.getName()), () -> {
-                    Version newestVersion = Collections.max(workflowVersions, Comparator.comparingInt(s -> s.getDbUpdateDate().getNanos()));
+                    Version newestVersion = Collections.max(workflowVersions, Comparator.comparingLong(s -> s.getDate().getTime()));
                     entry.setActualDefaultVersion(newestVersion);
                 });
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -18,6 +18,7 @@ package io.dockstore.webservice.helpers;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
@@ -335,14 +336,22 @@ public abstract class SourceCodeRepoInterface {
     }
 
     /**
+     * Currently this function is only ran when during tool/workflow refreshes
      * Sets the default version if there isn't already one present.
      * This is required because entry-level metadata depends on the default version
+     * Makes sure that the entry actually has that workflowVersion
+     * First tries to get the default branch from the Git repository and sets it there.
+     * If the current versions do not have that, then it falls back to the newest version.
      *
      * @param entry
      * @param repositoryId
      */
     public void setDefaultBranchIfNotSet(Entry entry, String repositoryId) {
-        if (entry.getDefaultVersion() == null) {
+        Version defaultVersion = entry.getActualDefaultVersion();
+        Set<Long> workflowVersionIds = (Set<Long>)entry.getWorkflowVersions().stream().map(version -> ((Version)version).getId()).collect(Collectors.toSet());
+        if (defaultVersion == null  || !workflowVersionIds.contains(defaultVersion.getId())) {
+            // Set null for now in case workflowVersions doesn't contain the current default version for some reason
+            entry.setActualDefaultVersion(null);
             String branch = getMainBranch(entry, repositoryId);
             if (branch == null) {
                 String message = String.format("%s : Error getting the main branch.", repositoryId);
@@ -354,7 +363,10 @@ public abstract class SourceCodeRepoInterface {
                             String reference = workflowVersion.getReference();
                             return branch.equals(reference);
                         }).findFirst();
-                firstWorkflowVersion.ifPresent(version -> entry.checkAndSetDefaultVersion(version.getName()));
+                firstWorkflowVersion.ifPresentOrElse(version -> entry.checkAndSetDefaultVersion(version.getName()), () -> {
+                    Version newestVersion = Collections.max(workflowVersions, Comparator.comparingInt(s -> s.getDbUpdateDate().getNanos()));
+                    entry.setActualDefaultVersion(newestVersion);
+                });
             }
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -366,7 +366,9 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
         checkHosted(entry);
         // If the version that's about to be deleted is the default version, unset it
         if (entry.getActualDefaultVersion().getName().equals(version)) {
-            entry.setActualDefaultVersion(null);
+            Optional<U> max = entry.getWorkflowVersions().stream().filter(v -> !Objects.equals(v.getName(), version))
+                    .max(Comparator.comparingLong(ver -> ver.getDate().getTime()));
+            entry.setActualDefaultVersion(max.orElse(null));
         }
         entry.getWorkflowVersions().removeIf(v -> Objects.equals(v.getName(), version));
         PublicStateManager.getInstance().handleIndexUpdate(entry, StateManagerMode.UPDATE);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -241,7 +241,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
         entry.checkAndSetDefaultVersion(validatedVersion.getName());
         // Set entry-level metadata to this latest version
         // TODO: handle when latest version is removed
-        entry.setDefaultVersion(validatedVersion.getName());
+        entry.setActualDefaultVersion(validatedVersion);
         entry.syncMetadataWithDefault();
         FileFormatHelper.updateFileFormats(entry.getWorkflowVersions(), fileFormatDAO);
         // TODO: Not setting lastModified for hosted tools now because we plan to get rid of the lastmodified column in Tool table in the future.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -235,6 +235,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         for (WorkflowVersion version : workflow.getWorkflowVersions()) {
             workflowVersionDAO.delete(version);
         }
+        workflow.setActualDefaultVersion(null);
         workflow.getWorkflowVersions().clear();
 
         // Do we maintain the checker workflow association? For now we won't

--- a/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
@@ -118,5 +118,11 @@
         <addForeignKeyConstraint baseColumnNames="actualdefaultversion" baseTableName="workflow" constraintName="fk_workflow_default_workflowversion" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="workflowversion"/>
         <addForeignKeyConstraint baseColumnNames="actualdefaultversion" baseTableName="service" constraintName="fk_service_default_workflowversion" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="workflowversion"/>
         <addForeignKeyConstraint baseColumnNames="actualdefaultversion" baseTableName="tool" constraintName="fk_tool_default_tag" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="tag"/>
+        <sql>update tool s set actualdefaultversion = t.id from tag t join tool e on e.id = t.parentid where s.defaultversion = t.reference</sql>
+        <sql>update tool s set actualdefaultversion = t.id from tag t join tool e on e.id = t.parentid where s.defaultversion = t.name</sql>
+        <sql>update workflow s set actualdefaultversion = t.id from workflowversion t join workflow e on e.id = t.parentid where s.defaultversion = t.reference</sql>
+        <sql>update workflow s set actualdefaultversion = t.id from workflowversion t join workflow e on e.id = t.parentid where s.defaultversion = t.name</sql>
+        <sql>update service s set actualdefaultversion = t.id from workflowversion t join service e on e.id = t.parentid where s.defaultversion = t.reference</sql>
+        <sql>update service s set actualdefaultversion = t.id from workflowversion t join service e on e.id = t.parentid where s.defaultversion = t.name</sql>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
@@ -88,10 +88,6 @@
             <column name="checksums" type="varchar"/>
         </addColumn>
     </changeSet>
-<<<<<<< HEAD
-  
-=======
->>>>>>> Add new column, temporarily add new property
     <changeSet author="natalieperez (generated)" id="addDockerHubColumnsToImages">
         <addColumn tableName="image">
             <column name="architecture" type="varchar(255 BYTE)"/>
@@ -105,7 +101,7 @@
             <column name="orcid" type="varchar(255 BYTE)"/>
         </addColumn>
     </changeSet>
-    <changeSet author="gluu (generated)" id="1585679980673-1">
+    <changeSet author="gluu (generated)" id="addNewDefaultVersionColumn">
         <addColumn tableName="service">
             <column name="actualdefaultversion" type="int8"/>
         </addColumn>
@@ -124,5 +120,10 @@
         <sql>update workflow s set actualdefaultversion = t.id from workflowversion t join workflow e on e.id = t.parentid where s.defaultversion = t.name</sql>
         <sql>update service s set actualdefaultversion = t.id from workflowversion t join service e on e.id = t.parentid where s.defaultversion = t.reference</sql>
         <sql>update service s set actualdefaultversion = t.id from workflowversion t join service e on e.id = t.parentid where s.defaultversion = t.name</sql>
+    </changeSet>
+    <changeSet author="gluu (generated)" id="removeOldDefaultVersionColumn">
+        <dropColumn columnName="defaultversion" tableName="service"/>
+        <dropColumn columnName="defaultversion" tableName="tool"/>
+        <dropColumn columnName="defaultversion" tableName="workflow"/>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
@@ -88,7 +88,10 @@
             <column name="checksums" type="varchar"/>
         </addColumn>
     </changeSet>
+<<<<<<< HEAD
   
+=======
+>>>>>>> Add new column, temporarily add new property
     <changeSet author="natalieperez (generated)" id="addDockerHubColumnsToImages">
         <addColumn tableName="image">
             <column name="architecture" type="varchar(255 BYTE)"/>
@@ -97,10 +100,23 @@
             <column name="os" type="varchar(255 BYTE)"/>
         </addColumn>
     </changeSet>
-
     <changeSet author="esoth (generated)" id="addUserOrcidIDColumn">
         <addColumn tableName="enduser">
             <column name="orcid" type="varchar(255 BYTE)"/>
         </addColumn>
+    </changeSet>
+    <changeSet author="gluu (generated)" id="1585679980673-1">
+        <addColumn tableName="service">
+            <column name="actualdefaultversion" type="int8"/>
+        </addColumn>
+        <addColumn tableName="workflow">
+            <column name="actualdefaultversion" type="int8"/>
+        </addColumn>
+        <addColumn tableName="tool">
+            <column name="actualdefaultversion" type="int8"/>
+        </addColumn>
+        <addForeignKeyConstraint baseColumnNames="actualdefaultversion" baseTableName="workflow" constraintName="fk_workflow_default_workflowversion" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="workflowversion"/>
+        <addForeignKeyConstraint baseColumnNames="actualdefaultversion" baseTableName="service" constraintName="fk_service_default_workflowversion" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="workflowversion"/>
+        <addForeignKeyConstraint baseColumnNames="actualdefaultversion" baseTableName="tool" constraintName="fk_tool_default_tag" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="tag"/>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -6487,7 +6487,7 @@ definitions:
       defaultVersion:
         type: "string"
         position: 7
-        description: "This is the default version of the entry"
+        description: "This is the name of the default version of the entry"
       is_published:
         type: "boolean"
         position: 8
@@ -6723,7 +6723,7 @@ definitions:
       defaultVersion:
         type: "string"
         position: 7
-        description: "This is the default version of the entry"
+        description: "This is the name of the default version of the entry"
       is_published:
         type: "boolean"
         position: 8
@@ -8202,7 +8202,7 @@ definitions:
       defaultVersion:
         type: "string"
         position: 7
-        description: "This is the default version of the entry"
+        description: "This is the name of the default version of the entry"
       is_published:
         type: "boolean"
         position: 8

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/JsonLdRetrieverTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/JsonLdRetrieverTest.java
@@ -49,6 +49,7 @@ public class JsonLdRetrieverTest {
         file.setAbsolutePath("/dummy path");
         tag.addSourceFile(file);
         tag.setReference("master");
+        tag.setName("master");
         tool.addWorkflowVersion(tag);
         tool.setActualDefaultVersion(tag);
 
@@ -58,7 +59,7 @@ public class JsonLdRetrieverTest {
         File expected = new File(ResourceHelpers.resourceFilePath(json));
         String expectedJson = Files.asCharSource(expected, Charsets.UTF_8).read();
 
-        assertEquals(schemaJson, expectedJson);
+        assertEquals(expectedJson, schemaJson);
     }
 
     @Test

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/JsonLdRetrieverTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/JsonLdRetrieverTest.java
@@ -50,7 +50,7 @@ public class JsonLdRetrieverTest {
         tag.addSourceFile(file);
         tag.setReference("master");
         tool.addWorkflowVersion(tag);
-        tool.setDefaultVersion("master");
+        tool.setActualDefaultVersion(tag);
 
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         String schemaJson = gson.toJson(JsonLdRetriever.getSchema(tool));

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/PublicStateManagerIT.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/PublicStateManagerIT.java
@@ -90,7 +90,7 @@ public class PublicStateManagerIT {
         tool.setRegistry("potato");
         tool.addWorkflowVersion(fakeTag1);
         tool.addWorkflowVersion(fakeTag2);
-        tool.setDefaultVersion("master");
+        tool.setActualDefaultVersion(fakeTag1);
         tool.setIsPublished(true);
         return tool;
     }

--- a/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
+++ b/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
@@ -325,7 +325,6 @@ public class ToolsImplCommonTest {
         workflow.setLabels(Collections.emptySortedSet());
         workflow.setUsers(Collections.emptySortedSet());
         workflow.setEmail(null);
-        workflow.setDefaultVersion(reference2);
         workflow.setIsPublished(true);
         workflow.setLastModified(null);
         workflow.setLastUpdated(null);


### PR DESCRIPTION
For #3345 
Also for: #3340


Got rid of the old default version column and added a new column that's has the version id instead.
Some default versions settings were lost when using prod db (but they don't exist anyways).  
Try to better set the default version during refresh.  

Could not seem to automatically set default version to null when default version was deleted.  Have to manually set it to null before deleting.
