### PR TITLE
#3210 define en_US.UTF-8 locale before setting LC_ALL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ RUN apt-get update \
     locales \
     curl \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-RUN locale-gen en_US.UTF-8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # copy the jar not ending in 's', to make sure we get don't get the one ending in 'sources'


### PR DESCRIPTION
`localedef` command copied from example [here](https://github.com/docker-library/docs/blob/master/debian/content.md#locales)

#3210