### PR TITLE
save dag and tooltable

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -336,7 +336,6 @@ public class WorkflowIT extends BaseIT {
         final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
 
-        //master, test
         Workflow workflow = manualRegisterAndPublish(workflowApi, "DockstoreTestUser2/cwl-gene-prioritization", "", "cwl", SourceControl.GITHUB, "/Dockstore.cwl", true);
         workflow = workflowApi.refresh((workflow.getId()));
         WorkflowVersion branchVersion = workflow.getWorkflowVersions().stream().filter(wv -> wv.getName().equals("master")).findFirst().get();
@@ -344,7 +343,9 @@ public class WorkflowIT extends BaseIT {
 
         workflowApi.getTableToolContent(workflow.getId(), branchVersion.getId());
         String toolJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
-        assertTrue(toolJson == null);
+        assertFalse(toolJson == null);
+        assertFalse(toolJson.isEmpty());
+
         workflowApi.getTableToolContent(workflow.getId(), tagVersion.getId());
         toolJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", tagVersion.getId()), String.class);
         assertTrue(toolJson != null);
@@ -352,7 +353,11 @@ public class WorkflowIT extends BaseIT {
 
         workflowApi.getWorkflowDag(workflow.getId(), branchVersion.getId());
         String dagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
-        assertTrue(dagJson == null);
+        String commitShaForJson = testingPostgres.runSelectStatement(String.format("select commitforjsongeneration from workflowversion where id = '%s'", branchVersion.getId()), String.class);
+        assertFalse(commitShaForJson.isEmpty());
+        assertTrue(dagJson != null);
+        assertFalse(dagJson.isEmpty());
+
         workflowApi.getWorkflowDag(workflow.getId(), tagVersion.getId());
         dagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", tagVersion.getId()), String.class);
         assertTrue(dagJson != null);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -92,11 +92,6 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
     @Column(columnDefinition = "TEXT")
     private String toolTableJson;
 
-    // Keeps track of the commit used to generate the dag and tool table json.
-    @JsonIgnore
-    @Column()
-    private String commitForJsonGeneration;
-
     public WorkflowVersion() {
         super();
     }
@@ -228,14 +223,6 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
 
     public void setToolTableJson(final String toolTableJson) {
         this.toolTableJson = toolTableJson;
-    }
-
-    public String getCommitForJsonGeneration() {
-        return commitForJsonGeneration;
-    }
-
-    public void setCommitForJsonGeneration(final String commitForJsonGeneration) {
-        this.commitForJsonGeneration = commitForJsonGeneration;
     }
 
     @ApiModel(value = "WorkflowVersionPathInfo", description = "Object that "

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -83,6 +83,14 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
     @ApiModelProperty(value = "The subclass of this for services.", position = 103)
     private Service.SubClass subClass = null;
 
+    @Column(columnDefinition = "TEXT")
+    @ApiModelProperty(value = "JSON needed to create DAG in UI", position = 104)
+    private String dagJson;
+
+    @Column(columnDefinition = "TEXT")
+    @ApiModelProperty(value = "JSON needed to create tool table in UI", position = 105)
+    private String toolTableJson;
+
     public WorkflowVersion() {
         super();
     }
@@ -198,6 +206,22 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
 
     public void setLegacyVersion(boolean legacyVersion) {
         isLegacyVersion = legacyVersion;
+    }
+
+    public String getDagJson() {
+        return dagJson;
+    }
+
+    public void setDagJson(final String dagJson) {
+        this.dagJson = dagJson;
+    }
+
+    public String getToolTableJson() {
+        return toolTableJson;
+    }
+
+    public void setToolTableJson(final String toolTableJson) {
+        this.toolTableJson = toolTableJson;
     }
 
     @ApiModel(value = "WorkflowVersionPathInfo", description = "Object that "

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -32,6 +32,7 @@ import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
@@ -83,13 +84,18 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
     @ApiModelProperty(value = "The subclass of this for services.", position = 103)
     private Service.SubClass subClass = null;
 
+    @JsonIgnore
     @Column(columnDefinition = "TEXT")
-    @ApiModelProperty(value = "JSON needed to create DAG in UI", position = 104)
     private String dagJson;
 
+    @JsonIgnore
     @Column(columnDefinition = "TEXT")
-    @ApiModelProperty(value = "JSON needed to create tool table in UI", position = 105)
     private String toolTableJson;
+
+    // Keeps track of the commit used to generate the dag and tool table json.
+    @JsonIgnore
+    @Column()
+    private String commitForJsonGeneration;
 
     public WorkflowVersion() {
         super();
@@ -222,6 +228,14 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
 
     public void setToolTableJson(final String toolTableJson) {
         this.toolTableJson = toolTableJson;
+    }
+
+    public String getCommitForJsonGeneration() {
+        return commitForJsonGeneration;
+    }
+
+    public void setCommitForJsonGeneration(final String commitForJsonGeneration) {
+        this.commitForJsonGeneration = commitForJsonGeneration;
     }
 
     @ApiModel(value = "WorkflowVersionPathInfo", description = "Object that "

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -193,6 +193,8 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 workflow.getWorkflowVersions().add(workflowVersionFromDB);
                 existingVersionMap.put(workflowVersionFromDB.getName(), workflowVersionFromDB);
             }
+            workflowVersionFromDB.setToolTableJson(null);
+            workflowVersionFromDB.setDagJson(null);
 
             // Update sourcefiles
             updateDBVersionSourceFilesWithRemoteVersionSourceFiles(workflowVersionFromDB, version);
@@ -446,7 +448,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             // So we have workflowversion which is the new version, we want to update the version and associated source files
             Optional<WorkflowVersion> existingWorkflowVersion = workflow.getWorkflowVersions().stream().filter(wv -> wv.equals(remoteWorkflowVersion)).findFirst();
 
-            // Update existing source files, add new source files, remove deleted sourcefiles
+            // Update existing source files, add new source files, remove deleted sourcefiles, clear json for dag and tool table
             if (existingWorkflowVersion.isPresent()) {
                 // Copy over workflow version level information
                 existingWorkflowVersion.get().setWorkflowPath(remoteWorkflowVersion.getWorkflowPath());
@@ -455,6 +457,8 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 existingWorkflowVersion.get().setAliases(remoteWorkflowVersion.getAliases());
                 existingWorkflowVersion.get().setSubClass(remoteWorkflowVersion.getSubClass());
                 existingWorkflowVersion.get().setCommitID(remoteWorkflowVersion.getCommitID());
+                existingWorkflowVersion.get().setDagJson(null);
+                existingWorkflowVersion.get().setToolTableJson(null);
 
                 updateDBVersionSourceFilesWithRemoteVersionSourceFiles(existingWorkflowVersion.get(), remoteWorkflowVersion);
             } else {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1404,7 +1404,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         WorkflowVersion workflowVersion = getWorkflowVersion(workflow, workflowVersionId);
         SourceFile mainDescriptor = getMainDescriptorFile(workflowVersion);
 
-        if (workflowVersion.getCommitID() != null && workflowVersion.getCommitID().equals(workflowVersion.getCommitForJsonGeneration()) && workflowVersion.getDagJson() != null) {
+        // json in db cleared after a refresh
+        if (workflowVersion.getDagJson() != null) {
             return workflowVersion.getDagJson();
         }
 
@@ -1416,7 +1417,6 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                     LanguageHandlerInterface.Type.DAG, toolDAO);
 
             workflowVersion.setDagJson(dagJson);
-            workflowVersion.setCommitForJsonGeneration(workflowVersion.getCommitID());
             return dagJson;
         }
         return null;
@@ -1448,7 +1448,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             throw new CustomWebApplicationException("workflow version " + workflowVersionId + " does not exist", HttpStatus.SC_BAD_REQUEST);
         }
 
-        if (workflowVersion.getCommitID() != null && workflowVersion.getCommitID().equals(workflowVersion.getCommitForJsonGeneration()) && workflowVersion.getToolTableJson() != null) {
+        // json in db cleared after a refresh
+        if (workflowVersion.getToolTableJson() != null) {
             return workflowVersion.getToolTableJson();
         }
 
@@ -1459,7 +1460,6 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             final String toolTableJson = lInterface.getContent(workflowVersion.getWorkflowPath(), mainDescriptor.getContent(), secondaryDescContent,
                 LanguageHandlerInterface.Type.TOOLS, toolDAO);
             workflowVersion.setToolTableJson(toolTableJson);
-            workflowVersion.setCommitForJsonGeneration(workflowVersion.getCommitID());
             return toolTableJson;
         }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1358,7 +1358,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                 boolean wasFrozen = existingTag.isFrozen();
                 existingTag.updateByUser(version);
                 boolean nowFrozen = existingTag.isFrozen();
-                // If version is snapshotted on this update, grab and store image information
+                // If version is snapshotted on this update, grab and store image information. Also store dag and tool table json if not available.
                 if (!wasFrozen && nowFrozen) {
                     LanguageHandlerInterface lInterface = LanguageHandlerFactory.getInterface(w.getFileType());
                     String toolsJSONTable = lInterface.getContent(w.getWorkflowPath(), getMainDescriptorFile(existingTag).getContent(), extractDescriptorAndSecondaryFiles(existingTag), LanguageHandlerInterface.Type.TOOLS, toolDAO);
@@ -1378,6 +1378,14 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                             }
                         }
 
+                    }
+
+                    //store dag and tool table json
+                    if (existingTag.getDagJson() == null) {
+                        existingTag.setDagJson(getWorkflowDag(Optional.of(user), w.getId(), existingTag.getId()));
+                    }
+                    if (existingTag.getToolTableJson() == null) {
+                        existingTag.setToolTableJson(getTableToolContent(Optional.of(user), w.getId(), existingTag.getId()));
                     }
                 }
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1389,7 +1389,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
                     // store dag
                     if (existingTag.getDagJson() == null) {
-                        String dagJson = lInterface.getCleanDAG(w.getWorkflowPath(),getMainDescriptorFile(existingTag).getContent(), extractDescriptorAndSecondaryFiles(existingTag), LanguageHandlerInterface.Type.DAG, toolDAO);
+                        String dagJson = lInterface.getCleanDAG(w.getWorkflowPath(), getMainDescriptorFile(existingTag).getContent(), extractDescriptorAndSecondaryFiles(existingTag), LanguageHandlerInterface.Type.DAG, toolDAO);
                         existingTag.setDagJson(dagJson);
                     }
                 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1404,7 +1404,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         WorkflowVersion workflowVersion = getWorkflowVersion(workflow, workflowVersionId);
         SourceFile mainDescriptor = getMainDescriptorFile(workflowVersion);
 
-        if (workflowVersion.getDagJson() != null) {
+        if (workflowVersion.getCommitID() != null && workflowVersion.getCommitID().equals(workflowVersion.getCommitForJsonGeneration()) && workflowVersion.getDagJson() != null) {
             return workflowVersion.getDagJson();
         }
 
@@ -1412,11 +1412,11 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             Set<SourceFile> secondaryDescContent = extractDescriptorAndSecondaryFiles(workflowVersion);
 
             LanguageHandlerInterface lInterface = LanguageHandlerFactory.getInterface(workflow.getFileType());
-            String dagJson = lInterface.getCleanDAG(workflowVersion.getWorkflowPath(), mainDescriptor.getContent(), secondaryDescContent,
+            final String dagJson = lInterface.getCleanDAG(workflowVersion.getWorkflowPath(), mainDescriptor.getContent(), secondaryDescContent,
                     LanguageHandlerInterface.Type.DAG, toolDAO);
-            if (workflowVersion.getReferenceType() == Version.ReferenceType.TAG && workflowVersion.isValid()) {
-                workflowVersion.setDagJson(dagJson);
-            }
+
+            workflowVersion.setDagJson(dagJson);
+            workflowVersion.setCommitForJsonGeneration(workflowVersion.getCommitID());
             return dagJson;
         }
         return null;
@@ -1448,18 +1448,18 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             throw new CustomWebApplicationException("workflow version " + workflowVersionId + " does not exist", HttpStatus.SC_BAD_REQUEST);
         }
 
-        if (workflowVersion.getToolTableJson() != null) {
+        if (workflowVersion.getCommitID() != null && workflowVersion.getCommitID().equals(workflowVersion.getCommitForJsonGeneration()) && workflowVersion.getToolTableJson() != null) {
             return workflowVersion.getToolTableJson();
         }
+
         SourceFile mainDescriptor = getMainDescriptorFile(workflowVersion);
         if (mainDescriptor != null) {
             Set<SourceFile> secondaryDescContent = extractDescriptorAndSecondaryFiles(workflowVersion);
             LanguageHandlerInterface lInterface = LanguageHandlerFactory.getInterface(workflow.getFileType());
-            String toolTableJson = lInterface.getContent(workflowVersion.getWorkflowPath(), mainDescriptor.getContent(), secondaryDescContent,
+            final String toolTableJson = lInterface.getContent(workflowVersion.getWorkflowPath(), mainDescriptor.getContent(), secondaryDescContent,
                 LanguageHandlerInterface.Type.TOOLS, toolDAO);
-            if (workflowVersion.getReferenceType() == Version.ReferenceType.TAG && workflowVersion.isValid()) {
-                workflowVersion.setToolTableJson(toolTableJson);
-            }
+            workflowVersion.setToolTableJson(toolTableJson);
+            workflowVersion.setCommitForJsonGeneration(workflowVersion.getCommitID());
             return toolTableJson;
         }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1414,7 +1414,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             LanguageHandlerInterface lInterface = LanguageHandlerFactory.getInterface(workflow.getFileType());
             String dagJson = lInterface.getCleanDAG(workflowVersion.getWorkflowPath(), mainDescriptor.getContent(), secondaryDescContent,
                     LanguageHandlerInterface.Type.DAG, toolDAO);
-            if (workflowVersion.getReferenceType() == Version.ReferenceType.TAG) {
+            if (workflowVersion.getReferenceType() == Version.ReferenceType.TAG && workflowVersion.isValid()) {
                 workflowVersion.setDagJson(dagJson);
             }
             return dagJson;
@@ -1457,7 +1457,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             LanguageHandlerInterface lInterface = LanguageHandlerFactory.getInterface(workflow.getFileType());
             String toolTableJson = lInterface.getContent(workflowVersion.getWorkflowPath(), mainDescriptor.getContent(), secondaryDescContent,
                 LanguageHandlerInterface.Type.TOOLS, toolDAO);
-            if (workflowVersion.getReferenceType() == Version.ReferenceType.TAG) {
+            if (workflowVersion.getReferenceType() == Version.ReferenceType.TAG && workflowVersion.isValid()) {
                 workflowVersion.setToolTableJson(toolTableJson);
             }
             return toolTableJson;

--- a/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
@@ -134,8 +134,5 @@
         <addColumn tableName="workflowversion">
             <column name="tooltablejson" type="text"/>
         </addColumn>
-        <addColumn tableName="workflowversion">
-            <column name="commitforjsongeneration" type="varchar(255 BYTE)"/>
-        </addColumn>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
@@ -126,4 +126,13 @@
         <dropColumn columnName="defaultversion" tableName="tool"/>
         <dropColumn columnName="defaultversion" tableName="workflow"/>
     </changeSet>
+
+    <changeSet author="natalieperez (generated)" id="dagAndToolTableJsonColumnsToWorkflowVersion">
+        <addColumn tableName="workflowversion">
+            <column name="dagjson" type="text"/>
+        </addColumn>
+        <addColumn tableName="workflowversion">
+            <column name="tooltablejson" type="text"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
@@ -134,5 +134,8 @@
         <addColumn tableName="workflowversion">
             <column name="tooltablejson" type="text"/>
         </addColumn>
+        <addColumn tableName="workflowversion">
+            <column name="commitforjsongeneration" type="varchar(255 BYTE)"/>
+        </addColumn>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -24,12 +24,9 @@ components:
         type: object
       type: object
     Checksum:
-      description: A production (immutable) tool version is required to have a hashcode.
-        Not required otherwise, but might be useful to detect changes.  This exposes
-        the hashcode for specific image versions to verify that the container version
-        pulled is actually the version that was indexed by the registry.
-      example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182,
-        type=sha256}]'
+      description: 'A production (immutable) tool version is required to have a hashcode.
+        Not required otherwise, but might be useful to detect changes. '
+      example: '[{checksum=ea2a5db69bd20a42976838790bc29294df3af02b, type=sha1}]'
       properties:
         checksum:
           description: 'The hex-string encoded checksum for the data. '

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -24,9 +24,12 @@ components:
         type: object
       type: object
     Checksum:
-      description: 'A production (immutable) tool version is required to have a hashcode.
-        Not required otherwise, but might be useful to detect changes. '
-      example: '[{checksum=ea2a5db69bd20a42976838790bc29294df3af02b, type=sha1}]'
+      description: A production (immutable) tool version is required to have a hashcode.
+        Not required otherwise, but might be useful to detect changes.  This exposes
+        the hashcode for specific image versions to verify that the container version
+        pulled is actually the version that was indexed by the registry.
+      example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182,
+        type=sha256}]'
       properties:
         checksum:
           description: 'The hex-string encoded checksum for the data. '
@@ -2908,7 +2911,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/Collection'
           description: default response
       security:
       - bearer: []

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -8333,8 +8333,6 @@ definitions:
         description: "aliases can be used as an alternate unique id for workflow versions"
         additionalProperties:
           $ref: "#/definitions/Alias"
-      commitForJsonGeneration:
-        type: "string"
       id:
         type: "integer"
         format: "int64"

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -8492,6 +8492,14 @@ definitions:
         - "SWARM"
         - "KUBERNETES"
         - "HELM"
+      dagJson:
+        type: "string"
+        position: 104
+        description: "JSON needed to create DAG in UI"
+      toolTableJson:
+        type: "string"
+        position: 105
+        description: "JSON needed to create tool table in UI"
     description: "This describes one workflow version associated with a workflow."
   WorkflowVersionPathInfo:
     type: "object"

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -8333,6 +8333,8 @@ definitions:
         description: "aliases can be used as an alternate unique id for workflow versions"
         additionalProperties:
           $ref: "#/definitions/Alias"
+      commitForJsonGeneration:
+        type: "string"
       id:
         type: "integer"
         format: "int64"
@@ -8492,14 +8494,6 @@ definitions:
         - "SWARM"
         - "KUBERNETES"
         - "HELM"
-      dagJson:
-        type: "string"
-        position: 104
-        description: "JSON needed to create DAG in UI"
-      toolTableJson:
-        type: "string"
-        position: 105
-        description: "JSON needed to create tool table in UI"
     description: "This describes one workflow version associated with a workflow."
   WorkflowVersionPathInfo:
     type: "object"


### PR DESCRIPTION
#3212 also stores the tool table
Decided to only store for workflow versions that are tags and published. Branches seem more likely to change, and I'm unsure what type `unset` means.
This makes the two endpoints about 5 times faster once the data is stored.
I made a script that called the tooltablejson endpoint for every published, valid, and type tag workflow version. The size of workflowversion table went from 9272 kb to 9344 kB
