### PR TITLE
Fix/3434/my workflows further optimization

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/RefreshByOrgIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/RefreshByOrgIT.java
@@ -32,9 +32,8 @@ import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.TestingPostgres;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
-import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.MyWorkflows;
 import io.dockstore.webservice.core.Tool;
-import io.dockstore.webservice.core.Workflow;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.DropwizardTestSupport;
@@ -70,7 +69,7 @@ public class RefreshByOrgIT {
     private static ObjectMapper objectMapper;
     private static Long id;
     private static List<Tool> previousTools;
-    private static List<Workflow> previousWorkflows;
+    private static List<MyWorkflows> previousWorkflows;
     private static TestingPostgres testingPostgres;
 
     @AfterClass
@@ -92,7 +91,7 @@ public class RefreshByOrgIT {
 
     private void checkInitialDB() throws IOException {
         // The DB initially has no workflows
-        List<Workflow> currentWorkflows = getWorkflows();
+        List<MyWorkflows> currentWorkflows = getWorkflows();
         // Leaving this in here so we don't forget to change this when there is a workflow in the test DB
         assertThat(currentWorkflows.size()).isGreaterThanOrEqualTo(0);
 
@@ -199,7 +198,7 @@ public class RefreshByOrgIT {
         checkInitialDB();
 
         testRefreshWorkflowsByOrg1();
-        List<Workflow> currentWorkflows = getWorkflows();
+        List<MyWorkflows> currentWorkflows = getWorkflows();
         assertThat(currentWorkflows.size() - previousWorkflows.size()).isGreaterThanOrEqualTo(NEW_DOCKSTORE_TEST_USER_2_WORKFLOWS_ARRAY.size());
         previousWorkflows = currentWorkflows;
 
@@ -228,7 +227,7 @@ public class RefreshByOrgIT {
      */
     private void testRefreshWorkflowsByOrg1() throws IOException {
         String url = usersURLPrefix + "/workflows/DockstoreTestUser2/refresh";
-        List<Workflow> workflows = clientHelperWorkflow(url);
+        List<MyWorkflows> workflows = clientHelperWorkflow(url);
         // Remove all the tools that have the same name as the previous ones
         workflows.removeIf(workflow -> previousWorkflowsHaveName(workflow.getRepository()));
         // Ensure that there are at least 14 new tools
@@ -243,7 +242,7 @@ public class RefreshByOrgIT {
      */
     private void testRefreshWorkflowsByOrg2() throws IOException {
         String url = usersURLPrefix + "/workflows/dockstore/refresh";
-        List<Workflow> workflows = clientHelperWorkflow(url);
+        List<MyWorkflows> workflows = clientHelperWorkflow(url);
         // Remove all the tools that have the same name as the previous ones
         workflows.removeIf(workflow -> previousWorkflowsHaveName(workflow.getRepository()));
         // Ensure that there are at least 14 new tools
@@ -256,7 +255,7 @@ public class RefreshByOrgIT {
      */
     private void testRefreshWorkflowsByOrg3() throws IOException {
         String url = usersURLPrefix + "/workflows/mmmrrrggglll/refresh";
-        List<Workflow> workflows = clientHelperWorkflow(url);
+        List<MyWorkflows> workflows = clientHelperWorkflow(url);
         // Remove all the tools that have the same name as the previous ones
         workflows.removeIf(workflow -> previousWorkflowsHaveName(workflow.getRepository()));
         // Ensure that there are at least 14 new tools
@@ -268,7 +267,7 @@ public class RefreshByOrgIT {
      */
     private void testRefreshWorkflowsByOrg4() throws IOException {
         String url = usersURLPrefix + "/workflows/dockstore_testuser2/refresh";
-        List<Workflow> workflows = clientHelperWorkflow(url);
+        List<MyWorkflows> workflows = clientHelperWorkflow(url);
         // Remove all the tools that have the same name as the previous ones
         workflows.removeIf(workflow -> previousWorkflowsHaveName(workflow.getRepository()));
         // Ensure that there are at least 14 new tools
@@ -282,7 +281,7 @@ public class RefreshByOrgIT {
      */
     private void testRefreshWorkflowsByOrg5() throws IOException {
         String url = usersURLPrefix + "/workflows/dockstore.test.user2/refresh";
-        List<Workflow> workflows = clientHelperWorkflow(url);
+        List<MyWorkflows> workflows = clientHelperWorkflow(url);
         // Remove all the tools that have the same name as the previous ones
         workflows.removeIf(workflow -> previousWorkflowsHaveName(workflow.getRepository()));
         // Ensure that there are at least 14 new tools
@@ -291,15 +290,15 @@ public class RefreshByOrgIT {
             workflows.parallelStream().anyMatch(workflow -> workflow.getRepository().equals(workflowRepository))).isTrue());
     }
 
-    private List<Workflow> clientHelperWorkflow(String url) throws IOException {
+    private List<MyWorkflows> clientHelperWorkflow(String url) throws IOException {
         Response response = client.target(String.format(url, SUPPORT.getLocalPort())).request()
             .header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
         String entity = response.readEntity(String.class);
-        return objectMapper.readValue(entity, new TypeReference<List<BioWorkflow>>() {
+        return objectMapper.readValue(entity, new TypeReference<List<MyWorkflows>>() {
         });
     }
 
-    private List<Workflow> getWorkflows() throws IOException {
+    private List<MyWorkflows> getWorkflows() throws IOException {
         String url = usersURLPrefix + "/workflows";
         return clientHelperWorkflow(url);
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -218,7 +218,7 @@ public class ServiceIT extends BaseIT {
         // Test user endpoints
         UsersApi usersApi = new UsersApi(webClient);
         List<io.swagger.client.model.Workflow> services = usersApi.userServices(service.getUsers().get(0).getId());
-        List<io.swagger.client.model.Workflow> workflows = usersApi.userWorkflows(service.getUsers().get(0).getId());
+        List<io.swagger.client.model.MyWorkflows> workflows = usersApi.userWorkflows(service.getUsers().get(0).getId());
         assertEquals("There should be one service", 1, services.size());
         assertEquals("There should be no workflows", 0, workflows.size());
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
@@ -37,7 +37,8 @@ import io.swagger.annotations.ApiModelProperty;
 @Table(name = "workflow")
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.BioWorkflow.findAllPublishedPaths", query = "SELECT new io.dockstore.webservice.core.database.WorkflowPath(c.sourceControl, c.organization, c.repository, c.workflowName) from BioWorkflow c where c.isPublished = true"),
-        @NamedQuery(name = "io.dockstore.webservice.core.BioWorkflow.findAllPublishedPathsOrderByDbupdatedate", query = "SELECT new io.dockstore.webservice.core.database.RSSWorkflowPath(c.sourceControl, c.organization, c.repository, c.workflowName, c.lastUpdated, c.description) from BioWorkflow c where c.isPublished = true and c.dbUpdateDate is not null ORDER BY c.dbUpdateDate desc")
+        @NamedQuery(name = "io.dockstore.webservice.core.BioWorkflow.findAllPublishedPathsOrderByDbupdatedate", query = "SELECT new io.dockstore.webservice.core.database.RSSWorkflowPath(c.sourceControl, c.organization, c.repository, c.workflowName, c.lastUpdated, c.description) from BioWorkflow c where c.isPublished = true and c.dbUpdateDate is not null ORDER BY c.dbUpdateDate desc"),
+        @NamedQuery(name = "io.dockstore.webservice.core.BioWorkflow.findUserBioWorkflows", query = "SELECT new io.dockstore.webservice.core.database.MyWorkflows(c.organization, c.id, c.sourceControl, c.isPublished, c.workflowName, c.repository) from BioWorkflow c where c.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)")
 })
 @SuppressWarnings("checkstyle:magicnumber")
 public class BioWorkflow extends Workflow {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
@@ -38,7 +38,7 @@ import io.swagger.annotations.ApiModelProperty;
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.BioWorkflow.findAllPublishedPaths", query = "SELECT new io.dockstore.webservice.core.database.WorkflowPath(c.sourceControl, c.organization, c.repository, c.workflowName) from BioWorkflow c where c.isPublished = true"),
         @NamedQuery(name = "io.dockstore.webservice.core.BioWorkflow.findAllPublishedPathsOrderByDbupdatedate", query = "SELECT new io.dockstore.webservice.core.database.RSSWorkflowPath(c.sourceControl, c.organization, c.repository, c.workflowName, c.lastUpdated, c.description) from BioWorkflow c where c.isPublished = true and c.dbUpdateDate is not null ORDER BY c.dbUpdateDate desc"),
-        @NamedQuery(name = "io.dockstore.webservice.core.BioWorkflow.findUserBioWorkflows", query = "SELECT new io.dockstore.webservice.core.database.MyWorkflows(c.organization, c.id, c.sourceControl, c.isPublished, c.workflowName, c.repository) from BioWorkflow c where c.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)")
+        @NamedQuery(name = "io.dockstore.webservice.core.BioWorkflow.findUserBioWorkflows", query = "SELECT new io.dockstore.webservice.core.MyWorkflows(c.organization, c.id, c.sourceControl, c.isPublished, c.workflowName, c.repository) from BioWorkflow c where c.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)")
 })
 @SuppressWarnings("checkstyle:magicnumber")
 public class BioWorkflow extends Workflow {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/MyWorkflows.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/MyWorkflows.java
@@ -14,6 +14,8 @@ public class MyWorkflows {
     private String workflowName;
     private String repository;
 
+    public MyWorkflows() {}
+
     public MyWorkflows(String organization, long id, SourceControl sourceControl, boolean isPublished, String workflowName,
             String repository) {
         this.organization = organization;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/MyWorkflows.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/MyWorkflows.java
@@ -14,7 +14,7 @@ public class MyWorkflows {
     private String workflowName;
     private String repository;
 
-    public MyWorkflows() {}
+    public MyWorkflows() { }
 
     public MyWorkflows(String organization, long id, SourceControl sourceControl, boolean isPublished, String workflowName,
             String repository) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/MyWorkflows.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/MyWorkflows.java
@@ -1,4 +1,4 @@
-package io.dockstore.webservice.core.database;
+package io.dockstore.webservice.core;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dockstore.common.SourceControl;
@@ -61,7 +61,7 @@ public class MyWorkflows {
         return getPath() + (workflowName == null || "".equals(workflowName) ? "" : '/' + workflowName);
     }
 
-    public String getPath() {
+    private String getPath() {
         return sourceControl.toString() + '/' + organization + '/' + repository;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/MyWorkflows.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/MyWorkflows.java
@@ -1,0 +1,74 @@
+package io.dockstore.webservice.core.database;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dockstore.common.SourceControl;
+
+/**
+ * This class is for the list of objects returned by the endpoint which gets the user's workflows (which is only for populating sidebar)
+ */
+public class MyWorkflows {
+    private String organization;
+    private long id;
+    private SourceControl sourceControl;
+    private boolean isPublished;
+    private String workflowName;
+    private String repository;
+
+    public String getOrganization() {
+        return organization;
+    }
+
+    public void setOrganization(String organization) {
+        this.organization = organization;
+    }
+
+    public String getWorkflowName() {
+        return workflowName;
+    }
+
+    public void setWorkflowName(String workflowName) {
+        this.workflowName = workflowName;
+    }
+
+    public String getRepository() {
+        return repository;
+    }
+
+    public void setRepository(String repository) {
+        this.repository = repository;
+    }
+
+    public SourceControl getSourceControl() {
+        return sourceControl;
+    }
+
+    public void setSourceControl(SourceControl sourceControl) {
+        this.sourceControl = sourceControl;
+    }
+
+    @JsonProperty("full_workflow_path")
+    public String getWorkflowPath() {
+        return getPath() + (workflowName == null || "".equals(workflowName) ? "" : '/' + workflowName);
+    }
+
+    public String getPath() {
+        return sourceControl.toString() + '/' + organization + '/' + repository;
+    }
+
+    @JsonProperty("is_published")
+    public boolean isPublished() {
+        return isPublished;
+    }
+
+    public void setPublished(boolean published) {
+        isPublished = published;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/MyWorkflows.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/MyWorkflows.java
@@ -14,6 +14,16 @@ public class MyWorkflows {
     private String workflowName;
     private String repository;
 
+    public MyWorkflows(String organization, long id, SourceControl sourceControl, boolean isPublished, String workflowName,
+            String repository) {
+        this.organization = organization;
+        this.id = id;
+        this.sourceControl = sourceControl;
+        this.isPublished = isPublished;
+        this.workflowName = workflowName;
+        this.repository = repository;
+    }
+
     public String getOrganization() {
         return organization;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/BioWorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/BioWorkflowDAO.java
@@ -18,7 +18,7 @@ package io.dockstore.webservice.jdbi;
 import java.util.List;
 
 import io.dockstore.webservice.core.BioWorkflow;
-import io.dockstore.webservice.core.database.MyWorkflows;
+import io.dockstore.webservice.core.MyWorkflows;
 import io.dockstore.webservice.core.database.RSSWorkflowPath;
 import io.dockstore.webservice.core.database.WorkflowPath;
 import org.hibernate.SessionFactory;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/BioWorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/BioWorkflowDAO.java
@@ -18,6 +18,7 @@ package io.dockstore.webservice.jdbi;
 import java.util.List;
 
 import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.database.MyWorkflows;
 import io.dockstore.webservice.core.database.RSSWorkflowPath;
 import io.dockstore.webservice.core.database.WorkflowPath;
 import org.hibernate.SessionFactory;
@@ -40,5 +41,9 @@ public class BioWorkflowDAO extends EntryDAO<BioWorkflow> {
     public List<RSSWorkflowPath> findAllPublishedPathsOrderByDbupdatedate() {
         return list(namedQuery("io.dockstore.webservice.core.BioWorkflow.findAllPublishedPathsOrderByDbupdatedate").setMaxResults(
                 RSS_ENTRY_LIMIT));
+    }
+
+    public List<MyWorkflows> findUserBioWorkflows(long userId) {
+        return list(namedQuery("io.dockstore.webservice.core.BioWorkflow.findUserBioWorkflows").setParameter("userId", userId));
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -56,6 +56,7 @@ import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Collection;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.ExtendedUserData;
+import io.dockstore.webservice.core.MyWorkflows;
 import io.dockstore.webservice.core.Organization;
 import io.dockstore.webservice.core.OrganizationUser;
 import io.dockstore.webservice.core.Service;
@@ -66,7 +67,6 @@ import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowMode;
-import io.dockstore.webservice.core.database.MyWorkflows;
 import io.dockstore.webservice.helpers.EntryVersionHelper;
 import io.dockstore.webservice.helpers.GoogleHelper;
 import io.dockstore.webservice.helpers.PublicStateManager;
@@ -551,7 +551,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     @Path("/{userId}/workflows")
     @Timed
     @UnitOfWork(readOnly = true)
-    @ApiOperation(value = "List all workflows owned by the authenticated user.", nickname = "userWorkflows", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, responseContainer = "List")
+    @ApiOperation(value = "List all workflows owned by the authenticated user.", nickname = "userWorkflows", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = MyWorkflows.class, responseContainer = "List")
     public List<MyWorkflows> userWorkflows(@ApiParam(hidden = true) @Auth User user,
             @ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId) {
         checkUser(user, userId);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -72,6 +72,7 @@ import io.dockstore.webservice.helpers.GoogleHelper;
 import io.dockstore.webservice.helpers.PublicStateManager;
 import io.dockstore.webservice.helpers.SourceCodeRepoFactory;
 import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
+import io.dockstore.webservice.jdbi.BioWorkflowDAO;
 import io.dockstore.webservice.jdbi.EntryDAO;
 import io.dockstore.webservice.jdbi.EventDAO;
 import io.dockstore.webservice.jdbi.TokenDAO;
@@ -117,6 +118,7 @@ public class UserResource implements AuthenticatedResourceInterface {
     private final WorkflowDAO workflowDAO;
     private final ToolDAO toolDAO;
     private final EventDAO eventDAO;
+    private final BioWorkflowDAO bioWorkflowDAO;
     private PermissionsInterface authorizer;
     private final CachingAuthenticator cachingAuthenticator;
     private final HttpClient client;
@@ -130,6 +132,7 @@ public class UserResource implements AuthenticatedResourceInterface {
         this.tokenDAO = new TokenDAO(sessionFactory);
         this.workflowDAO = new WorkflowDAO(sessionFactory);
         this.toolDAO = new ToolDAO(sessionFactory);
+        this.bioWorkflowDAO = new BioWorkflowDAO(sessionFactory);
         this.workflowResource = workflowResource;
         this.serviceResource = serviceResource;
         this.dockerRepoResource = dockerRepoResource;
@@ -556,20 +559,7 @@ public class UserResource implements AuthenticatedResourceInterface {
         if (fetchedUser == null) {
             throw new CustomWebApplicationException("The given user does not exist.", HttpStatus.SC_NOT_FOUND);
         }
-        List<Workflow> workflows = getWorkflows(fetchedUser);
-        return workflows.parallelStream().map(workflow -> convertWorkflowToMyWorkflows(workflow)).collect(
-                Collectors.toList());
-    }
-
-    private static MyWorkflows convertWorkflowToMyWorkflows(Workflow workflow) {
-        MyWorkflows newWorkflow = new MyWorkflows();
-        newWorkflow.setOrganization(workflow.getOrganization());
-        newWorkflow.setId(workflow.getId());
-        newWorkflow.setSourceControl(workflow.getSourceControl());
-        newWorkflow.setPublished(workflow.getIsPublished());
-        newWorkflow.setWorkflowName(workflow.getWorkflowName());
-        newWorkflow.setRepository(workflow.getRepository());
-        return newWorkflow;
+        return this.bioWorkflowDAO.findUserBioWorkflows(fetchedUser.getId());
     }
 
     private List<Workflow> getWorkflows(User user) {

--- a/dockstore-webservice/src/main/resources/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@ info:
   description: This describes the dockstore API, a webservice that manages pairs of Docker
     images and associated metadata such as CWL documents and Dockerfiles used to
     build those images
-  version: 1.8.1-SNAPSHOT
+  version: 1.8.5
   title: Dockstore API
   termsOfService: TBD
   contact:
@@ -4957,7 +4957,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Workflow"
+                  $ref: "#/components/schemas/MyWorkflows"
       security:
         - BEARER: []
   "/users/{userId}/workflows/published":
@@ -7367,6 +7367,30 @@ components:
         version:
           type: string
       description: Describes this registry to better allow for mirroring and indexing.
+    MyWorkflows:
+      type: object
+      properties:
+        full_workflow_path:
+          type: string
+          readOnly: true
+        id:
+          type: integer
+          format: int64
+        is_published:
+          type: boolean
+        organization:
+          type: string
+        repository:
+          type: string
+        sourceControl:
+          type: string
+          enum:
+            - dockstore.org
+            - github.com
+            - bitbucket.org
+            - gitlab.com
+        workflowName:
+          type: string
     Notification:
       type: object
       properties:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -138,42 +138,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Collection'
-  /organizations/{organizationName}/collections/{collectionName}/name:
-    get:
-      tags:
-      - organizations
-      summary: Retrieve a collection by name.
-      description: Retrieve a collection by name. Supports optional authentication.
-      operationId: getCollectionById
-      parameters:
-      - name: organizationName
-        in: path
-        description: Organization name.
-        required: true
-        schema:
-          type: string
-      - name: collectionName
-        in: path
-        description: Collection name.
-        required: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Collection'
-      security:
-      - bearer: []
   /organizations/{organizationId}/collections/{collectionId}:
     get:
       tags:
       - organizations
       summary: Retrieve a collection by ID.
       description: Retrieve a collection by ID. Supports optional authentication.
-      operationId: getCollectionById_1
+      operationId: getCollectionById
       parameters:
       - name: organizationId
         in: path
@@ -227,6 +198,35 @@ paths:
             schema:
               $ref: '#/components/schemas/Collection'
         required: true
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+      security:
+      - bearer: []
+  /organizations/{organizationName}/collections/{collectionName}/name:
+    get:
+      tags:
+      - organizations
+      summary: Retrieve a collection by name.
+      description: Retrieve a collection by name. Supports optional authentication.
+      operationId: getCollectionById_1
+      parameters:
+      - name: organizationName
+        in: path
+        description: Organization name.
+        required: true
+        schema:
+          type: string
+      - name: collectionName
+        in: path
+        description: Collection name.
+        required: true
+        schema:
+          type: string
       responses:
         default:
           description: default response
@@ -506,6 +506,52 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/RegistryBean'
+  /metadata/descriptorLanguageList:
+    get:
+      tags:
+      - metadata
+      summary: Get the list of descriptor languages supported on Dockstore
+      description: Get the list of descriptor languages supported on Dockstore, NO
+        authentication
+      operationId: getDescriptorLanguages
+      responses:
+        default:
+          description: List of descriptor languages
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DescriptorLanguageBean'
+  /metadata/okHttpCachePerformance:
+    get:
+      tags:
+      - metadata
+      summary: Get measures of cache performance
+      description: Get measures of cache performance, NO authentication
+      operationId: getCachePerformance
+      responses:
+        default:
+          description: Cache performance information
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+  /metadata/elasticSearch:
+    get:
+      tags:
+      - metadata
+      summary: Successful response if elastic search is up and running
+      description: Successful response if elastic search is up and running, NO authentication
+      operationId: checkElasticSearch
+      responses:
+        default:
+          description: default response
+          content:
+            text/html: {}
+            text/xml: {}
   /metadata/sitemap:
     get:
       tags:
@@ -598,116 +644,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SourceControlBean'
-  /metadata/descriptorLanguageList:
-    get:
-      tags:
-      - metadata
-      summary: Get the list of descriptor languages supported on Dockstore
-      description: Get the list of descriptor languages supported on Dockstore, NO
-        authentication
-      operationId: getDescriptorLanguages
-      responses:
-        default:
-          description: List of descriptor languages
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DescriptorLanguageBean'
-  /metadata/okHttpCachePerformance:
-    get:
-      tags:
-      - metadata
-      summary: Get measures of cache performance
-      description: Get measures of cache performance, NO authentication
-      operationId: getCachePerformance
-      responses:
-        default:
-          description: Cache performance information
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties:
-                  type: string
-  /metadata/elasticSearch:
-    get:
-      tags:
-      - metadata
-      summary: Successful response if elastic search is up and running
-      description: Successful response if elastic search is up and running, NO authentication
-      operationId: checkElasticSearch
-      responses:
-        default:
-          description: default response
-          content:
-            text/html: {}
-            text/xml: {}
-  /organizations:
-    get:
-      tags:
-      - organizations
-      summary: List all available organizations.
-      description: List all organizations that have been approved by a curator or
-        admin, sorted by number of stars.
-      operationId: getApprovedOrganizations
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Organization'
-    post:
-      tags:
-      - organizations
-      summary: Create an organization.
-      description: Create an organization. Organization requires approval by an admin
-        before being made public.
-      operationId: createOrganization
-      requestBody:
-        description: Organization to register.
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/Organization'
-        required: true
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Organization'
-      security:
-      - bearer: []
-  /organizations/{organizationId}/approve:
-    post:
-      tags:
-      - organizations
-      summary: Approve an organization.
-      description: Approve the organization with the given id. Admin/curator only.
-      operationId: approveOrganization
-      parameters:
-      - name: organizationId
-        in: path
-        description: Organization ID.
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        default:
-          description: default response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Organization'
-      security:
-      - bearer: []
   /organizations/{organizationId}/reject:
     post:
       tags:
@@ -882,6 +818,70 @@ paths:
             schema:
               type: string
         required: true
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+      security:
+      - bearer: []
+  /organizations:
+    get:
+      tags:
+      - organizations
+      summary: List all available organizations.
+      description: List all organizations that have been approved by a curator or
+        admin, sorted by number of stars.
+      operationId: getApprovedOrganizations
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Organization'
+    post:
+      tags:
+      - organizations
+      summary: Create an organization.
+      description: Create an organization. Organization requires approval by an admin
+        before being made public.
+      operationId: createOrganization
+      requestBody:
+        description: Organization to register.
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/Organization'
+        required: true
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+      security:
+      - bearer: []
+  /organizations/{organizationId}/approve:
+    post:
+      tags:
+      - organizations
+      summary: Approve an organization.
+      description: Approve the organization with the given id. Admin/curator only.
+      operationId: approveOrganization
+      parameters:
+      - name: organizationId
+        in: path
+        description: Organization ID.
+        required: true
+        schema:
+          type: integer
+          format: int64
       responses:
         default:
           description: default response
@@ -1542,18 +1542,11 @@ paths:
                   $ref: '#/components/schemas/Repository'
       security:
       - bearer: []
-  /users/{userId}:
+  /users/user:
     get:
       tags:
       - users
-      operationId: getSpecificUser
-      parameters:
-      - name: userId
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
+      operationId: getUser
       requestBody:
         content:
           '*/*':
@@ -1566,11 +1559,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
-  /users/user:
+  /users/{userId}:
     get:
       tags:
       - users
-      operationId: getUser
+      operationId: getSpecificUser
+      parameters:
+      - name: userId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
       requestBody:
         content:
           '*/*':
@@ -1805,6 +1805,88 @@ components:
           items:
             $ref: '#/components/schemas/Version'
       writeOnly: true
+    EntryObjectObject:
+      type: object
+      properties:
+        aliases:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Alias'
+        author:
+          type: string
+        checker_id:
+          type: integer
+          format: int64
+        conceptDoi:
+          type: string
+        dbCreateDate:
+          type: string
+          format: date-time
+        dbUpdateDate:
+          type: string
+          format: date-time
+        defaultVersion:
+          type: string
+        description:
+          type: string
+        email:
+          type: string
+        gitUrl:
+          type: string
+        has_checker:
+          type: boolean
+        id:
+          type: integer
+          format: int64
+        input_file_formats:
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/FileFormat'
+        is_published:
+          type: boolean
+        labels:
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/Label'
+        lastUpdated:
+          type: string
+          format: date-time
+        last_modified:
+          type: integer
+          format: int32
+        last_modified_date:
+          type: string
+          format: date-time
+        metadataFromEntry:
+          type: object
+          writeOnly: true
+        metadataFromVersion:
+          $ref: '#/components/schemas/Version'
+        output_file_formats:
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/FileFormat'
+        starredUsers:
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
+        topicId:
+          type: integer
+          format: int64
+        users:
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
+        workflowVersions:
+          uniqueItems: true
+          type: array
+          items:
+            type: object
     FileFormat:
       type: object
       properties:
@@ -2010,6 +2092,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
+        parent:
+          $ref: '#/components/schemas/EntryObjectObject'
         reference:
           type: string
         referenceType:
@@ -2061,8 +2145,8 @@ components:
           - WDL
           - NFL
           - service
-          
-          
+          - cwl
+          - wdl
         aliases:
           type: object
           additionalProperties:
@@ -2373,6 +2457,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
+        parent:
+          $ref: '#/components/schemas/EntryObjectObject'
         reference:
           type: string
         referenceType:
@@ -2558,8 +2644,8 @@ components:
           - WDL
           - NFL
           - service
-          
-          
+          - cwl
+          - wdl
         aliases:
           type: object
           additionalProperties:
@@ -2737,6 +2823,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FileFormat'
+        parent:
+          $ref: '#/components/schemas/EntryObjectObject'
         reference:
           type: string
         referenceType:
@@ -2860,14 +2948,14 @@ components:
           type: string
         url:
           type: string
-    SourceControlBean:
+    DescriptorLanguageBean:
       type: object
       properties:
         friendlyName:
           type: string
         value:
           type: string
-    DescriptorLanguageBean:
+    SourceControlBean:
       type: object
       properties:
         friendlyName:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This describes the dockstore API, a webservice that manages pairs\
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images"
-  version: "1.8.1-SNAPSHOT"
+  version: "1.8.5"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:
@@ -4653,7 +4653,7 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/Workflow"
+              $ref: "#/definitions/MyWorkflows"
       security:
       - BEARER: []
   /users/{userId}/workflows/published:
@@ -7011,6 +7011,30 @@ definitions:
       version:
         type: "string"
     description: "Describes this registry to better allow for mirroring and indexing."
+  MyWorkflows:
+    type: "object"
+    properties:
+      full_workflow_path:
+        type: "string"
+        readOnly: true
+      id:
+        type: "integer"
+        format: "int64"
+      is_published:
+        type: "boolean"
+      organization:
+        type: "string"
+      repository:
+        type: "string"
+      sourceControl:
+        type: "string"
+        enum:
+        - "dockstore.org"
+        - "github.com"
+        - "bitbucket.org"
+        - "gitlab.com"
+      workflowName:
+        type: "string"
   Notification:
     type: "object"
     properties:


### PR DESCRIPTION
For #3434 

282 MB => 504 KB => 24 KB

A new object that's solely used on a single endpoint.


```
INFO  [2020-05-08 17:58:57,681] org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: Session Metrics {
    96900 nanoseconds spent acquiring 2 JDBC connections;
    60500 nanoseconds spent releasing 2 JDBC connections;
    313500 nanoseconds spent preparing 3 JDBC statements;
    2469900 nanoseconds spent executing 3 JDBC statements;
    0 nanoseconds spent executing 0 JDBC batches;
    0 nanoseconds spent performing 0 L2C puts;
    0 nanoseconds spent performing 0 L2C hits;
    0 nanoseconds spent performing 0 L2C misses;
    303600 nanoseconds spent executing 1 flushes (flushing a total of 2 entities and 5 collections);
    7300 nanoseconds spent executing 1 partial-flushes (flushing a total of 0 entities and 0 collections)
}
INFO  [2020-05-08 17:58:57,692] org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: Session Metrics {
    55600 nanoseconds spent acquiring 2 JDBC connections;
    32800 nanoseconds spent releasing 2 JDBC connections;
    15900 nanoseconds spent preparing 2 JDBC statements;
    4873200 nanoseconds spent executing 2 JDBC statements;
    0 nanoseconds spent executing 0 JDBC batches;
    0 nanoseconds spent performing 0 L2C puts;
    0 nanoseconds spent performing 0 L2C hits;
    0 nanoseconds spent performing 0 L2C misses;
    61700 nanoseconds spent executing 1 flushes (flushing a total of 1 entities and 5 collections);
    60700 nanoseconds spent executing 1 partial-flushes (flushing a total of 1 entities and 1 collections)
}
127.0.0.1 - - [08/May/2020:17:58:57 +0000] "GET /users/14291/workflows HTTP/1.1" 200 20187 "-" "curl/7.58.0" 29
```
First set is getting the user, 2nd set is what I did.  Not sure why there's 2 statements instead of 1, oh well.



May want to check this out and test if myWorkflows page is broken in ways I don't see.