### PR TITLE
Evict versions and users

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -92,6 +92,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.hibernate.Hibernate;
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,9 +120,11 @@ public class UserResource implements AuthenticatedResourceInterface {
     private PermissionsInterface authorizer;
     private final CachingAuthenticator cachingAuthenticator;
     private final HttpClient client;
+    private SessionFactory sessionFactory;
 
     public UserResource(HttpClient client, SessionFactory sessionFactory, WorkflowResource workflowResource, ServiceResource serviceResource,
                         DockerRepoResource dockerRepoResource, CachingAuthenticator cachingAuthenticator, PermissionsInterface authorizer) {
+        this.sessionFactory = sessionFactory;
         this.eventDAO = new EventDAO(sessionFactory);
         this.userDAO = new UserDAO(sessionFactory);
         this.tokenDAO = new TokenDAO(sessionFactory);
@@ -554,7 +557,12 @@ public class UserResource implements AuthenticatedResourceInterface {
             throw new CustomWebApplicationException("The given user does not exist.", HttpStatus.SC_NOT_FOUND);
         }
         List<Workflow> workflows = getWorkflows(fetchedUser);
-        EntryVersionHelper.stripContent(workflows, this.userDAO);
+        Session currentSession = sessionFactory.getCurrentSession();
+        workflows.forEach(workflow -> {
+            currentSession.evict(workflow);
+            workflow.setUsers(null);
+            workflow.setWorkflowVersions(new HashSet<>());
+        });
         return workflows;
     }
 


### PR DESCRIPTION
For #3434 

Previous line stripped users and sourcefile content.  Don't want to risk things by modifying that function.  So just stripped versions and users in the endpoint instead.

I've only tested this with the UI by:
going to my-workflows and checking if my default workflows has versions and sourcefiles, then clicking to another random workflow and checking the same