### PR TITLE
Feature/fix discourse api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,8 +99,8 @@ install:
 - scripts/install-tests.sh
 
 before_script:
-- psql -c "create user dockstore with password 'dockstore' createdb;" -U postgres
-- psql -c 'create database webservice_test with owner = dockstore;' -U postgres
+- psql -h localhost -c "create user dockstore with password 'dockstore' createdb;" -U postgres
+- psql -h localhost -c 'create database webservice_test with owner = dockstore;' -U postgres
 - export PATH=$PATH:$PWD/dockstore-client/target
 # debug by double checking versions of stuff
 - mvn -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 services:
 - docker
+- postgresql
 
 addons:
   postgresql: "11"
@@ -99,8 +100,8 @@ install:
 - scripts/install-tests.sh
 
 before_script:
-- psql -h localhost -c "create user dockstore with password 'dockstore' createdb;" -U postgres
-- psql -h localhost -c 'create database webservice_test with owner = dockstore;' -U postgres
+- psql -c "create user dockstore with password 'dockstore' createdb;" -U postgres
+- psql -c 'create database webservice_test with owner = dockstore;' -U postgres
 - export PATH=$PATH:$PWD/dockstore-client/target
 # debug by double checking versions of stuff
 - mvn -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ services:
 
 addons:
   postgresql: "11"
-  apt:
-    packages:
-    - postgresql-11
-    - postgresql-client-11
   snaps:
     - yq
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 services:
 - docker
-- postgresql
 
 addons:
   postgresql: "11"

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -161,9 +161,6 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
             throw new CustomWebApplicationException("Entry " + id + " already has an associated Discourse topic.", HttpStatus.SC_BAD_REQUEST);
         }
 
-        // Verify and set category
-        Integer category = discourseCategoryId;
-
         // Create title and link to entry
         String entryLink = "https://dockstore.org/";
         String title;
@@ -211,10 +208,10 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
             // Create a discourse topic
             InlineResponse2005 response;
             try {
-                response = topicsApi.postsJsonPost(description, discourseKey, discourseApiUsername, title, null, category, null, null, null);
+                response = topicsApi.postsJsonPost(description, discourseKey, discourseApiUsername, title, null, discourseCategoryId, null, null, null);
                 entry.setTopicId(response.getTopicId().longValue());
             } catch (ApiException ex) {
-                String message = "Could not add a topic " + title + " to category " + category;
+                String message = "Could not add a topic " + title + " to category " + discourseCategoryId;
                 LOG.error(message, ex);
                 throw new CustomWebApplicationException(message, HttpStatus.SC_BAD_REQUEST);
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -214,7 +214,7 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
                 response = topicsApi.postsJsonPost(description, discourseKey, discourseApiUsername, title, null, category, null, null, null);
                 entry.setTopicId(response.getTopicId().longValue());
             } catch (ApiException ex) {
-                String message = "Could not add a topic to the given entry.";
+                String message = "Could not add a topic " + title + " to category " + category;
                 LOG.error(message, ex);
                 throw new CustomWebApplicationException(message, HttpStatus.SC_BAD_REQUEST);
             }

--- a/swagger-java-discourse-client/src/main/resources/api.json
+++ b/swagger-java-discourse-client/src/main/resources/api.json
@@ -1,4 +1,4 @@
-{
+ {
     "swagger": "2.0",
     "info": {
         "title": "Discourse API Documentation",
@@ -853,13 +853,13 @@
                 ],
                 "parameters": [
                     {
-                        "in": "formData",
-                        "name": "api_key",
+                        "in": "header",
+                        "name": "Api-Key",
                         "type": "string"
                     },
                     {
-                        "in": "formData",
-                        "name": "api_username",
+                        "in": "header",
+                        "name": "Api-Username",
                         "type": "string"
                     },
                     {


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-1135

Previously we passed auth info in query parameters, something changed (maybe discourse update) and now these must be in the header. I've tested locally by running the test publishWorkflowAndTestDiscourseTopicCreation. It fails for develop but works on this branch.

Do we want this in a hotfix?