### PR TITLE
Enhance validation of dockstore.yml workflows

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -60,6 +60,7 @@ import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
 import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -427,7 +428,7 @@ public class ServiceIT extends BaseIT {
             testService.setMode(WorkflowMode.DOCKSTORE_YML);
             testService.setOrganization("hydra");
             testService.setRepository("hydra_repo");
-            testService.setDefaultWorkflowPath(".dockstore.yml");
+            testService.setDefaultWorkflowPath(DOCKSTORE_YML_PATH);
 
             Service test2Service = new Service();
             test2Service.setDescription("test service");
@@ -437,7 +438,7 @@ public class ServiceIT extends BaseIT {
             test2Service.setDescriptorType(DescriptorLanguage.SERVICE);
             test2Service.setOrganization("hydra");
             test2Service.setRepository("hydra_repo2");
-            test2Service.setDefaultWorkflowPath(".dockstore.yml");
+            test2Service.setDefaultWorkflowPath(DOCKSTORE_YML_PATH);
 
             final Map<DescriptorLanguage.FileType, String> defaultPaths = test2Service.getDefaultPaths();
             for (DescriptorLanguage.FileType val : DescriptorLanguage.FileType.values()) {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -304,8 +304,11 @@ public class WebhookIT extends BaseIT {
         workflow = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "validations", false);
         assertNotNull(workflow);
         assertEquals("Should have two versions", 2, workflow.getWorkflowVersions().size());
+
         WorkflowVersion missingPrimaryDescriptorVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> Objects.equals(workflowVersion.getName(), "missingPrimaryDescriptor")).findFirst().get();
         assertFalse("Version should be invalid", missingPrimaryDescriptorVersion.isValid());
+
+        // Check existence of files and validations
         assertTrue("Should have .dockstore.yml file", missingPrimaryDescriptorVersion.getSourceFiles().stream().filter(sourceFile -> Objects.equals(sourceFile.getAbsolutePath(), "/.dockstore.yml")).findFirst().isPresent());
         assertTrue("Should not have doesnotexist.wdl file", missingPrimaryDescriptorVersion.getSourceFiles().stream().filter(sourceFile -> Objects.equals(sourceFile.getAbsolutePath(), "/doesnotexist.wdl")).findFirst().isEmpty());
         assertFalse("Should have invalid .dockstore.yml", missingPrimaryDescriptorVersion.getValidations().stream().filter(validation -> Objects.equals(validation.getType(), Validation.TypeEnum.DOCKSTORE_YML)).findFirst().get().isValid());
@@ -319,8 +322,11 @@ public class WebhookIT extends BaseIT {
         workflow = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "validations", false);
         assertNotNull(workflow);
         assertEquals("Should have three versions", 3, workflow.getWorkflowVersions().size());
+
         WorkflowVersion missingTestParameterFileVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> Objects.equals(workflowVersion.getName(), "missingTestParameterFile")).findFirst().get();
         assertFalse("Version should be invalid", missingTestParameterFileVersion.isValid());
+
+        // Check existence of files and validations
         assertTrue("Should have .dockstore.yml file", missingTestParameterFileVersion.getSourceFiles().stream().filter(sourceFile -> Objects.equals(sourceFile.getAbsolutePath(), "/.dockstore.yml")).findFirst().isPresent());
         assertTrue("Should not have /test/doesnotexist.txt file", missingTestParameterFileVersion.getSourceFiles().stream().filter(sourceFile -> Objects.equals(sourceFile.getAbsolutePath(), "/test/doesnotexist.txt")).findFirst().isEmpty());
         assertTrue("Should have Dockstore2.wdl file", missingTestParameterFileVersion.getSourceFiles().stream().filter(sourceFile -> Objects.equals(sourceFile.getAbsolutePath(), "/Dockstore2.wdl")).findFirst().isPresent());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -325,7 +325,7 @@ public class WebhookIT extends BaseIT {
         assertEquals("Should have three versions", 3, workflow.getWorkflowVersions().size());
 
         WorkflowVersion missingTestParameterFileVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> Objects.equals(workflowVersion.getName(), "missingTestParameterFile")).findFirst().get();
-        assertFalse("Version should be invalid", missingTestParameterFileVersion.isValid());
+        assertTrue("Version should be valid (missing test parameter doesn't make the version invalid)", missingTestParameterFileVersion.isValid());
 
         // Check existence of files and validations
         assertTrue("Should have .dockstore.yml file", missingTestParameterFileVersion.getSourceFiles().stream().filter(sourceFile -> Objects.equals(sourceFile.getAbsolutePath(), DOCKSTORE_YML_PATH)).findFirst().isPresent());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -48,6 +48,7 @@ import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -309,7 +310,7 @@ public class WebhookIT extends BaseIT {
         assertFalse("Version should be invalid", missingPrimaryDescriptorVersion.isValid());
 
         // Check existence of files and validations
-        assertTrue("Should have .dockstore.yml file", missingPrimaryDescriptorVersion.getSourceFiles().stream().filter(sourceFile -> Objects.equals(sourceFile.getAbsolutePath(), "/.dockstore.yml")).findFirst().isPresent());
+        assertTrue("Should have .dockstore.yml file", missingPrimaryDescriptorVersion.getSourceFiles().stream().filter(sourceFile -> Objects.equals(sourceFile.getAbsolutePath(), DOCKSTORE_YML_PATH)).findFirst().isPresent());
         assertTrue("Should not have doesnotexist.wdl file", missingPrimaryDescriptorVersion.getSourceFiles().stream().filter(sourceFile -> Objects.equals(sourceFile.getAbsolutePath(), "/doesnotexist.wdl")).findFirst().isEmpty());
         assertFalse("Should have invalid .dockstore.yml", missingPrimaryDescriptorVersion.getValidations().stream().filter(validation -> Objects.equals(validation.getType(), Validation.TypeEnum.DOCKSTORE_YML)).findFirst().get().isValid());
         assertFalse("Should have invalid doesnotexist.wdl", missingPrimaryDescriptorVersion.getValidations().stream().filter(validation -> Objects.equals(validation.getType(), Validation.TypeEnum.DOCKSTORE_WDL)).findFirst().get().isValid());
@@ -327,7 +328,7 @@ public class WebhookIT extends BaseIT {
         assertFalse("Version should be invalid", missingTestParameterFileVersion.isValid());
 
         // Check existence of files and validations
-        assertTrue("Should have .dockstore.yml file", missingTestParameterFileVersion.getSourceFiles().stream().filter(sourceFile -> Objects.equals(sourceFile.getAbsolutePath(), "/.dockstore.yml")).findFirst().isPresent());
+        assertTrue("Should have .dockstore.yml file", missingTestParameterFileVersion.getSourceFiles().stream().filter(sourceFile -> Objects.equals(sourceFile.getAbsolutePath(), DOCKSTORE_YML_PATH)).findFirst().isPresent());
         assertTrue("Should not have /test/doesnotexist.txt file", missingTestParameterFileVersion.getSourceFiles().stream().filter(sourceFile -> Objects.equals(sourceFile.getAbsolutePath(), "/test/doesnotexist.txt")).findFirst().isEmpty());
         assertTrue("Should have Dockstore2.wdl file", missingTestParameterFileVersion.getSourceFiles().stream().filter(sourceFile -> Objects.equals(sourceFile.getAbsolutePath(), "/Dockstore2.wdl")).findFirst().isPresent());
         assertFalse("Should have invalid .dockstore.yml", missingTestParameterFileVersion.getValidations().stream().filter(validation -> Objects.equals(validation.getType(), Validation.TypeEnum.DOCKSTORE_YML)).findFirst().get().isValid());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/Constants.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/Constants.java
@@ -24,6 +24,7 @@ public final class Constants {
     public static final int LAMBDA_FAILURE = 418; // Tell lambda to not try again
     public static final String OPTIONAL_AUTH_MESSAGE = "Does not require authentication for published workflows,"
             + " authentication can be provided for restricted workflows";
+    public static final String DOCKSTORE_YML_PATH = "/.dockstore.yml";
 
     private Constants() {
         // not called

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -686,14 +686,14 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         String fileContent = this.readFileFromRepo(primaryDescriptorPath, ref.getLeft(), repository);
         if (fileContent != null) {
             // Add primary descriptor file and resolve imports
-            SourceFile file = new SourceFile();
-            file.setAbsolutePath(primaryDescriptorPath);
-            file.setPath(primaryDescriptorPath);
-            file.setContent(fileContent);
+            SourceFile primaryDescriptorFile = new SourceFile();
+            primaryDescriptorFile.setAbsolutePath(primaryDescriptorPath);
+            primaryDescriptorFile.setPath(primaryDescriptorPath);
+            primaryDescriptorFile.setContent(fileContent);
             DescriptorLanguage.FileType identifiedType = workflow.getDescriptorType().getFileType();
-            file.setType(identifiedType);
+            primaryDescriptorFile.setType(identifiedType);
 
-            version = combineVersionAndSourcefile(repository.getFullName(), file, workflow, identifiedType, version, existingDefaults);
+            version = combineVersionAndSourcefile(repository.getFullName(), primaryDescriptorFile, workflow, identifiedType, version, existingDefaults);
 
             if (testParameterPaths != null) {
                 List<String> missingParamFiles = new ArrayList<>();
@@ -719,13 +719,13 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
                 if (missingParamFiles.size() > 0) {
                     validationMessage.put("/.dockstore.yml", String.format("The following file(s) are missing: %s.",
-                            missingParamFiles.stream().collect(Collectors.joining(", "))));
+                            missingParamFiles.stream().map(paramFile -> String.format("'%s'", paramFile)).collect(Collectors.joining(", "))));
                 }
             }
         } else {
             // File not found or null
             LOG.info("Could not find file " + primaryDescriptorPath + " in repo " + repository);
-            validationMessage.put("/.dockstore.yml", "Could not find the primary descriptor file " + primaryDescriptorPath + ".");
+            validationMessage.put("/.dockstore.yml", "Could not find the primary descriptor file '" + primaryDescriptorPath + "'.");
         }
 
         VersionTypeValidation dockstoreYmlValidationMessage = new VersionTypeValidation(validationMessage.isEmpty(), validationMessage);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -708,8 +708,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                         testJson.setContent(testJsonContent);
 
                         // Only add test parameter file if it hasn't already been added
-                        boolean hasDuplicate = version.getSourceFiles().stream().anyMatch(
-                                (SourceFile sf) -> sf.getPath().equals(workflow.getDefaultTestParameterFilePath()) && sf.getType() == testJson.getType());
+                        boolean hasDuplicate = version.getSourceFiles().stream().anyMatch((SourceFile sf) -> sf.getPath().equals(workflow.getDefaultTestParameterFilePath()) && sf.getType() == testJson.getType());
                         if (!hasDuplicate) {
                             version.getSourceFiles().add(testJson);
                         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -82,6 +82,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
 import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
 
 /**
@@ -318,7 +319,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         service.setGitUrl("git@github.com:" + repositoryId + ".git");
         service.setLastUpdated(new Date());
         service.setDescriptorType(DescriptorLanguage.SERVICE);
-        service.setDefaultWorkflowPath("/.dockstore.yml");
+        service.setDefaultWorkflowPath(DOCKSTORE_YML_PATH);
         service.setMode(WorkflowMode.DOCKSTORE_YML);
 
         // Validate subclass
@@ -359,7 +360,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         } catch (UnsupportedOperationException ex) {
             throw new CustomWebApplicationException("The given descriptor type is not supported: " + subclass, LAMBDA_FAILURE);
         }
-        workflow.setDefaultWorkflowPath("/.dockstore.yml");
+        workflow.setDefaultWorkflowPath(DOCKSTORE_YML_PATH);
         return workflow;
     }
 
@@ -718,14 +719,14 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                 }
 
                 if (missingParamFiles.size() > 0) {
-                    validationMessage.put("/.dockstore.yml", String.format("The following file(s) are missing: %s.",
+                    validationMessage.put(DOCKSTORE_YML_PATH, String.format("%s: %s.", missingParamFiles.size() == 1 ? "The following file is missing" : "The following files are missing",
                             missingParamFiles.stream().map(paramFile -> String.format("'%s'", paramFile)).collect(Collectors.joining(", "))));
                 }
             }
         } else {
             // File not found or null
-            LOG.info("Could not find file " + primaryDescriptorPath + " in repo " + repository);
-            validationMessage.put("/.dockstore.yml", "Could not find the primary descriptor file '" + primaryDescriptorPath + "'.");
+            LOG.info("Could not find the file " + primaryDescriptorPath + " in repo " + repository);
+            validationMessage.put(DOCKSTORE_YML_PATH, "Could not find the primary descriptor file '" + primaryDescriptorPath + "'.");
         }
 
         VersionTypeValidation dockstoreYmlValidationMessage = new VersionTypeValidation(validationMessage.isEmpty(), validationMessage);
@@ -742,20 +743,19 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
      * @return dockstore YML file
      */
     public SourceFile getDockstoreYml(String repositoryId, String gitReference) {
-        String dockstoreYmlPath = "/.dockstore.yml";
         GHRepository repository;
         try {
             repository = getRepository(repositoryId);
         } catch (CustomWebApplicationException ex) {
             throw new CustomWebApplicationException("Could not find repository " + repositoryId + ".", LAMBDA_FAILURE);
         }
-        String dockstoreYmlContent = this.readFileFromRepo(dockstoreYmlPath, gitReference, repository);
+        String dockstoreYmlContent = this.readFileFromRepo(DOCKSTORE_YML_PATH, gitReference, repository);
         if (dockstoreYmlContent != null) {
             // Create file for .dockstore.yml
             SourceFile dockstoreYml = new SourceFile();
             dockstoreYml.setContent(dockstoreYmlContent);
-            dockstoreYml.setPath(dockstoreYmlPath);
-            dockstoreYml.setAbsolutePath(dockstoreYmlPath);
+            dockstoreYml.setPath(DOCKSTORE_YML_PATH);
+            dockstoreYml.setAbsolutePath(DOCKSTORE_YML_PATH);
             dockstoreYml.setType(DescriptorLanguage.FileType.DOCKSTORE_YML);
 
             return dockstoreYml;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -696,7 +696,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             version = combineVersionAndSourcefile(repository.getFullName(), file, workflow, identifiedType, version, existingDefaults);
 
             if (testParameterPaths != null) {
-                List<String> missingFiles = new ArrayList<>();
+                List<String> missingParamFiles = new ArrayList<>();
                 for (String testParameterPath : testParameterPaths) {
                     String testJsonContent = this.readFileFromRepo(testParameterPath, ref.getLeft(), repository);
                     if (testJsonContent != null) {
@@ -713,11 +713,14 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                             version.getSourceFiles().add(testJson);
                         }
                     } else {
-                        missingFiles.add(testParameterPath);
+                        missingParamFiles.add(testParameterPath);
                     }
                 }
 
-                validationMessage.put("/.dockstore.yml", String.format("The following file(s) are missing: %s.", missingFiles.stream().collect(Collectors.joining(", "))));
+                if (missingParamFiles.size() > 0) {
+                    validationMessage.put("/.dockstore.yml", String.format("The following file(s) are missing: %s.",
+                            missingParamFiles.stream().collect(Collectors.joining(", "))));
+                }
             }
         } else {
             // File not found or null
@@ -725,7 +728,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             validationMessage.put("/.dockstore.yml", "Could not find the primary descriptor file " + primaryDescriptorPath + ".");
         }
 
-        VersionTypeValidation dockstoreYmlValidationMessage = new VersionTypeValidation(false, validationMessage);
+        VersionTypeValidation dockstoreYmlValidationMessage = new VersionTypeValidation(validationMessage.isEmpty(), validationMessage);
         Validation dockstoreYmlValidation = new Validation(DescriptorLanguage.FileType.DOCKSTORE_YML, dockstoreYmlValidationMessage);
         version.addOrUpdateValidation(dockstoreYmlValidation);
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -690,30 +690,30 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             file.setType(identifiedType);
 
             version = combineVersionAndSourcefile(repository.getFullName(), file, workflow, identifiedType, version, existingDefaults);
-
-            if (testParameterPaths != null) {
-                for (String testParameterPath : testParameterPaths) {
-                    String testJsonContent = this.readFileFromRepo(testParameterPath, ref.getLeft(), repository);
-                    if (testJsonContent != null) {
-                        SourceFile testJson = new SourceFile();
-                        // find type from file type, then find matching test param type
-                        testJson.setType(workflow.getDescriptorType().getTestParamType());
-                        testJson.setPath(workflow.getDefaultTestParameterFilePath());
-                        testJson.setAbsolutePath(workflow.getDefaultTestParameterFilePath());
-                        testJson.setContent(testJsonContent);
-
-                        // Only add test parameter file if it hasn't already been added
-                        boolean hasDuplicate = version.getSourceFiles().stream().anyMatch(
-                            (SourceFile sf) -> sf.getPath().equals(workflow.getDefaultTestParameterFilePath()) && sf.getType() == testJson.getType());
-                        if (!hasDuplicate) {
-                            version.getSourceFiles().add(testJson);
-                        }
-                    }
-                }
-            }
         } else {
             // File not found or null
             LOG.info("Could not find file " + primaryDescriptorPath + " in repo " + repository);
+        }
+
+        if (testParameterPaths != null) {
+            for (String testParameterPath : testParameterPaths) {
+                String testJsonContent = this.readFileFromRepo(testParameterPath, ref.getLeft(), repository);
+                if (testJsonContent != null) {
+                    SourceFile testJson = new SourceFile();
+                    // find type from file type, then find matching test param type
+                    testJson.setType(workflow.getDescriptorType().getTestParamType());
+                    testJson.setPath(workflow.getDefaultTestParameterFilePath());
+                    testJson.setAbsolutePath(workflow.getDefaultTestParameterFilePath());
+                    testJson.setContent(testJsonContent);
+
+                    // Only add test parameter file if it hasn't already been added
+                    boolean hasDuplicate = version.getSourceFiles().stream().anyMatch(
+                            (SourceFile sf) -> sf.getPath().equals(workflow.getDefaultTestParameterFilePath()) && sf.getType() == testJson.getType());
+                    if (!hasDuplicate) {
+                        version.getSourceFiles().add(testJson);
+                    }
+                }
+            }
         }
 
         return version;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -688,7 +688,6 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             file.setContent(fileContent);
             DescriptorLanguage.FileType identifiedType = workflow.getDescriptorType().getFileType();
             file.setType(identifiedType);
-            version.setWorkflowPath(primaryDescriptorPath);
 
             version = combineVersionAndSourcefile(repository.getFullName(), file, workflow, identifiedType, version, existingDefaults);
 
@@ -715,7 +714,6 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         } else {
             // File not found or null
             LOG.info("Could not find file " + primaryDescriptorPath + " in repo " + repository);
-            return null;
         }
 
         return version;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -56,6 +56,8 @@ import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
+
 /**
  * This defines the set of operations that is needed to interact with a particular
  * source code repository.
@@ -188,7 +190,7 @@ public abstract class SourceCodeRepoInterface {
         Service service = (Service)initializeWorkflow(repositoryId, new Service());
         service.setDescriptorType(DescriptorLanguage.SERVICE);
         service.setMode(WorkflowMode.DOCKSTORE_YML);
-        service.setDefaultWorkflowPath(".dockstore.yml");
+        service.setDefaultWorkflowPath(DOCKSTORE_YML_PATH);
         return service;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -677,6 +677,7 @@ public abstract class SourceCodeRepoInterface {
      * @return True if valid workflow version, false otherwise
      */
     private boolean isValidVersion(WorkflowVersion version) {
-        return version.getValidations().stream().allMatch(Validation::isValid);
+        return version.getValidations().stream().filter(validation -> !Objects.equals(validation.getType(),
+                DescriptorLanguage.FileType.DOCKSTORE_YML)).allMatch(Validation::isValid);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZipSourceFileHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZipSourceFileHelper.java
@@ -23,6 +23,8 @@ import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
+
 /**
  * Converts the contents of a zip file into a <code>SourceFiles</code> object, ensuring that
  * no zip exploits (e.g., zip bomb, path traversal) can execute.
@@ -136,7 +138,7 @@ public final class ZipSourceFileHelper {
                         SourceFile sourceFile = new SourceFile();
                         if (testParameterFiles != null && testParameterFiles.contains(zipEntry.getName())) {
                             sourceFile.setType(paramFileType(workflowFileType));
-                        } else if (".dockstore.yml".equals(zipEntry.getName())) {
+                        } else if (DOCKSTORE_YML_PATH.equals(zipEntry.getName())) {
                             sourceFile.setType(DescriptorLanguage.FileType.DOCKSTORE_YML);
                         } else {
                             sourceFile.setType(workflowFileType);
@@ -209,7 +211,7 @@ public final class ZipSourceFileHelper {
     }
 
     private static DockstoreYaml10 readAndPrevalidateDockstoreYml(final ZipFile zipFile) {
-        ZipEntry dockstoreYml = zipFile.stream().filter(zipEntry -> ".dockstore.yml".equals(zipEntry.getName())).findFirst()
+        ZipEntry dockstoreYml = zipFile.stream().filter(zipEntry -> DOCKSTORE_YML_PATH.equals(zipEntry.getName())).findFirst()
                 .orElseThrow(() -> new CustomWebApplicationException("Missing .dockstore.yml", HttpStatus.SC_BAD_REQUEST));
         try {
             return readAndPrevalidateDockstoreYml(zipFile.getInputStream(dockstoreYml));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZipSourceFileHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZipSourceFileHelper.java
@@ -23,8 +23,6 @@ import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
-
 /**
  * Converts the contents of a zip file into a <code>SourceFiles</code> object, ensuring that
  * no zip exploits (e.g., zip bomb, path traversal) can execute.
@@ -138,7 +136,7 @@ public final class ZipSourceFileHelper {
                         SourceFile sourceFile = new SourceFile();
                         if (testParameterFiles != null && testParameterFiles.contains(zipEntry.getName())) {
                             sourceFile.setType(paramFileType(workflowFileType));
-                        } else if (DOCKSTORE_YML_PATH.equals(zipEntry.getName())) {
+                        } else if (".dockstore.yml".equals(zipEntry.getName())) {
                             sourceFile.setType(DescriptorLanguage.FileType.DOCKSTORE_YML);
                         } else {
                             sourceFile.setType(workflowFileType);
@@ -211,7 +209,7 @@ public final class ZipSourceFileHelper {
     }
 
     private static DockstoreYaml10 readAndPrevalidateDockstoreYml(final ZipFile zipFile) {
-        ZipEntry dockstoreYml = zipFile.stream().filter(zipEntry -> DOCKSTORE_YML_PATH.equals(zipEntry.getName())).findFirst()
+        ZipEntry dockstoreYml = zipFile.stream().filter(zipEntry -> ".dockstore.yml".equals(zipEntry.getName())).findFirst()
                 .orElseThrow(() -> new CustomWebApplicationException("Missing .dockstore.yml", HttpStatus.SC_BAD_REQUEST));
         try {
             return readAndPrevalidateDockstoreYml(zipFile.getInputStream(dockstoreYml));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -50,6 +50,7 @@ import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
 import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
 import static io.dockstore.webservice.core.WorkflowMode.DOCKSTORE_YML;
 import static io.dockstore.webservice.core.WorkflowMode.FULL;
@@ -418,7 +419,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             if (Objects.equals(workflowToUpdate.getMode(), FULL) || Objects.equals(workflowToUpdate.getMode(), STUB)) {
                 LOG.info("Converting workflow to DOCKSTORE_YML");
                 workflowToUpdate.setMode(DOCKSTORE_YML);
-                workflowToUpdate.setDefaultWorkflowPath("/.dockstore.yml");
+                workflowToUpdate.setDefaultWorkflowPath(DOCKSTORE_YML_PATH);
             }
         }
 


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/3410
Previously if a primary descriptor was not found for a dockstore yml workflow, the version is not added.

Now, the version is added and a validation message is associated with the dockstore.yml. If a test parameter file is missing, this is also kept.

Also adds a test for this situation.

Question for the group:
If a dockstore.yml is missing a test parameter file, it will currently cause the version to be invalid. Do we want this to be true?