### PR TITLE
Json ignore collection entities, need a hibernate overrride

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -28,6 +28,7 @@ import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -82,6 +83,7 @@ public class Collection implements Serializable, Aliasable {
 
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "collection_entry", joinColumns = @JoinColumn(name = "collectionid"), inverseJoinColumns = @JoinColumn(name = "entryid"))
+    @JsonIgnoreProperties({ "workflowVersions" })
     private Set<Entry> entries = new HashSet<>();
 
     @JsonIgnore


### PR DESCRIPTION
Would ideally override this on a Hibernate level for 1.9 or query more carefully
For https://ucsc-cgl.atlassian.net/browse/SEAB-1132
Brings things down to 11 seconds locally and negligible size, but I suspect data is still being loaded, just not transferred