### PR TITLE
Set surefire memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker: # run the steps with Docker
       - image: circleci/openjdk:11.0.4-jdk-stretch
         environment:
-          JAVA_TOOL_OPTIONS: -Xmx3g # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/2 memory as heap.
+          JAVA_TOOL_OPTIONS: -Xmx1g # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/2 memory as heap.
           PGHOST: 127.0.0.1
       - image: circleci/postgres:9.6.5-alpine-ram
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker: # run the steps with Docker
       - image: circleci/openjdk:11.0.4-jdk-stretch
         environment:
-          JAVA_TOOL_OPTIONS: -Xmx3g # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/4 memory as heap. Nothing to do with surefire plugin, it has its own JVM.
+          JAVA_TOOL_OPTIONS: -Xmx512m # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/4 memory as heap. Nothing to do with surefire plugin, it has its own JVM.
           PGHOST: 127.0.0.1
       - image: circleci/postgres:9.6.5-alpine-ram
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker: # run the steps with Docker
       - image: circleci/openjdk:11.0.4-jdk-stretch
         environment:
-          JAVA_TOOL_OPTIONS: -Xmx1g # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/4 memory as heap. Nothing to do with surefire plugin, it has its own JVM.
+          JAVA_TOOL_OPTIONS: -Xmx3g # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/4 memory as heap. Nothing to do with surefire plugin, it has its own JVM.
           PGHOST: 127.0.0.1
       - image: circleci/postgres:9.6.5-alpine-ram
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker: # run the steps with Docker
       - image: circleci/openjdk:11.0.4-jdk-stretch
         environment:
-          JAVA_TOOL_OPTIONS: -Xmx1g # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/2 memory as heap.
+          JAVA_TOOL_OPTIONS: -Xmx1g # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/4 memory as heap. Nothing to do with surefire plugin, it has its own JVM.
           PGHOST: 127.0.0.1
       - image: circleci/postgres:9.6.5-alpine-ram
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker: # run the steps with Docker
       - image: circleci/openjdk:11.0.4-jdk-stretch
         environment:
-          JAVA_TOOL_OPTIONS: -Xmx512m # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Using 1/4 memory as heap. Nothing to do with surefire plugin, it has its own JVM.
+          JAVA_TOOL_OPTIONS: -Xmx512m # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Nothing to do with surefire plugin, it has its own JVM. The two of these must add up to a bit less than 4GB.
           PGHOST: 127.0.0.1
       - image: circleci/postgres:9.6.5-alpine-ram
         environment:

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -195,7 +195,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- nothing to do with the JAVA_TOOL_OPTIONS in .cirleci/config.yml because surefire has its own JVM-->
-                    <argLine>-Xmx2g</argLine>
+                    <argLine>-Xmx3g</argLine>
                     <!-- seems like some form of Jackson fork issue for this module with random order -->
                     <runOrder>filesystem</runOrder>
                 </configuration>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -194,6 +194,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <!-- nothing to do with the JAVA_TOOL_OPTIONS in .cirleci/config.yml because surefire has its own JVM-->
                     <argLine>-Xmx2g</argLine>
                     <!-- seems like some form of Jackson fork issue for this module with random order -->
                     <runOrder>filesystem</runOrder>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -195,6 +195,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- nothing to do with the JAVA_TOOL_OPTIONS in .cirleci/config.yml because surefire has its own JVM-->
+                    <!-- This plus the .circle/config.yml must add to a bit less than 4GB -->
                     <argLine>-Xmx3g</argLine>
                     <!-- seems like some form of Jackson fork issue for this module with random order -->
                     <runOrder>filesystem</runOrder>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -194,6 +194,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>-Xmx2g</argLine>
                     <!-- seems like some form of Jackson fork issue for this module with random order -->
                     <runOrder>filesystem</runOrder>
                 </configuration>


### PR DESCRIPTION
6/6 times so far

Apparently surefire plugin is completely separate from the JAVA_TOOL_OPTIONS because it's another JVM fork.  No idea how it managed to work before.

From what I gather
The sum of JAVA_TOOL_OPTIONS and the value in surefire pom.xml needs to be under 4 GB (with room for non-Java stuff).
JAVA_TOOL_OPTIONS can be a smaller number as it doesn't really need that much memory (will scale).
surefire plugin needs to have a large amount or else it will fail.