### PR TITLE
Lazy load event entities

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -6,6 +6,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -47,35 +48,35 @@ public class Event {
     @ApiModelProperty(value = "Implementation specific ID for the event in this web service", position = 0)
     private long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId", referencedColumnName = "id")
     @ApiModelProperty(value = "User that the event is acting on.", position = 1)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "organizationId", referencedColumnName = "id")
     @ApiModelProperty(value = "Organization that the event is acting on.", position = 2)
     private Organization organization;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "toolId", referencedColumnName = "id")
     @ApiModelProperty(value = "Tool that the event is acting on.", position = 3)
     @JsonIgnoreProperties({ "workflowVersions" })
     private Tool tool;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "workflowId", referencedColumnName = "id")
     @ApiModelProperty(value = "Workflow that the event is acting on.", position = 4)
     @JsonIgnoreProperties({ "workflowVersions" })
     private BioWorkflow workflow;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "collectionId", referencedColumnName = "id")
     @ApiModelProperty(value = "Collection that the event is acting on.", position = 5)
     @JsonIgnoreProperties({ "entries" })
     private Collection collection;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "initiatorUserId", referencedColumnName = "id")
     @ApiModelProperty(value = "User initiating the event.", position = 6)
     private User initiatorUser;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
@@ -46,6 +46,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.hibernate.Hibernate;
 
 import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
 import static io.dockstore.webservice.jdbi.EventDAO.MAX_LIMIT;
@@ -84,17 +85,35 @@ public class EventResource {
         switch (eventSearchType) {
         case STARRED_ENTRIES:
             Set<Long> entryIDs = userWithSession.getStarredEntries().stream().map(Entry::getId).collect(Collectors.toSet());
-            return this.eventDAO.findEventsByEntryIDs(entryIDs, offset, limit);
+            List<Event> eventsByEntryIDs = this.eventDAO.findEventsByEntryIDs(entryIDs, offset, limit);
+            eagerLoadEventEntries(eventsByEntryIDs);
+            return eventsByEntryIDs;
         case STARRED_ORGANIZATION:
             Set<Long> organizationIDs = userWithSession.getStarredOrganizations().stream().map(Organization::getId).collect(Collectors.toSet());
-            return this.eventDAO.findAllByOrganizationIds(organizationIDs, offset, limit);
+            List<Event> allByOrganizationIds = this.eventDAO.findAllByOrganizationIds(organizationIDs, offset, limit);
+            eagerLoadEventEntries(allByOrganizationIds);
+            return allByOrganizationIds;
         case ALL_STARRED:
             Set<Long> organizationIDs2 = userWithSession.getStarredOrganizations().stream().map(Organization::getId).collect(Collectors.toSet());
             Set<Long> entryIDs2 = userWithSession.getStarredEntries().stream().map(Entry::getId).collect(Collectors.toSet());
-            return this.eventDAO.findAllByOrganizationIdsOrEntryIds(organizationIDs2, entryIDs2, offset, limit);
+            List<Event> allByOrganizationIdsOrEntryIds = this.eventDAO
+                    .findAllByOrganizationIdsOrEntryIds(organizationIDs2, entryIDs2, offset, limit);
+            eagerLoadEventEntries(allByOrganizationIdsOrEntryIds);
+            return allByOrganizationIdsOrEntryIds;
         default:
             return Collections.emptyList();
         }
+    }
+
+    private void eagerLoadEventEntries(List<Event> events) {
+        events.forEach(event -> {
+            Hibernate.initialize(event.getUser());
+            Hibernate.initialize(event.getOrganization());
+            Hibernate.initialize(event.getTool());
+            Hibernate.initialize(event.getWorkflow());
+            Hibernate.initialize(event.getCollection());
+            Hibernate.initialize(event.getInitiatorUser());
+        });
     }
 }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
@@ -322,7 +322,12 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
         getOrganizationByIdOptionalAuth(user, id);
         response.addHeader("X-total-count", String.valueOf(eventDAO.countAllEventsForOrganization(id)));
         response.addHeader("Access-Control-Expose-Headers", "X-total-count");
-        return eventDAO.findEventsForOrganization(id, offset, limit);
+        List<Event> eventsForOrganization = eventDAO.findEventsForOrganization(id, offset, limit);
+        for (Event event : eventsForOrganization) {
+            Hibernate.initialize(event.getInitiatorUser());
+            Hibernate.initialize(event.getCollection());
+        }
+        return eventsForOrganization;
     }
 
     @PUT


### PR DESCRIPTION
To optimize https://dockstore.org/api/organizations/16/events?offset=0&limit=30
from https://dockstore.org/organizations/BroadInstitute

| |  Payload Size    | Time  | JDBC statements |
| ------------- |-------------| -----|-----|
| Before     | 35.4 KB  | 9.84 seconds | 10085 |
| After      | 3.2 KB      |  41ms  | 8 |

This does absolutely nothing for the logged-in homepage events but that's not even in production right now.  I do have a plan for it, but it requires a significant change.  Not a hotfix change and probably too late for 1.9.0 also.