### PR TITLE
change order of migrations in migrations.xml

### DIFF
--- a/dockstore-webservice/src/main/resources/migrations.xml
+++ b/dockstore-webservice/src/main/resources/migrations.xml
@@ -27,6 +27,8 @@
     <include file="migrations.1.6.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.7.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.7.0.relinquish.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.test.add_service_1.7.0.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.test.alter_test_user_1.7.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.8.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.9.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.xml" relativeToChangelogFile="true"/>
@@ -35,6 +37,4 @@
     <include file="migrations.test.confidential1_1.5.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.confidential2_1.5.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test_1.5.0.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.test.add_service_1.7.0.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.test.alter_test_user_1.7.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.xml
+++ b/dockstore-webservice/src/main/resources/migrations.xml
@@ -22,19 +22,19 @@
     <include file="migrations.1.3.1.consistency.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.confidential1.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.confidential2.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.test.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.4.0.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.test.testworkflow.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.5.0.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.test.confidential1_1.5.0.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.test.confidential2_1.5.0.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.test_1.5.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.6.0.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.test.samepaths.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.7.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.7.0.relinquish.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.add_service_1.7.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.alter_test_user_1.7.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.8.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.9.0.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.test.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.test.samepaths.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.test.testworkflow.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.test.confidential1_1.5.0.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.test.confidential2_1.5.0.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.test_1.5.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
When running migrations by context, it seems that the order they are run in is the same as they are defined in migrations.xml. So simply running the below command wasn't enough to ensure the order of the contexts.
```
java -jar dockstore-webservice.jar db migrate -i 1.5.0,1.6.0,1.7.0,add_service_1.7.0,alter_test_user_1.7.0,1.8.0,1.9.0 travisci/web.yml
```