### PR TITLE
Feature/3097/duplicate token registration

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
@@ -375,7 +375,7 @@ public class TokenResourceIT {
             otherUserTokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
             fail();
         } catch (ApiException e) {
-            Assert.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, e.getCode());
+            Assert.assertEquals(HttpStatus.SC_CONFLICT, e.getCode());
             Assert.assertTrue(e.getMessage().contains("already exists"));
             // Call should fail
         }
@@ -392,7 +392,7 @@ public class TokenResourceIT {
             otherUserTokensApi.addGithubToken(getFakeCode(SUFFIX1));
             fail();
         } catch (ApiException e) {
-            Assert.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, e.getCode());
+            Assert.assertEquals(HttpStatus.SC_CONFLICT, e.getCode());
             Assert.assertTrue(e.getMessage().contains("already exists"));
             // Call should fail
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
@@ -69,7 +69,9 @@ import org.hibernate.annotations.UpdateTimestamp;
     @NamedQuery(name = "io.dockstore.webservice.core.Token.findOrcidByUserId",
             query = "SELECT t FROM Token t WHERE t.userId = :userId AND t.tokenSource = 'orcid.org'"),
     @NamedQuery(name = "io.dockstore.webservice.core.Token.findTokenByGitHubUsername",
-            query = "SELECT t FROM Token t WHERE t.username = :username AND t.tokenSource = 'github.com'")
+            query = "SELECT t FROM Token t WHERE t.username = :username AND t.tokenSource = 'github.com'"),
+    @NamedQuery(name = "io.dockstore.webservice.core.Token.findTokenByUserNameAndTokenSource",
+            query = "SELECT t FROM Token t WHERE t.username = :username AND t.tokenSource = :tokenSource")
 })
 
 @SuppressWarnings("checkstyle:magicnumber")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/TokenDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/TokenDAO.java
@@ -19,6 +19,7 @@ package io.dockstore.webservice.jdbi;
 import java.util.List;
 
 import io.dockstore.webservice.core.Token;
+import io.dockstore.webservice.core.TokenType;
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -91,5 +92,9 @@ public class TokenDAO extends AbstractDAO<Token> {
 
     public Token findTokenByGitHubUsername(String githubUsername) {
         return uniqueResult(namedQuery("io.dockstore.webservice.core.Token.findTokenByGitHubUsername").setParameter("username", githubUsername));
+    }
+
+    public Token findTokenByUserNameAndTokenSource(String username, TokenType tokenSource) {
+        return uniqueResult(namedQuery("io.dockstore.webservice.core.Token.findTokenByUserNameAndTokenSource").setParameter("username", username).setParameter("tokenSource", tokenSource));
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -230,7 +230,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     private void checkIfAccountHasBeenLinked(String username, TokenType tokenType) {
         Token existingToken = tokenDAO.findTokenByUserNameAndTokenSource(username, tokenType);
         if (existingToken != null) {
-            String msg = "A '" + tokenType.toString() + "' token already exists on Dockstore for the third party service with the account name '" + username + "'";
+            String msg = "A '" + tokenType.toString() + "' token already exists on Dockstore for the account '" + username + "'";
             LOG.info(msg);
             throw new CustomWebApplicationException(msg, HttpStatus.SC_CONFLICT);
         }


### PR DESCRIPTION
When a user tries to connect an account that has already been used for another account (or the users own account), have a better error message.

Previously, we were only catching this exception if the current user already had an account linked.

https://github.com/dockstore/dockstore/issues/3097

Ex. Bitbucket message
![Screen Shot 2020-06-12 at 1 01 34 PM](https://user-images.githubusercontent.com/6331159/84529221-10d6fa80-acaf-11ea-9a37-bc0f3f21229a.png)
