### PR TITLE
Fix/store jar on circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,19 @@ jobs:
           path: ~/junit
       - store_artifacts:
           path: ~/junit
+      - run:
+          name: Make jar directory
+          command: mkdir /tmp/artifacts
+      - run:
+          name: Move jars
+          command: cp dockstore-webservice/target/dockstore*.jar /tmp/artifacts
+      - run:
+          name: Move swagger.yaml
+          command: |
+            cp dockstore-webservice/src/main/resources/swagger.yaml /tmp/artifacts
+            cp dockstore-webservice/src/main/resources/openapi3/openapi.yaml /tmp/artifacts
+      - store_artifacts:
+          path: /tmp/artifacts
     branches:
       ignore:
         - gh-pages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
           command: mkdir /tmp/artifacts
       - run:
           name: Move jars
-          command: cp dockstore-webservice/target/dockstore*.jar /tmp/artifacts
+          command: cp dockstore-webservice/target/dockstore*[^s].jar /tmp/artifacts
       - run:
           name: Move swagger.yaml
           command: |

--- a/dockstore-webservice/src/main/resources/migrations.xml
+++ b/dockstore-webservice/src/main/resources/migrations.xml
@@ -22,18 +22,18 @@
     <include file="migrations.1.3.1.consistency.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.confidential1.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.confidential2.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.1.4.0.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.1.5.0.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.1.6.0.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.1.7.0.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.1.7.0.relinquish.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.1.8.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.test.samepaths.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.1.4.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.testworkflow.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.1.5.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.confidential1_1.5.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.confidential2_1.5.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test_1.5.0.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.1.6.0.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.test.samepaths.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.1.7.0.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.1.7.0.relinquish.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.add_service_1.7.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.alter_test_user_1.7.0.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.1.8.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
This PR does two things. 

- it uploads a JAR onto CircleCI (for every successful commit) so we can do frontend integration tests before making a webservice release.
- Cherry-pick the migration fixes so that the frontend tests do not fail (probably failing since 1.8.x hotfixes  if it were to be tested at all).