### PR TITLE
Refresh individual version fix

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -378,8 +378,10 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             GHRef[] refs = repository.getRefs();
             for (GHRef ref : refs) {
                 Triple<String, Date, String> referenceTriple = getRef(ref, repository);
-                if (versionName.isEmpty() || Objects.equals(versionName.get(), referenceTriple.getLeft())) {
-                    references.add(referenceTriple);
+                if (referenceTriple != null) {
+                    if (versionName.isEmpty() || Objects.equals(versionName.get(), referenceTriple.getLeft())) {
+                        references.add(referenceTriple);
+                    }
                 }
             }
         } catch (GHFileNotFoundException e) {


### PR DESCRIPTION
The function getRef(ref, repository) will return null if the reference is a pull type. Unfortunately some new code assumed it is never null. We now simply check if it is null before going to the next steps.

https://github.com/dockstore/dockstore/issues/3452