### PR TITLE
Feature/3386/slow collections endpoint

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -1236,6 +1236,8 @@ public class OrganizationIT extends BaseIT {
         List<Collection> collections = organizationsApi.getCollectionsFromOrganization(organization.getId(), "");
         assertEquals("There should be 1 collection associated with the Organization, there are " + collections.size(), 1,
             collections.size());
+        assertEquals("There should be no entries because entries is not specified to be included " + collections.get(0).getEntries().size(), 0,
+                collections.get(0).getEntries().size());
 
         collections = organizationsApi.getCollectionsFromOrganization(organization.getId(), "entries");
         assertEquals("There should be 1 entry associated with the collection, there are " + collections.get(0).getEntries().size(), 1,


### PR DESCRIPTION
For #3386 

Turns out lazy loading is not working as intended because any property that references a Lazy property will force it to Eager load.  This is kind of a problem throughout the entire webservice (workflowVersions, etc) 

Before on dev.dockstore.net:
20.4 MB 
7.95s

After:
516 B
49ms
