### PR TITLE
Feature/3572/catch http import exceptions

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -244,7 +244,12 @@ public class WDLHandler implements LanguageHandlerInterface {
                 tempMainDescriptor = File.createTempFile("main", "descriptor", Files.createTempDir());
                 Files.asCharSink(tempMainDescriptor, StandardCharsets.UTF_8).write(mainDescriptor);
                 String content = FileUtils.readFileToString(tempMainDescriptor, StandardCharsets.UTF_8);
-                checkForRecursiveHTTPImports(content, new HashSet<>());
+                try {
+                    checkForRecursiveHTTPImports(content, new HashSet<>());
+                } catch (IOException | CustomWebApplicationException e) {
+                    validationMessageObject.put(primaryDescriptorFilePath, e.getMessage());
+                    return new VersionTypeValidation(false, validationMessageObject);
+                }
 
                 Optional<String> optValidationMessage = reportValidationForLocalRecursiveImports(content,
                         sourcefiles, primaryDescriptorFilePath);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -246,8 +246,11 @@ public class WDLHandler implements LanguageHandlerInterface {
                 String content = FileUtils.readFileToString(tempMainDescriptor, StandardCharsets.UTF_8);
                 try {
                     checkForRecursiveHTTPImports(content, new HashSet<>());
-                } catch (IOException | CustomWebApplicationException e) {
+                } catch (IOException e) {
                     validationMessageObject.put(primaryDescriptorFilePath, e.getMessage());
+                    return new VersionTypeValidation(false, validationMessageObject);
+                } catch (CustomWebApplicationException e) {
+                    validationMessageObject.put(primaryDescriptorFilePath, e.getErrorMessage());
                     return new VersionTypeValidation(false, validationMessageObject);
                 }
 

--- a/dockstore-webservice/src/test/java/core/WDLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/WDLParseTest.java
@@ -183,6 +183,7 @@ public class WDLParseTest {
         File recursiveWDL = new File(ResourceHelpers.resourceFilePath("recursive.wdl"));
         String primaryDescriptorFilePath = recursiveWDL.getAbsolutePath();
         SourceFile sourceFile = new SourceFile();
+        VersionTypeValidation versionTypeValidation = null;
         try {
             sourceFile.setContent(FileUtils.readFileToString(recursiveWDL, StandardCharsets.UTF_8));
             sourceFile.setAbsolutePath(recursiveWDL.getAbsolutePath());
@@ -191,13 +192,14 @@ public class WDLParseTest {
             Set<SourceFile> sourceFileSet = new HashSet<>();
             sourceFileSet.add(sourceFile);
             WDLHandler wdlHandler = new WDLHandler();
-            wdlHandler.validateEntrySet(sourceFileSet, primaryDescriptorFilePath, type);
-            Assert.fail();
+            versionTypeValidation = wdlHandler.validateEntrySet(sourceFileSet, primaryDescriptorFilePath, type);
         } catch (IOException e) {
             Assert.fail();
         } catch (CustomWebApplicationException e) {
             assertTrue(StringUtils.contains(e.getErrorMessage(), ERROR_PARSING_WORKFLOW_YOU_MAY_HAVE_A_RECURSIVE_IMPORT));
         }
+        assertTrue(StringUtils.contains(versionTypeValidation.getMessage().get(recursiveWDL.getAbsolutePath()), ERROR_PARSING_WORKFLOW_YOU_MAY_HAVE_A_RECURSIVE_IMPORT));
+
     }
 
     /**


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/3572

During a refresh of a WDL workflow we check for recursive https imports. If the file did not exist, we threw an exception. This means that a single version with an invalid https import would break a refresh.

Now we catch the exception and add as a validation object so the version is invalid, and the refresh does not fail.

Also catches the recursive exception and also adds as a validation object.