### PR TITLE
Feature/3412/dockstoreyml metadata capture

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -20,6 +20,7 @@ package io.dockstore.webservice;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import com.google.common.collect.Lists;
 import io.dockstore.client.cli.BaseIT;
@@ -224,6 +225,17 @@ public class WebhookIT extends BaseIT {
         workflow2 = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar2", "", false);
         assertTrue("Should have a master version.", workflow2.getWorkflowVersions().stream().anyMatch((io.dockstore.openapi.client.model.WorkflowVersion version) -> Objects.equals(version.getName(), "master")));
         assertTrue("Should have a 0.2 version.", workflow2.getWorkflowVersions().stream().anyMatch((io.dockstore.openapi.client.model.WorkflowVersion version) -> Objects.equals(version.getName(), "0.2")));
+
+        // Master version should have metadata set
+        Optional<io.dockstore.openapi.client.model.WorkflowVersion> masterVersion = workflow.getWorkflowVersions().stream().filter((io.dockstore.openapi.client.model.WorkflowVersion version) -> Objects.equals(version.getName(), "master")).findFirst();
+        assertEquals("Should have author set", "Test User", masterVersion.get().getAuthor());
+        assertEquals("Should have email set", "test@dockstore.org", masterVersion.get().getEmail());
+        assertEquals("Should have email set", "This is a description", masterVersion.get().getDescription());
+
+        masterVersion = workflow2.getWorkflowVersions().stream().filter((io.dockstore.openapi.client.model.WorkflowVersion version) -> Objects.equals(version.getName(), "master")).findFirst();
+        assertEquals("Should have author set", "Test User", masterVersion.get().getAuthor());
+        assertEquals("Should have email set", "test@dockstore.org", masterVersion.get().getEmail());
+        assertEquals("Should have email set", "This is a description", masterVersion.get().getDescription());
 
         boolean hasLegacyVersion = workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> workflowVersion.isLegacyVersion());
         assertFalse("Workflow should not have any legacy refresh versions.", hasLegacyVersion);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -373,7 +373,7 @@ public abstract class SourceCodeRepoInterface {
         }
     }
 
-    private void updateVersionMetadata(String filePath, Version<?> version, DescriptorLanguage type, String repositoryId) {
+    public void updateVersionMetadata(String filePath, Version<?> version, DescriptorLanguage type, String repositoryId) {
         Set<SourceFile> sourceFiles = version.getSourceFiles();
         String branch = version.getName();
         if (Strings.isNullOrEmpty(filePath)) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -498,10 +498,16 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 existingWorkflowVersion.get().setCommitID(remoteWorkflowVersion.getCommitID());
                 existingWorkflowVersion.get().setDagJson(null);
                 existingWorkflowVersion.get().setToolTableJson(null);
+                existingWorkflowVersion.get().setReferenceType(remoteWorkflowVersion.getReferenceType());
 
                 updateDBVersionSourceFilesWithRemoteVersionSourceFiles(existingWorkflowVersion.get(), remoteWorkflowVersion);
             } else {
                 workflow.addWorkflowVersion(remoteWorkflowVersion);
+            }
+
+            Optional<WorkflowVersion> addedVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> Objects.equals(workflowVersion.getName(), remoteWorkflowVersion.getName())).findFirst();
+            if (addedVersion.isPresent()) {
+                gitHubSourceCodeRepo.updateVersionMetadata(addedVersion.get().getWorkflowPath(), addedVersion.get(), workflow.getDescriptorType(), repository);
             }
 
             LOG.info("Version " + remoteWorkflowVersion.getName() + " has been added to workflow " + workflow.getWorkflowPath() + ".");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -506,9 +506,8 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             }
 
             Optional<WorkflowVersion> addedVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> Objects.equals(workflowVersion.getName(), remoteWorkflowVersion.getName())).findFirst();
-            if (addedVersion.isPresent()) {
-                gitHubSourceCodeRepo.updateVersionMetadata(addedVersion.get().getWorkflowPath(), addedVersion.get(), workflow.getDescriptorType(), repository);
-            }
+            addedVersion.ifPresent(workflowVersion -> gitHubSourceCodeRepo
+                    .updateVersionMetadata(workflowVersion.getWorkflowPath(), workflowVersion, workflow.getDescriptorType(), repository));
 
             LOG.info("Version " + remoteWorkflowVersion.getName() + " has been added to workflow " + workflow.getWorkflowPath() + ".");
         } catch (IOException ex) {


### PR DESCRIPTION
Previously we weren't setting the metadata for dockstore.yml workflows. Now we do. Note that we are not pulling from the dockstore.yml file, but instead, we are pulling from descriptor files (same as non-dockstore.yml workflows).
https://github.com/dockstore/dockstore/issues/3412