### PR TITLE
successful descriptor validations will not have any messages

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -754,7 +754,7 @@ public class CWLHandler implements LanguageHandlerInterface {
         }
 
         if (isValid) {
-            return new VersionTypeValidation(true, new HashMap<>());
+            return new VersionTypeValidation(true, Collections.emptyMap());
         } else {
             validationMessageObject.put(primaryDescriptorFilePath, validationMessage.toString());
             return new VersionTypeValidation(false, validationMessageObject);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -753,8 +753,12 @@ public class CWLHandler implements LanguageHandlerInterface {
             isValid = false;
         }
 
-        validationMessageObject.put(primaryDescriptorFilePath, validationMessage.toString());
-        return new VersionTypeValidation(isValid, validationMessageObject);
+        if (isValid) {
+            return new VersionTypeValidation(true, new HashMap<>());
+        } else {
+            validationMessageObject.put(primaryDescriptorFilePath, validationMessage.toString());
+            return new VersionTypeValidation(false, validationMessageObject);
+        }
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -77,7 +77,7 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
             }
             return ((RecommendedLanguageInterface)minimalLanguageInterface).validateWorkflowSet(primaryDescriptorFilePath, content, sourcefilesToIndexedFiles(sourcefiles));
         } else {
-            return new VersionTypeValidation(true, new HashMap<>());
+            return new VersionTypeValidation(true, Collections.emptyMap());
         }
     }
 
@@ -123,12 +123,12 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
 
     @Override
     public VersionTypeValidation validateToolSet(Set<SourceFile> sourcefiles, String primaryDescriptorFilePath) {
-        return new VersionTypeValidation(true, new HashMap<>());
+        return new VersionTypeValidation(true, Collections.emptyMap());
     }
 
     @Override
     public VersionTypeValidation validateTestParameterSet(Set<SourceFile> sourceFiles) {
-        return new VersionTypeValidation(true, new HashMap<>());
+        return new VersionTypeValidation(true, Collections.emptyMap());
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -16,6 +16,7 @@
 package io.dockstore.webservice.languages;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -514,7 +514,7 @@ public class NextflowHandler implements LanguageHandlerInterface {
         if (mainDescriptor.isPresent()) {
             content = mainDescriptor.get().getContent();
             if (content.contains("manifest")) {
-                return new VersionTypeValidation(true, new HashMap<>());
+                return new VersionTypeValidation(true, Collections.emptyMap());
             } else {
                 validationMessage = "Descriptor file '" + primaryDescriptorFilePath + "' is missing the manifest section.";
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -514,7 +514,7 @@ public class NextflowHandler implements LanguageHandlerInterface {
         if (mainDescriptor.isPresent()) {
             content = mainDescriptor.get().getContent();
             if (content.contains("manifest")) {
-                return new VersionTypeValidation(true, null);
+                return new VersionTypeValidation(true, new HashMap<>());
             } else {
                 validationMessage = "Descriptor file '" + primaryDescriptorFilePath + "' is missing the manifest section.";
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/ServicePrototypePlugin.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/ServicePrototypePlugin.java
@@ -87,7 +87,7 @@ public class ServicePrototypePlugin implements RecommendedLanguageInterface {
 
     @Override
     public VersionTypeValidation validateTestParameterSet(Map<String, Pair<String, GenericFileType>> indexedFiles) {
-        return new VersionTypeValidation(true, new HashMap<>());
+        return new VersionTypeValidation(true, Collections.emptyMap());
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/ServicePrototypePlugin.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/ServicePrototypePlugin.java
@@ -15,6 +15,7 @@
  */
 package io.dockstore.webservice.languages;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -276,7 +276,7 @@ public class WDLHandler implements LanguageHandlerInterface {
             validationMessageObject.put(primaryDescriptorFilePath, "Primary WDL descriptor is not present.");
             return new VersionTypeValidation(false, validationMessageObject);
         }
-        return new VersionTypeValidation(true, new HashMap<>());
+        return new VersionTypeValidation(true, Collections.emptyMap());
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -276,7 +276,7 @@ public class WDLHandler implements LanguageHandlerInterface {
             validationMessageObject.put(primaryDescriptorFilePath, "Primary WDL descriptor is not present.");
             return new VersionTypeValidation(false, validationMessageObject);
         }
-        return new VersionTypeValidation(true, null);
+        return new VersionTypeValidation(true, new HashMap<>());
     }
 
     /**

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3036,7 +3036,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organization'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
       - bearer: []


### PR DESCRIPTION
Successful validations are expected to have no error messages. For CWL files we were adding the validation message with the file name, which would cause an empty alert to be displayed in the UI.

Also for consistency, use new hashmap instead of null for success validations.