### PR TITLE
Feature/fix tool date

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
@@ -152,7 +152,9 @@ public class CRUDClientIT extends BaseIT {
         first = dockstoreTool.getWorkflowVersions().stream().max(Comparator.comparingInt((Tag t) -> Integer.parseInt(t.getName())));
         assertEquals("correct number of source files", 2, first.get().getSourceFiles().size());
 
+        // Default version automatically updated to the latest version (3).
         dockstoreTool = api.deleteHostedToolVersion(hostedTool.getId(), "3");
+        assertEquals("Default version should have updated to the next newest one", "2", dockstoreTool.getDefaultVersion());
         assertEquals("should only be two revisions", 2, dockstoreTool.getWorkflowVersions().size());
 
         //check that all revisions have editing users

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
@@ -152,7 +152,7 @@ public class CRUDClientIT extends BaseIT {
         first = dockstoreTool.getWorkflowVersions().stream().max(Comparator.comparingInt((Tag t) -> Integer.parseInt(t.getName())));
         assertEquals("correct number of source files", 2, first.get().getSourceFiles().size());
 
-        dockstoreTool = api.deleteHostedToolVersion(hostedTool.getId(), "1");
+        dockstoreTool = api.deleteHostedToolVersion(hostedTool.getId(), "3");
         assertEquals("should only be two revisions", 2, dockstoreTool.getWorkflowVersions().size());
 
         //check that all revisions have editing users
@@ -209,6 +209,7 @@ public class CRUDClientIT extends BaseIT {
     @Test
     public void testWorkflowEditing() throws IOException {
         HostedApi api = new HostedApi(getWebClient(ADMIN_USERNAME, testingPostgres));
+        WorkflowsApi workflowsApi = new WorkflowsApi(getWebClient(ADMIN_USERNAME, testingPostgres));
         Workflow hostedWorkflow = api.createHostedWorkflow("awesomeTool", null, CWL.getLowerShortName(), null, null);
         SourceFile file = new SourceFile();
         file.setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("1st-workflow.cwl")), StandardCharsets.UTF_8));
@@ -276,7 +277,6 @@ public class CRUDClientIT extends BaseIT {
         assertTrue(thrownException);
 
         // Publish workflow
-        WorkflowsApi workflowsApi = new WorkflowsApi(getWebClient(ADMIN_USERNAME, testingPostgres));
         PublishRequest pub = SwaggerUtility.createPublishRequest(true);
         workflowsApi.publish(dockstoreWorkflow.getId(), pub);
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -18,6 +18,7 @@ package io.dockstore.webservice.core;
 
 import java.util.Date;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -90,7 +91,7 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
 
     @Override
     public Date getDate() {
-        return this.getLastBuilt();
+        return Stream.of(this.getLastBuilt(), this.getDbCreateDate()).filter(Objects::nonNull).findFirst().orElse(null);
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -18,7 +18,6 @@ package io.dockstore.webservice.core;
 
 import java.util.Date;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -33,6 +32,7 @@ import com.google.common.collect.Ordering;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.ObjectUtils;
 
 /**
  * This describes one tag associated with a container. For our implementation, this means one tag on quay.io or Docker Hub which is
@@ -91,7 +91,7 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
 
     @Override
     public Date getDate() {
-        return Stream.of(this.getLastBuilt(), this.getDbCreateDate()).filter(Objects::nonNull).findFirst().orElse(null);
+        return ObjectUtils.firstNonNull(this.getLastBuilt(), this.getDbCreateDate());
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -205,7 +205,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     }
 
     /**
-     * Used to determine the "newer" version. WorkflowVersion relies on last_modified, Tag relies on last_built.
+     * Used to determine the "newer" version. WorkflowVersion relies on last_modified, Tag relies on last_built (hosted tools fall back to dbCreateDate).
      * @return  The date used to determine the "newer" version
      */
     @JsonIgnore

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -390,7 +390,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
         // If the version that's about to be deleted is the default version, unset it
         if (entry.getActualDefaultVersion().getName().equals(version)) {
             Optional<U> max = entry.getWorkflowVersions().stream().filter(v -> !Objects.equals(v.getName(), version))
-                    .max(Comparator.comparingLong(ver -> ver.getDbCreateDate().getTime()));
+                    .max(Comparator.comparingLong(ver -> ver.getDate().getTime()));
             entry.setActualDefaultVersion(max.orElse(null));
         }
         entry.getWorkflowVersions().removeIf(v -> Objects.equals(v.getName(), version));


### PR DESCRIPTION
Previously https://github.com/dockstore/dockstore/pull/3374 didn't test for hosted tool deletion of a default version. This adds the test and fixes it.  This allows ~my PR and~ Andrew's PR on the UI to pass (since it requires a new webservice).  Everyone else is unaffected for now.

~Push cancelled on purpose.~ Restarting push since Travis isn't so busy now.