### PR TITLE
Feature/3455/progress towards lazy sourcefiles

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
+import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.Registry;
 import io.dockstore.common.ToolTest;
 import io.dockstore.openapi.client.api.Ga4Ghv20Api;
@@ -425,7 +426,7 @@ public class GeneralIT extends BaseIT {
         io.dockstore.openapi.client.api.EntriesApi entriesApi = new io.dockstore.openapi.client.api.EntriesApi(client);
 
         Workflow workflow = workflowApi
-                .manualRegister("github", "DockstoreTestUser2/hello-dockstore-workflow", "/Dockstore.wdl", "altname", "wdl", "/test.json");
+                .manualRegister("github", "DockstoreTestUser2/hello-dockstore-workflow", "/Dockstore.wdl", "altname", DescriptorLanguage.WDL.getShortName(), "/test.json");
 
         workflow = workflowApi.refresh(workflow.getId());
         SourceFile sourceFile = workflow.getWorkflowVersions().get(0).getSourceFiles().get(0);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -34,17 +34,20 @@ import io.dockstore.common.ToolTest;
 import io.dockstore.openapi.client.api.Ga4Ghv20Api;
 import io.dockstore.openapi.client.model.FileWrapper;
 import io.dockstore.openapi.client.model.Tool;
+import io.dockstore.openapi.client.model.VersionVerifiedPlatform;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.ContainersApi;
 import io.swagger.client.api.ContainertagsApi;
 import io.swagger.client.api.EntriesApi;
 import io.swagger.client.api.UsersApi;
+import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.DockstoreTool;
 import io.swagger.client.model.Entry;
 import io.swagger.client.model.PublishRequest;
 import io.swagger.client.model.SourceFile;
 import io.swagger.client.model.Tag;
+import io.swagger.client.model.Workflow;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Before;
@@ -411,6 +414,41 @@ public class GeneralIT extends BaseIT {
                 });
             });
         });
+    }
+
+    @Test
+    public void testGettingVerifiedVersions() {
+        io.dockstore.openapi.client.ApiClient client = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        io.dockstore.openapi.client.api.WorkflowsApi workflowsOpenApi = new io.dockstore.openapi.client.api.WorkflowsApi(client);
+        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowApi = new WorkflowsApi(webClient);
+        io.dockstore.openapi.client.api.EntriesApi entriesApi = new io.dockstore.openapi.client.api.EntriesApi(client);
+
+        Workflow workflow = workflowApi
+                .manualRegister("github", "DockstoreTestUser2/hello-dockstore-workflow", "/Dockstore.wdl", "altname", "wdl", "/test.json");
+
+        workflow = workflowApi.refresh(workflow.getId());
+        SourceFile sourceFile = workflow.getWorkflowVersions().get(0).getSourceFiles().get(0);
+        PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        workflowApi.publish(workflow.getId(), publishRequest);
+        List<VersionVerifiedPlatform> versionsVerified = entriesApi.getVerifiedPlatforms(workflow.getId());
+        Assert.assertEquals(0, versionsVerified.size());
+
+        testingPostgres.runUpdateStatement("INSERT INTO sourcefile_verified(id, verified, source, metadata) VALUES (" + sourceFile.getId() + ", true, 'Potato CLI', 'Idaho')");
+        versionsVerified = entriesApi.getVerifiedPlatforms(workflow.getId());
+        Assert.assertEquals(1, versionsVerified.size());
+
+        ContainersApi toolApi = new ContainersApi(webClient);
+        DockstoreTool tool = toolApi.getContainerByToolPath("quay.io/dockstoretestuser2/quayandgithub", null);
+        sourceFile = tool.getWorkflowVersions().get(0).getSourceFiles().get(0);
+        toolApi.publish(tool.getId(), publishRequest);
+        versionsVerified = entriesApi.getVerifiedPlatforms(tool.getId());
+        Assert.assertEquals(0, versionsVerified.size());
+
+        testingPostgres.runUpdateStatement("INSERT INTO sourcefile_verified(id, verified, source, metadata) VALUES (" + sourceFile.getId() + ", true, 'Potato CLI', 'Idaho')");
+        versionsVerified = entriesApi.getVerifiedPlatforms(tool.getId());
+        Assert.assertEquals(1, versionsVerified.size());
+
     }
 
     public void verifyTRSSourceFileConversion(final List<FileWrapper> fileWrappers) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -307,7 +307,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
 
         final PermissionsInterface authorizer = PermissionsFactory.getAuthorizer(tokenDAO, configuration);
 
-        final EntryResource entryResource = new EntryResource(toolDAO, configuration);
+        final EntryResource entryResource = new EntryResource(toolDAO, versionDAO, configuration);
         environment.jersey().register(entryResource);
 
         final WorkflowResource workflowResource = new WorkflowResource(httpClient, hibernate.getSessionFactory(), authorizer, entryResource, configuration);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -265,8 +265,8 @@ public class Tool extends Entry<Tool, Tag> {
         return registry + '/' + namespace + '/' + name;
     }
 
-    // Make into actual column, run some migration/script to fill all the rows, and update on refresh.
     /**
+     * TODO: Make into actual column, run some migration/script to fill all the rows, and update on refresh.
      * Calculated property for demonstrating search by language, inefficient
      *
      * @return the languages that this tool supports

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -265,6 +265,7 @@ public class Tool extends Entry<Tool, Tag> {
         return registry + '/' + namespace + '/' + name;
     }
 
+    // Make into actual column, run some migration/script to fill all the rows, and update on refresh.
     /**
      * Calculated property for demonstrating search by language, inefficient
      *

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -73,7 +73,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 // Ensure that the version requested belongs to a workflow a user has access to.
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.Version.findVersionInEntry", query = "SELECT v FROM Version v WHERE :entryId = v.parent.id AND :versionId = v.id"),
-        @NamedQuery(name = "io.dockstore.webservice.core.database.VersionVerifiedPlatfrom.findVerifiedPlatformsForEntry",
+        @NamedQuery(name = "io.dockstore.webservice.core.database.VersionVerifiedPlatform.findEntryVersionsWithVerifiedPlatforms",
                 query = "SELECT new io.dockstore.webservice.core.database.VersionVerifiedPlatform(version.id, KEY(verifiedbysource), verifiedbysource.metadata) FROM Version version "
                         + "INNER JOIN version.sourceFiles as sourcefiles INNER JOIN sourcefiles.verifiedBySource as verifiedbysource WHERE KEY(verifiedbysource) IS NOT NULL AND "
                         + "version.parent.id = :entryId"

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -72,7 +72,12 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 // Ensure that the version requested belongs to a workflow a user has access to.
 @NamedQueries({
-        @NamedQuery(name = "io.dockstore.webservice.core.Version.findVersionInEntry", query = "SELECT v FROM Version v WHERE :entryId = v.parent.id AND :versionId = v.id")
+        @NamedQuery(name = "io.dockstore.webservice.core.Version.findVersionInEntry", query = "SELECT v FROM Version v WHERE :entryId = v.parent.id AND :versionId = v.id"),
+        @NamedQuery(name = "io.dockstore.webservice.core.database.VersionVerifiedPlatfrom.findVerifiedPlatformsForEntry",
+                query = "SELECT new io.dockstore.webservice.core.database.VersionVerifiedPlatform(version.id, KEY(verifiedbysource), verifiedbysource.metadata) FROM Version version "
+                        + "INNER JOIN version.sourceFiles as sourcefiles INNER JOIN sourcefiles.verifiedBySource as verifiedbysource WHERE KEY(verifiedbysource) IS NOT NULL AND "
+                        + "version.parent.id = :entryId"
+        )
 })
 
 @SuppressWarnings("checkstyle:magicnumber")
@@ -117,7 +122,8 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     private ReferenceType referenceType = ReferenceType.UNSET;
 
     // watch out for https://hibernate.atlassian.net/browse/HHH-3799 if this is set to EAGER
-    @OneToMany(fetch = FetchType.EAGER, orphanRemoval = true, cascade = CascadeType.ALL)
+    // Maybe can change to lazy once db column for descriptorType has been made
+    @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
     @JoinTable(name = "version_sourcefile", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "sourcefileid", referencedColumnName = "id"))
     @ApiModelProperty(value = "Cached files for each version. Includes Dockerfile and Descriptor files", position = 6)
     @Cascade(org.hibernate.annotations.CascadeType.DETACH)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -122,9 +122,9 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     private ReferenceType referenceType = ReferenceType.UNSET;
 
     // watch out for https://hibernate.atlassian.net/browse/HHH-3799 if this is set to EAGER
-    // Maybe can change to lazy once db column for descriptorType has been made
-    // @JsonIgnore this field to catch more places in UI that use it.
-    @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
+    // TODO: @JsonIgnore this field to catch more places in UI that use it.
+    // TODO: Change to FetchType.LAZY
+    @OneToMany(fetch = FetchType.EAGER, orphanRemoval = true, cascade = CascadeType.ALL)
     @JoinTable(name = "version_sourcefile", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "sourcefileid", referencedColumnName = "id"))
     @ApiModelProperty(value = "Cached files for each version. Includes Dockerfile and Descriptor files", position = 6)
     @Cascade(org.hibernate.annotations.CascadeType.DETACH)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -123,6 +123,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     // watch out for https://hibernate.atlassian.net/browse/HHH-3799 if this is set to EAGER
     // Maybe can change to lazy once db column for descriptorType has been made
+    // @JsonIgnore this field to catch more places in UI that use it.
     @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
     @JoinTable(name = "version_sourcefile", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "sourcefileid", referencedColumnName = "id"))
     @ApiModelProperty(value = "Cached files for each version. Includes Dockerfile and Descriptor files", position = 6)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/VersionVerifiedPlatform.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/VersionVerifiedPlatform.java
@@ -8,9 +8,9 @@ package io.dockstore.webservice.core.database;
  */
 public class VersionVerifiedPlatform {
 
-    final private Long versionId;
-    final private String metadata;
-    final private String source;
+    private final Long versionId;
+    private final String metadata;
+    private final String source;
 
     public VersionVerifiedPlatform(final Long versionId, final String source, final String metadata) {
         this.versionId = versionId;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/VersionVerifiedPlatform.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/VersionVerifiedPlatform.java
@@ -8,11 +8,11 @@ package io.dockstore.webservice.core.database;
  */
 public class VersionVerifiedPlatform {
 
-    private long versionId;
-    private String metadata;
-    private String source;
+    final private Long versionId;
+    final private String metadata;
+    final private String source;
 
-    public VersionVerifiedPlatform(long versionId, String source, String metadata) {
+    public VersionVerifiedPlatform(final Long versionId, final String source, final String metadata) {
         this.versionId = versionId;
         this.source = source;
         this.metadata = metadata;
@@ -22,23 +22,11 @@ public class VersionVerifiedPlatform {
         return versionId;
     }
 
-    public void setVersionId(final long versionId) {
-        this.versionId = versionId;
-    }
-
     public String getMetadata() {
         return metadata;
     }
 
-    public void setMetadata(final String metadata) {
-        this.metadata = metadata;
-    }
-
     public String getSource() {
         return source;
-    }
-
-    public void setSource(final String source) {
-        this.source = source;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/VersionVerifiedPlatform.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/VersionVerifiedPlatform.java
@@ -1,5 +1,11 @@
 package io.dockstore.webservice.core.database;
 
+/**
+ * This class is a subset of fields from sourcefile and verificationinformation. States what platform (source) a version has been verified on
+ * and who performed the verification (metadata).
+ * @author natalieperez
+ * @since 1.10.0
+ */
 public class VersionVerifiedPlatform {
 
     private long versionId;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/VersionVerifiedPlatform.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/VersionVerifiedPlatform.java
@@ -1,0 +1,38 @@
+package io.dockstore.webservice.core.database;
+
+public class VersionVerifiedPlatform {
+
+    private long versionId;
+    private String metadata;
+    private String source;
+
+    public VersionVerifiedPlatform(long versionId, String source, String metadata) {
+        this.versionId = versionId;
+        this.source = source;
+        this.metadata = metadata;
+    }
+
+    public long getVersionId() {
+        return versionId;
+    }
+
+    public void setVersionId(final long versionId) {
+        this.versionId = versionId;
+    }
+
+    public String getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(final String metadata) {
+        this.metadata = metadata;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(final String source) {
+        this.source = source;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
@@ -49,6 +49,6 @@ public class VersionDAO<T extends Version> extends AbstractDAO<T> {
     }
 
     public List<VersionVerifiedPlatform> findEntryVersionsWithVerifiedPlatforms(Long entryId) {
-        return list(namedQuery("io.dockstore.webservice.core.database.VersionVerifiedPlatfrom.findEntryVersionsWithVerifiedPlatforms").setParameter("entryId", entryId));
+        return list(namedQuery("io.dockstore.webservice.core.database.VersionVerifiedPlatform.findEntryVersionsWithVerifiedPlatforms").setParameter("entryId", entryId));
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
@@ -16,7 +16,10 @@
 
 package io.dockstore.webservice.jdbi;
 
+import java.util.List;
+
 import io.dockstore.webservice.core.Version;
+import io.dockstore.webservice.core.database.VersionVerifiedPlatform;
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.SessionFactory;
 
@@ -43,5 +46,9 @@ public class VersionDAO<T extends Version> extends AbstractDAO<T> {
 
     public Version<T> findVersionInEntry(Long entryId, Long versionId) {
         return uniqueResult(namedQuery("io.dockstore.webservice.core.Version.findVersionInEntry").setParameter("entryId", entryId).setParameter("versionId", versionId));
+    }
+
+    public List<VersionVerifiedPlatform> findEntryVersionsWithVerifiedPlatforms(Long entryId) {
+        return list(namedQuery("io.dockstore.webservice.core.database.VersionVerifiedPlatfrom.findEntryVersionsWithVerifiedPlatforms").setParameter("entryId", entryId));
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -143,7 +143,7 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
     @UnitOfWork
     @Operation(operationId = "getVerifiedPlatforms", description = "Get the verified platforms for each version", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     public List<VersionVerifiedPlatform> getVerifiedPlatforms(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth Optional<User> user,
-            @Parameter(name = "entryId", description = "id of the entry", required = true, in = ParameterIn.PATH) @PathParam("entryId") long entryId) {
+            @Parameter(name = "entryId", description = "id of the entry", required = true, in = ParameterIn.PATH) @PathParam("entryId") Long entryId) {
         Entry<? extends Entry, ? extends Version> entry = toolDAO.getGenericEntryById(entryId);
         checkOptionalAuthRead(user, entry);
         List<VersionVerifiedPlatform> verifiedVersions = versionDAO.findEntryVersionsWithVerifiedPlatforms(entryId);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -137,7 +137,6 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
         return this.toolDAO.findCollectionsByEntryId(entry.getId());
     }
 
-    // TODO: Write tests for this endpoint.
     @GET
     @Path("/{entryId}/verifiedPlatforms")
     @UnitOfWork

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -40,8 +40,10 @@ import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Version;
+import io.dockstore.webservice.core.database.VersionVerifiedPlatform;
 import io.dockstore.webservice.helpers.PublicStateManager;
 import io.dockstore.webservice.jdbi.ToolDAO;
+import io.dockstore.webservice.jdbi.VersionDAO;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.swagger.annotations.Api;
@@ -83,6 +85,7 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
     private static final Logger LOG = LoggerFactory.getLogger(EntryResource.class);
 
     private final ToolDAO toolDAO;
+    private final VersionDAO versionDAO;
     private final TopicsApi topicsApi;
     private final String discourseKey;
     private final String discourseUrl;
@@ -90,8 +93,9 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
     private final String discourseApiUsername = "system";
     private final int maxDescriptionLength = 500;
 
-    public EntryResource(ToolDAO toolDAO, DockstoreWebserviceConfiguration configuration) {
+    public EntryResource(ToolDAO toolDAO, VersionDAO versionDAO, DockstoreWebserviceConfiguration configuration) {
         this.toolDAO = toolDAO;
+        this.versionDAO = versionDAO;
 
         discourseUrl = configuration.getDiscourseUrl();
         discourseKey = configuration.getDiscourseKey();
@@ -131,6 +135,19 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
             throw new CustomWebApplicationException("Published entry does not exist.", HttpStatus.SC_BAD_REQUEST);
         }
         return this.toolDAO.findCollectionsByEntryId(entry.getId());
+    }
+
+    // Write tests for this.
+    @GET
+    @Path("/{entryId}/verifiedPlatforms")
+    @UnitOfWork
+    @Operation(operationId = "getVerifiedPlatforms", description = "Get the verified platforms for each version", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
+    public List<VersionVerifiedPlatform> getVerifiedPlatforms(@Parameter(hidden = true, name = "user")@Auth Optional<User> user,
+            @Parameter(name = "entryId", description = "id of the entry", required = true, in = ParameterIn.PATH) @PathParam("entryId") long entryId) {
+        Entry<? extends Entry, ? extends Version> entry = toolDAO.getGenericEntryById(entryId);
+        checkOptionalAuthRead(user, entry);
+        List<VersionVerifiedPlatform> verifiedVersions = versionDAO.findEntryVersionsWithVerifiedPlatforms(entryId);
+        return verifiedVersions;
     }
 
     @POST

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -140,8 +140,9 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
     @GET
     @Path("/{entryId}/verifiedPlatforms")
     @UnitOfWork
-    @Operation(operationId = "getVerifiedPlatforms", description = "Get the verified platforms for each version", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
-    public List<VersionVerifiedPlatform> getVerifiedPlatforms(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth Optional<User> user,
+    @ApiOperation(value = "Get the verified platforms for each version of an entry.",  hidden = true)
+    @Operation(operationId = "getVerifiedPlatforms", description = "Get the verified platforms for each version of an entry.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
+    public List<VersionVerifiedPlatform> getVerifiedPlatforms(@Parameter(hidden = true, name = "user")@Auth Optional<User> user,
             @Parameter(name = "entryId", description = "id of the entry", required = true, in = ParameterIn.PATH) @PathParam("entryId") Long entryId) {
         Entry<? extends Entry, ? extends Version> entry = toolDAO.getGenericEntryById(entryId);
         checkOptionalAuthRead(user, entry);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -137,12 +137,12 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
         return this.toolDAO.findCollectionsByEntryId(entry.getId());
     }
 
-    // Write tests for this.
+    // TODO: Write tests for this endpoint.
     @GET
     @Path("/{entryId}/verifiedPlatforms")
     @UnitOfWork
     @Operation(operationId = "getVerifiedPlatforms", description = "Get the verified platforms for each version", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
-    public List<VersionVerifiedPlatform> getVerifiedPlatforms(@Parameter(hidden = true, name = "user")@Auth Optional<User> user,
+    public List<VersionVerifiedPlatform> getVerifiedPlatforms(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth Optional<User> user,
             @Parameter(name = "entryId", description = "id of the entry", required = true, in = ParameterIn.PATH) @PathParam("entryId") long entryId) {
         Entry<? extends Entry, ? extends Version> entry = toolDAO.getGenericEntryById(entryId);
         checkOptionalAuthRead(user, entry);

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -24,8 +24,8 @@ components:
           type: object
       type: object
     Checksum:
-      description: 'A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes. '
-      example: '[{checksum=ea2a5db69bd20a42976838790bc29294df3af02b, type=sha1}]'
+      description: A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes.  This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
+      example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182, type=sha256}]'
       properties:
         checksum:
           description: 'The hex-string encoded checksum for the data. '
@@ -1705,7 +1705,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WorkflowVersion'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -3567,7 +3567,7 @@ paths:
         - curation
   /entries/{entryId}/verifiedPlatforms:
     get:
-      description: Get the verified platforms for each version
+      description: Get the verified platforms for each version of an entry.
       operationId: getVerifiedPlatforms
       parameters:
         - description: id of the entry
@@ -3610,7 +3610,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -4474,7 +4474,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Collection'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -6483,7 +6483,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3610,7 +3610,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -14,34 +14,28 @@ components:
       type: object
     BioWorkflow:
       allOf:
-      - $ref: '#/components/schemas/Workflow'
-      - properties:
-          is_checker:
-            type: boolean
-          parent_id:
-            format: int64
-            type: integer
-        type: object
+        - $ref: '#/components/schemas/Workflow'
+        - properties:
+            is_checker:
+              type: boolean
+            parent_id:
+              format: int64
+              type: integer
+          type: object
       type: object
     Checksum:
-      description: 'A production (immutable) tool version is required to have a hashcode.
-        Not required otherwise, but might be useful to detect changes. '
+      description: 'A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes. '
       example: '[{checksum=ea2a5db69bd20a42976838790bc29294df3af02b, type=sha1}]'
       properties:
         checksum:
           description: 'The hex-string encoded checksum for the data. '
           type: string
         type:
-          description: The digest method used to create the checksum. The value (e.g.
-            `sha-256`) SHOULD be listed as `Hash Name String` in the https://github.com/ga4gh-discovery/ga4gh-checksum/blob/master/hash-alg.csv[GA4GH
-            Checksum Hash Algorithm Registry]. Other values MAY be used, as long as
-            implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4[RFC6920].
-            GA4GH may provide more explicit guidance for use of non-IANA-registered
-            algorithms in the future.
+          description: The digest method used to create the checksum. The value (e.g. `sha-256`) SHOULD be listed as `Hash Name String` in the https://github.com/ga4gh-discovery/ga4gh-checksum/blob/master/hash-alg.csv[GA4GH Checksum Hash Algorithm Registry]. Other values MAY be used, as long as implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4[RFC6920]. GA4GH may provide more explicit guidance for use of non-IANA-registered algorithms in the future.
           type: string
       required:
-      - checksum
-      - type
+        - checksum
+        - type
       type: object
     Collection:
       description: Collection in an organization, collects entries
@@ -89,8 +83,8 @@ components:
           example: A collection of alignment algorithms
           type: string
       required:
-      - name
-      - topic
+        - name
+        - topic
       type: object
     CollectionEntry:
       properties:
@@ -373,9 +367,9 @@ components:
       properties:
         entryType:
           enum:
-          - TOOL
-          - WORKFLOW
-          - SERVICE
+            - TOOL
+            - WORKFLOW
+            - SERVICE
           type: string
         lastUpdateDate:
           format: date-time
@@ -393,7 +387,7 @@ components:
         message:
           type: string
       required:
-      - code
+        - code
       type: object
     Event:
       properties:
@@ -416,22 +410,22 @@ components:
           $ref: '#/components/schemas/Tool'
         type:
           enum:
-          - CREATE_ORG
-          - DELETE_ORG
-          - MODIFY_ORG
-          - APPROVE_ORG
-          - REJECT_ORG
-          - REREQUEST_ORG
-          - ADD_USER_TO_ORG
-          - REMOVE_USER_FROM_ORG
-          - MODIFY_USER_ROLE_ORG
-          - APPROVE_ORG_INVITE
-          - REJECT_ORG_INVITE
-          - CREATE_COLLECTION
-          - MODIFY_COLLECTION
-          - REMOVE_FROM_COLLECTION
-          - ADD_TO_COLLECTION
-          - ADD_VERSION_TO_ENTRY
+            - CREATE_ORG
+            - DELETE_ORG
+            - MODIFY_ORG
+            - APPROVE_ORG
+            - REJECT_ORG
+            - REREQUEST_ORG
+            - ADD_USER_TO_ORG
+            - REMOVE_USER_FROM_ORG
+            - MODIFY_USER_ROLE_ORG
+            - APPROVE_ORG_INVITE
+            - REJECT_ORG_INVITE
+            - CREATE_COLLECTION
+            - MODIFY_COLLECTION
+            - REMOVE_FROM_COLLECTION
+            - ADD_TO_COLLECTION
+            - ADD_VERSION_TO_ENTRY
           type: string
         user:
           $ref: '#/components/schemas/User'
@@ -451,16 +445,10 @@ components:
           type: string
       type: object
     FileWrapper:
-      description: 'A file provides content for one of - A tool descriptor is a metadata
-        document that describes one or more tools. - A tool document that describes
-        how to test with one or more sample test JSON. - A containerfile is a document
-        that describes how to build a particular container image. Examples include
-        Dockerfiles for creating Docker images and Singularity recipes for Singularity
-        images '
+      description: 'A file provides content for one of - A tool descriptor is a metadata document that describes one or more tools. - A tool document that describes how to test with one or more sample test JSON. - A containerfile is a document that describes how to build a particular container image. Examples include Dockerfiles for creating Docker images and Singularity recipes for Singularity images '
       properties:
         checksum:
-          description: 'A production (immutable) tool version is required to have
-            a hashcode. Not required otherwise, but might be useful to detect changes. '
+          description: 'A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes. '
           example: '[{checksum=ea2a5db69bd20a42976838790bc29294df3af02b, type=sha1}]'
           items:
             $ref: '#/components/schemas/Checksum'
@@ -469,10 +457,7 @@ components:
           description: The content of the file itself. One of url or content is required.
           type: string
         url:
-          description: Optional url to the underlying content, should include version
-            information, and can include a git hash.  Note that this URL should resolve
-            to the raw unwrapped content that would otherwise be available in content.
-            One of url or content is required.
+          description: Optional url to the underlying content, should include version information, and can include a git hash.  Note that this URL should resolve to the raw unwrapped content that would otherwise be available in content. One of url or content is required.
           type: string
       type: object
     Image:
@@ -487,11 +472,11 @@ components:
           type: string
         imageRegistry:
           enum:
-          - QUAY_IO
-          - DOCKER_HUB
-          - GITLAB
-          - AMAZON_ECR
-          - SEVEN_BRIDGES
+            - QUAY_IO
+            - DOCKER_HUB
+            - GITLAB
+            - AMAZON_ECR
+            - SEVEN_BRIDGES
           type: string
         os:
           type: string
@@ -504,28 +489,22 @@ components:
       description: Describes one container image.
       properties:
         checksum:
-          description: A production (immutable) tool version is required to have a
-            hashcode. Not required otherwise, but might be useful to detect changes.  This
-            exposes the hashcode for specific image versions to verify that the container
-            version pulled is actually the version that was indexed by the registry.
-          example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182,
-            type=sha256}]'
+          description: A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes.  This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
+          example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182, type=sha256}]'
           items:
             $ref: '#/components/schemas/Checksum'
           type: array
         image_name:
-          description: Used in conjunction with a registry_url if provided to locate
-            images.
+          description: Used in conjunction with a registry_url if provided to locate images.
           type: string
         image_type:
           enum:
-          - Docker
-          - Singularity
-          - Conda
+            - Docker
+            - Singularity
+            - Conda
           type: string
         registry_host:
-          description: A docker registry or a URL to a Singularity registry. Used
-            along with image_name to locate a specific image.
+          description: A docker registry or a URL to a Singularity registry. Used along with image_name to locate a specific image.
           type: string
         size:
           description: Size of the container in bytes.
@@ -565,9 +544,9 @@ components:
           type: boolean
         type:
           enum:
-          - PUSH
-          - DELETE
-          - INSTALL
+            - PUSH
+            - DELETE
+            - INSTALL
           type: string
       type: object
     Limits:
@@ -599,14 +578,14 @@ components:
           type: string
         priority:
           enum:
-          - LOW
-          - MEDIUM
-          - CRITICAL
+            - LOW
+            - MEDIUM
+            - CRITICAL
           type: string
         type:
           enum:
-          - SITEWIDE
-          - NEWSBODY
+            - SITEWIDE
+            - NEWSBODY
           type: string
       type: object
     Organization:
@@ -652,9 +631,9 @@ components:
           uniqueItems: true
         status:
           enum:
-          - PENDING
-          - REJECTED
-          - APPROVED
+            - PENDING
+            - REJECTED
+            - APPROVED
           type: string
         topic:
           type: string
@@ -690,8 +669,8 @@ components:
           $ref: '#/components/schemas/Organization'
         role:
           enum:
-          - MAINTAINER
-          - MEMBER
+            - MAINTAINER
+            - MEMBER
           type: string
         user:
           $ref: '#/components/schemas/User'
@@ -711,9 +690,9 @@ components:
           type: string
         role:
           enum:
-          - OWNER
-          - WRITER
-          - READER
+            - OWNER
+            - WRITER
+            - READER
           type: string
       type: object
     Profile:
@@ -759,10 +738,10 @@ components:
           type: boolean
         gitRegistry:
           enum:
-          - dockstore.org
-          - github.com
-          - bitbucket.org
-          - gitlab.com
+            - dockstore.org
+            - github.com
+            - bitbucket.org
+            - gitlab.com
           type: string
         organization:
           type: string
@@ -775,15 +754,15 @@ components:
       type: object
     Service:
       allOf:
-      - $ref: '#/components/schemas/Workflow'
+        - $ref: '#/components/schemas/Workflow'
       type: object
     SharedWorkflows:
       properties:
         role:
           enum:
-          - OWNER
-          - WRITER
-          - READER
+            - OWNER
+            - WRITER
+            - READER
           type: string
         workflows:
           items:
@@ -816,22 +795,22 @@ components:
           type: string
         type:
           enum:
-          - DOCKSTORE_CWL
-          - DOCKSTORE_WDL
-          - DOCKERFILE
-          - CWL_TEST_JSON
-          - WDL_TEST_JSON
-          - NEXTFLOW
-          - NEXTFLOW_CONFIG
-          - NEXTFLOW_TEST_PARAMS
-          - DOCKSTORE_YML
-          - DOCKSTORE_SERVICE_YML
-          - DOCKSTORE_SERVICE_TEST_JSON
-          - DOCKSTORE_SERVICE_OTHER
-          - DOCKSTORE_GXFORMAT2
-          - GXFORMAT2_TEST_FILE
-          - DOCKSTORE_SWL
-          - SWL_TEST_JSON
+            - DOCKSTORE_CWL
+            - DOCKSTORE_WDL
+            - DOCKERFILE
+            - CWL_TEST_JSON
+            - WDL_TEST_JSON
+            - NEXTFLOW
+            - NEXTFLOW_CONFIG
+            - NEXTFLOW_TEST_PARAMS
+            - DOCKSTORE_YML
+            - DOCKSTORE_SERVICE_YML
+            - DOCKSTORE_SERVICE_TEST_JSON
+            - DOCKSTORE_SERVICE_OTHER
+            - DOCKSTORE_GXFORMAT2
+            - GXFORMAT2_TEST_FILE
+            - DOCKSTORE_SWL
+            - SWL_TEST_JSON
           type: string
         verifiedBySource:
           additionalProperties:
@@ -860,8 +839,8 @@ components:
           type: string
         descriptionSource:
           enum:
-          - README
-          - DESCRIPTOR
+            - README
+            - DESCRIPTOR
           type: string
         dirtyBit:
           type: boolean
@@ -869,9 +848,9 @@ components:
           type: string
         doiStatus:
           enum:
-          - NOT_REQUESTED
-          - REQUESTED
-          - CREATED
+            - NOT_REQUESTED
+            - REQUESTED
+            - CREATED
           type: string
         doiURL:
           type: string
@@ -912,11 +891,11 @@ components:
           type: string
         referenceType:
           enum:
-          - COMMIT
-          - TAG
-          - BRANCH
-          - NOT_APPLICABLE
-          - UNSET
+            - COMMIT
+            - TAG
+            - BRANCH
+            - NOT_APPLICABLE
+            - UNSET
           type: string
         size:
           format: int64
@@ -967,14 +946,14 @@ components:
           type: string
         tokenSource:
           enum:
-          - quay.io
-          - github.com
-          - dockstore
-          - bitbucket.org
-          - gitlab.com
-          - zenodo.org
-          - google.com
-          - orcid.org
+            - quay.io
+            - github.com
+            - dockstore
+            - bitbucket.org
+            - gitlab.com
+            - zenodo.org
+            - google.com
+            - orcid.org
           type: string
         userId:
           format: int64
@@ -983,27 +962,16 @@ components:
           type: string
       type: object
     Tool:
-      description: A tool (or described tool) is defined as a tuple of a descriptor
-        file (which potentially consists of multiple files), a set of container images,
-        and a set of instructions for creating those images.
+      description: A tool (or described tool) is defined as a tuple of a descriptor file (which potentially consists of multiple files), a set of container images, and a set of instructions for creating those images.
       properties:
         aliases:
-          description: Support for this parameter is optional for tool registries
-            that support aliases. A list of strings that can be used to identify this
-            tool which could be  straight up URLs.  This can be used to expose alternative
-            ids (such as GUIDs) for a tool for registries. Can be used to match tools
-            across registries.
+          description: Support for this parameter is optional for tool registries that support aliases. A list of strings that can be used to identify this tool which could be  straight up URLs.  This can be used to expose alternative ids (such as GUIDs) for a tool for registries. Can be used to match tools across registries.
           items:
-            description: Support for this parameter is optional for tool registries
-              that support aliases. A list of strings that can be used to identify
-              this tool which could be  straight up URLs.  This can be used to expose
-              alternative ids (such as GUIDs) for a tool for registries. Can be used
-              to match tools across registries.
+            description: Support for this parameter is optional for tool registries that support aliases. A list of strings that can be used to identify this tool which could be  straight up URLs.  This can be used to expose alternative ids (such as GUIDs) for a tool for registries. Can be used to match tools across registries.
             type: string
           type: array
         checker_url:
-          description: Optional url to the checker tool that will exit successfully
-            if this tool produced the expected result given test data.
+          description: Optional url to the checker tool that will exit successfully if this tool produced the expected result given test data.
           type: string
         description:
           description: The description of the tool.
@@ -1016,8 +984,7 @@ components:
           example: "123456"
           type: string
         meta_version:
-          description: The version of this tool in the registry. Iterates when fields
-            like the description, author, etc. are updated.
+          description: The version of this tool in the registry. Iterates when fields like the description, author, etc. are updated.
           type: string
         name:
           description: The name of the tool.
@@ -1037,11 +1004,11 @@ components:
             $ref: '#/components/schemas/ToolVersion'
           type: array
       required:
-      - id
-      - organization
-      - toolclass
-      - url
-      - versions
+        - id
+        - organization
+        - toolclass
+        - url
+        - versions
       type: object
     ToolClass:
       properties:
@@ -1058,16 +1025,16 @@ components:
           type: string
         type:
           enum:
-          - CWL
-          - WDL
-          - NFL
-          - SERVICE
-          - GXFORMAT2
+            - CWL
+            - WDL
+            - NFL
+            - SERVICE
+            - GXFORMAT2
           type: string
         url:
           type: string
       required:
-      - type
+        - type
       type: object
     ToolDockerfile:
       properties:
@@ -1080,15 +1047,14 @@ components:
       properties:
         file_type:
           enum:
-          - TEST_FILE
-          - PRIMARY_DESCRIPTOR
-          - SECONDARY_DESCRIPTOR
-          - CONTAINERFILE
-          - OTHER
+            - TEST_FILE
+            - PRIMARY_DESCRIPTOR
+            - SECONDARY_DESCRIPTOR
+            - CONTAINERFILE
+            - OTHER
           type: string
         path:
-          description: Relative path of the file.  A descriptor's path can be used
-            with the GA4GH .../{type}/descriptor/{relative_path} endpoint.
+          description: Relative path of the file.  A descriptor's path can be used with the GA4GH .../{type}/descriptor/{relative_path} endpoint.
           type: string
       type: object
     ToolTesterLog:
@@ -1097,8 +1063,8 @@ components:
           type: string
         logType:
           enum:
-          - FULL
-          - SUMMARY
+            - FULL
+            - SUMMARY
           type: string
         runner:
           type: string
@@ -1150,65 +1116,51 @@ components:
           type: array
       type: object
     ToolVersion:
-      description: A tool version describes a particular iteration of a tool as described
-        by a reference to a specific image and/or documents.
+      description: A tool version describes a particular iteration of a tool as described by a reference to a specific image and/or documents.
       properties:
         author:
-          description: Contact information for the author of this version of the tool
-            in the registry. (More complex authorship information is handled by the
-            descriptor).
+          description: Contact information for the author of this version of the tool in the registry. (More complex authorship information is handled by the descriptor).
           items:
-            description: Contact information for the author of this version of the
-              tool in the registry. (More complex authorship information is handled
-              by the descriptor).
+            description: Contact information for the author of this version of the tool in the registry. (More complex authorship information is handled by the descriptor).
             type: string
           type: array
         containerfile:
-          description: Reports if this tool has a containerfile available. (For Docker-based
-            tools, this would indicate the presence of a Dockerfile)
+          description: Reports if this tool has a containerfile available. (For Docker-based tools, this would indicate the presence of a Dockerfile)
           type: boolean
         descriptor_type:
           description: The type (or types) of descriptors available.
           items:
             description: The type (or types) of descriptors available.
             enum:
-            - CWL
-            - WDL
-            - NFL
-            - SERVICE
-            - GXFORMAT2
+              - CWL
+              - WDL
+              - NFL
+              - SERVICE
+              - GXFORMAT2
             type: string
           type: array
         id:
-          description: An identifier of the version of this tool for this particular
-            tool registry.
+          description: An identifier of the version of this tool for this particular tool registry.
           example: v1
           type: string
         images:
-          description: All known docker images (and versions/hashes) used by this
-            tool. If the tool has to evaluate any of the docker images strings at
-            runtime, those ones cannot be reported here.
+          description: All known docker images (and versions/hashes) used by this tool. If the tool has to evaluate any of the docker images strings at runtime, those ones cannot be reported here.
           items:
             $ref: '#/components/schemas/ImageData'
           type: array
         included_apps:
-          description: An array of IDs for the applications that are stored inside
-            this tool.
+          description: An array of IDs for the applications that are stored inside this tool.
           example: '[https://bio.tools/tool/mytum.de/SNAP2/1, https://bio.tools/bioexcel_seqqc]'
           items:
-            description: An array of IDs for the applications that are stored inside
-              this tool.
+            description: An array of IDs for the applications that are stored inside this tool.
             example: '[https://bio.tools/tool/mytum.de/SNAP2/1, https://bio.tools/bioexcel_seqqc]'
             type: string
           type: array
         is_production:
-          description: This version of a tool is guaranteed to not change over time
-            (for example, a  tool built from a tag in git as opposed to a branch).
-            A production quality tool  is required to have a checksum
+          description: This version of a tool is guaranteed to not change over time (for example, a  tool built from a tag in git as opposed to a branch). A production quality tool  is required to have a checksum
           type: boolean
         meta_version:
-          description: The version of this tool version in the registry. Iterates
-            when fields like the description, author, etc. are updated.
+          description: The version of this tool version in the registry. Iterates when fields like the description, author, etc. are updated.
           type: string
         name:
           description: The name of the version.
@@ -1221,28 +1173,25 @@ components:
           example: http://agora.broadinstitute.org/tools/123456/versions/1
           type: string
         verified:
-          description: Reports whether this tool has been verified by a specific organization
-            or individual.
+          description: Reports whether this tool has been verified by a specific organization or individual.
           type: boolean
         verified_source:
-          description: Source of metadata that can support a verified tool, such as
-            an email or URL.
+          description: Source of metadata that can support a verified tool, such as an email or URL.
           items:
-            description: Source of metadata that can support a verified tool, such
-              as an email or URL.
+            description: Source of metadata that can support a verified tool, such as an email or URL.
             type: string
           type: array
       required:
-      - id
-      - url
+        - id
+        - url
       type: object
     ToolVersionV1:
       properties:
         descriptor-type:
           items:
             enum:
-            - CWL
-            - WDL
+              - CWL
+              - WDL
             type: string
           type: array
         dockerfile:
@@ -1279,8 +1228,8 @@ components:
           type: string
         privacyPolicyVersion:
           enum:
-          - NONE
-          - PRIVACY_POLICY_VERSION_2_5
+            - NONE
+            - PRIVACY_POLICY_VERSION_2_5
           type: string
         privacyPolicyVersionAcceptanceDate:
           format: date-time
@@ -1292,8 +1241,8 @@ components:
           type: string
         tosversion:
           enum:
-          - NONE
-          - TOS_VERSION_1
+            - NONE
+            - TOS_VERSION_1
           type: string
         tosversionAcceptanceDate:
           format: date-time
@@ -1315,22 +1264,22 @@ components:
           type: string
         type:
           enum:
-          - DOCKSTORE_CWL
-          - DOCKSTORE_WDL
-          - DOCKERFILE
-          - CWL_TEST_JSON
-          - WDL_TEST_JSON
-          - NEXTFLOW
-          - NEXTFLOW_CONFIG
-          - NEXTFLOW_TEST_PARAMS
-          - DOCKSTORE_YML
-          - DOCKSTORE_SERVICE_YML
-          - DOCKSTORE_SERVICE_TEST_JSON
-          - DOCKSTORE_SERVICE_OTHER
-          - DOCKSTORE_GXFORMAT2
-          - GXFORMAT2_TEST_FILE
-          - DOCKSTORE_SWL
-          - SWL_TEST_JSON
+            - DOCKSTORE_CWL
+            - DOCKSTORE_WDL
+            - DOCKERFILE
+            - CWL_TEST_JSON
+            - WDL_TEST_JSON
+            - NEXTFLOW
+            - NEXTFLOW_CONFIG
+            - NEXTFLOW_TEST_PARAMS
+            - DOCKSTORE_YML
+            - DOCKSTORE_SERVICE_YML
+            - DOCKSTORE_SERVICE_TEST_JSON
+            - DOCKSTORE_SERVICE_OTHER
+            - DOCKSTORE_GXFORMAT2
+            - GXFORMAT2_TEST_FILE
+            - DOCKSTORE_SWL
+            - SWL_TEST_JSON
           type: string
         valid:
           type: boolean
@@ -1357,16 +1306,16 @@ components:
           type: string
         descriptionSource:
           enum:
-          - README
-          - DESCRIPTOR
+            - README
+            - DESCRIPTOR
           type: string
         dirtyBit:
           type: boolean
         doiStatus:
           enum:
-          - NOT_REQUESTED
-          - REQUESTED
-          - CREATED
+            - NOT_REQUESTED
+            - REQUESTED
+            - CREATED
           type: string
         doiURL:
           type: string
@@ -1402,11 +1351,11 @@ components:
           type: string
         referenceType:
           enum:
-          - COMMIT
-          - TAG
-          - BRANCH
-          - NOT_APPLICABLE
-          - UNSET
+            - COMMIT
+            - TAG
+            - BRANCH
+            - NOT_APPLICABLE
+            - UNSET
           type: string
         sourceFiles:
           items:
@@ -1472,22 +1421,22 @@ components:
           type: string
         descriptorType:
           enum:
-          - CWL
-          - WDL
-          - gxformat2
-          - SWL
-          - NFL
-          - service
-          
-          
+            - CWL
+            - WDL
+            - gxformat2
+            - SWL
+            - NFL
+            - service
+            
+            
           type: string
         descriptorTypeSubclass:
           enum:
-          - docker-compose
-          - helm
-          - swarm
-          - kubernetes
-          - n/a
+            - docker-compose
+            - helm
+            - swarm
+            - kubernetes
+            - n/a
           type: string
         email:
           type: string
@@ -1529,10 +1478,10 @@ components:
           $ref: '#/components/schemas/Version'
         mode:
           enum:
-          - FULL
-          - STUB
-          - HOSTED
-          - DOCKSTORE_YML
+            - FULL
+            - STUB
+            - HOSTED
+            - DOCKSTORE_YML
           type: string
         organization:
           type: string
@@ -1549,10 +1498,10 @@ components:
           type: string
         sourceControl:
           enum:
-          - dockstore.org
-          - github.com
-          - bitbucket.org
-          - gitlab.com
+            - dockstore.org
+            - github.com
+            - bitbucket.org
+            - gitlab.com
           type: string
         source_control_provider:
           type: string
@@ -1581,7 +1530,7 @@ components:
         workflow_path:
           type: string
       required:
-      - type
+        - type
       type: object
     WorkflowVersion:
       properties:
@@ -1600,16 +1549,16 @@ components:
           type: string
         descriptionSource:
           enum:
-          - README
-          - DESCRIPTOR
+            - README
+            - DESCRIPTOR
           type: string
         dirtyBit:
           type: boolean
         doiStatus:
           enum:
-          - NOT_REQUESTED
-          - REQUESTED
-          - CREATED
+            - NOT_REQUESTED
+            - REQUESTED
+            - CREATED
           type: string
         doiURL:
           type: string
@@ -1650,11 +1599,11 @@ components:
           type: string
         referenceType:
           enum:
-          - COMMIT
-          - TAG
-          - BRANCH
-          - NOT_APPLICABLE
-          - UNSET
+            - COMMIT
+            - TAG
+            - BRANCH
+            - NOT_APPLICABLE
+            - UNSET
           type: string
         sourceFiles:
           items:
@@ -1663,10 +1612,10 @@ components:
           uniqueItems: true
         subClass:
           enum:
-          - DOCKER_COMPOSE
-          - SWARM
-          - KUBERNETES
-          - HELM
+            - DOCKER_COMPOSE
+            - SWARM
+            - KUBERNETES
+            - HELM
           type: string
         valid:
           type: boolean
@@ -1706,10 +1655,7 @@ info:
     email: theglobalalliance@genomicsandhealth.org
     name: Dockstore@ga4gh
     url: https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506
-  description: This describes the dockstore API, a webservice that manages pairs of
-    Docker images and associated metadata such as CWL documents and Dockerfiles used
-    to build those images. Explore swagger.json for a Swagger 2.0 description of our
-    API and explore openapi.yaml for OpenAPI 3.0 descriptions.
+  description: This describes the dockstore API, a webservice that manages pairs of Docker images and associated metadata such as CWL documents and Dockerfiles used to build those images. Explore swagger.json for a Swagger 2.0 description of our API and explore openapi.yaml for OpenAPI 3.0 descriptions.
   license:
     name: Apache License Version 2.0
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
@@ -1723,11 +1669,11 @@ paths:
       description: Retrieves workflow version path information by alias.
       operationId: getWorkflowVersionPathInfoByAlias
       parameters:
-      - in: path
-        name: alias
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: alias
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -1736,78 +1682,77 @@ paths:
                 $ref: '#/components/schemas/WorkflowVersionPathInfo'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - aliases
+        - aliases
   /aliases/workflow-versions/{workflowVersionId}:
     post:
       description: Add aliases linked to a workflow version in Dockstore.
       operationId: addAliases_1
       parameters:
-      - in: path
-        name: workflowVersionId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: aliases
-        schema:
-          type: string
+        - in: path
+          name: workflowVersionId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: aliases
+          schema:
+            type: string
       responses:
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/WorkflowVersion'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - aliases
+        - aliases
   /api/ga4gh/v1/tools:
     get:
-      description: This endpoint returns all tools available or a filtered subset
-        using metadata query parameters.
+      description: This endpoint returns all tools available or a filtered subset using metadata query parameters.
       operationId: toolsGetV1
       parameters:
-      - in: query
-        name: id
-        schema:
-          type: string
-      - in: query
-        name: registry
-        schema:
-          type: string
-      - in: query
-        name: organization
-        schema:
-          type: string
-      - in: query
-        name: name
-        schema:
-          type: string
-      - in: query
-        name: toolname
-        schema:
-          type: string
-      - in: query
-        name: description
-        schema:
-          type: string
-      - in: query
-        name: author
-        schema:
-          type: string
-      - in: query
-        name: offset
-        schema:
-          type: string
-      - in: query
-        name: limit
-        schema:
-          format: int32
-          type: integer
+        - in: query
+          name: id
+          schema:
+            type: string
+        - in: query
+          name: registry
+          schema:
+            type: string
+        - in: query
+          name: organization
+          schema:
+            type: string
+        - in: query
+          name: name
+          schema:
+            type: string
+        - in: query
+          name: toolname
+          schema:
+            type: string
+        - in: query
+          name: description
+          schema:
+            type: string
+        - in: query
+          name: author
+          schema:
+            type: string
+        - in: query
+          name: offset
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            format: int32
+            type: integer
       responses:
         "200":
           content:
@@ -1819,18 +1764,17 @@ paths:
           description: An array of Tools that match the filter.
       summary: List all tools
       tags:
-      - GA4GHV1
+        - GA4GHV1
   /api/ga4gh/v1/tools/{id}:
     get:
-      description: This endpoint returns one specific tool (which has ToolVersions
-        nested inside it)
+      description: This endpoint returns one specific tool (which has ToolVersions nested inside it)
       operationId: toolsIdGetV1
       parameters:
-      - in: path
-        name: id
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -1840,17 +1784,17 @@ paths:
           description: A tool.
       summary: List one specific tool, acts as an anchor for self references
       tags:
-      - GA4GHV1
+        - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions:
     get:
       description: Returns all versions of the specified tool
       operationId: toolsIdVersionGetV1
       parameters:
-      - in: path
-        name: id
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -1862,22 +1806,22 @@ paths:
           description: An array of tool versions
       summary: List versions of a tool
       tags:
-      - GA4GHV1
+        - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions/{version_id}:
     get:
       description: This endpoint returns one specific tool version
       operationId: versionIdGetV1
       parameters:
-      - in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: version_id
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: version_id
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -1887,22 +1831,22 @@ paths:
           description: A tool version.
       summary: List one specific tool version, acts as an anchor for self references
       tags:
-      - GA4GHV1
+        - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions/{version_id}/dockerfile:
     get:
       description: Returns the dockerfile for the specified image.
       operationId: dockerfileGetV1
       parameters:
-      - in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: version_id
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: version_id
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -1912,27 +1856,27 @@ paths:
           description: The tool payload.
       summary: Get the dockerfile for the specified image.
       tags:
-      - GA4GHV1
+        - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/descriptor:
     get:
       description: Returns the CWL or WDL descriptor for the specified tool.
       operationId: descriptorGetV1
       parameters:
-      - in: path
-        name: type
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: version_id
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: type
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: version_id
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -1948,33 +1892,32 @@ paths:
           description: The tool can not be output in the specified type.
       summary: Get the tool descriptor (CWL/WDL) for the specified tool.
       tags:
-      - GA4GHV1
+        - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}:
     get:
-      description: Returns additional CWL or WDL descriptors for the specified tool
-        in the same or subdirectories
+      description: Returns additional CWL or WDL descriptors for the specified tool in the same or subdirectories
       operationId: relativeDescriptorGetV1
       parameters:
-      - in: path
-        name: type
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: version_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: relative_path
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: type
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: version_id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: relative_path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -1988,29 +1931,28 @@ paths:
               schema:
                 $ref: '#/components/schemas/ToolDescriptor'
           description: The tool can not be output in the specified type.
-      summary: Get additional tool descriptor files (CWL/WDL) relative to the main
-        file
+      summary: Get additional tool descriptor files (CWL/WDL) relative to the main file
       tags:
-      - GA4GHV1
+        - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/tests:
     get:
       operationId: testsGetV1
       parameters:
-      - in: path
-        name: type
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: version_id
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: type
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: version_id
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -2030,17 +1972,17 @@ paths:
           description: The tool can not be output in the specified type.
       summary: Get an array of test JSONs suitable for use with this descriptor type.
       tags:
-      - GA4GHV1
+        - GA4GHV1
   /api/ga4gh/v2/extended/containers/{organization}:
     get:
       description: This endpoint returns entries of an organization.
       operationId: entriesOrgGet
       parameters:
-      - in: path
-        name: organization
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: organization
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -2052,7 +1994,7 @@ paths:
           description: An array of Tools of the input organization.
       summary: List entries of an organization
       tags:
-      - extendedGA4GH
+        - extendedGA4GH
   /api/ga4gh/v2/extended/organizations:
     get:
       description: This endpoint returns list of all organizations.
@@ -2068,11 +2010,10 @@ paths:
           description: An array of organizations' names.
       summary: List all organizations
       tags:
-      - extendedGA4GH
+        - extendedGA4GH
   /api/ga4gh/v2/extended/tools/entry/_search:
     post:
-      description: This endpoint searches the index for all published tools and workflows.
-        Used by utilities that expect to talk to an elastic search endpoint.
+      description: This endpoint searches the index for all published tools and workflows. Used by utilities that expect to talk to an elastic search endpoint.
       operationId: toolsIndexSearch
       requestBody:
         content:
@@ -2088,7 +2029,7 @@ paths:
           description: An elastic search result.
       summary: Search the index of tools
       tags:
-      - extendedGA4GH
+        - extendedGA4GH
   /api/ga4gh/v2/extended/tools/index:
     post:
       description: This endpoint updates the index for all published tools and workflows.
@@ -2101,20 +2042,20 @@ paths:
                 type: integer
           description: An array of Tools of the input organization.
       security:
-      - bearer: []
+        - bearer: []
       summary: Update the index of tools
       tags:
-      - extendedGA4GH
+        - extendedGA4GH
   /api/ga4gh/v2/extended/tools/{organization}:
     get:
       description: This endpoint returns tools of an organization.
       operationId: toolsOrgGet
       parameters:
-      - in: path
-        name: organization
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: organization
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -2126,17 +2067,17 @@ paths:
           description: An array of Tools of the input organization.
       summary: List tools of an organization
       tags:
-      - extendedGA4GH
+        - extendedGA4GH
   /api/ga4gh/v2/extended/workflows/{organization}:
     get:
       description: This endpoint returns workflows of an organization.
       operationId: workflowsOrgGet
       parameters:
-      - in: path
-        name: organization
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: organization
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -2148,49 +2089,48 @@ paths:
           description: An array of Tools of the input organization.
       summary: List workflows of an organization
       tags:
-      - extendedGA4GH
+        - extendedGA4GH
   /api/ga4gh/v2/extended/{id}/versions/{version_id}/{type}/tests/{relative_path}:
     post:
-      description: Test JSON can be annotated with whether they ran correctly keyed
-        by platform and associated with some metadata.
+      description: Test JSON can be annotated with whether they ran correctly keyed by platform and associated with some metadata.
       operationId: verifyTestParameterFilePost
       parameters:
-      - in: path
-        name: type
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: version_id
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: relative_path
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: platform
-        schema:
-          type: string
-      - in: query
-        name: platform_version
-        schema:
-          type: string
-      - in: query
-        name: verified
-        schema:
-          type: boolean
-      - in: query
-        name: metadata
-        schema:
-          type: string
+        - in: path
+          name: type
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: version_id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: relative_path
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: platform
+          schema:
+            type: string
+        - in: query
+          name: platform_version
+          schema:
+            type: string
+        - in: query
+          name: verified
+          schema:
+            type: boolean
+        - in: query
+          name: metadata
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -2211,20 +2151,19 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool test cannot be found to annotate.
       security:
-      - bearer: []
-      summary: Annotate test JSON with information on whether it ran successfully
-        on particular platforms plus metadata
+        - bearer: []
+      summary: Annotate test JSON with information on whether it ran successfully on particular platforms plus metadata
       tags:
-      - extendedGA4GH
+        - extendedGA4GH
   /auth/tokens/bitbucket.org:
     get:
       description: Add a new bitbucket.org token, used by quay.io redirect.
       operationId: addBitbucketToken
       parameters:
-      - in: query
-        name: code
-        schema:
-          type: string
+        - in: query
+          name: code
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2233,13 +2172,12 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - tokens
+        - tokens
   /auth/tokens/github:
     post:
-      description: Allow satellizer to post a new GitHub token to dockstore, used
-        by login, can create new users.
+      description: Allow satellizer to post a new GitHub token to dockstore, used by login, can create new users.
       operationId: addToken
       requestBody:
         content:
@@ -2254,18 +2192,18 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - tokens
+        - tokens
   /auth/tokens/github.com:
     get:
       description: Add a new github.com token, used by accounts page.
       operationId: addGithubToken
       parameters:
-      - in: query
-        name: code
-        schema:
-          type: string
+        - in: query
+          name: code
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2274,18 +2212,18 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - tokens
+        - tokens
   /auth/tokens/gitlab.com:
     get:
       description: Add a new gitlab.com token.
       operationId: addGitlabToken
       parameters:
-      - in: query
-        name: code
-        schema:
-          type: string
+        - in: query
+          name: code
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2294,9 +2232,9 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - tokens
+        - tokens
   /auth/tokens/google:
     post:
       description: Allow satellizer to post a new Google token to Dockstore.
@@ -2314,19 +2252,18 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - tokens
+        - tokens
   /auth/tokens/orcid.org:
     post:
-      description: Using OAuth code from ORCID, request and store tokens from ORCID
-        API
+      description: Using OAuth code from ORCID, request and store tokens from ORCID API
       operationId: addOrcidToken
       parameters:
-      - in: query
-        name: code
-        schema:
-          type: string
+        - in: query
+          name: code
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2335,19 +2272,19 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Add a new orcid.org token
       tags:
-      - tokens
+        - tokens
   /auth/tokens/quay.io:
     get:
       description: Add a new quay IO token.
       operationId: addQuayToken
       parameters:
-      - in: query
-        name: access_token
-        schema:
-          type: string
+        - in: query
+          name: access_token
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2356,18 +2293,18 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - tokens
+        - tokens
   /auth/tokens/zenodo.org:
     get:
       description: Add a new zenodo.org token, used by accounts page.
       operationId: addZenodoToken
       parameters:
-      - in: query
-        name: code
-        schema:
-          type: string
+        - in: query
+          name: code
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2376,39 +2313,39 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - tokens
+        - tokens
   /auth/tokens/{tokenId}:
     delete:
       description: Delete a token.
       operationId: deleteToken
       parameters:
-      - in: path
-        name: tokenId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: tokenId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - tokens
+        - tokens
     get:
       description: Get a specific token by id.
       operationId: listToken
       parameters:
-      - in: path
-        name: tokenId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: tokenId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -2417,9 +2354,9 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - tokens
+        - tokens
   /containers/dockerRegistryList:
     get:
       description: Get the list of docker registries supported on Dockstore.
@@ -2434,32 +2371,32 @@ paths:
                 type: array
           description: default response
       tags:
-      - containers
+        - containers
   /containers/hostedEntry:
     post:
       description: Create a hosted tool.
       operationId: createHostedTool_1
       parameters:
-      - in: query
-        name: registry
-        schema:
-          type: string
-      - in: query
-        name: name
-        schema:
-          type: string
-      - in: query
-        name: descriptorType
-        schema:
-          type: string
-      - in: query
-        name: namespace
-        schema:
-          type: string
-      - in: query
-        name: entryName
-        schema:
-          type: string
+        - in: query
+          name: registry
+          schema:
+            type: string
+        - in: query
+          name: name
+          schema:
+            type: string
+        - in: query
+          name: descriptorType
+          schema:
+            type: string
+        - in: query
+          name: namespace
+          schema:
+            type: string
+        - in: query
+          name: entryName
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2468,24 +2405,24 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - hosted
+        - hosted
   /containers/hostedEntry/{entryId}:
     delete:
       description: Delete a revision of a hosted tool.
       operationId: deleteHostedToolVersion_1
       parameters:
-      - in: path
-        name: entryId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: version
-        schema:
-          type: string
+        - in: path
+          name: entryId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: version
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2494,19 +2431,19 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - hosted
+        - hosted
     patch:
       description: Non-idempotent operation for creating new revisions of hosted tools.
       operationId: editHostedTool
       parameters:
-      - in: path
-        name: entryId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: entryId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -2523,19 +2460,19 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - hosted
+        - hosted
   /containers/namespace/{namespace}/published:
     get:
       description: List all published tools belonging to the specified namespace.
       operationId: getPublishedContainersByNamespace
       parameters:
-      - in: path
-        name: namespace
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: namespace
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2546,21 +2483,21 @@ paths:
                 type: array
           description: default response
       tags:
-      - containers
+        - containers
   /containers/path/tool/{repository}:
     get:
       description: Get a tool by the specific tool path
       operationId: getContainerByToolPath
       parameters:
-      - in: path
-        name: repository
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: include
-        schema:
-          type: string
+        - in: path
+          name: repository
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: include
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2569,23 +2506,23 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/path/tool/{repository}/published:
     get:
       description: Get a published tool by the specific tool path.
       operationId: getPublishedContainerByToolPath
       parameters:
-      - in: path
-        name: repository
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: include
-        schema:
-          type: string
+        - in: path
+          name: repository
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: include
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2594,18 +2531,18 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       tags:
-      - containers
+        - containers
   /containers/path/{containerId}/tags:
     get:
       description: Get tags for a tool by id.
       operationId: getTagsByPath
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -2617,19 +2554,19 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containertags
+        - containertags
   /containers/path/{repository}:
     get:
       description: Get a list of tools by path.
       operationId: getContainerByPath
       parameters:
-      - in: path
-        name: repository
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: repository
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2640,19 +2577,19 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/path/{repository}/published:
     get:
       description: Get a list of published tools by path.
       operationId: getPublishedContainerByPath
       parameters:
-      - in: path
-        name: repository
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: repository
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2663,39 +2600,39 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/published:
     get:
       description: List all published tools.
       operationId: allPublishedContainers
       parameters:
-      - in: query
-        name: offset
-        schema:
-          type: string
-      - in: query
-        name: limit
-        schema:
-          default: 100
-          format: int32
-          type: integer
-      - in: query
-        name: filter
-        schema:
-          default: ""
-          type: string
-      - in: query
-        name: sortCol
-        schema:
-          default: stars
-          type: string
-      - in: query
-        name: sortOrder
-        schema:
-          default: desc
-          type: string
+        - in: query
+          name: offset
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            default: 100
+            format: int32
+            type: integer
+        - in: query
+          name: filter
+          schema:
+            default: ""
+            type: string
+        - in: query
+          name: sortCol
+          schema:
+            default: stars
+            type: string
+        - in: query
+          name: sortOrder
+          schema:
+            default: desc
+            type: string
       responses:
         default:
           content:
@@ -2706,7 +2643,7 @@ paths:
                 type: array
           description: default response
       tags:
-      - containers
+        - containers
   /containers/registerManual:
     post:
       description: Register a tool manually, along with tags.
@@ -2724,20 +2661,20 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/schema/{containerId}/published:
     get:
       description: Get a published tool's schema by ID.
       operationId: getPublishedContainerSchema
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -2748,17 +2685,17 @@ paths:
                 type: array
           description: default response
       tags:
-      - containers
+        - containers
   /containers/tags:
     get:
       description: List the tags for a tool.
       operationId: tags
       parameters:
-      - in: query
-        name: containerId
-        schema:
-          format: int64
-          type: integer
+        - in: query
+          name: containerId
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -2769,19 +2706,19 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{alias}/aliases:
     get:
       description: Retrieves a tool by alias.
       operationId: getToolByAlias
       parameters:
-      - in: path
-        name: alias
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: alias
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2790,43 +2727,43 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{containerId}:
     delete:
       description: Delete a tool.
       operationId: deleteContainer
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
     get:
       description: Retrieve a tool
       operationId: getContainer
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: include
-        schema:
-          type: string
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: include
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2835,19 +2772,19 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
     put:
       description: Update the tool with the given tool.
       operationId: updateContainer
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -2861,33 +2798,33 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{containerId}/descriptor/{relative-path}:
     get:
       description: Get the corresponding descriptor file.
       operationId: secondaryDescriptorPath
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: tag
-        schema:
-          type: string
-      - in: path
-        name: relative-path
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: language
-        schema:
-          type: string
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: tag
+          schema:
+            type: string
+        - in: path
+          name: relative-path
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: language
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2896,24 +2833,24 @@ paths:
                 $ref: '#/components/schemas/SourceFile'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{containerId}/dockerfile:
     get:
       description: Get the corresponding Dockerfile.
       operationId: dockerfile
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: tag
-        schema:
-          type: string
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: tag
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2922,24 +2859,24 @@ paths:
                 $ref: '#/components/schemas/SourceFile'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{containerId}/labels:
     put:
       description: Update the labels linked to a tool.
       operationId: updateLabels
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: labels
-        schema:
-          type: string
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: labels
+          schema:
+            type: string
       requestBody:
         content:
           '*/*':
@@ -2953,28 +2890,28 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{containerId}/primaryDescriptor:
     get:
       description: Get the primary descriptor file.
       operationId: primaryDescriptor
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: tag
-        schema:
-          type: string
-      - in: query
-        name: language
-        schema:
-          type: string
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: tag
+          schema:
+            type: string
+        - in: query
+          name: language
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -2983,20 +2920,20 @@ paths:
                 $ref: '#/components/schemas/SourceFile'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{containerId}/publish:
     post:
       description: Publish or unpublish a tool.
       operationId: publish
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -3010,20 +2947,20 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{containerId}/refresh:
     get:
       description: Refresh one particular tool.
       operationId: refresh
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -3032,26 +2969,26 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{containerId}/requestDOI/{tagId}:
     post:
       description: Request a DOI for this version of a tool.
       operationId: requestDOIForToolTag
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: path
-        name: tagId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: tagId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -3063,28 +3000,28 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containertags
+        - containertags
   /containers/{containerId}/secondaryDescriptors:
     get:
       description: Get a list of secondary descriptor files.
       operationId: secondaryDescriptors
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: tag
-        schema:
-          type: string
-      - in: query
-        name: language
-        schema:
-          type: string
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: tag
+          schema:
+            type: string
+        - in: query
+          name: language
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -3095,20 +3032,20 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{containerId}/star:
     put:
       description: Star a tool.
       operationId: starEntry
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -3120,20 +3057,20 @@ paths:
             application/json: {}
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{containerId}/starredUsers:
     get:
       description: Returns list of users who starred a tool.
       operationId: getStarredUsers
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -3145,18 +3082,18 @@ paths:
                 uniqueItems: true
           description: default response
       tags:
-      - containers
+        - containers
   /containers/{containerId}/tags:
     post:
       description: Add new tags linked to a tool.
       operationId: addTags
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -3175,19 +3112,19 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containertags
+        - containertags
     put:
       description: Update the tags linked to a tool.
       operationId: updateTags
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -3206,78 +3143,78 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containertags
+        - containertags
   /containers/{containerId}/tags/{tagId}:
     delete:
       description: Delete tag linked to a tool.
       operationId: deleteTags
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: path
-        name: tagId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: tagId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containertags
+        - containertags
   /containers/{containerId}/tags/{tagId}/sourcefiles:
     get:
       description: Retrieve sourcefiles for a container's version
       operationId: getTagsSourcefiles
       parameters:
-      - description: Container to retrieve the version from
-        in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Tag to retrieve the sourcefiles from
-        in: path
-        name: tagId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: List of file types to filter sourcefiles by
-        in: query
-        name: fileTypes
-        schema:
-          items:
-            enum:
-            - DOCKSTORE_CWL
-            - DOCKSTORE_WDL
-            - DOCKERFILE
-            - CWL_TEST_JSON
-            - WDL_TEST_JSON
-            - NEXTFLOW
-            - NEXTFLOW_CONFIG
-            - NEXTFLOW_TEST_PARAMS
-            - DOCKSTORE_YML
-            - DOCKSTORE_SERVICE_YML
-            - DOCKSTORE_SERVICE_TEST_JSON
-            - DOCKSTORE_SERVICE_OTHER
-            - DOCKSTORE_GXFORMAT2
-            - GXFORMAT2_TEST_FILE
-            - DOCKSTORE_SWL
-            - SWL_TEST_JSON
-            type: string
-          type: array
+        - description: Container to retrieve the version from
+          in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Tag to retrieve the sourcefiles from
+          in: path
+          name: tagId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: List of file types to filter sourcefiles by
+          in: query
+          name: fileTypes
+          schema:
+            items:
+              enum:
+                - DOCKSTORE_CWL
+                - DOCKSTORE_WDL
+                - DOCKERFILE
+                - CWL_TEST_JSON
+                - WDL_TEST_JSON
+                - NEXTFLOW
+                - NEXTFLOW_CONFIG
+                - NEXTFLOW_TEST_PARAMS
+                - DOCKSTORE_YML
+                - DOCKSTORE_SERVICE_YML
+                - DOCKSTORE_SERVICE_TEST_JSON
+                - DOCKSTORE_SERVICE_OTHER
+                - DOCKSTORE_GXFORMAT2
+                - GXFORMAT2_TEST_FILE
+                - DOCKSTORE_SWL
+                - SWL_TEST_JSON
+              type: string
+            type: array
       responses:
         default:
           content:
@@ -3289,34 +3226,34 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containertags
+        - containertags
   /containers/{containerId}/testParameterFiles:
     delete:
       description: Delete test parameter files to a tag.
       operationId: deleteTestParameterFiles
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: testParameterPaths
-        schema:
-          items:
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: testParameterPaths
+          schema:
+            items:
+              type: string
+            type: array
+        - in: query
+          name: tagName
+          schema:
             type: string
-          type: array
-      - in: query
-        name: tagName
-        schema:
-          type: string
-      - in: query
-        name: descriptorType
-        schema:
-          type: string
+        - in: query
+          name: descriptorType
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -3328,27 +3265,27 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
     get:
       description: Get the corresponding test parameter files.
       operationId: getTestParameterFiles
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: tag
-        schema:
-          type: string
-      - in: query
-        name: descriptorType
-        schema:
-          type: string
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: tag
+          schema:
+            type: string
+        - in: query
+          name: descriptorType
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -3359,33 +3296,33 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
     put:
       description: Add test parameter files to a tag.
       operationId: addTestParameterFiles
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: testParameterPaths
-        schema:
-          items:
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: testParameterPaths
+          schema:
+            items:
+              type: string
+            type: array
+        - in: query
+          name: tagName
+          schema:
             type: string
-          type: array
-      - in: query
-        name: tagName
-        schema:
-          type: string
-      - in: query
-        name: descriptorType
-        schema:
-          type: string
+        - in: query
+          name: descriptorType
+          schema:
+            type: string
       requestBody:
         content:
           '*/*':
@@ -3402,40 +3339,40 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{containerId}/unstar:
     delete:
       description: Unstar a tool.
       operationId: unstarEntry
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{containerId}/updateTagPaths:
     put:
       description: Change the tool paths.
       operationId: updateTagContainerPath
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -3449,20 +3386,20 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{containerId}/users:
     get:
       description: Get users of a tool.
       operationId: getUsers
       parameters:
-      - in: path
-        name: containerId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: containerId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -3473,20 +3410,20 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{toolId}/defaultVersion:
     put:
       description: Update the default version of the given tool.
       operationId: updateDefaultVersion
       parameters:
-      - in: path
-        name: toolId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: toolId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -3500,35 +3437,35 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /containers/{toolId}/zip/{tagId}:
     get:
       description: Download a ZIP file of a tool and all associated files.
       operationId: getToolZip
       parameters:
-      - in: path
-        name: toolId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: path
-        name: tagId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: toolId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: tagId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
             application/zip: {}
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - containers
+        - containers
   /curation/notifications:
     get:
       description: Return all active notifications
@@ -3543,7 +3480,7 @@ paths:
                 type: array
           description: default response
       tags:
-      - curation
+        - curation
     post:
       description: Create a notification
       operationId: createNotification
@@ -3560,39 +3497,39 @@ paths:
                 $ref: '#/components/schemas/Notification'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - curation
+        - curation
   /curation/notifications/{id}:
     delete:
       description: Delete a notification
       operationId: deleteNotification
       parameters:
-      - in: path
-        name: id
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - curation
+        - curation
     get:
       description: Return the notification with given id
       operationId: getNotification
       parameters:
-      - in: path
-        name: id
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -3601,17 +3538,17 @@ paths:
                 $ref: '#/components/schemas/Notification'
           description: default response
       tags:
-      - curation
+        - curation
     put:
       description: Update a notification
       operationId: updateNotification
       parameters:
-      - in: path
-        name: id
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -3625,21 +3562,21 @@ paths:
                 $ref: '#/components/schemas/Notification'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - curation
+        - curation
   /entries/{entryId}/verifiedPlatforms:
     get:
       description: Get the verified platforms for each version
       operationId: getVerifiedPlatforms
       parameters:
-      - description: id of the entry
-        in: path
-        name: entryId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: id of the entry
+          in: path
+          name: entryId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -3650,47 +3587,46 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - entries
+        - entries
   /entries/{id}/aliases:
     post:
       description: Add aliases linked to a entry in Dockstore.
       operationId: addAliases_2
       parameters:
-      - in: path
-        name: id
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: aliases
-        schema:
-          type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: aliases
+          schema:
+            type: string
       responses:
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - entries
+        - entries
   /entries/{id}/collections:
     get:
-      description: Get the collections and organizations that contain the published
-        entry
+      description: Get the collections and organizations that contain the published entry
       operationId: entryCollections
       parameters:
-      - in: path
-        name: id
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -3701,19 +3637,19 @@ paths:
                 type: array
           description: default response
       tags:
-      - entries
+        - entries
   /entries/{id}/topic:
     post:
       description: Create a discourse topic for an entry.
       operationId: setDiscourseTopic
       parameters:
-      - description: The id of the entry to add a topic to.
-        in: path
-        name: id
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: The id of the entry to add a topic to.
+          in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -3722,36 +3658,36 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - entries
+        - entries
   /events:
     get:
       description: Optional authentication.
       operationId: getEvents
       parameters:
-      - in: query
-        name: event_search_type
-        schema:
-          enum:
-          - STARRED_ENTRIES
-          - STARRED_ORGANIZATION
-          - ALL_STARRED
-          type: string
-      - in: query
-        name: limit
-        schema:
-          default: 10
-          format: int32
-          maximum: 100
-          minimum: 1
-          type: integer
-      - in: query
-        name: offset
-        schema:
-          default: 0
-          format: int32
-          type: integer
+        - in: query
+          name: event_search_type
+          schema:
+            enum:
+              - STARRED_ENTRIES
+              - STARRED_ORGANIZATION
+              - ALL_STARRED
+            type: string
+        - in: query
+          name: limit
+          schema:
+            default: 10
+            format: int32
+            maximum: 100
+            minimum: 1
+            type: integer
+        - in: query
+          name: offset
+          schema:
+            default: 0
+            format: int32
+            type: integer
       responses:
         default:
           content:
@@ -3762,10 +3698,10 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Get events based on filters.
       tags:
-      - events
+        - events
   /ga4gh/trs/v2/toolClasses:
     get:
       description: 'This endpoint returns all tool-classes available. '
@@ -3785,83 +3721,76 @@ paths:
                 type: array
           description: A list of potential tool classes.
       security:
-      - BEARER: []
+        - BEARER: []
       summary: List all tool types
       tags:
-      - GA4GHV20
+        - GA4GHV20
   /ga4gh/trs/v2/tools:
     get:
-      description: 'This endpoint returns all tools available or a filtered subset
-        using metadata query parameters. '
+      description: 'This endpoint returns all tools available or a filtered subset using metadata query parameters. '
       operationId: toolsGet
       parameters:
-      - description: A unique identifier of the tool, scoped to this registry, for
-          example `123456`.
-        in: query
-        name: id
-        schema:
-          type: string
-      - description: Support for this parameter is optional for tool registries that
-          support aliases. If provided will only return entries with the given alias.
-        in: query
-        name: alias
-        schema:
-          type: string
-      - description: Filter tools by the name of the subclass (#/definitions/ToolClass)
-        in: query
-        name: toolClass
-        schema:
-          type: string
-      - description: The image registry that contains the image.
-        in: query
-        name: registry
-        schema:
-          type: string
-      - description: The organization in the registry that published the image.
-        in: query
-        name: organization
-        schema:
-          type: string
-      - description: The name of the image.
-        in: query
-        name: name
-        schema:
-          type: string
-      - description: The name of the tool.
-        in: query
-        name: toolname
-        schema:
-          type: string
-      - description: The description of the tool.
-        in: query
-        name: description
-        schema:
-          type: string
-      - description: The author of the tool (TODO a thought occurs, are we assuming
-          that the author of the CWL and the image are the same?).
-        in: query
-        name: author
-        schema:
-          type: string
-      - description: Return only checker workflows.
-        in: query
-        name: checker
-        schema:
-          type: boolean
-      - description: Start index of paging. Pagination results can be based on numbers
-          or other values chosen by the registry implementor (for example, SHA values).
-          If this exceeds the current result set return an empty set.  If not specified
-          in the request, this will start at the beginning of the results.
-        in: query
-        name: offset
-        schema:
-          type: string
-      - description: Amount of records to return in a given page.
-        in: query
-        name: limit
-        schema:
-          format: int32
-          type: integer
+        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
+          in: query
+          name: id
+          schema:
+            type: string
+        - description: Support for this parameter is optional for tool registries that support aliases. If provided will only return entries with the given alias.
+          in: query
+          name: alias
+          schema:
+            type: string
+        - description: Filter tools by the name of the subclass (#/definitions/ToolClass)
+          in: query
+          name: toolClass
+          schema:
+            type: string
+        - description: The image registry that contains the image.
+          in: query
+          name: registry
+          schema:
+            type: string
+        - description: The organization in the registry that published the image.
+          in: query
+          name: organization
+          schema:
+            type: string
+        - description: The name of the image.
+          in: query
+          name: name
+          schema:
+            type: string
+        - description: The name of the tool.
+          in: query
+          name: toolname
+          schema:
+            type: string
+        - description: The description of the tool.
+          in: query
+          name: description
+          schema:
+            type: string
+        - description: The author of the tool (TODO a thought occurs, are we assuming that the author of the CWL and the image are the same?).
+          in: query
+          name: author
+          schema:
+            type: string
+        - description: Return only checker workflows.
+          in: query
+          name: checker
+          schema:
+            type: boolean
+        - description: Start index of paging. Pagination results can be based on numbers or other values chosen by the registry implementor (for example, SHA values). If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.
+          in: query
+          name: offset
+          schema:
+            type: string
+        - description: Amount of records to return in a given page.
+          in: query
+          name: limit
+          schema:
+            format: int32
+            type: integer
       responses:
         "200":
           content:
@@ -3877,23 +3806,21 @@ paths:
                 type: array
           description: An array of Tools that match the filter.
       security:
-      - BEARER: []
+        - BEARER: []
       summary: List all tools
       tags:
-      - GA4GHV20
+        - GA4GHV20
   /ga4gh/trs/v2/tools/{id}:
     get:
-      description: This endpoint returns one specific tool (which has ToolVersions
-        nested inside it).
+      description: This endpoint returns one specific tool (which has ToolVersions nested inside it).
       operationId: toolsIdGet
       parameters:
-      - description: A unique identifier of the tool, scoped to this registry, for
-          example `123456`.
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
+        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -3914,22 +3841,21 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool can not be found.
       security:
-      - BEARER: []
+        - BEARER: []
       summary: List one specific tool, acts as an anchor for self references
       tags:
-      - GA4GHV20
+        - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions:
     get:
       description: Returns all versions of the specified tool.
       operationId: toolsIdVersionsGet
       parameters:
-      - description: A unique identifier of the tool, scoped to this registry, for
-          example `123456`.
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
+        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -3945,30 +3871,27 @@ paths:
                 type: array
           description: An array of tool versions.
       security:
-      - BEARER: []
+        - BEARER: []
       summary: List versions of a tool
       tags:
-      - GA4GHV20
+        - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}:
     get:
       description: This endpoint returns one specific tool version.
       operationId: toolsIdVersionsVersionIdGet
       parameters:
-      - description: A unique identifier of the tool, scoped to this registry, for
-          example `123456`.
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      - description: An identifier of the tool version, scoped to this registry, for
-          example `v1`. We recommend that versions use semantic versioning https://semver.org/spec/v2.0.0.html  (For
-          example, `1.0.0` instead of `develop`)
-        in: path
-        name: version_id
-        required: true
-        schema:
-          type: string
+        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: An identifier of the tool version, scoped to this registry, for example `v1`. We recommend that versions use semantic versioning https://semver.org/spec/v2.0.0.html  (For example, `1.0.0` instead of `develop`)
+          in: path
+          name: version_id
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -3989,32 +3912,27 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool can not be found.
       security:
-      - BEARER: []
+        - BEARER: []
       summary: List one specific tool version, acts as an anchor for self references
       tags:
-      - GA4GHV20
+        - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}/containerfile:
     get:
-      description: Returns the container specifications(s) for the specified image.
-        For example, a CWL CommandlineTool can be associated with one specification
-        for a container, a CWL Workflow can be associated with multiple specifications
-        for containers.
+      description: Returns the container specifications(s) for the specified image. For example, a CWL CommandlineTool can be associated with one specification for a container, a CWL Workflow can be associated with multiple specifications for containers.
       operationId: toolsIdVersionsVersionIdContainerfileGet
       parameters:
-      - description: A unique identifier of the tool, scoped to this registry, for
-          example `123456`.
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      - description: An identifier of the tool version for this particular tool registry,
-          for example `v1`.
-        in: path
-        name: version_id
-        required: true
-        schema:
-          type: string
+        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: An identifier of the tool version for this particular tool registry, for example `v1`.
+          in: path
+          name: version_id
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -4039,39 +3957,33 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: There are no container specifications for this tool.
       security:
-      - BEARER: []
+        - BEARER: []
       summary: Get the container specification(s) for the specified image.
       tags:
-      - GA4GHV20
+        - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}/{type}/descriptor:
     get:
-      description: Returns the descriptor for the specified tool (examples include
-        CWL, WDL, or Nextflow documents).
+      description: Returns the descriptor for the specified tool (examples include CWL, WDL, or Nextflow documents).
       operationId: toolsIdVersionsVersionIdTypeDescriptorGet
       parameters:
-      - description: The output type of the descriptor. Plain types return the bare
-          descriptor while the "non-plain" types return a descriptor wrapped with
-          metadata. Allowable values include "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL",
-          "PLAIN_NFL".
-        in: path
-        name: type
-        required: true
-        schema:
-          type: string
-      - description: A unique identifier of the tool, scoped to this registry, for
-          example `123456`.
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      - description: An identifier of the tool version, scoped to this registry, for
-          example `v1`.
-        in: path
-        name: version_id
-        required: true
-        schema:
-          type: string
+        - description: The output type of the descriptor. Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped with metadata. Allowable values include "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL".
+          in: path
+          name: type
+          required: true
+          schema:
+            type: string
+        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: An identifier of the tool version, scoped to this registry, for example `v1`.
+          in: path
+          name: version_id
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -4092,55 +4004,39 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool descriptor can not be found.
       security:
-      - BEARER: []
+        - BEARER: []
       summary: Get the tool descriptor for the specified tool
       tags:
-      - GA4GHV20
+        - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}:
     get:
-      description: Descriptors can often include imports that refer to additional
-        descriptors. This returns additional descriptors for the specified tool in
-        the same or other directories that can be reached as a relative path. This
-        endpoint can be useful for workflow engine implementations like cwltool to
-        programmatically download all the descriptors for a tool and run it. This
-        can optionally include other files described with FileWrappers such as test
-        parameters and containerfiles.
+      description: Descriptors can often include imports that refer to additional descriptors. This returns additional descriptors for the specified tool in the same or other directories that can be reached as a relative path. This endpoint can be useful for workflow engine implementations like cwltool to programmatically download all the descriptors for a tool and run it. This can optionally include other files described with FileWrappers such as test parameters and containerfiles.
       operationId: toolsIdVersionsVersionIdTypeDescriptorRelativePathGet
       parameters:
-      - description: The output type of the descriptor. If not specified, it is up
-          to the underlying implementation to determine which output type to return.
-          Plain types return the bare descriptor while the "non-plain" types return
-          a descriptor wrapped with metadata. Allowable values are "CWL", "WDL", "NFL",
-          "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL".
-        in: path
-        name: type
-        required: true
-        schema:
-          type: string
-      - description: A unique identifier of the tool, scoped to this registry, for
-          example `123456`.
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      - description: An identifier of the tool version for this particular tool registry,
-          for example `v1`.
-        in: path
-        name: version_id
-        required: true
-        schema:
-          type: string
-      - description: A relative path to the additional file (same directory or subdirectories),
-          for example 'foo.cwl' would return a 'foo.cwl' from the same directory as
-          the main descriptor. 'nestedDirectory/foo.cwl' would return the file  from
-          a nested subdirectory.  Unencoded paths such 'sampleDirectory/foo.cwl' should
-          also be allowed.
-        in: path
-        name: relative_path
-        required: true
-        schema:
-          type: string
+        - description: The output type of the descriptor. If not specified, it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped with metadata. Allowable values are "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL".
+          in: path
+          name: type
+          required: true
+          schema:
+            type: string
+        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: An identifier of the tool version for this particular tool registry, for example `v1`.
+          in: path
+          name: version_id
+          required: true
+          schema:
+            type: string
+        - description: A relative path to the additional file (same directory or subdirectories), for example 'foo.cwl' would return a 'foo.cwl' from the same directory as the main descriptor. 'nestedDirectory/foo.cwl' would return the file  from a nested subdirectory.  Unencoded paths such 'sampleDirectory/foo.cwl' should also be allowed.
+          in: path
+          name: relative_path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -4161,38 +4057,33 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool can not be output in the specified type.
       security:
-      - BEARER: []
+        - BEARER: []
       summary: Get additional tool descriptor files relative to the main file
       tags:
-      - GA4GHV20
+        - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}/{type}/files:
     get:
-      description: 'Get a list of objects that contain the relative path and file
-        type. The descriptors are intended for use with the /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path
-        : .+} endpoint.'
+      description: 'Get a list of objects that contain the relative path and file type. The descriptors are intended for use with the /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path : .+} endpoint.'
       operationId: toolsIdVersionsVersionIdTypeFilesGet
       parameters:
-      - description: The output type of the descriptor. Examples of allowable values
-          are "CWL", "WDL", and "NFL".
-        in: path
-        name: type
-        required: true
-        schema:
-          type: string
-      - description: A unique identifier of the tool, scoped to this registry, for
-          example `123456`.
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      - description: An identifier of the tool version for this particular tool registry,
-          for example `v1`.
-        in: path
-        name: version_id
-        required: true
-        schema:
-          type: string
+        - description: The output type of the descriptor. Examples of allowable values are "CWL", "WDL", and "NFL".
+          in: path
+          name: type
+          required: true
+          schema:
+            type: string
+        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: An identifier of the tool version for this particular tool registry, for example `v1`.
+          in: path
+          name: version_id
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -4217,39 +4108,33 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool can not be output in the specified type.
       security:
-      - BEARER: []
+        - BEARER: []
       summary: Get a list of objects that contain the relative path and file type
       tags:
-      - GA4GHV20
+        - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}/{type}/tests:
     get:
-      description: Get a list of test JSONs (these allow you to execute the tool successfully)
-        suitable for use with this descriptor type.
+      description: Get a list of test JSONs (these allow you to execute the tool successfully) suitable for use with this descriptor type.
       operationId: toolsIdVersionsVersionIdTypeTestsGet
       parameters:
-      - description: The type of the underlying descriptor. Allowable values include
-          "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL". For example,
-          "CWL" would return an list of ToolTests objects while "PLAIN_CWL" would
-          return a bare JSON list with the content of the tests.
-        in: path
-        name: type
-        required: true
-        schema:
-          type: string
-      - description: A unique identifier of the tool, scoped to this registry, for
-          example `123456`.
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      - description: An identifier of the tool version for this particular tool registry,
-          for example `v1`.
-        in: path
-        name: version_id
-        required: true
-        schema:
-          type: string
+        - description: The type of the underlying descriptor. Allowable values include "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL". For example, "CWL" would return an list of ToolTests objects while "PLAIN_CWL" would return a bare JSON list with the content of the tests.
+          in: path
+          name: type
+          required: true
+          schema:
+            type: string
+        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: An identifier of the tool version for this particular tool registry, for example `v1`.
+          in: path
+          name: version_id
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -4274,31 +4159,31 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool can not be output in the specified type.
       security:
-      - BEARER: []
+        - BEARER: []
       summary: Get a list of test JSONs
       tags:
-      - GA4GHV20
+        - GA4GHV20
   /lambdaEvents/{organization}:
     get:
       description: Get all of the Lambda Events for the given GitHub organization.
       operationId: getLambdaEventsByOrganization
       parameters:
-      - in: path
-        name: organization
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: offset
-        schema:
-          default: "0"
-          type: string
-      - in: query
-        name: limit
-        schema:
-          default: 100
-          format: int32
-          type: integer
+        - in: path
+          name: organization
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: offset
+          schema:
+            default: "0"
+            type: string
+        - in: query
+          name: limit
+          schema:
+            default: 100
+            format: int32
+            type: integer
       responses:
         default:
           content:
@@ -4309,9 +4194,9 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - lambdaEvents
+        - lambdaEvents
   /metadata/config.json:
     get:
       description: Configuration, NO authentication
@@ -4325,11 +4210,10 @@ paths:
           description: default response
       summary: Configuration for UI clients of the API
       tags:
-      - metadata
+        - metadata
   /metadata/descriptorLanguageList:
     get:
-      description: Get the list of descriptor languages supported on Dockstore, NO
-        authentication
+      description: Get the list of descriptor languages supported on Dockstore, NO authentication
       operationId: getDescriptorLanguages
       responses:
         default:
@@ -4342,7 +4226,7 @@ paths:
           description: List of descriptor languages
       summary: Get the list of descriptor languages supported on Dockstore
       tags:
-      - metadata
+        - metadata
   /metadata/dockerRegistryList:
     get:
       description: Get the list of docker registries supported on Dockstore, NO authentication
@@ -4358,7 +4242,7 @@ paths:
           description: List of Docker registries
       summary: Get the list of docker registries supported on Dockstore
       tags:
-      - metadata
+        - metadata
   /metadata/elasticSearch:
     get:
       description: Successful response if elastic search is up and running, NO authentication
@@ -4371,7 +4255,7 @@ paths:
           description: default response
       summary: Successful response if elastic search is up and running
       tags:
-      - metadata
+        - metadata
   /metadata/okHttpCachePerformance:
     get:
       description: Get measures of cache performance, NO authentication
@@ -4387,7 +4271,7 @@ paths:
           description: Cache performance information
       summary: Get measures of cache performance
       tags:
-      - metadata
+        - metadata
   /metadata/rss:
     get:
       description: List all published tools and workflows in creation order, NO authentication
@@ -4401,40 +4285,40 @@ paths:
           description: default response
       summary: List all published tools and workflows in creation order
       tags:
-      - metadata
+        - metadata
   /metadata/runner_dependencies:
     get:
       description: Returns the file containing runner dependencies, NO authentication
       operationId: getRunnerDependencies
       parameters:
-      - description: The Dockstore client version
-        in: query
-        name: client_version
-        schema:
-          type: string
-      - description: Python version, only relevant for the cwltool runner
-        in: query
-        name: python_version
-        schema:
-          default: "3"
-          type: string
-      - description: The tool runner
-        in: query
-        name: runner
-        schema:
-          default: cwltool
-          enum:
-          - cwltool
-          type: string
-      - description: Response type
-        in: query
-        name: output
-        schema:
-          default: text
-          enum:
-          - json
-          - text
-          type: string
+        - description: The Dockstore client version
+          in: query
+          name: client_version
+          schema:
+            type: string
+        - description: Python version, only relevant for the cwltool runner
+          in: query
+          name: python_version
+          schema:
+            default: "3"
+            type: string
+        - description: The tool runner
+          in: query
+          name: runner
+          schema:
+            default: cwltool
+            enum:
+              - cwltool
+            type: string
+        - description: Response type
+          in: query
+          name: output
+          schema:
+            default: text
+            enum:
+              - json
+              - text
+            type: string
       responses:
         default:
           content:
@@ -4444,12 +4328,10 @@ paths:
           description: The requirements.txt file
       summary: Returns the file containing runner dependencies
       tags:
-      - metadata
+        - metadata
   /metadata/sitemap:
     get:
-      description: List all available workflow, tool, organization, and collection
-        paths. Available means published for tools/workflows, and approved for organizations
-        and their respective collections. NO authentication
+      description: List all available workflow, tool, organization, and collection paths. Available means published for tools/workflows, and approved for organizations and their respective collections. NO authentication
       operationId: sitemap
       responses:
         default:
@@ -4463,7 +4345,7 @@ paths:
           description: default response
       summary: List all available workflow, tool, organization, and collection paths.
       tags:
-      - metadata
+        - metadata
   /metadata/sourceControlList:
     get:
       description: Get the list of source controls supported on Dockstore, NO authentication
@@ -4479,11 +4361,10 @@ paths:
           description: List of source control repositories
       summary: Get the list of source controls supported on Dockstore
       tags:
-      - metadata
+        - metadata
   /organizations:
     get:
-      description: List all organizations that have been approved by a curator or
-        admin, sorted by number of stars.
+      description: List all organizations that have been approved by a curator or admin, sorted by number of stars.
       operationId: getApprovedOrganizations
       responses:
         default:
@@ -4496,10 +4377,9 @@ paths:
           description: default response
       summary: List all available organizations.
       tags:
-      - organizations
+        - organizations
     post:
-      description: Create an organization. Organization requires approval by an admin
-        before being made public.
+      description: Create an organization. Organization requires approval by an admin before being made public.
       operationId: createOrganization
       requestBody:
         content:
@@ -4516,27 +4396,26 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Create an organization.
       tags:
-      - organizations
+        - organizations
   /organizations/all:
     get:
-      description: List all organizations, regardless of organization status. Admin/curator
-        only.
+      description: List all organizations, regardless of organization status. Admin/curator only.
       operationId: getAllOrganizations
       parameters:
-      - description: Filter to apply to organizations.
-        in: query
-        name: type
-        required: true
-        schema:
-          enum:
-          - all
-          - pending
-          - rejected
-          - approved
-          type: string
+        - description: Filter to apply to organizations.
+          in: query
+          name: type
+          required: true
+          schema:
+            enum:
+              - all
+              - pending
+              - rejected
+              - approved
+            type: string
       responses:
         default:
           content:
@@ -4547,21 +4426,21 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: List all organizations.
       tags:
-      - organizations
+        - organizations
   /organizations/collections/{alias}/aliases:
     get:
       description: Retrieve a collection by alias.
       operationId: getCollectionByAlias
       parameters:
-      - description: Alias of the collection.
-        in: path
-        name: alias
-        required: true
-        schema:
-          type: string
+        - description: Alias of the collection.
+          in: path
+          name: alias
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -4571,49 +4450,48 @@ paths:
           description: default response
       summary: Retrieve a collection by alias.
       tags:
-      - organizations
+        - organizations
   /organizations/collections/{collectionId}/aliases:
     post:
-      description: Aliases are alphanumerical (case-insensitive and may contain internal
-        hyphens), given in a comma-delimited list.
+      description: Aliases are alphanumerical (case-insensitive and may contain internal hyphens), given in a comma-delimited list.
       operationId: addCollectionAliases_1
       parameters:
-      - description: Collection to modify.
-        in: path
-        name: collectionId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Comma-delimited list of aliases.
-        in: query
-        name: aliases
-        required: true
-        schema:
-          type: string
+        - description: Collection to modify.
+          in: path
+          name: collectionId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Comma-delimited list of aliases.
+          in: query
+          name: aliases
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/Collection'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Add aliases linked to a collection in Dockstore.
       tags:
-      - organizations
+        - organizations
   /organizations/name/{name}:
     get:
       description: Retrieve an organization by name. Supports optional authentication.
       operationId: getOrganizationByName
       parameters:
-      - description: Organization name.
-        in: path
-        name: name
-        required: true
-        schema:
-          type: string
+        - description: Organization name.
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -4622,21 +4500,21 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Retrieve an organization by name.
       tags:
-      - organizations
+        - organizations
   /organizations/{alias}/aliases:
     get:
       description: Retrieve an organization by alias.
       operationId: getOrganizationByAlias
       parameters:
-      - description: Alias.
-        in: path
-        name: alias
-        required: true
-        schema:
-          type: string
+        - description: Alias.
+          in: path
+          name: alias
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -4646,19 +4524,19 @@ paths:
           description: default response
       summary: Retrieve an organization by alias.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}:
     get:
       description: Retrieve an organization by ID. Supports optional authentication.
       operationId: getOrganizationById
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -4667,22 +4545,21 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Retrieve an organization by ID.
       tags:
-      - organizations
+        - organizations
     put:
-      description: Update an organization. Currently only name, display name, description,
-        topic, email, link, avatarUrl, and location can be updated.
+      description: Update an organization. Currently only name, display name, description, topic, email, link, avatarUrl, and location can be updated.
       operationId: updateOrganization
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -4698,30 +4575,28 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Update an organization.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/aliases:
     post:
-      description: Add aliases linked to a listing in Dockstore. Aliases are alphanumerical
-        (case-insensitive and may contain internal hyphens), given in a comma-delimited
-        list.
+      description: Add aliases linked to a listing in Dockstore. Aliases are alphanumerical (case-insensitive and may contain internal hyphens), given in a comma-delimited list.
       operationId: addOrganizationAliases_1
       parameters:
-      - description: Organization to modify.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Comma-delimited list of aliases.
-        in: query
-        name: aliases
-        required: true
-        schema:
-          type: string
+        - description: Organization to modify.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Comma-delimited list of aliases.
+          in: query
+          name: aliases
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -4730,22 +4605,22 @@ paths:
                 $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Add aliases linked to a listing in Dockstore.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/approve:
     post:
       description: Approve the organization with the given id. Admin/curator only.
       operationId: approveOrganization
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -4754,29 +4629,28 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Approve an organization.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/collections:
     get:
-      description: Retrieve all collections for an organization. Supports optional
-        authentication.
+      description: Retrieve all collections for an organization. Supports optional authentication.
       operationId: getCollectionsFromOrganization
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Included fields.
-        in: query
-        name: include
-        required: true
-        schema:
-          type: string
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Included fields.
+          in: query
+          name: include
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -4787,21 +4661,21 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Retrieve all collections for an organization.
       tags:
-      - organizations
+        - organizations
     post:
       description: Create a collection in the given organization.
       operationId: createCollection
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -4817,29 +4691,29 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Create a collection in the given organization.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/collections/{collectionId}:
     get:
       description: Retrieve a collection by ID. Supports optional authentication.
       operationId: getCollectionById
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Collection ID.
-        in: path
-        name: collectionId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Collection ID.
+          in: path
+          name: collectionId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -4848,29 +4722,28 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Retrieve a collection by ID.
       tags:
-      - organizations
+        - organizations
     put:
-      description: Update a collection. Currently only name, display name, description,
-        and topic can be updated.
+      description: Update a collection. Currently only name, display name, description, and topic can be updated.
       operationId: updateCollection
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Collection ID.
-        in: path
-        name: collectionId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Collection ID.
+          in: path
+          name: collectionId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -4886,30 +4759,29 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Update a collection.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/collections/{collectionId}/description:
     get:
-      description: Retrieve a collection description by organization ID and collection
-        ID. Supports optional authentication.
+      description: Retrieve a collection description by organization ID and collection ID. Supports optional authentication.
       operationId: getCollectionDescription
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Collection ID.
-        in: path
-        name: collectionId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Collection ID.
+          in: path
+          name: collectionId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -4918,29 +4790,28 @@ paths:
                 type: string
           description: default response
       security:
-      - bearer: []
-      summary: Retrieve a collection description by organization ID and collection
-        ID.
+        - bearer: []
+      summary: Retrieve a collection description by organization ID and collection ID.
       tags:
-      - organizations
+        - organizations
     put:
       description: Update a collection's description. Description in markdown.
       operationId: updateCollectionDescription
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Collection ID.
-        in: path
-        name: collectionId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Collection ID.
+          in: path
+          name: collectionId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -4956,36 +4827,36 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Update a collection's description.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/collections/{collectionId}/entry:
     delete:
       description: Delete an entry to a collection.
       operationId: deleteEntryFromCollection
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Collection ID.
-        in: path
-        name: collectionId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Entry ID.
-        in: query
-        name: entryId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Collection ID.
+          in: path
+          name: collectionId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Entry ID.
+          in: query
+          name: entryId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -4994,35 +4865,35 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Delete an entry to a collection.
       tags:
-      - organizations
+        - organizations
     post:
       description: Add an entry to a collection.
       operationId: addEntryToCollection
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Collection ID.
-        in: path
-        name: collectionId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Entry ID.
-        in: query
-        name: entryId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Collection ID.
+          in: path
+          name: collectionId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Entry ID.
+          in: query
+          name: entryId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -5031,23 +4902,22 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Add an entry to a collection.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/description:
     get:
-      description: Retrieve an organization description by organization ID. Supports
-        optional authentication.
+      description: Retrieve an organization description by organization ID. Supports optional authentication.
       operationId: getOrganizationDescription
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -5056,22 +4926,21 @@ paths:
                 type: string
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Retrieve an organization description by organization ID.
       tags:
-      - organizations
+        - organizations
     put:
-      description: Update an organization's description. Expects description in markdown
-        format.
+      description: Update an organization's description. Expects description in markdown format.
       operationId: updateOrganizationDescription
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -5087,42 +4956,40 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Update an organization's description.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/events:
     get:
       description: Retrieve all events for an organization. Supports optional authentication.
       operationId: getOrganizationEvents
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Start index of paging.  If this exceeds the current result set
-          return an empty set.  If not specified in the request, this will start at
-          the beginning of the results.
-        in: query
-        name: offset
-        required: true
-        schema:
-          default: 0
-          format: int32
-          type: integer
-      - description: Amount of records to return in a given page, limited to 100
-        in: query
-        name: limit
-        required: true
-        schema:
-          default: 100
-          format: int32
-          maximum: 100
-          minimum: 1
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Start index of paging.  If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.
+          in: query
+          name: offset
+          required: true
+          schema:
+            default: 0
+            format: int32
+            type: integer
+        - description: Amount of records to return in a given page, limited to 100
+          in: query
+          name: limit
+          required: true
+          schema:
+            default: 100
+            format: int32
+            maximum: 100
+            minimum: 1
+            type: integer
       responses:
         default:
           content:
@@ -5133,51 +5000,50 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Retrieve all events for an organization.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/invitation:
     post:
-      description: Accept or reject an organization invitation. True accepts the invitation,
-        false rejects the invitation.
+      description: Accept or reject an organization invitation. True accepts the invitation, false rejects the invitation.
       operationId: acceptOrRejectInvitation
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Accept or reject.
-        in: query
-        name: accept
-        required: true
-        schema:
-          type: boolean
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Accept or reject.
+          in: query
+          name: accept
+          required: true
+          schema:
+            type: boolean
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Accept or reject an organization invitation.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/members:
     get:
       description: Retrieve all members for an organization. Supports optional authentication.
       operationId: getOrganizationMembers
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -5189,22 +5055,22 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Retrieve all members for an organization.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/reject:
     post:
       description: Reject the organization with the given id. Admin/curator only.
       operationId: rejectOrganization
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -5213,23 +5079,22 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Reject an organization.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/request:
     post:
-      description: Re-request a review of the given organization. Requires the organization
-        to be rejected.
+      description: Re-request a review of the given organization. Requires the organization to be rejected.
       operationId: requestOrganizationReview
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -5238,22 +5103,22 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Re-request an organization review.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/star:
     put:
       description: Star an organization.
       operationId: starOrganization
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -5267,22 +5132,22 @@ paths:
             application/json: {}
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Star an organization.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/starredUsers:
     get:
       description: Return list of users who starred the given approved organization.
       operationId: getStarredUsersForApprovedOrganization
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -5295,85 +5160,85 @@ paths:
           description: default response
       summary: Return list of users who starred the given approved organization.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/unstar:
     delete:
       description: Unstar an organization.
       operationId: unstarOrganization
       parameters:
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Unstar an organization.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/user:
     delete:
       description: Remove a user from an organization.
       operationId: deleteUserRole
       parameters:
-      - description: User ID of user to add to organization.
-        in: query
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: User ID of user to add to organization.
+          in: query
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Remove a user from an organization.
       tags:
-      - organizations
+        - organizations
     post:
       description: Update a user role in an organization.
       operationId: updateUserRole
       parameters:
-      - description: Role of user.
-        in: query
-        name: role
-        required: true
-        schema:
-          enum:
-          - MAINTAINER
-          - MEMBER
-          type: string
-      - description: User ID of user to add to organization.
-        in: query
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Role of user.
+          in: query
+          name: role
+          required: true
+          schema:
+            enum:
+              - MAINTAINER
+              - MEMBER
+            type: string
+        - description: User ID of user to add to organization.
+          in: query
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -5382,44 +5247,43 @@ paths:
                 $ref: '#/components/schemas/OrganizationUser'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Update a user role in an organization.
       tags:
-      - organizations
+        - organizations
     put:
       description: Add a user role to an organization.
       operationId: addUserToOrg
       parameters:
-      - description: Role of user.
-        in: query
-        name: role
-        required: true
-        schema:
-          enum:
-          - MAINTAINER
-          - MEMBER
-          type: string
-      - description: User ID of user to add to organization.
-        in: query
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: Role of user.
+          in: query
+          name: role
+          required: true
+          schema:
+            enum:
+              - MAINTAINER
+              - MEMBER
+            type: string
+        - description: User ID of user to add to organization.
+          in: query
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
             schema:
               type: string
-        description: This is here to appease Swagger. It requires PUT methods to have
-          a body, even if it is empty. Please leave it empty.
+        description: This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.
       responses:
         default:
           content:
@@ -5428,35 +5292,35 @@ paths:
                 $ref: '#/components/schemas/OrganizationUser'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Add a user role to an organization.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationId}/users/{username}:
     put:
       description: Add a user role to an organization.
       operationId: addUserToOrgByUsername
       parameters:
-      - description: User to add to org.
-        in: path
-        name: username
-        required: true
-        schema:
-          type: string
-      - description: Organization ID.
-        in: path
-        name: organizationId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: User to add to org.
+          in: path
+          name: username
+          required: true
+          schema:
+            type: string
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
             schema:
               enum:
-              - MAINTAINER
-              - MEMBER
+                - MAINTAINER
+                - MEMBER
               type: string
         description: Role of user.
         required: true
@@ -5468,27 +5332,27 @@ paths:
                 $ref: '#/components/schemas/OrganizationUser'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Add a user role to an organization.
       tags:
-      - organizations
+        - organizations
   /organizations/{organizationName}/collections/{collectionName}/name:
     get:
       description: Retrieve a collection by name. Supports optional authentication.
       operationId: getCollectionById_1
       parameters:
-      - description: Organization name.
-        in: path
-        name: organizationName
-        required: true
-        schema:
-          type: string
-      - description: Collection name.
-        in: path
-        name: collectionName
-        required: true
-        schema:
-          type: string
+        - description: Organization name.
+          in: path
+          name: organizationName
+          required: true
+          schema:
+            type: string
+        - description: Collection name.
+          in: path
+          name: collectionName
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -5497,53 +5361,53 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Retrieve a collection by name.
       tags:
-      - organizations
+        - organizations
   /toolTester/logs:
     get:
       operationId: getToolTesterLog
       parameters:
-      - description: TRS Tool Id
-        example: '#workflow/github.com/dockstore/hello_world'
-        in: query
-        name: tool_id
-        required: true
-        schema:
-          type: string
-      - example: v1.0.0
-        in: query
-        name: tool_version_name
-        required: true
-        schema:
-          type: string
-      - example: hello_world.cwl.json
-        in: query
-        name: test_filename
-        required: true
-        schema:
-          type: string
-      - example: cwltool
-        in: query
-        name: runner
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: log_type
-        required: true
-        schema:
-          enum:
-          - FULL
-          - SUMMARY
-          type: string
-      - example: 1554477737092.log
-        in: query
-        name: filename
-        required: true
-        schema:
-          type: string
+        - description: TRS Tool Id
+          example: '#workflow/github.com/dockstore/hello_world'
+          in: query
+          name: tool_id
+          required: true
+          schema:
+            type: string
+        - example: v1.0.0
+          in: query
+          name: tool_version_name
+          required: true
+          schema:
+            type: string
+        - example: hello_world.cwl.json
+          in: query
+          name: test_filename
+          required: true
+          schema:
+            type: string
+        - example: cwltool
+          in: query
+          name: runner
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: log_type
+          required: true
+          schema:
+            enum:
+              - FULL
+              - SUMMARY
+            type: string
+        - example: 1554477737092.log
+          in: query
+          name: filename
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -5553,24 +5417,24 @@ paths:
           description: default response
       summary: Get ToolTester log file
       tags:
-      - toolTester
+        - toolTester
   /toolTester/logs/search:
     get:
       operationId: search
       parameters:
-      - description: TRS Tool Id
-        example: '#workflow/github.com/dockstore/hello_world'
-        in: query
-        name: tool_id
-        required: true
-        schema:
-          type: string
-      - example: v1.0.0
-        in: query
-        name: tool_version_name
-        required: true
-        schema:
-          type: string
+        - description: TRS Tool Id
+          example: '#workflow/github.com/dockstore/hello_world'
+          in: query
+          name: tool_id
+          required: true
+          schema:
+            type: string
+        - example: v1.0.0
+          in: query
+          name: tool_version_name
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -5582,17 +5446,17 @@ paths:
           description: default response
       summary: Search for ToolTester log files
       tags:
-      - toolTester
+        - toolTester
   /users/checkUser/{username}:
     get:
       description: Check if user with some username exists.
       operationId: checkUserExists
       parameters:
-      - in: path
-        name: username
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: username
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -5601,9 +5465,9 @@ paths:
                 type: boolean
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/dockerRegistries:
     get:
       description: Get all of the Docker registries accessible to the logged-in user.
@@ -5618,21 +5482,20 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/dockerRegistries/{dockerRegistry}/organizations:
     get:
-      description: Get all of the organizations/namespaces of the Docker registry
-        accessible to the logged-in user.
+      description: Get all of the organizations/namespaces of the Docker registry accessible to the logged-in user.
       operationId: getDockerRegistriesOrganization
       parameters:
-      - description: Name of Docker registry
-        in: path
-        name: dockerRegistry
-        required: true
-        schema:
-          type: string
+        - description: Name of Docker registry
+          in: path
+          name: dockerRegistry
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -5643,27 +5506,26 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/dockerRegistries/{dockerRegistry}/organizations/{organization}/repositories:
     get:
-      description: Get names of repositories associated with a specific namespace
-        and Docker registry of the logged-in user.
+      description: Get names of repositories associated with a specific namespace and Docker registry of the logged-in user.
       operationId: getDockerRegistryOrganizationRepositories
       parameters:
-      - description: Name of Docker registry
-        in: path
-        name: dockerRegistry
-        required: true
-        schema:
-          type: string
-      - description: Name of organization or namespace
-        in: path
-        name: organization
-        required: true
-        schema:
-          type: string
+        - description: Name of Docker registry
+          in: path
+          name: dockerRegistry
+          required: true
+          schema:
+            type: string
+        - description: Name of organization or namespace
+          in: path
+          name: organization
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -5674,24 +5536,24 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/github/events:
     get:
       description: Get all of the GitHub Events for the logged in user.
       operationId: getUserGitHubEvents
       parameters:
-      - in: query
-        name: offset
-        schema:
-          type: string
-      - in: query
-        name: limit
-        schema:
-          default: 100
-          format: int32
-          type: integer
+        - in: query
+          name: offset
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            default: 100
+            format: int32
+            type: integer
       responses:
         default:
           content:
@@ -5702,9 +5564,9 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/github/sync:
     post:
       description: Syncs Dockstore account with GitHub App Installations.
@@ -5719,9 +5581,9 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/registries:
     get:
       description: Get all of the git registries accessible to the logged in user.
@@ -5733,34 +5595,33 @@ paths:
               schema:
                 items:
                   enum:
-                  - dockstore.org
-                  - github.com
-                  - bitbucket.org
-                  - gitlab.com
+                    - dockstore.org
+                    - github.com
+                    - bitbucket.org
+                    - gitlab.com
                   type: string
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/registries/{gitRegistry}/organizations:
     get:
-      description: Get all of the organizations for a given git registry accessible
-        to the logged in user.
+      description: Get all of the organizations for a given git registry accessible to the logged in user.
       operationId: getUserOrganizations
       parameters:
-      - description: Git registry
-        in: path
-        name: gitRegistry
-        required: true
-        schema:
-          enum:
-          - dockstore.org
-          - github.com
-          - bitbucket.org
-          - gitlab.com
-          type: string
+        - description: Git registry
+          in: path
+          name: gitRegistry
+          required: true
+          schema:
+            enum:
+              - dockstore.org
+              - github.com
+              - bitbucket.org
+              - gitlab.com
+            type: string
       responses:
         default:
           content:
@@ -5772,32 +5633,31 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/registries/{gitRegistry}/organizations/{organization}:
     get:
-      description: Get all of the repositories for an organization for a given git
-        registry accessible to the logged in user.
+      description: Get all of the repositories for an organization for a given git registry accessible to the logged in user.
       operationId: getUserOrganizationRepositories
       parameters:
-      - description: Git registry
-        in: path
-        name: gitRegistry
-        required: true
-        schema:
-          enum:
-          - dockstore.org
-          - github.com
-          - bitbucket.org
-          - gitlab.com
-          type: string
-      - description: Git organization
-        in: path
-        name: organization
-        required: true
-        schema:
-          type: string
+        - description: Git registry
+          in: path
+          name: gitRegistry
+          required: true
+          schema:
+            enum:
+              - dockstore.org
+              - github.com
+              - bitbucket.org
+              - gitlab.com
+            type: string
+        - description: Git organization
+          in: path
+          name: organization
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -5808,9 +5668,9 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/starredOrganizations:
     get:
       description: Get the authenticated user's starred organizations.
@@ -5826,9 +5686,9 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/starredTools:
     get:
       description: Get the authenticated user's starred tools.
@@ -5844,9 +5704,9 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/starredWorkflows:
     get:
       description: Get the authenticated user's starred workflows.
@@ -5862,9 +5722,9 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/updateUserMetadata:
     get:
       description: Update metadata of all users.
@@ -5879,9 +5739,9 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/user:
     delete:
       description: Delete user if possible.
@@ -5894,9 +5754,9 @@ paths:
                 type: boolean
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
     get:
       description: Get the logged-in user.
       operationId: getUser
@@ -5908,18 +5768,18 @@ paths:
                 $ref: '#/components/schemas/User'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/user/changeUsername:
     post:
       description: Change username if possible.
       operationId: changeUsername
       parameters:
-      - in: query
-        name: username
-        schema:
-          type: string
+        - in: query
+          name: username
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -5928,9 +5788,9 @@ paths:
                 $ref: '#/components/schemas/User'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/user/extended:
     get:
       description: Get additional information about the authenticated user.
@@ -5943,9 +5803,9 @@ paths:
                 $ref: '#/components/schemas/ExtendedUserData'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/user/memberships:
     get:
       description: Get the logged-in user's memberships.
@@ -5961,27 +5821,27 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/user/updateUserMetadata:
     get:
       description: Update metadata for logged in user.
       operationId: updateLoggedInUserMetadata
       parameters:
-      - in: query
-        name: source
-        schema:
-          enum:
-          - quay.io
-          - github.com
-          - dockstore
-          - bitbucket.org
-          - gitlab.com
-          - zenodo.org
-          - google.com
-          - orcid.org
-          type: string
+        - in: query
+          name: source
+          schema:
+            enum:
+              - quay.io
+              - github.com
+              - dockstore
+              - bitbucket.org
+              - gitlab.com
+              - zenodo.org
+              - google.com
+              - orcid.org
+            type: string
       responses:
         default:
           content:
@@ -5990,20 +5850,20 @@ paths:
                 $ref: '#/components/schemas/User'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/user/{userId}:
     delete:
       description: Terminate user if possible.
       operationId: terminateUsers
       parameters:
-      - in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -6012,20 +5872,20 @@ paths:
                 type: boolean
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/user/{userId}/limits:
     get:
       description: Returns the specified user's limits. ADMIN or CURATOR only
       operationId: getUserLimits
       parameters:
-      - in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -6034,19 +5894,19 @@ paths:
                 $ref: '#/components/schemas/Limits'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
     put:
       description: Update the specified user's limits. ADMIN or CURATOR only
       operationId: setUserLimits
       parameters:
-      - in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -6060,19 +5920,19 @@ paths:
                 $ref: '#/components/schemas/Limits'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/username/{username}:
     get:
       description: Get a user by username.
       operationId: listUser
       parameters:
-      - in: path
-        name: username
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: username
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -6081,25 +5941,25 @@ paths:
                 $ref: '#/components/schemas/User'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/users/entries:
     get:
       description: Get all of the entries for a user, sorted by most recently updated.
       operationId: getUserEntries
       parameters:
-      - description: Maximum number of entries to return
-        in: query
-        name: count
-        schema:
-          format: int32
-          type: integer
-      - description: Filter paths with matching text
-        in: query
-        name: filter
-        schema:
-          type: string
+        - description: Maximum number of entries to return
+          in: query
+          name: count
+          schema:
+            format: int32
+            type: integer
+        - description: Filter paths with matching text
+          in: query
+          name: filter
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -6110,26 +5970,25 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/users/organizations:
     get:
-      description: Get all of the Dockstore organizations for a user, sorted by most
-        recently updated.
+      description: Get all of the Dockstore organizations for a user, sorted by most recently updated.
       operationId: getUserDockstoreOrganizations
       parameters:
-      - description: Maximum number of organizations to return
-        in: query
-        name: count
-        schema:
-          format: int32
-          type: integer
-      - description: Filter paths with matching text
-        in: query
-        name: filter
-        schema:
-          type: string
+        - description: Maximum number of organizations to return
+          in: query
+          name: count
+          schema:
+            format: int32
+            type: integer
+        - description: Filter paths with matching text
+          in: query
+          name: filter
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -6140,20 +5999,20 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/{userId}:
     get:
       description: Get user by id.
       operationId: getSpecificUser
       parameters:
-      - in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -6162,20 +6021,20 @@ paths:
                 $ref: '#/components/schemas/User'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/{userId}/containers:
     get:
       description: List all tools owned by the authenticated user.
       operationId: userContainers
       parameters:
-      - in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -6186,20 +6045,20 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/{userId}/containers/published:
     get:
       description: List all published tools from a user.
       operationId: userPublishedContainers
       parameters:
-      - in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -6210,30 +6069,29 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/{userId}/containers/{organization}/refresh:
     get:
-      description: Refresh all tools owned by the authenticated user with specified
-        organization.
+      description: Refresh all tools owned by the authenticated user with specified organization.
       operationId: refreshToolsByOrganization
       parameters:
-      - in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: path
-        name: organization
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: dockerRegistry
-        schema:
-          type: string
+        - in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: organization
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: dockerRegistry
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -6244,20 +6102,20 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/{userId}/services:
     get:
       description: List all services owned by the authenticated user.
       operationId: userServices
       parameters:
-      - in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -6268,20 +6126,20 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/{userId}/tokens:
     get:
       description: Get tokens with user id.
       operationId: getUserTokens
       parameters:
-      - in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -6292,20 +6150,20 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/{userId}/tokens/dockstore:
     get:
       description: Get Dockstore tokens with user id.
       operationId: getDockstoreUserTokens
       parameters:
-      - in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -6316,20 +6174,20 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/{userId}/tokens/github.com:
     get:
       description: Get Github tokens with user id.
       operationId: getGithubUserTokens
       parameters:
-      - in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -6340,20 +6198,20 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/{userId}/tokens/gitlab.com:
     get:
       description: Get Gitlab tokens with user id.
       operationId: getGitlabUserTokens
       parameters:
-      - in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -6364,20 +6222,20 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/{userId}/tokens/quay.io:
     get:
       description: Get Quay tokens with user id.
       operationId: getQuayUserTokens
       parameters:
-      - in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -6388,21 +6246,21 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/{userId}/workflows:
     get:
       description: List all workflows owned by the authenticated user.
       operationId: userWorkflows
       parameters:
-      - description: User ID
-        in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: User ID
+          in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -6413,28 +6271,26 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
     patch:
-      description: Adds the logged-in user to any Dockstore workflows that they should
-        have access to.
+      description: Adds the logged-in user to any Dockstore workflows that they should have access to.
       operationId: addUserToDockstoreWorkflows
       parameters:
-      - description: User to update
-        in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: User to update
+          in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
             schema:
               type: string
-        description: This is here to appease Swagger. It requires PATCH methods to
-          have a body, even if it is empty. Please leave it empty.
+        description: This is here to appease Swagger. It requires PATCH methods to have a body, even if it is empty. Please leave it empty.
       responses:
         default:
           content:
@@ -6445,20 +6301,20 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /users/{userId}/workflows/published:
     get:
       description: List all published workflows from a user.
       operationId: userPublishedWorkflows
       parameters:
-      - in: path
-        name: userId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: userId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -6469,51 +6325,48 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - users
+        - users
   /workflows/github:
     delete:
-      description: Handles the deletion of a branch on GitHub. Will delete all workflow
-        versions that match in all workflows that share the same repository.
+      description: Handles the deletion of a branch on GitHub. Will delete all workflow versions that match in all workflows that share the same repository.
       operationId: handleGitHubBranchDeletion
       parameters:
-      - description: Repository path (ex. dockstore/dockstore-ui2)
-        in: query
-        name: repository
-        required: true
-        schema:
-          type: string
-      - description: Username of user on GitHub who triggered action
-        in: query
-        name: username
-        required: true
-        schema:
-          type: string
-      - description: Full git reference for a GitHub branch/tag. Ex. refs/heads/master
-          or refs/tags/v1.0
-        in: query
-        name: gitReference
-        required: true
-        schema:
-          type: string
-      - description: GitHub installation ID
-        in: query
-        name: installationId
-        required: true
-        schema:
-          type: string
+        - description: Repository path (ex. dockstore/dockstore-ui2)
+          in: query
+          name: repository
+          required: true
+          schema:
+            type: string
+        - description: Username of user on GitHub who triggered action
+          in: query
+          name: username
+          required: true
+          schema:
+            type: string
+        - description: Full git reference for a GitHub branch/tag. Ex. refs/heads/master or refs/tags/v1.0
+          in: query
+          name: gitReference
+          required: true
+          schema:
+            type: string
+        - description: GitHub installation ID
+          in: query
+          name: installationId
+          required: true
+          schema:
+            type: string
       responses:
         "418":
           description: This code tells AWS Lambda not to retry.
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/github/install:
     post:
-      description: Handle the installation of our GitHub app onto a repository or
-        organization.
+      description: Handle the installation of our GitHub app onto a repository or organization.
       operationId: handleGitHubInstallation
       requestBody:
         content:
@@ -6527,21 +6380,20 @@ paths:
                 username:
                   type: string
               required:
-              - installationId
-              - repositories
-              - username
+                - installationId
+                - repositories
+                - username
               type: object
       responses:
         "418":
           description: This code tells AWS Lambda not to retry.
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/github/release:
     post:
-      description: Handle a release of a repository on GitHub. Will create a workflow/service
-        and version when necessary.
+      description: Handle a release of a repository on GitHub. Will create a workflow/service and version when necessary.
       operationId: handleGitHubRelease
       requestBody:
         content:
@@ -6557,10 +6409,10 @@ paths:
                 username:
                   type: string
               required:
-              - gitReference
-              - installationId
-              - repository
-              - username
+                - gitReference
+                - installationId
+                - repository
+                - username
               type: object
       responses:
         default:
@@ -6572,60 +6424,34 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/hostedEntry:
     post:
       description: Create a hosted workflow.
       operationId: createHostedWorkflow_1
       parameters:
-      - in: query
-        name: registry
-        schema:
-          type: string
-      - in: query
-        name: name
-        schema:
-          type: string
-      - in: query
-        name: descriptorType
-        schema:
-          type: string
-      - in: query
-        name: namespace
-        schema:
-          type: string
-      - in: query
-        name: entryName
-        schema:
-          type: string
-      responses:
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Entry'
-          description: default response
-      security:
-      - bearer: []
-      tags:
-      - hosted
-  /workflows/hostedEntry/{entryId}:
-    delete:
-      description: Delete a revision of a hosted workflow.
-      operationId: deleteHostedWorkflowVersion_1
-      parameters:
-      - in: path
-        name: entryId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: version
-        schema:
-          type: string
+        - in: query
+          name: registry
+          schema:
+            type: string
+        - in: query
+          name: name
+          schema:
+            type: string
+        - in: query
+          name: descriptorType
+          schema:
+            type: string
+        - in: query
+          name: namespace
+          schema:
+            type: string
+        - in: query
+          name: entryName
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -6634,19 +6460,45 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - hosted
+        - hosted
+  /workflows/hostedEntry/{entryId}:
+    delete:
+      description: Delete a revision of a hosted workflow.
+      operationId: deleteHostedWorkflowVersion_1
+      parameters:
+        - in: path
+          name: entryId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: version
+          schema:
+            type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Workflow'
+          description: default response
+      security:
+        - bearer: []
+      tags:
+        - hosted
     patch:
       description: Non-idempotent operation for creating new revisions of hosted workflows
       operationId: editHostedWorkflow
       parameters:
-      - in: path
-        name: entryId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: entryId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -6663,20 +6515,20 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - hosted
+        - hosted
     post:
       deprecated: true
       operationId: addZip
       parameters:
-      - description: hosted entry ID
-        in: path
-        name: entryId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - description: hosted entry ID
+          in: path
+          name: entryId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           multipart/form-data:
@@ -6694,39 +6546,39 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: successful operation
       security:
-      - bearer: []
+        - bearer: []
       summary: Creates a new revision of a hosted workflow from a zip
       tags:
-      - hosted
+        - hosted
   /workflows/manualRegister:
     post:
       description: Manually register a workflow.
       operationId: manualRegister
       parameters:
-      - in: query
-        name: workflowRegistry
-        schema:
-          type: string
-      - in: query
-        name: workflowPath
-        schema:
-          type: string
-      - in: query
-        name: defaultWorkflowPath
-        schema:
-          type: string
-      - in: query
-        name: workflowName
-        schema:
-          type: string
-      - in: query
-        name: descriptorType
-        schema:
-          type: string
-      - in: query
-        name: defaultTestParameterFilePath
-        schema:
-          type: string
+        - in: query
+          name: workflowRegistry
+          schema:
+            type: string
+        - in: query
+          name: workflowPath
+          schema:
+            type: string
+        - in: query
+          name: defaultWorkflowPath
+          schema:
+            type: string
+        - in: query
+          name: workflowName
+          schema:
+            type: string
+        - in: query
+          name: descriptorType
+          schema:
+            type: string
+        - in: query
+          name: defaultTestParameterFilePath
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -6735,19 +6587,19 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/organization/{organization}/published:
     get:
       description: List all published workflows of an organization.
       operationId: getPublishedWorkflowsByOrganization
       parameters:
-      - in: path
-        name: organization
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: organization
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -6758,17 +6610,17 @@ paths:
                 type: array
           description: default response
       tags:
-      - workflows
+        - workflows
   /workflows/path/entry/{repository}:
     get:
       description: Get an entry by path.
       operationId: getEntryByPath
       parameters:
-      - in: path
-        name: repository
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: repository
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -6777,19 +6629,19 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/path/entry/{repository}/published:
     get:
       description: Get a published entry by path.
       operationId: getPublishedEntryByPath
       parameters:
-      - in: path
-        name: repository
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: repository
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -6798,29 +6650,29 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       tags:
-      - workflows
+        - workflows
   /workflows/path/workflow/{repository}:
     get:
       description: Requires full path (including workflow name if applicable).
       operationId: getWorkflowByPath
       parameters:
-      - description: Repository path
-        in: path
-        name: repository
-        required: true
-        schema:
-          type: string
-      - description: 'Comma-delimited list of fields to include: validations, aliases'
-        in: query
-        name: include
-        schema:
-          type: string
-      - description: Whether to get a service or workflow
-        in: query
-        name: services
-        schema:
-          default: false
-          type: boolean
+        - description: Repository path
+          in: path
+          name: repository
+          required: true
+          schema:
+            type: string
+        - description: 'Comma-delimited list of fields to include: validations, aliases'
+          in: query
+          name: include
+          schema:
+            type: string
+        - description: Whether to get a service or workflow
+          in: query
+          name: services
+          schema:
+            default: false
+            type: boolean
       responses:
         default:
           content:
@@ -6829,25 +6681,25 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Get a workflow by path.
       tags:
-      - workflows
+        - workflows
   /workflows/path/workflow/{repository}/actions:
     get:
       description: Gets all actions a user can perform on a workflow.
       operationId: getWorkflowActions
       parameters:
-      - in: path
-        name: repository
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: services
-        schema:
-          default: false
-          type: boolean
+        - in: path
+          name: repository
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: services
+          schema:
+            default: false
+            type: boolean
       responses:
         default:
           content:
@@ -6855,44 +6707,44 @@ paths:
               schema:
                 items:
                   enum:
-                  - write
-                  - read
-                  - delete
-                  - share
+                    - write
+                    - read
+                    - delete
+                    - share
                   type: string
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/path/workflow/{repository}/permissions:
     delete:
       description: Remove the specified user role for a workflow.
       operationId: removeWorkflowRole
       parameters:
-      - in: path
-        name: repository
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: email
-        schema:
-          type: string
-      - in: query
-        name: role
-        schema:
-          enum:
-          - OWNER
-          - WRITER
-          - READER
-          type: string
-      - in: query
-        name: services
-        schema:
-          default: false
-          type: boolean
+        - in: path
+          name: repository
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: email
+          schema:
+            type: string
+        - in: query
+          name: role
+          schema:
+            enum:
+              - OWNER
+              - WRITER
+              - READER
+            type: string
+        - in: query
+          name: services
+          schema:
+            default: false
+            type: boolean
       responses:
         default:
           content:
@@ -6903,23 +6755,23 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
     get:
       description: Get all permissions for a workflow.
       operationId: getWorkflowPermissions
       parameters:
-      - in: path
-        name: repository
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: services
-        schema:
-          default: false
-          type: boolean
+        - in: path
+          name: repository
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: services
+          schema:
+            default: false
+            type: boolean
       responses:
         default:
           content:
@@ -6930,23 +6782,23 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
     patch:
       description: Set the specified permission for a user on a workflow.
       operationId: addWorkflowPermission
       parameters:
-      - in: path
-        name: repository
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: services
-        schema:
-          default: false
-          type: boolean
+        - in: path
+          name: repository
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: services
+          schema:
+            default: false
+            type: boolean
       requestBody:
         content:
           '*/*':
@@ -6962,28 +6814,28 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/path/workflow/{repository}/published:
     get:
       description: Get a published workflow by path
       operationId: getPublishedWorkflowByPath
       parameters:
-      - in: path
-        name: repository
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: include
-        schema:
-          type: string
-      - in: query
-        name: services
-        schema:
-          default: false
-          type: boolean
+        - in: path
+          name: repository
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: include
+          schema:
+            type: string
+        - in: query
+          name: services
+          schema:
+            default: false
+            type: boolean
       responses:
         default:
           content:
@@ -6992,17 +6844,17 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       tags:
-      - workflows
+        - workflows
   /workflows/path/{repository}:
     get:
       description: Get a list of workflows by path.
       operationId: getAllWorkflowByPath
       parameters:
-      - in: path
-        name: repository
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: repository
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -7013,44 +6865,44 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/published:
     get:
       description: List all published workflows.
       operationId: allPublishedWorkflows
       parameters:
-      - in: query
-        name: offset
-        schema:
-          type: string
-      - in: query
-        name: limit
-        schema:
-          default: 100
-          format: int32
-          type: integer
-      - in: query
-        name: filter
-        schema:
-          default: ""
-          type: string
-      - in: query
-        name: sortCol
-        schema:
-          default: stars
-          type: string
-      - in: query
-        name: sortOrder
-        schema:
-          default: desc
-          type: string
-      - in: query
-        name: services
-        schema:
-          default: false
-          type: boolean
+        - in: query
+          name: offset
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            default: 100
+            format: int32
+            type: integer
+        - in: query
+          name: filter
+          schema:
+            default: ""
+            type: string
+        - in: query
+          name: sortCol
+          schema:
+            default: stars
+            type: string
+        - in: query
+          name: sortOrder
+          schema:
+            default: desc
+            type: string
+        - in: query
+          name: services
+          schema:
+            default: false
+            type: boolean
       responses:
         default:
           content:
@@ -7061,22 +6913,22 @@ paths:
                 type: array
           description: default response
       tags:
-      - workflows
+        - workflows
   /workflows/published/{workflowId}:
     get:
       description: Get a published workflow.
       operationId: getPublishedWorkflow
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: include
-        schema:
-          type: string
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: include
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -7085,72 +6937,71 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       tags:
-      - workflows
+        - workflows
   /workflows/registries/{gitRegistry}/organizations/{organization}/repositories/{repositoryName}:
     delete:
       description: Delete a stubbed workflow for a registry and repository path.
       operationId: deleteWorkflow
       parameters:
-      - description: Git registry
-        in: path
-        name: gitRegistry
-        required: true
-        schema:
-          enum:
-          - dockstore.org
-          - github.com
-          - bitbucket.org
-          - gitlab.com
-          type: string
-      - description: Git repository organization
-        in: path
-        name: organization
-        required: true
-        schema:
-          type: string
-      - description: Git repository name
-        in: path
-        name: repositoryName
-        required: true
-        schema:
-          type: string
+        - description: Git registry
+          in: path
+          name: gitRegistry
+          required: true
+          schema:
+            enum:
+              - dockstore.org
+              - github.com
+              - bitbucket.org
+              - gitlab.com
+            type: string
+        - description: Git repository organization
+          in: path
+          name: organization
+          required: true
+          schema:
+            type: string
+        - description: Git repository name
+          in: path
+          name: repositoryName
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
     post:
-      description: Adds a workflow for a registry and repository path with defaults
-        set.
+      description: Adds a workflow for a registry and repository path with defaults set.
       operationId: addWorkflow
       parameters:
-      - description: Git registry
-        in: path
-        name: gitRegistry
-        required: true
-        schema:
-          enum:
-          - dockstore.org
-          - github.com
-          - bitbucket.org
-          - gitlab.com
-          type: string
-      - description: Git repository organization
-        in: path
-        name: organization
-        required: true
-        schema:
-          type: string
-      - description: Git repository name
-        in: path
-        name: repositoryName
-        required: true
-        schema:
-          type: string
+        - description: Git registry
+          in: path
+          name: gitRegistry
+          required: true
+          schema:
+            enum:
+              - dockstore.org
+              - github.com
+              - bitbucket.org
+              - gitlab.com
+            type: string
+        - description: Git repository organization
+          in: path
+          name: organization
+          required: true
+          schema:
+            type: string
+        - description: Git repository name
+          in: path
+          name: repositoryName
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -7159,9 +7010,9 @@ paths:
                 $ref: '#/components/schemas/BioWorkflow'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/shared:
     get:
       description: Retrieve all workflows shared with user.
@@ -7176,19 +7027,19 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/versions:
     get:
       description: List the versions for a published workflow.
       operationId: tags_1
       parameters:
-      - in: query
-        name: workflowId
-        schema:
-          format: int64
-          type: integer
+        - in: query
+          name: workflowId
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -7199,19 +7050,19 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{alias}/aliases:
     get:
       description: Retrieves a workflow by alias.
       operationId: getWorkflowByAlias
       parameters:
-      - in: path
-        name: alias
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: alias
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -7220,33 +7071,33 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{entryId}/registerCheckerWorkflow/{descriptorType}:
     post:
       description: Register a checker workflow and associates it with the given tool/workflow.
       operationId: registerCheckerWorkflow
       parameters:
-      - in: query
-        name: checkerWorkflowPath
-        schema:
-          type: string
-      - in: query
-        name: testParameterPath
-        schema:
-          type: string
-      - in: path
-        name: entryId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: path
-        name: descriptorType
-        required: true
-        schema:
-          type: string
+        - in: query
+          name: checkerWorkflowPath
+          schema:
+            type: string
+        - in: query
+          name: testParameterPath
+          schema:
+            type: string
+        - in: path
+          name: entryId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: descriptorType
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -7255,24 +7106,24 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}:
     get:
       description: Retrieve a workflow
       operationId: getWorkflow
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: include
-        schema:
-          type: string
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: include
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -7281,19 +7132,19 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
     put:
       description: Update the workflow with the given workflow.
       operationId: updateWorkflow
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -7307,26 +7158,26 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/dag/{workflowVersionId}:
     get:
       description: Get the DAG for a given workflow version.
       operationId: getWorkflowDag
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: path
-        name: workflowVersionId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: workflowVersionId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -7335,20 +7186,20 @@ paths:
                 type: string
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/defaultVersion:
     put:
       description: Update the default version of a workflow.
       operationId: updateDefaultVersion_1
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -7362,33 +7213,33 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/descriptor/{relative-path}:
     get:
       description: Get the corresponding descriptor file from source control.
       operationId: secondaryDescriptorPath_1
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: tag
-        schema:
-          type: string
-      - in: path
-        name: relative-path
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: language
-        schema:
-          type: string
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: tag
+          schema:
+            type: string
+        - in: path
+          name: relative-path
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: language
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -7397,24 +7248,24 @@ paths:
                 $ref: '#/components/schemas/SourceFile'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/labels:
     put:
       description: Update the labels linked to a workflow.
       operationId: updateLabels_1
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: labels
-        schema:
-          type: string
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: labels
+          schema:
+            type: string
       requestBody:
         content:
           '*/*':
@@ -7428,28 +7279,28 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/primaryDescriptor:
     get:
       description: Get the primary descriptor file.
       operationId: primaryDescriptor_1
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: tag
-        schema:
-          type: string
-      - in: query
-        name: language
-        schema:
-          type: string
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: tag
+          schema:
+            type: string
+        - in: query
+          name: language
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -7458,20 +7309,20 @@ paths:
                 $ref: '#/components/schemas/SourceFile'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/publish:
     post:
       description: Publish or unpublish a workflow.
       operationId: publish_1
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -7485,20 +7336,20 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/refresh:
     get:
       description: Refresh one particular workflow.
       operationId: refresh_1
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -7507,25 +7358,25 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/refresh/{version}:
     get:
       description: Refresh one particular workflow version.
       operationId: refreshVersion
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: path
-        name: version
-        required: true
-        schema:
-          type: string
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: version
+          required: true
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -7534,26 +7385,26 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/requestDOI/{workflowVersionId}:
     put:
       description: Request a DOI for this version of a workflow.
       operationId: requestDOIForWorkflowVersion
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: path
-        name: workflowVersionId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: workflowVersionId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -7570,20 +7421,20 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/resetVersionPaths:
     put:
       description: Reset the workflow paths.
       operationId: updateWorkflowPath
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -7597,20 +7448,20 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/restub:
     get:
       description: Restub a workflow
       operationId: restub
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -7619,29 +7470,29 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       summary: Restub a workflow
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/secondaryDescriptors:
     get:
       description: Get the corresponding descriptor documents from source control.
       operationId: secondaryDescriptors_1
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: tag
-        schema:
-          type: string
-      - in: query
-        name: language
-        schema:
-          type: string
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: tag
+          schema:
+            type: string
+        - in: query
+          name: language
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -7652,20 +7503,20 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/star:
     put:
       description: Star a workflow.
       operationId: starEntry_1
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -7677,20 +7528,20 @@ paths:
             application/json: {}
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/starredUsers:
     get:
       description: Returns list of users who starred the given workflow.
       operationId: getStarredUsers_1
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -7702,28 +7553,28 @@ paths:
                 uniqueItems: true
           description: default response
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/testParameterFiles:
     delete:
       description: Delete test parameter files for a given version.
       operationId: deleteTestParameterFiles_1
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: testParameterPaths
-        schema:
-          items:
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: testParameterPaths
+          schema:
+            items:
+              type: string
+            type: array
+        - in: query
+          name: version
+          schema:
             type: string
-          type: array
-      - in: query
-        name: version
-        schema:
-          type: string
       responses:
         default:
           content:
@@ -7735,23 +7586,23 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
     get:
       description: Get the corresponding test parameter files.
       operationId: getTestParameterFiles_1
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: version
-        schema:
-          type: string
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: version
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -7762,29 +7613,29 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
     put:
       description: Add test parameter files for a given version.
       operationId: addTestParameterFiles_1
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: query
-        name: testParameterPaths
-        schema:
-          items:
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: testParameterPaths
+          schema:
+            items:
+              type: string
+            type: array
+        - in: query
+          name: version
+          schema:
             type: string
-          type: array
-      - in: query
-        name: version
-        schema:
-          type: string
       requestBody:
         content:
           '*/*':
@@ -7801,26 +7652,26 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/tools/{workflowVersionId}:
     get:
       description: Get the Tools for a given workflow version.
       operationId: getTableToolContent
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: path
-        name: workflowVersionId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: workflowVersionId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -7829,40 +7680,40 @@ paths:
                 type: string
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/unstar:
     delete:
       description: Unstar a workflow.
       operationId: unstarEntry_1
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/users:
     get:
       description: Get users of a workflow.
       operationId: getUsers_1
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
@@ -7873,20 +7724,20 @@ paths:
                 type: array
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/workflowVersions:
     put:
       description: Update the workflow versions linked to a workflow.
       operationId: updateWorkflowVersion
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
       requestBody:
         content:
           '*/*':
@@ -7905,52 +7756,52 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/workflowVersions/{workflowVersionId}/sourcefiles:
     get:
       description: Retrieve sourcefiles for an entry's version
       operationId: getWorkflowVersionsSourcefiles
       parameters:
-      - description: Workflow to retrieve the version from.
-        in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: Workflow version to retrieve the version from.
-        in: path
-        name: workflowVersionId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - description: List of file types to filter sourcefiles by
-        in: query
-        name: fileTypes
-        schema:
-          items:
-            enum:
-            - DOCKSTORE_CWL
-            - DOCKSTORE_WDL
-            - DOCKERFILE
-            - CWL_TEST_JSON
-            - WDL_TEST_JSON
-            - NEXTFLOW
-            - NEXTFLOW_CONFIG
-            - NEXTFLOW_TEST_PARAMS
-            - DOCKSTORE_YML
-            - DOCKSTORE_SERVICE_YML
-            - DOCKSTORE_SERVICE_TEST_JSON
-            - DOCKSTORE_SERVICE_OTHER
-            - DOCKSTORE_GXFORMAT2
-            - GXFORMAT2_TEST_FILE
-            - DOCKSTORE_SWL
-            - SWL_TEST_JSON
-            type: string
-          type: array
+        - description: Workflow to retrieve the version from.
+          in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: Workflow version to retrieve the version from.
+          in: path
+          name: workflowVersionId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - description: List of file types to filter sourcefiles by
+          in: query
+          name: fileTypes
+          schema:
+            items:
+              enum:
+                - DOCKSTORE_CWL
+                - DOCKSTORE_WDL
+                - DOCKERFILE
+                - CWL_TEST_JSON
+                - WDL_TEST_JSON
+                - NEXTFLOW
+                - NEXTFLOW_CONFIG
+                - NEXTFLOW_TEST_PARAMS
+                - DOCKSTORE_YML
+                - DOCKSTORE_SERVICE_YML
+                - DOCKSTORE_SERVICE_TEST_JSON
+                - DOCKSTORE_SERVICE_OTHER
+                - DOCKSTORE_GXFORMAT2
+                - GXFORMAT2_TEST_FILE
+                - DOCKSTORE_SWL
+                - SWL_TEST_JSON
+              type: string
+            type: array
       responses:
         default:
           content:
@@ -7962,94 +7813,85 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
   /workflows/{workflowId}/zip/{workflowVersionId}:
     get:
       description: Download a ZIP file of a workflow and all associated files.
       operationId: getWorkflowZip
       parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          format: int64
-          type: integer
-      - in: path
-        name: workflowVersionId
-        required: true
-        schema:
-          format: int64
-          type: integer
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: path
+          name: workflowVersionId
+          required: true
+          schema:
+            format: int64
+            type: integer
       responses:
         default:
           content:
             application/zip: {}
           description: default response
       security:
-      - bearer: []
+        - bearer: []
       tags:
-      - workflows
+        - workflows
 servers:
-- description: Current server when hosted on AWS
-  url: /api
-  variables: {}
-- description: When working locally
-  url: /
-  variables: {}
-- description: Production server
-  url: https://dockstore.org/api
-  variables: {}
-- description: Staging server
-  url: https://staging.dockstore.org/api
-  variables: {}
-- description: Nightly build server
-  url: https://dev.dockstore.net/api
-  variables: {}
+  - description: Current server when hosted on AWS
+    url: /api
+    variables: {}
+  - description: When working locally
+    url: /
+    variables: {}
+  - description: Production server
+    url: https://dockstore.org/api
+    variables: {}
+  - description: Staging server
+    url: https://staging.dockstore.org/api
+    variables: {}
+  - description: Nightly build server
+    url: https://dev.dockstore.net/api
+    variables: {}
 tags:
-- description: Create, update list aliases for accessing entries
-  name: aliases
-- description: Operations on Dockstore organizations
-  name: organizations
-- description: Needed for SmartAPI compatibility apparantly, might be cargo cult behaviour
-  name: NIHdatacommons
-- description: List and register entries in the dockstore (pairs of images + metadata
-    (CWL and Dockerfile))
-  name: containers
-- description: List and modify tags for containers
-  name: containertags
-- description: Interact with entries in Dockstore regardless of whether they are containers
-    or workflows
-  name: entries
-- description: Created and modify hosted entries in the dockstore
-  name: hosted
-- description: Query lambda events triggered by GitHub Apps
-  name: lambdaEvents
-- description: Information about Dockstore like RSS, sitemap, lists of dependencies,
-    etc.
-  name: metadata
-- description: List and modify notifications for users of Dockstore
-  name: curation
-- description: List and register workflows in the dockstore (CWL, Nextflow, WDL)
-  name: workflows
-- description: List, modify, refresh, and delete tokens for external services
-  name: tokens
-- description: Interactions with the Dockstore-support's ToolTester application
-  name: toolTester
-- description: List, modify, and manage end users of the dockstore
-  name: users
-- description: Optional experimental extensions of the GA4GH API
-  name: extendedGA4GH
-- description: A curated subset of resources proposed as a common standard for tool
-    repositories. Implements TRS [2.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0).
-  name: GA4GHV20
-- description: A curated subset of resources proposed as a common standard for tool
-    repositories. Implements TRS [2.0.0-beta.2](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0-beta.2)
-    . Integrators are welcome to use these endpoints but they are subject to change
-    based on community input.
-  name: GA4GH
-- description: A curated subset of resources proposed as a common standard for tool
-    repositories. Implements TRS [1.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/1.0.0)
-    and is considered final (not subject to change)
-  name: GA4GHV1
+  - description: Create, update list aliases for accessing entries
+    name: aliases
+  - description: Operations on Dockstore organizations
+    name: organizations
+  - description: Needed for SmartAPI compatibility apparantly, might be cargo cult behaviour
+    name: NIHdatacommons
+  - description: List and register entries in the dockstore (pairs of images + metadata (CWL and Dockerfile))
+    name: containers
+  - description: List and modify tags for containers
+    name: containertags
+  - description: Interact with entries in Dockstore regardless of whether they are containers or workflows
+    name: entries
+  - description: Created and modify hosted entries in the dockstore
+    name: hosted
+  - description: Query lambda events triggered by GitHub Apps
+    name: lambdaEvents
+  - description: Information about Dockstore like RSS, sitemap, lists of dependencies, etc.
+    name: metadata
+  - description: List and modify notifications for users of Dockstore
+    name: curation
+  - description: List and register workflows in the dockstore (CWL, Nextflow, WDL)
+    name: workflows
+  - description: List, modify, refresh, and delete tokens for external services
+    name: tokens
+  - description: Interactions with the Dockstore-support's ToolTester application
+    name: toolTester
+  - description: List, modify, and manage end users of the dockstore
+    name: users
+  - description: Optional experimental extensions of the GA4GH API
+    name: extendedGA4GH
+  - description: A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [2.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0).
+    name: GA4GHV20
+  - description: A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [2.0.0-beta.2](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0-beta.2) . Integrators are welcome to use these endpoints but they are subject to change based on community input.
+    name: GA4GH
+  - description: A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [1.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/1.0.0) and is considered final (not subject to change)
+    name: GA4GHV1

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -14,28 +14,34 @@ components:
       type: object
     BioWorkflow:
       allOf:
-        - $ref: '#/components/schemas/Workflow'
-        - properties:
-            is_checker:
-              type: boolean
-            parent_id:
-              format: int64
-              type: integer
-          type: object
+      - $ref: '#/components/schemas/Workflow'
+      - properties:
+          is_checker:
+            type: boolean
+          parent_id:
+            format: int64
+            type: integer
+        type: object
       type: object
     Checksum:
-      description: A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes.  This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
-      example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182, type=sha256}]'
+      description: 'A production (immutable) tool version is required to have a hashcode.
+        Not required otherwise, but might be useful to detect changes. '
+      example: '[{checksum=ea2a5db69bd20a42976838790bc29294df3af02b, type=sha1}]'
       properties:
         checksum:
           description: 'The hex-string encoded checksum for the data. '
           type: string
         type:
-          description: The digest method used to create the checksum. The value (e.g. `sha-256`) SHOULD be listed as `Hash Name String` in the https://github.com/ga4gh-discovery/ga4gh-checksum/blob/master/hash-alg.csv[GA4GH Checksum Hash Algorithm Registry]. Other values MAY be used, as long as implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4[RFC6920]. GA4GH may provide more explicit guidance for use of non-IANA-registered algorithms in the future.
+          description: The digest method used to create the checksum. The value (e.g.
+            `sha-256`) SHOULD be listed as `Hash Name String` in the https://github.com/ga4gh-discovery/ga4gh-checksum/blob/master/hash-alg.csv[GA4GH
+            Checksum Hash Algorithm Registry]. Other values MAY be used, as long as
+            implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4[RFC6920].
+            GA4GH may provide more explicit guidance for use of non-IANA-registered
+            algorithms in the future.
           type: string
       required:
-        - checksum
-        - type
+      - checksum
+      - type
       type: object
     Collection:
       description: Collection in an organization, collects entries
@@ -83,8 +89,8 @@ components:
           example: A collection of alignment algorithms
           type: string
       required:
-        - name
-        - topic
+      - name
+      - topic
       type: object
     CollectionEntry:
       properties:
@@ -367,9 +373,9 @@ components:
       properties:
         entryType:
           enum:
-            - TOOL
-            - WORKFLOW
-            - SERVICE
+          - TOOL
+          - WORKFLOW
+          - SERVICE
           type: string
         lastUpdateDate:
           format: date-time
@@ -387,7 +393,7 @@ components:
         message:
           type: string
       required:
-        - code
+      - code
       type: object
     Event:
       properties:
@@ -410,22 +416,22 @@ components:
           $ref: '#/components/schemas/Tool'
         type:
           enum:
-            - CREATE_ORG
-            - DELETE_ORG
-            - MODIFY_ORG
-            - APPROVE_ORG
-            - REJECT_ORG
-            - REREQUEST_ORG
-            - ADD_USER_TO_ORG
-            - REMOVE_USER_FROM_ORG
-            - MODIFY_USER_ROLE_ORG
-            - APPROVE_ORG_INVITE
-            - REJECT_ORG_INVITE
-            - CREATE_COLLECTION
-            - MODIFY_COLLECTION
-            - REMOVE_FROM_COLLECTION
-            - ADD_TO_COLLECTION
-            - ADD_VERSION_TO_ENTRY
+          - CREATE_ORG
+          - DELETE_ORG
+          - MODIFY_ORG
+          - APPROVE_ORG
+          - REJECT_ORG
+          - REREQUEST_ORG
+          - ADD_USER_TO_ORG
+          - REMOVE_USER_FROM_ORG
+          - MODIFY_USER_ROLE_ORG
+          - APPROVE_ORG_INVITE
+          - REJECT_ORG_INVITE
+          - CREATE_COLLECTION
+          - MODIFY_COLLECTION
+          - REMOVE_FROM_COLLECTION
+          - ADD_TO_COLLECTION
+          - ADD_VERSION_TO_ENTRY
           type: string
         user:
           $ref: '#/components/schemas/User'
@@ -445,10 +451,16 @@ components:
           type: string
       type: object
     FileWrapper:
-      description: 'A file provides content for one of - A tool descriptor is a metadata document that describes one or more tools. - A tool document that describes how to test with one or more sample test JSON. - A containerfile is a document that describes how to build a particular container image. Examples include Dockerfiles for creating Docker images and Singularity recipes for Singularity images '
+      description: 'A file provides content for one of - A tool descriptor is a metadata
+        document that describes one or more tools. - A tool document that describes
+        how to test with one or more sample test JSON. - A containerfile is a document
+        that describes how to build a particular container image. Examples include
+        Dockerfiles for creating Docker images and Singularity recipes for Singularity
+        images '
       properties:
         checksum:
-          description: 'A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes. '
+          description: 'A production (immutable) tool version is required to have
+            a hashcode. Not required otherwise, but might be useful to detect changes. '
           example: '[{checksum=ea2a5db69bd20a42976838790bc29294df3af02b, type=sha1}]'
           items:
             $ref: '#/components/schemas/Checksum'
@@ -457,7 +469,10 @@ components:
           description: The content of the file itself. One of url or content is required.
           type: string
         url:
-          description: Optional url to the underlying content, should include version information, and can include a git hash.  Note that this URL should resolve to the raw unwrapped content that would otherwise be available in content. One of url or content is required.
+          description: Optional url to the underlying content, should include version
+            information, and can include a git hash.  Note that this URL should resolve
+            to the raw unwrapped content that would otherwise be available in content.
+            One of url or content is required.
           type: string
       type: object
     Image:
@@ -472,11 +487,11 @@ components:
           type: string
         imageRegistry:
           enum:
-            - QUAY_IO
-            - DOCKER_HUB
-            - GITLAB
-            - AMAZON_ECR
-            - SEVEN_BRIDGES
+          - QUAY_IO
+          - DOCKER_HUB
+          - GITLAB
+          - AMAZON_ECR
+          - SEVEN_BRIDGES
           type: string
         os:
           type: string
@@ -489,22 +504,28 @@ components:
       description: Describes one container image.
       properties:
         checksum:
-          description: A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes.  This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
-          example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182, type=sha256}]'
+          description: A production (immutable) tool version is required to have a
+            hashcode. Not required otherwise, but might be useful to detect changes.  This
+            exposes the hashcode for specific image versions to verify that the container
+            version pulled is actually the version that was indexed by the registry.
+          example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182,
+            type=sha256}]'
           items:
             $ref: '#/components/schemas/Checksum'
           type: array
         image_name:
-          description: Used in conjunction with a registry_url if provided to locate images.
+          description: Used in conjunction with a registry_url if provided to locate
+            images.
           type: string
         image_type:
           enum:
-            - Docker
-            - Singularity
-            - Conda
+          - Docker
+          - Singularity
+          - Conda
           type: string
         registry_host:
-          description: A docker registry or a URL to a Singularity registry. Used along with image_name to locate a specific image.
+          description: A docker registry or a URL to a Singularity registry. Used
+            along with image_name to locate a specific image.
           type: string
         size:
           description: Size of the container in bytes.
@@ -544,9 +565,9 @@ components:
           type: boolean
         type:
           enum:
-            - PUSH
-            - DELETE
-            - INSTALL
+          - PUSH
+          - DELETE
+          - INSTALL
           type: string
       type: object
     Limits:
@@ -578,14 +599,14 @@ components:
           type: string
         priority:
           enum:
-            - LOW
-            - MEDIUM
-            - CRITICAL
+          - LOW
+          - MEDIUM
+          - CRITICAL
           type: string
         type:
           enum:
-            - SITEWIDE
-            - NEWSBODY
+          - SITEWIDE
+          - NEWSBODY
           type: string
       type: object
     Organization:
@@ -631,9 +652,9 @@ components:
           uniqueItems: true
         status:
           enum:
-            - PENDING
-            - REJECTED
-            - APPROVED
+          - PENDING
+          - REJECTED
+          - APPROVED
           type: string
         topic:
           type: string
@@ -669,8 +690,8 @@ components:
           $ref: '#/components/schemas/Organization'
         role:
           enum:
-            - MAINTAINER
-            - MEMBER
+          - MAINTAINER
+          - MEMBER
           type: string
         user:
           $ref: '#/components/schemas/User'
@@ -690,9 +711,9 @@ components:
           type: string
         role:
           enum:
-            - OWNER
-            - WRITER
-            - READER
+          - OWNER
+          - WRITER
+          - READER
           type: string
       type: object
     Profile:
@@ -738,10 +759,10 @@ components:
           type: boolean
         gitRegistry:
           enum:
-            - dockstore.org
-            - github.com
-            - bitbucket.org
-            - gitlab.com
+          - dockstore.org
+          - github.com
+          - bitbucket.org
+          - gitlab.com
           type: string
         organization:
           type: string
@@ -754,15 +775,15 @@ components:
       type: object
     Service:
       allOf:
-        - $ref: '#/components/schemas/Workflow'
+      - $ref: '#/components/schemas/Workflow'
       type: object
     SharedWorkflows:
       properties:
         role:
           enum:
-            - OWNER
-            - WRITER
-            - READER
+          - OWNER
+          - WRITER
+          - READER
           type: string
         workflows:
           items:
@@ -795,22 +816,22 @@ components:
           type: string
         type:
           enum:
-            - DOCKSTORE_CWL
-            - DOCKSTORE_WDL
-            - DOCKERFILE
-            - CWL_TEST_JSON
-            - WDL_TEST_JSON
-            - NEXTFLOW
-            - NEXTFLOW_CONFIG
-            - NEXTFLOW_TEST_PARAMS
-            - DOCKSTORE_YML
-            - DOCKSTORE_SERVICE_YML
-            - DOCKSTORE_SERVICE_TEST_JSON
-            - DOCKSTORE_SERVICE_OTHER
-            - DOCKSTORE_GXFORMAT2
-            - GXFORMAT2_TEST_FILE
-            - DOCKSTORE_SWL
-            - SWL_TEST_JSON
+          - DOCKSTORE_CWL
+          - DOCKSTORE_WDL
+          - DOCKERFILE
+          - CWL_TEST_JSON
+          - WDL_TEST_JSON
+          - NEXTFLOW
+          - NEXTFLOW_CONFIG
+          - NEXTFLOW_TEST_PARAMS
+          - DOCKSTORE_YML
+          - DOCKSTORE_SERVICE_YML
+          - DOCKSTORE_SERVICE_TEST_JSON
+          - DOCKSTORE_SERVICE_OTHER
+          - DOCKSTORE_GXFORMAT2
+          - GXFORMAT2_TEST_FILE
+          - DOCKSTORE_SWL
+          - SWL_TEST_JSON
           type: string
         verifiedBySource:
           additionalProperties:
@@ -839,8 +860,8 @@ components:
           type: string
         descriptionSource:
           enum:
-            - README
-            - DESCRIPTOR
+          - README
+          - DESCRIPTOR
           type: string
         dirtyBit:
           type: boolean
@@ -848,9 +869,9 @@ components:
           type: string
         doiStatus:
           enum:
-            - NOT_REQUESTED
-            - REQUESTED
-            - CREATED
+          - NOT_REQUESTED
+          - REQUESTED
+          - CREATED
           type: string
         doiURL:
           type: string
@@ -891,11 +912,11 @@ components:
           type: string
         referenceType:
           enum:
-            - COMMIT
-            - TAG
-            - BRANCH
-            - NOT_APPLICABLE
-            - UNSET
+          - COMMIT
+          - TAG
+          - BRANCH
+          - NOT_APPLICABLE
+          - UNSET
           type: string
         size:
           format: int64
@@ -946,14 +967,14 @@ components:
           type: string
         tokenSource:
           enum:
-            - quay.io
-            - github.com
-            - dockstore
-            - bitbucket.org
-            - gitlab.com
-            - zenodo.org
-            - google.com
-            - orcid.org
+          - quay.io
+          - github.com
+          - dockstore
+          - bitbucket.org
+          - gitlab.com
+          - zenodo.org
+          - google.com
+          - orcid.org
           type: string
         userId:
           format: int64
@@ -962,16 +983,27 @@ components:
           type: string
       type: object
     Tool:
-      description: A tool (or described tool) is defined as a tuple of a descriptor file (which potentially consists of multiple files), a set of container images, and a set of instructions for creating those images.
+      description: A tool (or described tool) is defined as a tuple of a descriptor
+        file (which potentially consists of multiple files), a set of container images,
+        and a set of instructions for creating those images.
       properties:
         aliases:
-          description: Support for this parameter is optional for tool registries that support aliases. A list of strings that can be used to identify this tool which could be  straight up URLs.  This can be used to expose alternative ids (such as GUIDs) for a tool for registries. Can be used to match tools across registries.
+          description: Support for this parameter is optional for tool registries
+            that support aliases. A list of strings that can be used to identify this
+            tool which could be  straight up URLs.  This can be used to expose alternative
+            ids (such as GUIDs) for a tool for registries. Can be used to match tools
+            across registries.
           items:
-            description: Support for this parameter is optional for tool registries that support aliases. A list of strings that can be used to identify this tool which could be  straight up URLs.  This can be used to expose alternative ids (such as GUIDs) for a tool for registries. Can be used to match tools across registries.
+            description: Support for this parameter is optional for tool registries
+              that support aliases. A list of strings that can be used to identify
+              this tool which could be  straight up URLs.  This can be used to expose
+              alternative ids (such as GUIDs) for a tool for registries. Can be used
+              to match tools across registries.
             type: string
           type: array
         checker_url:
-          description: Optional url to the checker tool that will exit successfully if this tool produced the expected result given test data.
+          description: Optional url to the checker tool that will exit successfully
+            if this tool produced the expected result given test data.
           type: string
         description:
           description: The description of the tool.
@@ -984,7 +1016,8 @@ components:
           example: "123456"
           type: string
         meta_version:
-          description: The version of this tool in the registry. Iterates when fields like the description, author, etc. are updated.
+          description: The version of this tool in the registry. Iterates when fields
+            like the description, author, etc. are updated.
           type: string
         name:
           description: The name of the tool.
@@ -1004,11 +1037,11 @@ components:
             $ref: '#/components/schemas/ToolVersion'
           type: array
       required:
-        - id
-        - organization
-        - toolclass
-        - url
-        - versions
+      - id
+      - organization
+      - toolclass
+      - url
+      - versions
       type: object
     ToolClass:
       properties:
@@ -1025,16 +1058,16 @@ components:
           type: string
         type:
           enum:
-            - CWL
-            - WDL
-            - NFL
-            - SERVICE
-            - GXFORMAT2
+          - CWL
+          - WDL
+          - NFL
+          - SERVICE
+          - GXFORMAT2
           type: string
         url:
           type: string
       required:
-        - type
+      - type
       type: object
     ToolDockerfile:
       properties:
@@ -1047,14 +1080,15 @@ components:
       properties:
         file_type:
           enum:
-            - TEST_FILE
-            - PRIMARY_DESCRIPTOR
-            - SECONDARY_DESCRIPTOR
-            - CONTAINERFILE
-            - OTHER
+          - TEST_FILE
+          - PRIMARY_DESCRIPTOR
+          - SECONDARY_DESCRIPTOR
+          - CONTAINERFILE
+          - OTHER
           type: string
         path:
-          description: Relative path of the file.  A descriptor's path can be used with the GA4GH .../{type}/descriptor/{relative_path} endpoint.
+          description: Relative path of the file.  A descriptor's path can be used
+            with the GA4GH .../{type}/descriptor/{relative_path} endpoint.
           type: string
       type: object
     ToolTesterLog:
@@ -1063,8 +1097,8 @@ components:
           type: string
         logType:
           enum:
-            - FULL
-            - SUMMARY
+          - FULL
+          - SUMMARY
           type: string
         runner:
           type: string
@@ -1116,51 +1150,65 @@ components:
           type: array
       type: object
     ToolVersion:
-      description: A tool version describes a particular iteration of a tool as described by a reference to a specific image and/or documents.
+      description: A tool version describes a particular iteration of a tool as described
+        by a reference to a specific image and/or documents.
       properties:
         author:
-          description: Contact information for the author of this version of the tool in the registry. (More complex authorship information is handled by the descriptor).
+          description: Contact information for the author of this version of the tool
+            in the registry. (More complex authorship information is handled by the
+            descriptor).
           items:
-            description: Contact information for the author of this version of the tool in the registry. (More complex authorship information is handled by the descriptor).
+            description: Contact information for the author of this version of the
+              tool in the registry. (More complex authorship information is handled
+              by the descriptor).
             type: string
           type: array
         containerfile:
-          description: Reports if this tool has a containerfile available. (For Docker-based tools, this would indicate the presence of a Dockerfile)
+          description: Reports if this tool has a containerfile available. (For Docker-based
+            tools, this would indicate the presence of a Dockerfile)
           type: boolean
         descriptor_type:
           description: The type (or types) of descriptors available.
           items:
             description: The type (or types) of descriptors available.
             enum:
-              - CWL
-              - WDL
-              - NFL
-              - SERVICE
-              - GXFORMAT2
+            - CWL
+            - WDL
+            - NFL
+            - SERVICE
+            - GXFORMAT2
             type: string
           type: array
         id:
-          description: An identifier of the version of this tool for this particular tool registry.
+          description: An identifier of the version of this tool for this particular
+            tool registry.
           example: v1
           type: string
         images:
-          description: All known docker images (and versions/hashes) used by this tool. If the tool has to evaluate any of the docker images strings at runtime, those ones cannot be reported here.
+          description: All known docker images (and versions/hashes) used by this
+            tool. If the tool has to evaluate any of the docker images strings at
+            runtime, those ones cannot be reported here.
           items:
             $ref: '#/components/schemas/ImageData'
           type: array
         included_apps:
-          description: An array of IDs for the applications that are stored inside this tool.
+          description: An array of IDs for the applications that are stored inside
+            this tool.
           example: '[https://bio.tools/tool/mytum.de/SNAP2/1, https://bio.tools/bioexcel_seqqc]'
           items:
-            description: An array of IDs for the applications that are stored inside this tool.
+            description: An array of IDs for the applications that are stored inside
+              this tool.
             example: '[https://bio.tools/tool/mytum.de/SNAP2/1, https://bio.tools/bioexcel_seqqc]'
             type: string
           type: array
         is_production:
-          description: This version of a tool is guaranteed to not change over time (for example, a  tool built from a tag in git as opposed to a branch). A production quality tool  is required to have a checksum
+          description: This version of a tool is guaranteed to not change over time
+            (for example, a  tool built from a tag in git as opposed to a branch).
+            A production quality tool  is required to have a checksum
           type: boolean
         meta_version:
-          description: The version of this tool version in the registry. Iterates when fields like the description, author, etc. are updated.
+          description: The version of this tool version in the registry. Iterates
+            when fields like the description, author, etc. are updated.
           type: string
         name:
           description: The name of the version.
@@ -1173,25 +1221,28 @@ components:
           example: http://agora.broadinstitute.org/tools/123456/versions/1
           type: string
         verified:
-          description: Reports whether this tool has been verified by a specific organization or individual.
+          description: Reports whether this tool has been verified by a specific organization
+            or individual.
           type: boolean
         verified_source:
-          description: Source of metadata that can support a verified tool, such as an email or URL.
+          description: Source of metadata that can support a verified tool, such as
+            an email or URL.
           items:
-            description: Source of metadata that can support a verified tool, such as an email or URL.
+            description: Source of metadata that can support a verified tool, such
+              as an email or URL.
             type: string
           type: array
       required:
-        - id
-        - url
+      - id
+      - url
       type: object
     ToolVersionV1:
       properties:
         descriptor-type:
           items:
             enum:
-              - CWL
-              - WDL
+            - CWL
+            - WDL
             type: string
           type: array
         dockerfile:
@@ -1228,8 +1279,8 @@ components:
           type: string
         privacyPolicyVersion:
           enum:
-            - NONE
-            - PRIVACY_POLICY_VERSION_2_5
+          - NONE
+          - PRIVACY_POLICY_VERSION_2_5
           type: string
         privacyPolicyVersionAcceptanceDate:
           format: date-time
@@ -1241,8 +1292,8 @@ components:
           type: string
         tosversion:
           enum:
-            - NONE
-            - TOS_VERSION_1
+          - NONE
+          - TOS_VERSION_1
           type: string
         tosversionAcceptanceDate:
           format: date-time
@@ -1264,22 +1315,22 @@ components:
           type: string
         type:
           enum:
-            - DOCKSTORE_CWL
-            - DOCKSTORE_WDL
-            - DOCKERFILE
-            - CWL_TEST_JSON
-            - WDL_TEST_JSON
-            - NEXTFLOW
-            - NEXTFLOW_CONFIG
-            - NEXTFLOW_TEST_PARAMS
-            - DOCKSTORE_YML
-            - DOCKSTORE_SERVICE_YML
-            - DOCKSTORE_SERVICE_TEST_JSON
-            - DOCKSTORE_SERVICE_OTHER
-            - DOCKSTORE_GXFORMAT2
-            - GXFORMAT2_TEST_FILE
-            - DOCKSTORE_SWL
-            - SWL_TEST_JSON
+          - DOCKSTORE_CWL
+          - DOCKSTORE_WDL
+          - DOCKERFILE
+          - CWL_TEST_JSON
+          - WDL_TEST_JSON
+          - NEXTFLOW
+          - NEXTFLOW_CONFIG
+          - NEXTFLOW_TEST_PARAMS
+          - DOCKSTORE_YML
+          - DOCKSTORE_SERVICE_YML
+          - DOCKSTORE_SERVICE_TEST_JSON
+          - DOCKSTORE_SERVICE_OTHER
+          - DOCKSTORE_GXFORMAT2
+          - GXFORMAT2_TEST_FILE
+          - DOCKSTORE_SWL
+          - SWL_TEST_JSON
           type: string
         valid:
           type: boolean
@@ -1306,16 +1357,16 @@ components:
           type: string
         descriptionSource:
           enum:
-            - README
-            - DESCRIPTOR
+          - README
+          - DESCRIPTOR
           type: string
         dirtyBit:
           type: boolean
         doiStatus:
           enum:
-            - NOT_REQUESTED
-            - REQUESTED
-            - CREATED
+          - NOT_REQUESTED
+          - REQUESTED
+          - CREATED
           type: string
         doiURL:
           type: string
@@ -1351,11 +1402,11 @@ components:
           type: string
         referenceType:
           enum:
-            - COMMIT
-            - TAG
-            - BRANCH
-            - NOT_APPLICABLE
-            - UNSET
+          - COMMIT
+          - TAG
+          - BRANCH
+          - NOT_APPLICABLE
+          - UNSET
           type: string
         sourceFiles:
           items:
@@ -1381,6 +1432,16 @@ components:
           $ref: '#/components/schemas/User'
         workingDirectory:
           type: string
+      type: object
+    VersionVerifiedPlatform:
+      properties:
+        metadata:
+          type: string
+        source:
+          type: string
+        versionId:
+          format: int64
+          type: integer
       type: object
     Workflow:
       discriminator:
@@ -1411,22 +1472,22 @@ components:
           type: string
         descriptorType:
           enum:
-            - CWL
-            - WDL
-            - gxformat2
-            - SWL
-            - NFL
-            - service
-            
-            
+          - CWL
+          - WDL
+          - gxformat2
+          - SWL
+          - NFL
+          - service
+          
+          
           type: string
         descriptorTypeSubclass:
           enum:
-            - docker-compose
-            - helm
-            - swarm
-            - kubernetes
-            - n/a
+          - docker-compose
+          - helm
+          - swarm
+          - kubernetes
+          - n/a
           type: string
         email:
           type: string
@@ -1468,10 +1529,10 @@ components:
           $ref: '#/components/schemas/Version'
         mode:
           enum:
-            - FULL
-            - STUB
-            - HOSTED
-            - DOCKSTORE_YML
+          - FULL
+          - STUB
+          - HOSTED
+          - DOCKSTORE_YML
           type: string
         organization:
           type: string
@@ -1488,10 +1549,10 @@ components:
           type: string
         sourceControl:
           enum:
-            - dockstore.org
-            - github.com
-            - bitbucket.org
-            - gitlab.com
+          - dockstore.org
+          - github.com
+          - bitbucket.org
+          - gitlab.com
           type: string
         source_control_provider:
           type: string
@@ -1520,7 +1581,7 @@ components:
         workflow_path:
           type: string
       required:
-        - type
+      - type
       type: object
     WorkflowVersion:
       properties:
@@ -1539,16 +1600,16 @@ components:
           type: string
         descriptionSource:
           enum:
-            - README
-            - DESCRIPTOR
+          - README
+          - DESCRIPTOR
           type: string
         dirtyBit:
           type: boolean
         doiStatus:
           enum:
-            - NOT_REQUESTED
-            - REQUESTED
-            - CREATED
+          - NOT_REQUESTED
+          - REQUESTED
+          - CREATED
           type: string
         doiURL:
           type: string
@@ -1589,11 +1650,11 @@ components:
           type: string
         referenceType:
           enum:
-            - COMMIT
-            - TAG
-            - BRANCH
-            - NOT_APPLICABLE
-            - UNSET
+          - COMMIT
+          - TAG
+          - BRANCH
+          - NOT_APPLICABLE
+          - UNSET
           type: string
         sourceFiles:
           items:
@@ -1602,10 +1663,10 @@ components:
           uniqueItems: true
         subClass:
           enum:
-            - DOCKER_COMPOSE
-            - SWARM
-            - KUBERNETES
-            - HELM
+          - DOCKER_COMPOSE
+          - SWARM
+          - KUBERNETES
+          - HELM
           type: string
         valid:
           type: boolean
@@ -1645,7 +1706,10 @@ info:
     email: theglobalalliance@genomicsandhealth.org
     name: Dockstore@ga4gh
     url: https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506
-  description: This describes the dockstore API, a webservice that manages pairs of Docker images and associated metadata such as CWL documents and Dockerfiles used to build those images. Explore swagger.json for a Swagger 2.0 description of our API and explore openapi.yaml for OpenAPI 3.0 descriptions.
+  description: This describes the dockstore API, a webservice that manages pairs of
+    Docker images and associated metadata such as CWL documents and Dockerfiles used
+    to build those images. Explore swagger.json for a Swagger 2.0 description of our
+    API and explore openapi.yaml for OpenAPI 3.0 descriptions.
   license:
     name: Apache License Version 2.0
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
@@ -1659,11 +1723,11 @@ paths:
       description: Retrieves workflow version path information by alias.
       operationId: getWorkflowVersionPathInfoByAlias
       parameters:
-        - in: path
-          name: alias
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: alias
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -1672,24 +1736,24 @@ paths:
                 $ref: '#/components/schemas/WorkflowVersionPathInfo'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - aliases
+      - aliases
   /aliases/workflow-versions/{workflowVersionId}:
     post:
       description: Add aliases linked to a workflow version in Dockstore.
       operationId: addAliases_1
       parameters:
-        - in: path
-          name: workflowVersionId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: aliases
-          schema:
-            type: string
+      - in: path
+        name: workflowVersionId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: aliases
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -1698,51 +1762,52 @@ paths:
                 $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - aliases
+      - aliases
   /api/ga4gh/v1/tools:
     get:
-      description: This endpoint returns all tools available or a filtered subset using metadata query parameters.
+      description: This endpoint returns all tools available or a filtered subset
+        using metadata query parameters.
       operationId: toolsGetV1
       parameters:
-        - in: query
-          name: id
-          schema:
-            type: string
-        - in: query
-          name: registry
-          schema:
-            type: string
-        - in: query
-          name: organization
-          schema:
-            type: string
-        - in: query
-          name: name
-          schema:
-            type: string
-        - in: query
-          name: toolname
-          schema:
-            type: string
-        - in: query
-          name: description
-          schema:
-            type: string
-        - in: query
-          name: author
-          schema:
-            type: string
-        - in: query
-          name: offset
-          schema:
-            type: string
-        - in: query
-          name: limit
-          schema:
-            format: int32
-            type: integer
+      - in: query
+        name: id
+        schema:
+          type: string
+      - in: query
+        name: registry
+        schema:
+          type: string
+      - in: query
+        name: organization
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: toolname
+        schema:
+          type: string
+      - in: query
+        name: description
+        schema:
+          type: string
+      - in: query
+        name: author
+        schema:
+          type: string
+      - in: query
+        name: offset
+        schema:
+          type: string
+      - in: query
+        name: limit
+        schema:
+          format: int32
+          type: integer
       responses:
         "200":
           content:
@@ -1754,17 +1819,18 @@ paths:
           description: An array of Tools that match the filter.
       summary: List all tools
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v1/tools/{id}:
     get:
-      description: This endpoint returns one specific tool (which has ToolVersions nested inside it)
+      description: This endpoint returns one specific tool (which has ToolVersions
+        nested inside it)
       operationId: toolsIdGetV1
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1774,17 +1840,17 @@ paths:
           description: A tool.
       summary: List one specific tool, acts as an anchor for self references
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions:
     get:
       description: Returns all versions of the specified tool
       operationId: toolsIdVersionGetV1
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1796,22 +1862,22 @@ paths:
           description: An array of tool versions
       summary: List versions of a tool
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions/{version_id}:
     get:
       description: This endpoint returns one specific tool version
       operationId: versionIdGetV1
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1821,22 +1887,22 @@ paths:
           description: A tool version.
       summary: List one specific tool version, acts as an anchor for self references
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions/{version_id}/dockerfile:
     get:
       description: Returns the dockerfile for the specified image.
       operationId: dockerfileGetV1
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1846,27 +1912,27 @@ paths:
           description: The tool payload.
       summary: Get the dockerfile for the specified image.
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/descriptor:
     get:
       description: Returns the CWL or WDL descriptor for the specified tool.
       operationId: descriptorGetV1
       parameters:
-        - in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1882,32 +1948,33 @@ paths:
           description: The tool can not be output in the specified type.
       summary: Get the tool descriptor (CWL/WDL) for the specified tool.
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}:
     get:
-      description: Returns additional CWL or WDL descriptors for the specified tool in the same or subdirectories
+      description: Returns additional CWL or WDL descriptors for the specified tool
+        in the same or subdirectories
       operationId: relativeDescriptorGetV1
       parameters:
-        - in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: relative_path
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: relative_path
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1921,28 +1988,29 @@ paths:
               schema:
                 $ref: '#/components/schemas/ToolDescriptor'
           description: The tool can not be output in the specified type.
-      summary: Get additional tool descriptor files (CWL/WDL) relative to the main file
+      summary: Get additional tool descriptor files (CWL/WDL) relative to the main
+        file
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/tests:
     get:
       operationId: testsGetV1
       parameters:
-        - in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1962,17 +2030,17 @@ paths:
           description: The tool can not be output in the specified type.
       summary: Get an array of test JSONs suitable for use with this descriptor type.
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v2/extended/containers/{organization}:
     get:
       description: This endpoint returns entries of an organization.
       operationId: entriesOrgGet
       parameters:
-        - in: path
-          name: organization
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: organization
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1984,7 +2052,7 @@ paths:
           description: An array of Tools of the input organization.
       summary: List entries of an organization
       tags:
-        - extendedGA4GH
+      - extendedGA4GH
   /api/ga4gh/v2/extended/organizations:
     get:
       description: This endpoint returns list of all organizations.
@@ -2000,10 +2068,11 @@ paths:
           description: An array of organizations' names.
       summary: List all organizations
       tags:
-        - extendedGA4GH
+      - extendedGA4GH
   /api/ga4gh/v2/extended/tools/entry/_search:
     post:
-      description: This endpoint searches the index for all published tools and workflows. Used by utilities that expect to talk to an elastic search endpoint.
+      description: This endpoint searches the index for all published tools and workflows.
+        Used by utilities that expect to talk to an elastic search endpoint.
       operationId: toolsIndexSearch
       requestBody:
         content:
@@ -2019,7 +2088,7 @@ paths:
           description: An elastic search result.
       summary: Search the index of tools
       tags:
-        - extendedGA4GH
+      - extendedGA4GH
   /api/ga4gh/v2/extended/tools/index:
     post:
       description: This endpoint updates the index for all published tools and workflows.
@@ -2032,20 +2101,20 @@ paths:
                 type: integer
           description: An array of Tools of the input organization.
       security:
-        - bearer: []
+      - bearer: []
       summary: Update the index of tools
       tags:
-        - extendedGA4GH
+      - extendedGA4GH
   /api/ga4gh/v2/extended/tools/{organization}:
     get:
       description: This endpoint returns tools of an organization.
       operationId: toolsOrgGet
       parameters:
-        - in: path
-          name: organization
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: organization
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -2057,17 +2126,17 @@ paths:
           description: An array of Tools of the input organization.
       summary: List tools of an organization
       tags:
-        - extendedGA4GH
+      - extendedGA4GH
   /api/ga4gh/v2/extended/workflows/{organization}:
     get:
       description: This endpoint returns workflows of an organization.
       operationId: workflowsOrgGet
       parameters:
-        - in: path
-          name: organization
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: organization
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -2079,48 +2148,49 @@ paths:
           description: An array of Tools of the input organization.
       summary: List workflows of an organization
       tags:
-        - extendedGA4GH
+      - extendedGA4GH
   /api/ga4gh/v2/extended/{id}/versions/{version_id}/{type}/tests/{relative_path}:
     post:
-      description: Test JSON can be annotated with whether they ran correctly keyed by platform and associated with some metadata.
+      description: Test JSON can be annotated with whether they ran correctly keyed
+        by platform and associated with some metadata.
       operationId: verifyTestParameterFilePost
       parameters:
-        - in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: relative_path
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: platform
-          schema:
-            type: string
-        - in: query
-          name: platform_version
-          schema:
-            type: string
-        - in: query
-          name: verified
-          schema:
-            type: boolean
-        - in: query
-          name: metadata
-          schema:
-            type: string
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: relative_path
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: platform
+        schema:
+          type: string
+      - in: query
+        name: platform_version
+        schema:
+          type: string
+      - in: query
+        name: verified
+        schema:
+          type: boolean
+      - in: query
+        name: metadata
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -2141,19 +2211,20 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool test cannot be found to annotate.
       security:
-        - bearer: []
-      summary: Annotate test JSON with information on whether it ran successfully on particular platforms plus metadata
+      - bearer: []
+      summary: Annotate test JSON with information on whether it ran successfully
+        on particular platforms plus metadata
       tags:
-        - extendedGA4GH
+      - extendedGA4GH
   /auth/tokens/bitbucket.org:
     get:
       description: Add a new bitbucket.org token, used by quay.io redirect.
       operationId: addBitbucketToken
       parameters:
-        - in: query
-          name: code
-          schema:
-            type: string
+      - in: query
+        name: code
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2162,12 +2233,13 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /auth/tokens/github:
     post:
-      description: Allow satellizer to post a new GitHub token to dockstore, used by login, can create new users.
+      description: Allow satellizer to post a new GitHub token to dockstore, used
+        by login, can create new users.
       operationId: addToken
       requestBody:
         content:
@@ -2182,18 +2254,18 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /auth/tokens/github.com:
     get:
       description: Add a new github.com token, used by accounts page.
       operationId: addGithubToken
       parameters:
-        - in: query
-          name: code
-          schema:
-            type: string
+      - in: query
+        name: code
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2202,18 +2274,18 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /auth/tokens/gitlab.com:
     get:
       description: Add a new gitlab.com token.
       operationId: addGitlabToken
       parameters:
-        - in: query
-          name: code
-          schema:
-            type: string
+      - in: query
+        name: code
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2222,9 +2294,9 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /auth/tokens/google:
     post:
       description: Allow satellizer to post a new Google token to Dockstore.
@@ -2242,18 +2314,19 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /auth/tokens/orcid.org:
     post:
-      description: Using OAuth code from ORCID, request and store tokens from ORCID API
+      description: Using OAuth code from ORCID, request and store tokens from ORCID
+        API
       operationId: addOrcidToken
       parameters:
-        - in: query
-          name: code
-          schema:
-            type: string
+      - in: query
+        name: code
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2262,19 +2335,19 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Add a new orcid.org token
       tags:
-        - tokens
+      - tokens
   /auth/tokens/quay.io:
     get:
       description: Add a new quay IO token.
       operationId: addQuayToken
       parameters:
-        - in: query
-          name: access_token
-          schema:
-            type: string
+      - in: query
+        name: access_token
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2283,18 +2356,18 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /auth/tokens/zenodo.org:
     get:
       description: Add a new zenodo.org token, used by accounts page.
       operationId: addZenodoToken
       parameters:
-        - in: query
-          name: code
-          schema:
-            type: string
+      - in: query
+        name: code
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2303,39 +2376,39 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /auth/tokens/{tokenId}:
     delete:
       description: Delete a token.
       operationId: deleteToken
       parameters:
-        - in: path
-          name: tokenId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: tokenId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
     get:
       description: Get a specific token by id.
       operationId: listToken
       parameters:
-        - in: path
-          name: tokenId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: tokenId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -2344,9 +2417,9 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /containers/dockerRegistryList:
     get:
       description: Get the list of docker registries supported on Dockstore.
@@ -2361,58 +2434,32 @@ paths:
                 type: array
           description: default response
       tags:
-        - containers
+      - containers
   /containers/hostedEntry:
     post:
       description: Create a hosted tool.
       operationId: createHostedTool_1
       parameters:
-        - in: query
-          name: registry
-          schema:
-            type: string
-        - in: query
-          name: name
-          schema:
-            type: string
-        - in: query
-          name: descriptorType
-          schema:
-            type: string
-        - in: query
-          name: namespace
-          schema:
-            type: string
-        - in: query
-          name: entryName
-          schema:
-            type: string
-      responses:
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Entry'
-          description: default response
-      security:
-        - bearer: []
-      tags:
-        - hosted
-  /containers/hostedEntry/{entryId}:
-    delete:
-      description: Delete a revision of a hosted tool.
-      operationId: deleteHostedToolVersion_1
-      parameters:
-        - in: path
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: version
-          schema:
-            type: string
+      - in: query
+        name: registry
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: descriptorType
+        schema:
+          type: string
+      - in: query
+        name: namespace
+        schema:
+          type: string
+      - in: query
+        name: entryName
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2421,19 +2468,45 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - hosted
+      - hosted
+  /containers/hostedEntry/{entryId}:
+    delete:
+      description: Delete a revision of a hosted tool.
+      operationId: deleteHostedToolVersion_1
+      parameters:
+      - in: path
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: version
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tool'
+          description: default response
+      security:
+      - bearer: []
+      tags:
+      - hosted
     patch:
       description: Non-idempotent operation for creating new revisions of hosted tools.
       operationId: editHostedTool
       parameters:
-        - in: path
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -2450,19 +2523,19 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - hosted
+      - hosted
   /containers/namespace/{namespace}/published:
     get:
       description: List all published tools belonging to the specified namespace.
       operationId: getPublishedContainersByNamespace
       parameters:
-        - in: path
-          name: namespace
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2473,21 +2546,21 @@ paths:
                 type: array
           description: default response
       tags:
-        - containers
+      - containers
   /containers/path/tool/{repository}:
     get:
       description: Get a tool by the specific tool path
       operationId: getContainerByToolPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: include
-          schema:
-            type: string
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: include
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2496,23 +2569,23 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/path/tool/{repository}/published:
     get:
       description: Get a published tool by the specific tool path.
       operationId: getPublishedContainerByToolPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: include
-          schema:
-            type: string
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: include
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2521,18 +2594,18 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       tags:
-        - containers
+      - containers
   /containers/path/{containerId}/tags:
     get:
       description: Get tags for a tool by id.
       operationId: getTagsByPath
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -2544,19 +2617,19 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containertags
+      - containertags
   /containers/path/{repository}:
     get:
       description: Get a list of tools by path.
       operationId: getContainerByPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2567,19 +2640,19 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/path/{repository}/published:
     get:
       description: Get a list of published tools by path.
       operationId: getPublishedContainerByPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2590,39 +2663,39 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/published:
     get:
       description: List all published tools.
       operationId: allPublishedContainers
       parameters:
-        - in: query
-          name: offset
-          schema:
-            type: string
-        - in: query
-          name: limit
-          schema:
-            default: 100
-            format: int32
-            type: integer
-        - in: query
-          name: filter
-          schema:
-            default: ""
-            type: string
-        - in: query
-          name: sortCol
-          schema:
-            default: stars
-            type: string
-        - in: query
-          name: sortOrder
-          schema:
-            default: desc
-            type: string
+      - in: query
+        name: offset
+        schema:
+          type: string
+      - in: query
+        name: limit
+        schema:
+          default: 100
+          format: int32
+          type: integer
+      - in: query
+        name: filter
+        schema:
+          default: ""
+          type: string
+      - in: query
+        name: sortCol
+        schema:
+          default: stars
+          type: string
+      - in: query
+        name: sortOrder
+        schema:
+          default: desc
+          type: string
       responses:
         default:
           content:
@@ -2633,7 +2706,7 @@ paths:
                 type: array
           description: default response
       tags:
-        - containers
+      - containers
   /containers/registerManual:
     post:
       description: Register a tool manually, along with tags.
@@ -2651,20 +2724,20 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/schema/{containerId}/published:
     get:
       description: Get a published tool's schema by ID.
       operationId: getPublishedContainerSchema
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -2675,17 +2748,17 @@ paths:
                 type: array
           description: default response
       tags:
-        - containers
+      - containers
   /containers/tags:
     get:
       description: List the tags for a tool.
       operationId: tags
       parameters:
-        - in: query
-          name: containerId
-          schema:
-            format: int64
-            type: integer
+      - in: query
+        name: containerId
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -2696,19 +2769,19 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{alias}/aliases:
     get:
       description: Retrieves a tool by alias.
       operationId: getToolByAlias
       parameters:
-        - in: path
-          name: alias
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: alias
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2717,43 +2790,43 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}:
     delete:
       description: Delete a tool.
       operationId: deleteContainer
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
     get:
       description: Retrieve a tool
       operationId: getContainer
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: include
-          schema:
-            type: string
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: include
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2762,19 +2835,19 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
     put:
       description: Update the tool with the given tool.
       operationId: updateContainer
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -2788,33 +2861,33 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/descriptor/{relative-path}:
     get:
       description: Get the corresponding descriptor file.
       operationId: secondaryDescriptorPath
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
-        - in: path
-          name: relative-path
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: language
-          schema:
-            type: string
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
+      - in: path
+        name: relative-path
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2823,24 +2896,24 @@ paths:
                 $ref: '#/components/schemas/SourceFile'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/dockerfile:
     get:
       description: Get the corresponding Dockerfile.
       operationId: dockerfile
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2849,24 +2922,24 @@ paths:
                 $ref: '#/components/schemas/SourceFile'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/labels:
     put:
       description: Update the labels linked to a tool.
       operationId: updateLabels
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: labels
-          schema:
-            type: string
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: labels
+        schema:
+          type: string
       requestBody:
         content:
           '*/*':
@@ -2880,28 +2953,28 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/primaryDescriptor:
     get:
       description: Get the primary descriptor file.
       operationId: primaryDescriptor
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
-        - in: query
-          name: language
-          schema:
-            type: string
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2910,20 +2983,20 @@ paths:
                 $ref: '#/components/schemas/SourceFile'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/publish:
     post:
       description: Publish or unpublish a tool.
       operationId: publish
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -2937,20 +3010,20 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/refresh:
     get:
       description: Refresh one particular tool.
       operationId: refresh
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -2959,26 +3032,26 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/requestDOI/{tagId}:
     post:
       description: Request a DOI for this version of a tool.
       operationId: requestDOIForToolTag
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: tagId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: tagId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -2990,28 +3063,28 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containertags
+      - containertags
   /containers/{containerId}/secondaryDescriptors:
     get:
       description: Get a list of secondary descriptor files.
       operationId: secondaryDescriptors
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
-        - in: query
-          name: language
-          schema:
-            type: string
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -3022,20 +3095,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/star:
     put:
       description: Star a tool.
       operationId: starEntry
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -3047,20 +3120,20 @@ paths:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/starredUsers:
     get:
       description: Returns list of users who starred a tool.
       operationId: getStarredUsers
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -3072,18 +3145,18 @@ paths:
                 uniqueItems: true
           description: default response
       tags:
-        - containers
+      - containers
   /containers/{containerId}/tags:
     post:
       description: Add new tags linked to a tool.
       operationId: addTags
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -3102,19 +3175,19 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containertags
+      - containertags
     put:
       description: Update the tags linked to a tool.
       operationId: updateTags
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -3133,78 +3206,78 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containertags
+      - containertags
   /containers/{containerId}/tags/{tagId}:
     delete:
       description: Delete tag linked to a tool.
       operationId: deleteTags
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: tagId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: tagId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containertags
+      - containertags
   /containers/{containerId}/tags/{tagId}/sourcefiles:
     get:
       description: Retrieve sourcefiles for a container's version
       operationId: getTagsSourcefiles
       parameters:
-        - description: Container to retrieve the version from
-          in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Tag to retrieve the sourcefiles from
-          in: path
-          name: tagId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: List of file types to filter sourcefiles by
-          in: query
-          name: fileTypes
-          schema:
-            items:
-              enum:
-                - DOCKSTORE_CWL
-                - DOCKSTORE_WDL
-                - DOCKERFILE
-                - CWL_TEST_JSON
-                - WDL_TEST_JSON
-                - NEXTFLOW
-                - NEXTFLOW_CONFIG
-                - NEXTFLOW_TEST_PARAMS
-                - DOCKSTORE_YML
-                - DOCKSTORE_SERVICE_YML
-                - DOCKSTORE_SERVICE_TEST_JSON
-                - DOCKSTORE_SERVICE_OTHER
-                - DOCKSTORE_GXFORMAT2
-                - GXFORMAT2_TEST_FILE
-                - DOCKSTORE_SWL
-                - SWL_TEST_JSON
-              type: string
-            type: array
+      - description: Container to retrieve the version from
+        in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Tag to retrieve the sourcefiles from
+        in: path
+        name: tagId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: List of file types to filter sourcefiles by
+        in: query
+        name: fileTypes
+        schema:
+          items:
+            enum:
+            - DOCKSTORE_CWL
+            - DOCKSTORE_WDL
+            - DOCKERFILE
+            - CWL_TEST_JSON
+            - WDL_TEST_JSON
+            - NEXTFLOW
+            - NEXTFLOW_CONFIG
+            - NEXTFLOW_TEST_PARAMS
+            - DOCKSTORE_YML
+            - DOCKSTORE_SERVICE_YML
+            - DOCKSTORE_SERVICE_TEST_JSON
+            - DOCKSTORE_SERVICE_OTHER
+            - DOCKSTORE_GXFORMAT2
+            - GXFORMAT2_TEST_FILE
+            - DOCKSTORE_SWL
+            - SWL_TEST_JSON
+            type: string
+          type: array
       responses:
         default:
           content:
@@ -3216,34 +3289,34 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containertags
+      - containertags
   /containers/{containerId}/testParameterFiles:
     delete:
       description: Delete test parameter files to a tag.
       operationId: deleteTestParameterFiles
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: testParameterPaths
-          schema:
-            items:
-              type: string
-            type: array
-        - in: query
-          name: tagName
-          schema:
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: testParameterPaths
+        schema:
+          items:
             type: string
-        - in: query
-          name: descriptorType
-          schema:
-            type: string
+          type: array
+      - in: query
+        name: tagName
+        schema:
+          type: string
+      - in: query
+        name: descriptorType
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -3255,27 +3328,27 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
     get:
       description: Get the corresponding test parameter files.
       operationId: getTestParameterFiles
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
-        - in: query
-          name: descriptorType
-          schema:
-            type: string
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
+      - in: query
+        name: descriptorType
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -3286,33 +3359,33 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
     put:
       description: Add test parameter files to a tag.
       operationId: addTestParameterFiles
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: testParameterPaths
-          schema:
-            items:
-              type: string
-            type: array
-        - in: query
-          name: tagName
-          schema:
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: testParameterPaths
+        schema:
+          items:
             type: string
-        - in: query
-          name: descriptorType
-          schema:
-            type: string
+          type: array
+      - in: query
+        name: tagName
+        schema:
+          type: string
+      - in: query
+        name: descriptorType
+        schema:
+          type: string
       requestBody:
         content:
           '*/*':
@@ -3329,40 +3402,40 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/unstar:
     delete:
       description: Unstar a tool.
       operationId: unstarEntry
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/updateTagPaths:
     put:
       description: Change the tool paths.
       operationId: updateTagContainerPath
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -3376,20 +3449,20 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/users:
     get:
       description: Get users of a tool.
       operationId: getUsers
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -3400,20 +3473,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{toolId}/defaultVersion:
     put:
       description: Update the default version of the given tool.
       operationId: updateDefaultVersion
       parameters:
-        - in: path
-          name: toolId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: toolId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -3427,35 +3500,35 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{toolId}/zip/{tagId}:
     get:
       description: Download a ZIP file of a tool and all associated files.
       operationId: getToolZip
       parameters:
-        - in: path
-          name: toolId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: tagId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: toolId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: tagId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/zip: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /curation/notifications:
     get:
       description: Return all active notifications
@@ -3470,7 +3543,7 @@ paths:
                 type: array
           description: default response
       tags:
-        - curation
+      - curation
     post:
       description: Create a notification
       operationId: createNotification
@@ -3487,39 +3560,39 @@ paths:
                 $ref: '#/components/schemas/Notification'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - curation
+      - curation
   /curation/notifications/{id}:
     delete:
       description: Delete a notification
       operationId: deleteNotification
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: id
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - curation
+      - curation
     get:
       description: Return the notification with given id
       operationId: getNotification
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: id
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -3528,17 +3601,17 @@ paths:
                 $ref: '#/components/schemas/Notification'
           description: default response
       tags:
-        - curation
+      - curation
     put:
       description: Update a notification
       operationId: updateNotification
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: id
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -3552,24 +3625,49 @@ paths:
                 $ref: '#/components/schemas/Notification'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - curation
+      - curation
+  /entries/{entryId}/verifiedPlatforms:
+    get:
+      description: Get the verified platforms for each version
+      operationId: getVerifiedPlatforms
+      parameters:
+      - description: id of the entry
+        in: path
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/VersionVerifiedPlatform'
+                type: array
+          description: default response
+      security:
+      - bearer: []
+      tags:
+      - entries
   /entries/{id}/aliases:
     post:
       description: Add aliases linked to a entry in Dockstore.
       operationId: addAliases_2
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: aliases
-          schema:
-            type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: aliases
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -3578,20 +3676,21 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - entries
+      - entries
   /entries/{id}/collections:
     get:
-      description: Get the collections and organizations that contain the published entry
+      description: Get the collections and organizations that contain the published
+        entry
       operationId: entryCollections
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: id
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -3602,19 +3701,19 @@ paths:
                 type: array
           description: default response
       tags:
-        - entries
+      - entries
   /entries/{id}/topic:
     post:
       description: Create a discourse topic for an entry.
       operationId: setDiscourseTopic
       parameters:
-        - description: The id of the entry to add a topic to.
-          in: path
-          name: id
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: The id of the entry to add a topic to.
+        in: path
+        name: id
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -3623,36 +3722,36 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - entries
+      - entries
   /events:
     get:
       description: Optional authentication.
       operationId: getEvents
       parameters:
-        - in: query
-          name: event_search_type
-          schema:
-            enum:
-              - STARRED_ENTRIES
-              - STARRED_ORGANIZATION
-              - ALL_STARRED
-            type: string
-        - in: query
-          name: limit
-          schema:
-            default: 10
-            format: int32
-            maximum: 100
-            minimum: 1
-            type: integer
-        - in: query
-          name: offset
-          schema:
-            default: 0
-            format: int32
-            type: integer
+      - in: query
+        name: event_search_type
+        schema:
+          enum:
+          - STARRED_ENTRIES
+          - STARRED_ORGANIZATION
+          - ALL_STARRED
+          type: string
+      - in: query
+        name: limit
+        schema:
+          default: 10
+          format: int32
+          maximum: 100
+          minimum: 1
+          type: integer
+      - in: query
+        name: offset
+        schema:
+          default: 0
+          format: int32
+          type: integer
       responses:
         default:
           content:
@@ -3663,10 +3762,10 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Get events based on filters.
       tags:
-        - events
+      - events
   /ga4gh/trs/v2/toolClasses:
     get:
       description: 'This endpoint returns all tool-classes available. '
@@ -3686,76 +3785,83 @@ paths:
                 type: array
           description: A list of potential tool classes.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: List all tool types
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools:
     get:
-      description: 'This endpoint returns all tools available or a filtered subset using metadata query parameters. '
+      description: 'This endpoint returns all tools available or a filtered subset
+        using metadata query parameters. '
       operationId: toolsGet
       parameters:
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: query
-          name: id
-          schema:
-            type: string
-        - description: Support for this parameter is optional for tool registries that support aliases. If provided will only return entries with the given alias.
-          in: query
-          name: alias
-          schema:
-            type: string
-        - description: Filter tools by the name of the subclass (#/definitions/ToolClass)
-          in: query
-          name: toolClass
-          schema:
-            type: string
-        - description: The image registry that contains the image.
-          in: query
-          name: registry
-          schema:
-            type: string
-        - description: The organization in the registry that published the image.
-          in: query
-          name: organization
-          schema:
-            type: string
-        - description: The name of the image.
-          in: query
-          name: name
-          schema:
-            type: string
-        - description: The name of the tool.
-          in: query
-          name: toolname
-          schema:
-            type: string
-        - description: The description of the tool.
-          in: query
-          name: description
-          schema:
-            type: string
-        - description: The author of the tool (TODO a thought occurs, are we assuming that the author of the CWL and the image are the same?).
-          in: query
-          name: author
-          schema:
-            type: string
-        - description: Return only checker workflows.
-          in: query
-          name: checker
-          schema:
-            type: boolean
-        - description: Start index of paging. Pagination results can be based on numbers or other values chosen by the registry implementor (for example, SHA values). If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.
-          in: query
-          name: offset
-          schema:
-            type: string
-        - description: Amount of records to return in a given page.
-          in: query
-          name: limit
-          schema:
-            format: int32
-            type: integer
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: query
+        name: id
+        schema:
+          type: string
+      - description: Support for this parameter is optional for tool registries that
+          support aliases. If provided will only return entries with the given alias.
+        in: query
+        name: alias
+        schema:
+          type: string
+      - description: Filter tools by the name of the subclass (#/definitions/ToolClass)
+        in: query
+        name: toolClass
+        schema:
+          type: string
+      - description: The image registry that contains the image.
+        in: query
+        name: registry
+        schema:
+          type: string
+      - description: The organization in the registry that published the image.
+        in: query
+        name: organization
+        schema:
+          type: string
+      - description: The name of the image.
+        in: query
+        name: name
+        schema:
+          type: string
+      - description: The name of the tool.
+        in: query
+        name: toolname
+        schema:
+          type: string
+      - description: The description of the tool.
+        in: query
+        name: description
+        schema:
+          type: string
+      - description: The author of the tool (TODO a thought occurs, are we assuming
+          that the author of the CWL and the image are the same?).
+        in: query
+        name: author
+        schema:
+          type: string
+      - description: Return only checker workflows.
+        in: query
+        name: checker
+        schema:
+          type: boolean
+      - description: Start index of paging. Pagination results can be based on numbers
+          or other values chosen by the registry implementor (for example, SHA values).
+          If this exceeds the current result set return an empty set.  If not specified
+          in the request, this will start at the beginning of the results.
+        in: query
+        name: offset
+        schema:
+          type: string
+      - description: Amount of records to return in a given page.
+        in: query
+        name: limit
+        schema:
+          format: int32
+          type: integer
       responses:
         "200":
           content:
@@ -3771,21 +3877,23 @@ paths:
                 type: array
           description: An array of Tools that match the filter.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: List all tools
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}:
     get:
-      description: This endpoint returns one specific tool (which has ToolVersions nested inside it).
+      description: This endpoint returns one specific tool (which has ToolVersions
+        nested inside it).
       operationId: toolsIdGet
       parameters:
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -3806,21 +3914,22 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool can not be found.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: List one specific tool, acts as an anchor for self references
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions:
     get:
       description: Returns all versions of the specified tool.
       operationId: toolsIdVersionsGet
       parameters:
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -3836,27 +3945,30 @@ paths:
                 type: array
           description: An array of tool versions.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: List versions of a tool
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}:
     get:
       description: This endpoint returns one specific tool version.
       operationId: toolsIdVersionsVersionIdGet
       parameters:
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - description: An identifier of the tool version, scoped to this registry, for example `v1`. We recommend that versions use semantic versioning https://semver.org/spec/v2.0.0.html  (For example, `1.0.0` instead of `develop`)
-          in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: An identifier of the tool version, scoped to this registry, for
+          example `v1`. We recommend that versions use semantic versioning https://semver.org/spec/v2.0.0.html  (For
+          example, `1.0.0` instead of `develop`)
+        in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -3877,27 +3989,32 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool can not be found.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: List one specific tool version, acts as an anchor for self references
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}/containerfile:
     get:
-      description: Returns the container specifications(s) for the specified image. For example, a CWL CommandlineTool can be associated with one specification for a container, a CWL Workflow can be associated with multiple specifications for containers.
+      description: Returns the container specifications(s) for the specified image.
+        For example, a CWL CommandlineTool can be associated with one specification
+        for a container, a CWL Workflow can be associated with multiple specifications
+        for containers.
       operationId: toolsIdVersionsVersionIdContainerfileGet
       parameters:
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - description: An identifier of the tool version for this particular tool registry, for example `v1`.
-          in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: An identifier of the tool version for this particular tool registry,
+          for example `v1`.
+        in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -3922,33 +4039,39 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: There are no container specifications for this tool.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: Get the container specification(s) for the specified image.
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}/{type}/descriptor:
     get:
-      description: Returns the descriptor for the specified tool (examples include CWL, WDL, or Nextflow documents).
+      description: Returns the descriptor for the specified tool (examples include
+        CWL, WDL, or Nextflow documents).
       operationId: toolsIdVersionsVersionIdTypeDescriptorGet
       parameters:
-        - description: The output type of the descriptor. Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped with metadata. Allowable values include "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL".
-          in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - description: An identifier of the tool version, scoped to this registry, for example `v1`.
-          in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - description: The output type of the descriptor. Plain types return the bare
+          descriptor while the "non-plain" types return a descriptor wrapped with
+          metadata. Allowable values include "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL",
+          "PLAIN_NFL".
+        in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: An identifier of the tool version, scoped to this registry, for
+          example `v1`.
+        in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -3969,39 +4092,55 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool descriptor can not be found.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: Get the tool descriptor for the specified tool
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}:
     get:
-      description: Descriptors can often include imports that refer to additional descriptors. This returns additional descriptors for the specified tool in the same or other directories that can be reached as a relative path. This endpoint can be useful for workflow engine implementations like cwltool to programmatically download all the descriptors for a tool and run it. This can optionally include other files described with FileWrappers such as test parameters and containerfiles.
+      description: Descriptors can often include imports that refer to additional
+        descriptors. This returns additional descriptors for the specified tool in
+        the same or other directories that can be reached as a relative path. This
+        endpoint can be useful for workflow engine implementations like cwltool to
+        programmatically download all the descriptors for a tool and run it. This
+        can optionally include other files described with FileWrappers such as test
+        parameters and containerfiles.
       operationId: toolsIdVersionsVersionIdTypeDescriptorRelativePathGet
       parameters:
-        - description: The output type of the descriptor. If not specified, it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped with metadata. Allowable values are "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL".
-          in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - description: An identifier of the tool version for this particular tool registry, for example `v1`.
-          in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
-        - description: A relative path to the additional file (same directory or subdirectories), for example 'foo.cwl' would return a 'foo.cwl' from the same directory as the main descriptor. 'nestedDirectory/foo.cwl' would return the file  from a nested subdirectory.  Unencoded paths such 'sampleDirectory/foo.cwl' should also be allowed.
-          in: path
-          name: relative_path
-          required: true
-          schema:
-            type: string
+      - description: The output type of the descriptor. If not specified, it is up
+          to the underlying implementation to determine which output type to return.
+          Plain types return the bare descriptor while the "non-plain" types return
+          a descriptor wrapped with metadata. Allowable values are "CWL", "WDL", "NFL",
+          "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL".
+        in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: An identifier of the tool version for this particular tool registry,
+          for example `v1`.
+        in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
+      - description: A relative path to the additional file (same directory or subdirectories),
+          for example 'foo.cwl' would return a 'foo.cwl' from the same directory as
+          the main descriptor. 'nestedDirectory/foo.cwl' would return the file  from
+          a nested subdirectory.  Unencoded paths such 'sampleDirectory/foo.cwl' should
+          also be allowed.
+        in: path
+        name: relative_path
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -4022,33 +4161,38 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool can not be output in the specified type.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: Get additional tool descriptor files relative to the main file
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}/{type}/files:
     get:
-      description: 'Get a list of objects that contain the relative path and file type. The descriptors are intended for use with the /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path : .+} endpoint.'
+      description: 'Get a list of objects that contain the relative path and file
+        type. The descriptors are intended for use with the /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path
+        : .+} endpoint.'
       operationId: toolsIdVersionsVersionIdTypeFilesGet
       parameters:
-        - description: The output type of the descriptor. Examples of allowable values are "CWL", "WDL", and "NFL".
-          in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - description: An identifier of the tool version for this particular tool registry, for example `v1`.
-          in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - description: The output type of the descriptor. Examples of allowable values
+          are "CWL", "WDL", and "NFL".
+        in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: An identifier of the tool version for this particular tool registry,
+          for example `v1`.
+        in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -4073,33 +4217,39 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool can not be output in the specified type.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: Get a list of objects that contain the relative path and file type
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}/{type}/tests:
     get:
-      description: Get a list of test JSONs (these allow you to execute the tool successfully) suitable for use with this descriptor type.
+      description: Get a list of test JSONs (these allow you to execute the tool successfully)
+        suitable for use with this descriptor type.
       operationId: toolsIdVersionsVersionIdTypeTestsGet
       parameters:
-        - description: The type of the underlying descriptor. Allowable values include "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL". For example, "CWL" would return an list of ToolTests objects while "PLAIN_CWL" would return a bare JSON list with the content of the tests.
-          in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - description: An identifier of the tool version for this particular tool registry, for example `v1`.
-          in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - description: The type of the underlying descriptor. Allowable values include
+          "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL". For example,
+          "CWL" would return an list of ToolTests objects while "PLAIN_CWL" would
+          return a bare JSON list with the content of the tests.
+        in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: An identifier of the tool version for this particular tool registry,
+          for example `v1`.
+        in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -4124,31 +4274,31 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool can not be output in the specified type.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: Get a list of test JSONs
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /lambdaEvents/{organization}:
     get:
       description: Get all of the Lambda Events for the given GitHub organization.
       operationId: getLambdaEventsByOrganization
       parameters:
-        - in: path
-          name: organization
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: offset
-          schema:
-            default: "0"
-            type: string
-        - in: query
-          name: limit
-          schema:
-            default: 100
-            format: int32
-            type: integer
+      - in: path
+        name: organization
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: offset
+        schema:
+          default: "0"
+          type: string
+      - in: query
+        name: limit
+        schema:
+          default: 100
+          format: int32
+          type: integer
       responses:
         default:
           content:
@@ -4159,9 +4309,9 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - lambdaEvents
+      - lambdaEvents
   /metadata/config.json:
     get:
       description: Configuration, NO authentication
@@ -4175,10 +4325,11 @@ paths:
           description: default response
       summary: Configuration for UI clients of the API
       tags:
-        - metadata
+      - metadata
   /metadata/descriptorLanguageList:
     get:
-      description: Get the list of descriptor languages supported on Dockstore, NO authentication
+      description: Get the list of descriptor languages supported on Dockstore, NO
+        authentication
       operationId: getDescriptorLanguages
       responses:
         default:
@@ -4191,7 +4342,7 @@ paths:
           description: List of descriptor languages
       summary: Get the list of descriptor languages supported on Dockstore
       tags:
-        - metadata
+      - metadata
   /metadata/dockerRegistryList:
     get:
       description: Get the list of docker registries supported on Dockstore, NO authentication
@@ -4207,7 +4358,7 @@ paths:
           description: List of Docker registries
       summary: Get the list of docker registries supported on Dockstore
       tags:
-        - metadata
+      - metadata
   /metadata/elasticSearch:
     get:
       description: Successful response if elastic search is up and running, NO authentication
@@ -4220,7 +4371,7 @@ paths:
           description: default response
       summary: Successful response if elastic search is up and running
       tags:
-        - metadata
+      - metadata
   /metadata/okHttpCachePerformance:
     get:
       description: Get measures of cache performance, NO authentication
@@ -4236,7 +4387,7 @@ paths:
           description: Cache performance information
       summary: Get measures of cache performance
       tags:
-        - metadata
+      - metadata
   /metadata/rss:
     get:
       description: List all published tools and workflows in creation order, NO authentication
@@ -4250,40 +4401,40 @@ paths:
           description: default response
       summary: List all published tools and workflows in creation order
       tags:
-        - metadata
+      - metadata
   /metadata/runner_dependencies:
     get:
       description: Returns the file containing runner dependencies, NO authentication
       operationId: getRunnerDependencies
       parameters:
-        - description: The Dockstore client version
-          in: query
-          name: client_version
-          schema:
-            type: string
-        - description: Python version, only relevant for the cwltool runner
-          in: query
-          name: python_version
-          schema:
-            default: "3"
-            type: string
-        - description: The tool runner
-          in: query
-          name: runner
-          schema:
-            default: cwltool
-            enum:
-              - cwltool
-            type: string
-        - description: Response type
-          in: query
-          name: output
-          schema:
-            default: text
-            enum:
-              - json
-              - text
-            type: string
+      - description: The Dockstore client version
+        in: query
+        name: client_version
+        schema:
+          type: string
+      - description: Python version, only relevant for the cwltool runner
+        in: query
+        name: python_version
+        schema:
+          default: "3"
+          type: string
+      - description: The tool runner
+        in: query
+        name: runner
+        schema:
+          default: cwltool
+          enum:
+          - cwltool
+          type: string
+      - description: Response type
+        in: query
+        name: output
+        schema:
+          default: text
+          enum:
+          - json
+          - text
+          type: string
       responses:
         default:
           content:
@@ -4293,10 +4444,12 @@ paths:
           description: The requirements.txt file
       summary: Returns the file containing runner dependencies
       tags:
-        - metadata
+      - metadata
   /metadata/sitemap:
     get:
-      description: List all available workflow, tool, organization, and collection paths. Available means published for tools/workflows, and approved for organizations and their respective collections. NO authentication
+      description: List all available workflow, tool, organization, and collection
+        paths. Available means published for tools/workflows, and approved for organizations
+        and their respective collections. NO authentication
       operationId: sitemap
       responses:
         default:
@@ -4310,7 +4463,7 @@ paths:
           description: default response
       summary: List all available workflow, tool, organization, and collection paths.
       tags:
-        - metadata
+      - metadata
   /metadata/sourceControlList:
     get:
       description: Get the list of source controls supported on Dockstore, NO authentication
@@ -4326,10 +4479,11 @@ paths:
           description: List of source control repositories
       summary: Get the list of source controls supported on Dockstore
       tags:
-        - metadata
+      - metadata
   /organizations:
     get:
-      description: List all organizations that have been approved by a curator or admin, sorted by number of stars.
+      description: List all organizations that have been approved by a curator or
+        admin, sorted by number of stars.
       operationId: getApprovedOrganizations
       responses:
         default:
@@ -4342,9 +4496,10 @@ paths:
           description: default response
       summary: List all available organizations.
       tags:
-        - organizations
+      - organizations
     post:
-      description: Create an organization. Organization requires approval by an admin before being made public.
+      description: Create an organization. Organization requires approval by an admin
+        before being made public.
       operationId: createOrganization
       requestBody:
         content:
@@ -4361,26 +4516,27 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Create an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/all:
     get:
-      description: List all organizations, regardless of organization status. Admin/curator only.
+      description: List all organizations, regardless of organization status. Admin/curator
+        only.
       operationId: getAllOrganizations
       parameters:
-        - description: Filter to apply to organizations.
-          in: query
-          name: type
-          required: true
-          schema:
-            enum:
-              - all
-              - pending
-              - rejected
-              - approved
-            type: string
+      - description: Filter to apply to organizations.
+        in: query
+        name: type
+        required: true
+        schema:
+          enum:
+          - all
+          - pending
+          - rejected
+          - approved
+          type: string
       responses:
         default:
           content:
@@ -4391,21 +4547,21 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: List all organizations.
       tags:
-        - organizations
+      - organizations
   /organizations/collections/{alias}/aliases:
     get:
       description: Retrieve a collection by alias.
       operationId: getCollectionByAlias
       parameters:
-        - description: Alias of the collection.
-          in: path
-          name: alias
-          required: true
-          schema:
-            type: string
+      - description: Alias of the collection.
+        in: path
+        name: alias
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -4415,25 +4571,26 @@ paths:
           description: default response
       summary: Retrieve a collection by alias.
       tags:
-        - organizations
+      - organizations
   /organizations/collections/{collectionId}/aliases:
     post:
-      description: Aliases are alphanumerical (case-insensitive and may contain internal hyphens), given in a comma-delimited list.
+      description: Aliases are alphanumerical (case-insensitive and may contain internal
+        hyphens), given in a comma-delimited list.
       operationId: addCollectionAliases_1
       parameters:
-        - description: Collection to modify.
-          in: path
-          name: collectionId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Comma-delimited list of aliases.
-          in: query
-          name: aliases
-          required: true
-          schema:
-            type: string
+      - description: Collection to modify.
+        in: path
+        name: collectionId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Comma-delimited list of aliases.
+        in: query
+        name: aliases
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -4442,21 +4599,21 @@ paths:
                 $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Add aliases linked to a collection in Dockstore.
       tags:
-        - organizations
+      - organizations
   /organizations/name/{name}:
     get:
       description: Retrieve an organization by name. Supports optional authentication.
       operationId: getOrganizationByName
       parameters:
-        - description: Organization name.
-          in: path
-          name: name
-          required: true
-          schema:
-            type: string
+      - description: Organization name.
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -4465,21 +4622,21 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve an organization by name.
       tags:
-        - organizations
+      - organizations
   /organizations/{alias}/aliases:
     get:
       description: Retrieve an organization by alias.
       operationId: getOrganizationByAlias
       parameters:
-        - description: Alias.
-          in: path
-          name: alias
-          required: true
-          schema:
-            type: string
+      - description: Alias.
+        in: path
+        name: alias
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -4489,19 +4646,19 @@ paths:
           description: default response
       summary: Retrieve an organization by alias.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}:
     get:
       description: Retrieve an organization by ID. Supports optional authentication.
       operationId: getOrganizationById
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -4510,21 +4667,22 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve an organization by ID.
       tags:
-        - organizations
+      - organizations
     put:
-      description: Update an organization. Currently only name, display name, description, topic, email, link, avatarUrl, and location can be updated.
+      description: Update an organization. Currently only name, display name, description,
+        topic, email, link, avatarUrl, and location can be updated.
       operationId: updateOrganization
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -4540,28 +4698,30 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Update an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/aliases:
     post:
-      description: Add aliases linked to a listing in Dockstore. Aliases are alphanumerical (case-insensitive and may contain internal hyphens), given in a comma-delimited list.
+      description: Add aliases linked to a listing in Dockstore. Aliases are alphanumerical
+        (case-insensitive and may contain internal hyphens), given in a comma-delimited
+        list.
       operationId: addOrganizationAliases_1
       parameters:
-        - description: Organization to modify.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Comma-delimited list of aliases.
-          in: query
-          name: aliases
-          required: true
-          schema:
-            type: string
+      - description: Organization to modify.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Comma-delimited list of aliases.
+        in: query
+        name: aliases
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -4570,22 +4730,22 @@ paths:
                 $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Add aliases linked to a listing in Dockstore.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/approve:
     post:
       description: Approve the organization with the given id. Admin/curator only.
       operationId: approveOrganization
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -4594,28 +4754,29 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Approve an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/collections:
     get:
-      description: Retrieve all collections for an organization. Supports optional authentication.
+      description: Retrieve all collections for an organization. Supports optional
+        authentication.
       operationId: getCollectionsFromOrganization
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Included fields.
-          in: query
-          name: include
-          required: true
-          schema:
-            type: string
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Included fields.
+        in: query
+        name: include
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -4626,21 +4787,21 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve all collections for an organization.
       tags:
-        - organizations
+      - organizations
     post:
       description: Create a collection in the given organization.
       operationId: createCollection
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -4656,29 +4817,29 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Create a collection in the given organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/collections/{collectionId}:
     get:
       description: Retrieve a collection by ID. Supports optional authentication.
       operationId: getCollectionById
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Collection ID.
-          in: path
-          name: collectionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Collection ID.
+        in: path
+        name: collectionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -4687,28 +4848,29 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve a collection by ID.
       tags:
-        - organizations
+      - organizations
     put:
-      description: Update a collection. Currently only name, display name, description, and topic can be updated.
+      description: Update a collection. Currently only name, display name, description,
+        and topic can be updated.
       operationId: updateCollection
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Collection ID.
-          in: path
-          name: collectionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Collection ID.
+        in: path
+        name: collectionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -4724,29 +4886,30 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Update a collection.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/collections/{collectionId}/description:
     get:
-      description: Retrieve a collection description by organization ID and collection ID. Supports optional authentication.
+      description: Retrieve a collection description by organization ID and collection
+        ID. Supports optional authentication.
       operationId: getCollectionDescription
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Collection ID.
-          in: path
-          name: collectionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Collection ID.
+        in: path
+        name: collectionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -4755,28 +4918,29 @@ paths:
                 type: string
           description: default response
       security:
-        - bearer: []
-      summary: Retrieve a collection description by organization ID and collection ID.
+      - bearer: []
+      summary: Retrieve a collection description by organization ID and collection
+        ID.
       tags:
-        - organizations
+      - organizations
     put:
       description: Update a collection's description. Description in markdown.
       operationId: updateCollectionDescription
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Collection ID.
-          in: path
-          name: collectionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Collection ID.
+        in: path
+        name: collectionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -4792,36 +4956,36 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Update a collection's description.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/collections/{collectionId}/entry:
     delete:
       description: Delete an entry to a collection.
       operationId: deleteEntryFromCollection
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Collection ID.
-          in: path
-          name: collectionId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Entry ID.
-          in: query
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Collection ID.
+        in: path
+        name: collectionId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Entry ID.
+        in: query
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -4830,35 +4994,35 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Delete an entry to a collection.
       tags:
-        - organizations
+      - organizations
     post:
       description: Add an entry to a collection.
       operationId: addEntryToCollection
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Collection ID.
-          in: path
-          name: collectionId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Entry ID.
-          in: query
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Collection ID.
+        in: path
+        name: collectionId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Entry ID.
+        in: query
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -4867,22 +5031,23 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Add an entry to a collection.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/description:
     get:
-      description: Retrieve an organization description by organization ID. Supports optional authentication.
+      description: Retrieve an organization description by organization ID. Supports
+        optional authentication.
       operationId: getOrganizationDescription
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -4891,21 +5056,22 @@ paths:
                 type: string
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve an organization description by organization ID.
       tags:
-        - organizations
+      - organizations
     put:
-      description: Update an organization's description. Expects description in markdown format.
+      description: Update an organization's description. Expects description in markdown
+        format.
       operationId: updateOrganizationDescription
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -4921,40 +5087,42 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Update an organization's description.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/events:
     get:
       description: Retrieve all events for an organization. Supports optional authentication.
       operationId: getOrganizationEvents
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Start index of paging.  If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.
-          in: query
-          name: offset
-          required: true
-          schema:
-            default: 0
-            format: int32
-            type: integer
-        - description: Amount of records to return in a given page, limited to 100
-          in: query
-          name: limit
-          required: true
-          schema:
-            default: 100
-            format: int32
-            maximum: 100
-            minimum: 1
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Start index of paging.  If this exceeds the current result set
+          return an empty set.  If not specified in the request, this will start at
+          the beginning of the results.
+        in: query
+        name: offset
+        required: true
+        schema:
+          default: 0
+          format: int32
+          type: integer
+      - description: Amount of records to return in a given page, limited to 100
+        in: query
+        name: limit
+        required: true
+        schema:
+          default: 100
+          format: int32
+          maximum: 100
+          minimum: 1
+          type: integer
       responses:
         default:
           content:
@@ -4965,50 +5133,51 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve all events for an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/invitation:
     post:
-      description: Accept or reject an organization invitation. True accepts the invitation, false rejects the invitation.
+      description: Accept or reject an organization invitation. True accepts the invitation,
+        false rejects the invitation.
       operationId: acceptOrRejectInvitation
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Accept or reject.
-          in: query
-          name: accept
-          required: true
-          schema:
-            type: boolean
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Accept or reject.
+        in: query
+        name: accept
+        required: true
+        schema:
+          type: boolean
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Accept or reject an organization invitation.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/members:
     get:
       description: Retrieve all members for an organization. Supports optional authentication.
       operationId: getOrganizationMembers
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5020,22 +5189,22 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve all members for an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/reject:
     post:
       description: Reject the organization with the given id. Admin/curator only.
       operationId: rejectOrganization
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5044,22 +5213,23 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Reject an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/request:
     post:
-      description: Re-request a review of the given organization. Requires the organization to be rejected.
+      description: Re-request a review of the given organization. Requires the organization
+        to be rejected.
       operationId: requestOrganizationReview
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5068,22 +5238,22 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Re-request an organization review.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/star:
     put:
       description: Star an organization.
       operationId: starOrganization
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -5097,22 +5267,22 @@ paths:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Star an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/starredUsers:
     get:
       description: Return list of users who starred the given approved organization.
       operationId: getStarredUsersForApprovedOrganization
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5125,85 +5295,85 @@ paths:
           description: default response
       summary: Return list of users who starred the given approved organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/unstar:
     delete:
       description: Unstar an organization.
       operationId: unstarOrganization
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Unstar an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/user:
     delete:
       description: Remove a user from an organization.
       operationId: deleteUserRole
       parameters:
-        - description: User ID of user to add to organization.
-          in: query
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: User ID of user to add to organization.
+        in: query
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Remove a user from an organization.
       tags:
-        - organizations
+      - organizations
     post:
       description: Update a user role in an organization.
       operationId: updateUserRole
       parameters:
-        - description: Role of user.
-          in: query
-          name: role
-          required: true
-          schema:
-            enum:
-              - MAINTAINER
-              - MEMBER
-            type: string
-        - description: User ID of user to add to organization.
-          in: query
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Role of user.
+        in: query
+        name: role
+        required: true
+        schema:
+          enum:
+          - MAINTAINER
+          - MEMBER
+          type: string
+      - description: User ID of user to add to organization.
+        in: query
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5212,43 +5382,44 @@ paths:
                 $ref: '#/components/schemas/OrganizationUser'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Update a user role in an organization.
       tags:
-        - organizations
+      - organizations
     put:
       description: Add a user role to an organization.
       operationId: addUserToOrg
       parameters:
-        - description: Role of user.
-          in: query
-          name: role
-          required: true
-          schema:
-            enum:
-              - MAINTAINER
-              - MEMBER
-            type: string
-        - description: User ID of user to add to organization.
-          in: query
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Role of user.
+        in: query
+        name: role
+        required: true
+        schema:
+          enum:
+          - MAINTAINER
+          - MEMBER
+          type: string
+      - description: User ID of user to add to organization.
+        in: query
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
             schema:
               type: string
-        description: This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.
+        description: This is here to appease Swagger. It requires PUT methods to have
+          a body, even if it is empty. Please leave it empty.
       responses:
         default:
           content:
@@ -5257,35 +5428,35 @@ paths:
                 $ref: '#/components/schemas/OrganizationUser'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Add a user role to an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/users/{username}:
     put:
       description: Add a user role to an organization.
       operationId: addUserToOrgByUsername
       parameters:
-        - description: User to add to org.
-          in: path
-          name: username
-          required: true
-          schema:
-            type: string
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: User to add to org.
+        in: path
+        name: username
+        required: true
+        schema:
+          type: string
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
             schema:
               enum:
-                - MAINTAINER
-                - MEMBER
+              - MAINTAINER
+              - MEMBER
               type: string
         description: Role of user.
         required: true
@@ -5297,27 +5468,27 @@ paths:
                 $ref: '#/components/schemas/OrganizationUser'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Add a user role to an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationName}/collections/{collectionName}/name:
     get:
       description: Retrieve a collection by name. Supports optional authentication.
       operationId: getCollectionById_1
       parameters:
-        - description: Organization name.
-          in: path
-          name: organizationName
-          required: true
-          schema:
-            type: string
-        - description: Collection name.
-          in: path
-          name: collectionName
-          required: true
-          schema:
-            type: string
+      - description: Organization name.
+        in: path
+        name: organizationName
+        required: true
+        schema:
+          type: string
+      - description: Collection name.
+        in: path
+        name: collectionName
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5326,53 +5497,53 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve a collection by name.
       tags:
-        - organizations
+      - organizations
   /toolTester/logs:
     get:
       operationId: getToolTesterLog
       parameters:
-        - description: TRS Tool Id
-          example: '#workflow/github.com/dockstore/hello_world'
-          in: query
-          name: tool_id
-          required: true
-          schema:
-            type: string
-        - example: v1.0.0
-          in: query
-          name: tool_version_name
-          required: true
-          schema:
-            type: string
-        - example: hello_world.cwl.json
-          in: query
-          name: test_filename
-          required: true
-          schema:
-            type: string
-        - example: cwltool
-          in: query
-          name: runner
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: log_type
-          required: true
-          schema:
-            enum:
-              - FULL
-              - SUMMARY
-            type: string
-        - example: 1554477737092.log
-          in: query
-          name: filename
-          required: true
-          schema:
-            type: string
+      - description: TRS Tool Id
+        example: '#workflow/github.com/dockstore/hello_world'
+        in: query
+        name: tool_id
+        required: true
+        schema:
+          type: string
+      - example: v1.0.0
+        in: query
+        name: tool_version_name
+        required: true
+        schema:
+          type: string
+      - example: hello_world.cwl.json
+        in: query
+        name: test_filename
+        required: true
+        schema:
+          type: string
+      - example: cwltool
+        in: query
+        name: runner
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: log_type
+        required: true
+        schema:
+          enum:
+          - FULL
+          - SUMMARY
+          type: string
+      - example: 1554477737092.log
+        in: query
+        name: filename
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5382,24 +5553,24 @@ paths:
           description: default response
       summary: Get ToolTester log file
       tags:
-        - toolTester
+      - toolTester
   /toolTester/logs/search:
     get:
       operationId: search
       parameters:
-        - description: TRS Tool Id
-          example: '#workflow/github.com/dockstore/hello_world'
-          in: query
-          name: tool_id
-          required: true
-          schema:
-            type: string
-        - example: v1.0.0
-          in: query
-          name: tool_version_name
-          required: true
-          schema:
-            type: string
+      - description: TRS Tool Id
+        example: '#workflow/github.com/dockstore/hello_world'
+        in: query
+        name: tool_id
+        required: true
+        schema:
+          type: string
+      - example: v1.0.0
+        in: query
+        name: tool_version_name
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5411,17 +5582,17 @@ paths:
           description: default response
       summary: Search for ToolTester log files
       tags:
-        - toolTester
+      - toolTester
   /users/checkUser/{username}:
     get:
       description: Check if user with some username exists.
       operationId: checkUserExists
       parameters:
-        - in: path
-          name: username
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: username
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5430,9 +5601,9 @@ paths:
                 type: boolean
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/dockerRegistries:
     get:
       description: Get all of the Docker registries accessible to the logged-in user.
@@ -5447,20 +5618,21 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/dockerRegistries/{dockerRegistry}/organizations:
     get:
-      description: Get all of the organizations/namespaces of the Docker registry accessible to the logged-in user.
+      description: Get all of the organizations/namespaces of the Docker registry
+        accessible to the logged-in user.
       operationId: getDockerRegistriesOrganization
       parameters:
-        - description: Name of Docker registry
-          in: path
-          name: dockerRegistry
-          required: true
-          schema:
-            type: string
+      - description: Name of Docker registry
+        in: path
+        name: dockerRegistry
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5471,26 +5643,27 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/dockerRegistries/{dockerRegistry}/organizations/{organization}/repositories:
     get:
-      description: Get names of repositories associated with a specific namespace and Docker registry of the logged-in user.
+      description: Get names of repositories associated with a specific namespace
+        and Docker registry of the logged-in user.
       operationId: getDockerRegistryOrganizationRepositories
       parameters:
-        - description: Name of Docker registry
-          in: path
-          name: dockerRegistry
-          required: true
-          schema:
-            type: string
-        - description: Name of organization or namespace
-          in: path
-          name: organization
-          required: true
-          schema:
-            type: string
+      - description: Name of Docker registry
+        in: path
+        name: dockerRegistry
+        required: true
+        schema:
+          type: string
+      - description: Name of organization or namespace
+        in: path
+        name: organization
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5501,24 +5674,24 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/github/events:
     get:
       description: Get all of the GitHub Events for the logged in user.
       operationId: getUserGitHubEvents
       parameters:
-        - in: query
-          name: offset
-          schema:
-            type: string
-        - in: query
-          name: limit
-          schema:
-            default: 100
-            format: int32
-            type: integer
+      - in: query
+        name: offset
+        schema:
+          type: string
+      - in: query
+        name: limit
+        schema:
+          default: 100
+          format: int32
+          type: integer
       responses:
         default:
           content:
@@ -5529,9 +5702,9 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/github/sync:
     post:
       description: Syncs Dockstore account with GitHub App Installations.
@@ -5546,9 +5719,9 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/registries:
     get:
       description: Get all of the git registries accessible to the logged in user.
@@ -5560,33 +5733,34 @@ paths:
               schema:
                 items:
                   enum:
-                    - dockstore.org
-                    - github.com
-                    - bitbucket.org
-                    - gitlab.com
+                  - dockstore.org
+                  - github.com
+                  - bitbucket.org
+                  - gitlab.com
                   type: string
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/registries/{gitRegistry}/organizations:
     get:
-      description: Get all of the organizations for a given git registry accessible to the logged in user.
+      description: Get all of the organizations for a given git registry accessible
+        to the logged in user.
       operationId: getUserOrganizations
       parameters:
-        - description: Git registry
-          in: path
-          name: gitRegistry
-          required: true
-          schema:
-            enum:
-              - dockstore.org
-              - github.com
-              - bitbucket.org
-              - gitlab.com
-            type: string
+      - description: Git registry
+        in: path
+        name: gitRegistry
+        required: true
+        schema:
+          enum:
+          - dockstore.org
+          - github.com
+          - bitbucket.org
+          - gitlab.com
+          type: string
       responses:
         default:
           content:
@@ -5598,31 +5772,32 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/registries/{gitRegistry}/organizations/{organization}:
     get:
-      description: Get all of the repositories for an organization for a given git registry accessible to the logged in user.
+      description: Get all of the repositories for an organization for a given git
+        registry accessible to the logged in user.
       operationId: getUserOrganizationRepositories
       parameters:
-        - description: Git registry
-          in: path
-          name: gitRegistry
-          required: true
-          schema:
-            enum:
-              - dockstore.org
-              - github.com
-              - bitbucket.org
-              - gitlab.com
-            type: string
-        - description: Git organization
-          in: path
-          name: organization
-          required: true
-          schema:
-            type: string
+      - description: Git registry
+        in: path
+        name: gitRegistry
+        required: true
+        schema:
+          enum:
+          - dockstore.org
+          - github.com
+          - bitbucket.org
+          - gitlab.com
+          type: string
+      - description: Git organization
+        in: path
+        name: organization
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5633,9 +5808,9 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/starredOrganizations:
     get:
       description: Get the authenticated user's starred organizations.
@@ -5651,9 +5826,9 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/starredTools:
     get:
       description: Get the authenticated user's starred tools.
@@ -5669,9 +5844,9 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/starredWorkflows:
     get:
       description: Get the authenticated user's starred workflows.
@@ -5687,9 +5862,9 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/updateUserMetadata:
     get:
       description: Update metadata of all users.
@@ -5704,9 +5879,9 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/user:
     delete:
       description: Delete user if possible.
@@ -5719,9 +5894,9 @@ paths:
                 type: boolean
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
     get:
       description: Get the logged-in user.
       operationId: getUser
@@ -5733,18 +5908,18 @@ paths:
                 $ref: '#/components/schemas/User'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/user/changeUsername:
     post:
       description: Change username if possible.
       operationId: changeUsername
       parameters:
-        - in: query
-          name: username
-          schema:
-            type: string
+      - in: query
+        name: username
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5753,9 +5928,9 @@ paths:
                 $ref: '#/components/schemas/User'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/user/extended:
     get:
       description: Get additional information about the authenticated user.
@@ -5768,9 +5943,9 @@ paths:
                 $ref: '#/components/schemas/ExtendedUserData'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/user/memberships:
     get:
       description: Get the logged-in user's memberships.
@@ -5786,27 +5961,27 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/user/updateUserMetadata:
     get:
       description: Update metadata for logged in user.
       operationId: updateLoggedInUserMetadata
       parameters:
-        - in: query
-          name: source
-          schema:
-            enum:
-              - quay.io
-              - github.com
-              - dockstore
-              - bitbucket.org
-              - gitlab.com
-              - zenodo.org
-              - google.com
-              - orcid.org
-            type: string
+      - in: query
+        name: source
+        schema:
+          enum:
+          - quay.io
+          - github.com
+          - dockstore
+          - bitbucket.org
+          - gitlab.com
+          - zenodo.org
+          - google.com
+          - orcid.org
+          type: string
       responses:
         default:
           content:
@@ -5815,20 +5990,20 @@ paths:
                 $ref: '#/components/schemas/User'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/user/{userId}:
     delete:
       description: Terminate user if possible.
       operationId: terminateUsers
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5837,20 +6012,20 @@ paths:
                 type: boolean
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/user/{userId}/limits:
     get:
       description: Returns the specified user's limits. ADMIN or CURATOR only
       operationId: getUserLimits
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5859,19 +6034,19 @@ paths:
                 $ref: '#/components/schemas/Limits'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
     put:
       description: Update the specified user's limits. ADMIN or CURATOR only
       operationId: setUserLimits
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -5885,19 +6060,19 @@ paths:
                 $ref: '#/components/schemas/Limits'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/username/{username}:
     get:
       description: Get a user by username.
       operationId: listUser
       parameters:
-        - in: path
-          name: username
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: username
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5906,25 +6081,25 @@ paths:
                 $ref: '#/components/schemas/User'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/users/entries:
     get:
       description: Get all of the entries for a user, sorted by most recently updated.
       operationId: getUserEntries
       parameters:
-        - description: Maximum number of entries to return
-          in: query
-          name: count
-          schema:
-            format: int32
-            type: integer
-        - description: Filter paths with matching text
-          in: query
-          name: filter
-          schema:
-            type: string
+      - description: Maximum number of entries to return
+        in: query
+        name: count
+        schema:
+          format: int32
+          type: integer
+      - description: Filter paths with matching text
+        in: query
+        name: filter
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5935,25 +6110,26 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/users/organizations:
     get:
-      description: Get all of the Dockstore organizations for a user, sorted by most recently updated.
+      description: Get all of the Dockstore organizations for a user, sorted by most
+        recently updated.
       operationId: getUserDockstoreOrganizations
       parameters:
-        - description: Maximum number of organizations to return
-          in: query
-          name: count
-          schema:
-            format: int32
-            type: integer
-        - description: Filter paths with matching text
-          in: query
-          name: filter
-          schema:
-            type: string
+      - description: Maximum number of organizations to return
+        in: query
+        name: count
+        schema:
+          format: int32
+          type: integer
+      - description: Filter paths with matching text
+        in: query
+        name: filter
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5964,20 +6140,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}:
     get:
       description: Get user by id.
       operationId: getSpecificUser
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5986,20 +6162,20 @@ paths:
                 $ref: '#/components/schemas/User'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/containers:
     get:
       description: List all tools owned by the authenticated user.
       operationId: userContainers
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6010,20 +6186,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/containers/published:
     get:
       description: List all published tools from a user.
       operationId: userPublishedContainers
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6034,29 +6210,30 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/containers/{organization}/refresh:
     get:
-      description: Refresh all tools owned by the authenticated user with specified organization.
+      description: Refresh all tools owned by the authenticated user with specified
+        organization.
       operationId: refreshToolsByOrganization
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: organization
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: dockerRegistry
-          schema:
-            type: string
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: organization
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: dockerRegistry
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6067,20 +6244,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/services:
     get:
       description: List all services owned by the authenticated user.
       operationId: userServices
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6091,20 +6268,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/tokens:
     get:
       description: Get tokens with user id.
       operationId: getUserTokens
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6115,20 +6292,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/tokens/dockstore:
     get:
       description: Get Dockstore tokens with user id.
       operationId: getDockstoreUserTokens
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6139,20 +6316,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/tokens/github.com:
     get:
       description: Get Github tokens with user id.
       operationId: getGithubUserTokens
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6163,20 +6340,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/tokens/gitlab.com:
     get:
       description: Get Gitlab tokens with user id.
       operationId: getGitlabUserTokens
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6187,20 +6364,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/tokens/quay.io:
     get:
       description: Get Quay tokens with user id.
       operationId: getQuayUserTokens
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6211,21 +6388,21 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/workflows:
     get:
       description: List all workflows owned by the authenticated user.
       operationId: userWorkflows
       parameters:
-        - description: User ID
-          in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: User ID
+        in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6236,26 +6413,28 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
     patch:
-      description: Adds the logged-in user to any Dockstore workflows that they should have access to.
+      description: Adds the logged-in user to any Dockstore workflows that they should
+        have access to.
       operationId: addUserToDockstoreWorkflows
       parameters:
-        - description: User to update
-          in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: User to update
+        in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
             schema:
               type: string
-        description: This is here to appease Swagger. It requires PATCH methods to have a body, even if it is empty. Please leave it empty.
+        description: This is here to appease Swagger. It requires PATCH methods to
+          have a body, even if it is empty. Please leave it empty.
       responses:
         default:
           content:
@@ -6266,20 +6445,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/workflows/published:
     get:
       description: List all published workflows from a user.
       operationId: userPublishedWorkflows
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6290,48 +6469,51 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /workflows/github:
     delete:
-      description: Handles the deletion of a branch on GitHub. Will delete all workflow versions that match in all workflows that share the same repository.
+      description: Handles the deletion of a branch on GitHub. Will delete all workflow
+        versions that match in all workflows that share the same repository.
       operationId: handleGitHubBranchDeletion
       parameters:
-        - description: Repository path (ex. dockstore/dockstore-ui2)
-          in: query
-          name: repository
-          required: true
-          schema:
-            type: string
-        - description: Username of user on GitHub who triggered action
-          in: query
-          name: username
-          required: true
-          schema:
-            type: string
-        - description: Full git reference for a GitHub branch/tag. Ex. refs/heads/master or refs/tags/v1.0
-          in: query
-          name: gitReference
-          required: true
-          schema:
-            type: string
-        - description: GitHub installation ID
-          in: query
-          name: installationId
-          required: true
-          schema:
-            type: string
+      - description: Repository path (ex. dockstore/dockstore-ui2)
+        in: query
+        name: repository
+        required: true
+        schema:
+          type: string
+      - description: Username of user on GitHub who triggered action
+        in: query
+        name: username
+        required: true
+        schema:
+          type: string
+      - description: Full git reference for a GitHub branch/tag. Ex. refs/heads/master
+          or refs/tags/v1.0
+        in: query
+        name: gitReference
+        required: true
+        schema:
+          type: string
+      - description: GitHub installation ID
+        in: query
+        name: installationId
+        required: true
+        schema:
+          type: string
       responses:
         "418":
           description: This code tells AWS Lambda not to retry.
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/github/install:
     post:
-      description: Handle the installation of our GitHub app onto a repository or organization.
+      description: Handle the installation of our GitHub app onto a repository or
+        organization.
       operationId: handleGitHubInstallation
       requestBody:
         content:
@@ -6345,20 +6527,21 @@ paths:
                 username:
                   type: string
               required:
-                - installationId
-                - repositories
-                - username
+              - installationId
+              - repositories
+              - username
               type: object
       responses:
         "418":
           description: This code tells AWS Lambda not to retry.
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/github/release:
     post:
-      description: Handle a release of a repository on GitHub. Will create a workflow/service and version when necessary.
+      description: Handle a release of a repository on GitHub. Will create a workflow/service
+        and version when necessary.
       operationId: handleGitHubRelease
       requestBody:
         content:
@@ -6374,10 +6557,10 @@ paths:
                 username:
                   type: string
               required:
-                - gitReference
-                - installationId
-                - repository
-                - username
+              - gitReference
+              - installationId
+              - repository
+              - username
               type: object
       responses:
         default:
@@ -6389,34 +6572,34 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/hostedEntry:
     post:
       description: Create a hosted workflow.
       operationId: createHostedWorkflow_1
       parameters:
-        - in: query
-          name: registry
-          schema:
-            type: string
-        - in: query
-          name: name
-          schema:
-            type: string
-        - in: query
-          name: descriptorType
-          schema:
-            type: string
-        - in: query
-          name: namespace
-          schema:
-            type: string
-        - in: query
-          name: entryName
-          schema:
-            type: string
+      - in: query
+        name: registry
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: descriptorType
+        schema:
+          type: string
+      - in: query
+        name: namespace
+        schema:
+          type: string
+      - in: query
+        name: entryName
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6425,45 +6608,45 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - hosted
+      - hosted
   /workflows/hostedEntry/{entryId}:
     delete:
       description: Delete a revision of a hosted workflow.
       operationId: deleteHostedWorkflowVersion_1
       parameters:
-        - in: path
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: version
-          schema:
-            type: string
+      - in: path
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: version
+        schema:
+          type: string
       responses:
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - hosted
+      - hosted
     patch:
       description: Non-idempotent operation for creating new revisions of hosted workflows
       operationId: editHostedWorkflow
       parameters:
-        - in: path
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -6480,20 +6663,20 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - hosted
+      - hosted
     post:
       deprecated: true
       operationId: addZip
       parameters:
-        - description: hosted entry ID
-          in: path
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: hosted entry ID
+        in: path
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           multipart/form-data:
@@ -6511,39 +6694,39 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: successful operation
       security:
-        - bearer: []
+      - bearer: []
       summary: Creates a new revision of a hosted workflow from a zip
       tags:
-        - hosted
+      - hosted
   /workflows/manualRegister:
     post:
       description: Manually register a workflow.
       operationId: manualRegister
       parameters:
-        - in: query
-          name: workflowRegistry
-          schema:
-            type: string
-        - in: query
-          name: workflowPath
-          schema:
-            type: string
-        - in: query
-          name: defaultWorkflowPath
-          schema:
-            type: string
-        - in: query
-          name: workflowName
-          schema:
-            type: string
-        - in: query
-          name: descriptorType
-          schema:
-            type: string
-        - in: query
-          name: defaultTestParameterFilePath
-          schema:
-            type: string
+      - in: query
+        name: workflowRegistry
+        schema:
+          type: string
+      - in: query
+        name: workflowPath
+        schema:
+          type: string
+      - in: query
+        name: defaultWorkflowPath
+        schema:
+          type: string
+      - in: query
+        name: workflowName
+        schema:
+          type: string
+      - in: query
+        name: descriptorType
+        schema:
+          type: string
+      - in: query
+        name: defaultTestParameterFilePath
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6552,19 +6735,19 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/organization/{organization}/published:
     get:
       description: List all published workflows of an organization.
       operationId: getPublishedWorkflowsByOrganization
       parameters:
-        - in: path
-          name: organization
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: organization
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6575,17 +6758,17 @@ paths:
                 type: array
           description: default response
       tags:
-        - workflows
+      - workflows
   /workflows/path/entry/{repository}:
     get:
       description: Get an entry by path.
       operationId: getEntryByPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6594,19 +6777,19 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/path/entry/{repository}/published:
     get:
       description: Get a published entry by path.
       operationId: getPublishedEntryByPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6615,29 +6798,29 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       tags:
-        - workflows
+      - workflows
   /workflows/path/workflow/{repository}:
     get:
       description: Requires full path (including workflow name if applicable).
       operationId: getWorkflowByPath
       parameters:
-        - description: Repository path
-          in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - description: 'Comma-delimited list of fields to include: validations, aliases'
-          in: query
-          name: include
-          schema:
-            type: string
-        - description: Whether to get a service or workflow
-          in: query
-          name: services
-          schema:
-            default: false
-            type: boolean
+      - description: Repository path
+        in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - description: 'Comma-delimited list of fields to include: validations, aliases'
+        in: query
+        name: include
+        schema:
+          type: string
+      - description: Whether to get a service or workflow
+        in: query
+        name: services
+        schema:
+          default: false
+          type: boolean
       responses:
         default:
           content:
@@ -6646,25 +6829,25 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Get a workflow by path.
       tags:
-        - workflows
+      - workflows
   /workflows/path/workflow/{repository}/actions:
     get:
       description: Gets all actions a user can perform on a workflow.
       operationId: getWorkflowActions
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: services
-          schema:
-            default: false
-            type: boolean
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: services
+        schema:
+          default: false
+          type: boolean
       responses:
         default:
           content:
@@ -6672,44 +6855,44 @@ paths:
               schema:
                 items:
                   enum:
-                    - write
-                    - read
-                    - delete
-                    - share
+                  - write
+                  - read
+                  - delete
+                  - share
                   type: string
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/path/workflow/{repository}/permissions:
     delete:
       description: Remove the specified user role for a workflow.
       operationId: removeWorkflowRole
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: email
-          schema:
-            type: string
-        - in: query
-          name: role
-          schema:
-            enum:
-              - OWNER
-              - WRITER
-              - READER
-            type: string
-        - in: query
-          name: services
-          schema:
-            default: false
-            type: boolean
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: email
+        schema:
+          type: string
+      - in: query
+        name: role
+        schema:
+          enum:
+          - OWNER
+          - WRITER
+          - READER
+          type: string
+      - in: query
+        name: services
+        schema:
+          default: false
+          type: boolean
       responses:
         default:
           content:
@@ -6720,23 +6903,23 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
     get:
       description: Get all permissions for a workflow.
       operationId: getWorkflowPermissions
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: services
-          schema:
-            default: false
-            type: boolean
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: services
+        schema:
+          default: false
+          type: boolean
       responses:
         default:
           content:
@@ -6747,23 +6930,23 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
     patch:
       description: Set the specified permission for a user on a workflow.
       operationId: addWorkflowPermission
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: services
-          schema:
-            default: false
-            type: boolean
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: services
+        schema:
+          default: false
+          type: boolean
       requestBody:
         content:
           '*/*':
@@ -6779,28 +6962,28 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/path/workflow/{repository}/published:
     get:
       description: Get a published workflow by path
       operationId: getPublishedWorkflowByPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: include
-          schema:
-            type: string
-        - in: query
-          name: services
-          schema:
-            default: false
-            type: boolean
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: include
+        schema:
+          type: string
+      - in: query
+        name: services
+        schema:
+          default: false
+          type: boolean
       responses:
         default:
           content:
@@ -6809,17 +6992,17 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       tags:
-        - workflows
+      - workflows
   /workflows/path/{repository}:
     get:
       description: Get a list of workflows by path.
       operationId: getAllWorkflowByPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6830,44 +7013,44 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/published:
     get:
       description: List all published workflows.
       operationId: allPublishedWorkflows
       parameters:
-        - in: query
-          name: offset
-          schema:
-            type: string
-        - in: query
-          name: limit
-          schema:
-            default: 100
-            format: int32
-            type: integer
-        - in: query
-          name: filter
-          schema:
-            default: ""
-            type: string
-        - in: query
-          name: sortCol
-          schema:
-            default: stars
-            type: string
-        - in: query
-          name: sortOrder
-          schema:
-            default: desc
-            type: string
-        - in: query
-          name: services
-          schema:
-            default: false
-            type: boolean
+      - in: query
+        name: offset
+        schema:
+          type: string
+      - in: query
+        name: limit
+        schema:
+          default: 100
+          format: int32
+          type: integer
+      - in: query
+        name: filter
+        schema:
+          default: ""
+          type: string
+      - in: query
+        name: sortCol
+        schema:
+          default: stars
+          type: string
+      - in: query
+        name: sortOrder
+        schema:
+          default: desc
+          type: string
+      - in: query
+        name: services
+        schema:
+          default: false
+          type: boolean
       responses:
         default:
           content:
@@ -6878,22 +7061,22 @@ paths:
                 type: array
           description: default response
       tags:
-        - workflows
+      - workflows
   /workflows/published/{workflowId}:
     get:
       description: Get a published workflow.
       operationId: getPublishedWorkflow
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: include
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: include
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6902,71 +7085,72 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       tags:
-        - workflows
+      - workflows
   /workflows/registries/{gitRegistry}/organizations/{organization}/repositories/{repositoryName}:
     delete:
       description: Delete a stubbed workflow for a registry and repository path.
       operationId: deleteWorkflow
       parameters:
-        - description: Git registry
-          in: path
-          name: gitRegistry
-          required: true
-          schema:
-            enum:
-              - dockstore.org
-              - github.com
-              - bitbucket.org
-              - gitlab.com
-            type: string
-        - description: Git repository organization
-          in: path
-          name: organization
-          required: true
-          schema:
-            type: string
-        - description: Git repository name
-          in: path
-          name: repositoryName
-          required: true
-          schema:
-            type: string
+      - description: Git registry
+        in: path
+        name: gitRegistry
+        required: true
+        schema:
+          enum:
+          - dockstore.org
+          - github.com
+          - bitbucket.org
+          - gitlab.com
+          type: string
+      - description: Git repository organization
+        in: path
+        name: organization
+        required: true
+        schema:
+          type: string
+      - description: Git repository name
+        in: path
+        name: repositoryName
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
     post:
-      description: Adds a workflow for a registry and repository path with defaults set.
+      description: Adds a workflow for a registry and repository path with defaults
+        set.
       operationId: addWorkflow
       parameters:
-        - description: Git registry
-          in: path
-          name: gitRegistry
-          required: true
-          schema:
-            enum:
-              - dockstore.org
-              - github.com
-              - bitbucket.org
-              - gitlab.com
-            type: string
-        - description: Git repository organization
-          in: path
-          name: organization
-          required: true
-          schema:
-            type: string
-        - description: Git repository name
-          in: path
-          name: repositoryName
-          required: true
-          schema:
-            type: string
+      - description: Git registry
+        in: path
+        name: gitRegistry
+        required: true
+        schema:
+          enum:
+          - dockstore.org
+          - github.com
+          - bitbucket.org
+          - gitlab.com
+          type: string
+      - description: Git repository organization
+        in: path
+        name: organization
+        required: true
+        schema:
+          type: string
+      - description: Git repository name
+        in: path
+        name: repositoryName
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6975,9 +7159,9 @@ paths:
                 $ref: '#/components/schemas/BioWorkflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/shared:
     get:
       description: Retrieve all workflows shared with user.
@@ -6992,19 +7176,19 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/versions:
     get:
       description: List the versions for a published workflow.
       operationId: tags_1
       parameters:
-        - in: query
-          name: workflowId
-          schema:
-            format: int64
-            type: integer
+      - in: query
+        name: workflowId
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -7015,19 +7199,19 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{alias}/aliases:
     get:
       description: Retrieves a workflow by alias.
       operationId: getWorkflowByAlias
       parameters:
-        - in: path
-          name: alias
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: alias
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7036,33 +7220,33 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{entryId}/registerCheckerWorkflow/{descriptorType}:
     post:
       description: Register a checker workflow and associates it with the given tool/workflow.
       operationId: registerCheckerWorkflow
       parameters:
-        - in: query
-          name: checkerWorkflowPath
-          schema:
-            type: string
-        - in: query
-          name: testParameterPath
-          schema:
-            type: string
-        - in: path
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: descriptorType
-          required: true
-          schema:
-            type: string
+      - in: query
+        name: checkerWorkflowPath
+        schema:
+          type: string
+      - in: query
+        name: testParameterPath
+        schema:
+          type: string
+      - in: path
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: descriptorType
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7071,24 +7255,24 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}:
     get:
       description: Retrieve a workflow
       operationId: getWorkflow
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: include
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: include
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7097,19 +7281,19 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
     put:
       description: Update the workflow with the given workflow.
       operationId: updateWorkflow
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -7123,26 +7307,26 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/dag/{workflowVersionId}:
     get:
       description: Get the DAG for a given workflow version.
       operationId: getWorkflowDag
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: workflowVersionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: workflowVersionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -7151,20 +7335,20 @@ paths:
                 type: string
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/defaultVersion:
     put:
       description: Update the default version of a workflow.
       operationId: updateDefaultVersion_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -7178,33 +7362,33 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/descriptor/{relative-path}:
     get:
       description: Get the corresponding descriptor file from source control.
       operationId: secondaryDescriptorPath_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
-        - in: path
-          name: relative-path
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: language
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
+      - in: path
+        name: relative-path
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7213,24 +7397,24 @@ paths:
                 $ref: '#/components/schemas/SourceFile'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/labels:
     put:
       description: Update the labels linked to a workflow.
       operationId: updateLabels_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: labels
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: labels
+        schema:
+          type: string
       requestBody:
         content:
           '*/*':
@@ -7244,28 +7428,28 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/primaryDescriptor:
     get:
       description: Get the primary descriptor file.
       operationId: primaryDescriptor_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
-        - in: query
-          name: language
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7274,20 +7458,20 @@ paths:
                 $ref: '#/components/schemas/SourceFile'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/publish:
     post:
       description: Publish or unpublish a workflow.
       operationId: publish_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -7301,20 +7485,20 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/refresh:
     get:
       description: Refresh one particular workflow.
       operationId: refresh_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -7323,25 +7507,25 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/refresh/{version}:
     get:
       description: Refresh one particular workflow version.
       operationId: refreshVersion
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: version
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: version
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7350,26 +7534,26 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/requestDOI/{workflowVersionId}:
     put:
       description: Request a DOI for this version of a workflow.
       operationId: requestDOIForWorkflowVersion
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: workflowVersionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: workflowVersionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -7386,20 +7570,20 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/resetVersionPaths:
     put:
       description: Reset the workflow paths.
       operationId: updateWorkflowPath
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -7413,20 +7597,20 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/restub:
     get:
       description: Restub a workflow
       operationId: restub
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -7435,29 +7619,29 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Restub a workflow
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/secondaryDescriptors:
     get:
       description: Get the corresponding descriptor documents from source control.
       operationId: secondaryDescriptors_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
-        - in: query
-          name: language
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7468,20 +7652,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/star:
     put:
       description: Star a workflow.
       operationId: starEntry_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -7493,20 +7677,20 @@ paths:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/starredUsers:
     get:
       description: Returns list of users who starred the given workflow.
       operationId: getStarredUsers_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -7518,28 +7702,28 @@ paths:
                 uniqueItems: true
           description: default response
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/testParameterFiles:
     delete:
       description: Delete test parameter files for a given version.
       operationId: deleteTestParameterFiles_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: testParameterPaths
-          schema:
-            items:
-              type: string
-            type: array
-        - in: query
-          name: version
-          schema:
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: testParameterPaths
+        schema:
+          items:
             type: string
+          type: array
+      - in: query
+        name: version
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7551,23 +7735,23 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
     get:
       description: Get the corresponding test parameter files.
       operationId: getTestParameterFiles_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: version
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: version
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7578,29 +7762,29 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
     put:
       description: Add test parameter files for a given version.
       operationId: addTestParameterFiles_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: testParameterPaths
-          schema:
-            items:
-              type: string
-            type: array
-        - in: query
-          name: version
-          schema:
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: testParameterPaths
+        schema:
+          items:
             type: string
+          type: array
+      - in: query
+        name: version
+        schema:
+          type: string
       requestBody:
         content:
           '*/*':
@@ -7617,26 +7801,26 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/tools/{workflowVersionId}:
     get:
       description: Get the Tools for a given workflow version.
       operationId: getTableToolContent
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: workflowVersionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: workflowVersionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -7645,40 +7829,40 @@ paths:
                 type: string
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/unstar:
     delete:
       description: Unstar a workflow.
       operationId: unstarEntry_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/users:
     get:
       description: Get users of a workflow.
       operationId: getUsers_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -7689,20 +7873,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/workflowVersions:
     put:
       description: Update the workflow versions linked to a workflow.
       operationId: updateWorkflowVersion
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -7721,52 +7905,52 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/workflowVersions/{workflowVersionId}/sourcefiles:
     get:
       description: Retrieve sourcefiles for an entry's version
       operationId: getWorkflowVersionsSourcefiles
       parameters:
-        - description: Workflow to retrieve the version from.
-          in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Workflow version to retrieve the version from.
-          in: path
-          name: workflowVersionId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: List of file types to filter sourcefiles by
-          in: query
-          name: fileTypes
-          schema:
-            items:
-              enum:
-                - DOCKSTORE_CWL
-                - DOCKSTORE_WDL
-                - DOCKERFILE
-                - CWL_TEST_JSON
-                - WDL_TEST_JSON
-                - NEXTFLOW
-                - NEXTFLOW_CONFIG
-                - NEXTFLOW_TEST_PARAMS
-                - DOCKSTORE_YML
-                - DOCKSTORE_SERVICE_YML
-                - DOCKSTORE_SERVICE_TEST_JSON
-                - DOCKSTORE_SERVICE_OTHER
-                - DOCKSTORE_GXFORMAT2
-                - GXFORMAT2_TEST_FILE
-                - DOCKSTORE_SWL
-                - SWL_TEST_JSON
-              type: string
-            type: array
+      - description: Workflow to retrieve the version from.
+        in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Workflow version to retrieve the version from.
+        in: path
+        name: workflowVersionId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: List of file types to filter sourcefiles by
+        in: query
+        name: fileTypes
+        schema:
+          items:
+            enum:
+            - DOCKSTORE_CWL
+            - DOCKSTORE_WDL
+            - DOCKERFILE
+            - CWL_TEST_JSON
+            - WDL_TEST_JSON
+            - NEXTFLOW
+            - NEXTFLOW_CONFIG
+            - NEXTFLOW_TEST_PARAMS
+            - DOCKSTORE_YML
+            - DOCKSTORE_SERVICE_YML
+            - DOCKSTORE_SERVICE_TEST_JSON
+            - DOCKSTORE_SERVICE_OTHER
+            - DOCKSTORE_GXFORMAT2
+            - GXFORMAT2_TEST_FILE
+            - DOCKSTORE_SWL
+            - SWL_TEST_JSON
+            type: string
+          type: array
       responses:
         default:
           content:
@@ -7778,85 +7962,94 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/zip/{workflowVersionId}:
     get:
       description: Download a ZIP file of a workflow and all associated files.
       operationId: getWorkflowZip
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: workflowVersionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: workflowVersionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/zip: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
 servers:
-  - description: Current server when hosted on AWS
-    url: /api
-    variables: {}
-  - description: When working locally
-    url: /
-    variables: {}
-  - description: Production server
-    url: https://dockstore.org/api
-    variables: {}
-  - description: Staging server
-    url: https://staging.dockstore.org/api
-    variables: {}
-  - description: Nightly build server
-    url: https://dev.dockstore.net/api
-    variables: {}
+- description: Current server when hosted on AWS
+  url: /api
+  variables: {}
+- description: When working locally
+  url: /
+  variables: {}
+- description: Production server
+  url: https://dockstore.org/api
+  variables: {}
+- description: Staging server
+  url: https://staging.dockstore.org/api
+  variables: {}
+- description: Nightly build server
+  url: https://dev.dockstore.net/api
+  variables: {}
 tags:
-  - description: Create, update list aliases for accessing entries
-    name: aliases
-  - description: Operations on Dockstore organizations
-    name: organizations
-  - description: Needed for SmartAPI compatibility apparantly, might be cargo cult behaviour
-    name: NIHdatacommons
-  - description: List and register entries in the dockstore (pairs of images + metadata (CWL and Dockerfile))
-    name: containers
-  - description: List and modify tags for containers
-    name: containertags
-  - description: Interact with entries in Dockstore regardless of whether they are containers or workflows
-    name: entries
-  - description: Created and modify hosted entries in the dockstore
-    name: hosted
-  - description: Query lambda events triggered by GitHub Apps
-    name: lambdaEvents
-  - description: Information about Dockstore like RSS, sitemap, lists of dependencies, etc.
-    name: metadata
-  - description: List and modify notifications for users of Dockstore
-    name: curation
-  - description: List and register workflows in the dockstore (CWL, Nextflow, WDL)
-    name: workflows
-  - description: List, modify, refresh, and delete tokens for external services
-    name: tokens
-  - description: Interactions with the Dockstore-support's ToolTester application
-    name: toolTester
-  - description: List, modify, and manage end users of the dockstore
-    name: users
-  - description: Optional experimental extensions of the GA4GH API
-    name: extendedGA4GH
-  - description: A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [2.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0).
-    name: GA4GHV20
-  - description: A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [2.0.0-beta.2](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0-beta.2) . Integrators are welcome to use these endpoints but they are subject to change based on community input.
-    name: GA4GH
-  - description: A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [1.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/1.0.0) and is considered final (not subject to change)
-    name: GA4GHV1
+- description: Create, update list aliases for accessing entries
+  name: aliases
+- description: Operations on Dockstore organizations
+  name: organizations
+- description: Needed for SmartAPI compatibility apparantly, might be cargo cult behaviour
+  name: NIHdatacommons
+- description: List and register entries in the dockstore (pairs of images + metadata
+    (CWL and Dockerfile))
+  name: containers
+- description: List and modify tags for containers
+  name: containertags
+- description: Interact with entries in Dockstore regardless of whether they are containers
+    or workflows
+  name: entries
+- description: Created and modify hosted entries in the dockstore
+  name: hosted
+- description: Query lambda events triggered by GitHub Apps
+  name: lambdaEvents
+- description: Information about Dockstore like RSS, sitemap, lists of dependencies,
+    etc.
+  name: metadata
+- description: List and modify notifications for users of Dockstore
+  name: curation
+- description: List and register workflows in the dockstore (CWL, Nextflow, WDL)
+  name: workflows
+- description: List, modify, refresh, and delete tokens for external services
+  name: tokens
+- description: Interactions with the Dockstore-support's ToolTester application
+  name: toolTester
+- description: List, modify, and manage end users of the dockstore
+  name: users
+- description: Optional experimental extensions of the GA4GH API
+  name: extendedGA4GH
+- description: A curated subset of resources proposed as a common standard for tool
+    repositories. Implements TRS [2.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0).
+  name: GA4GHV20
+- description: A curated subset of resources proposed as a common standard for tool
+    repositories. Implements TRS [2.0.0-beta.2](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0-beta.2)
+    . Integrators are welcome to use these endpoints but they are subject to change
+    based on community input.
+  name: GA4GH
+- description: A curated subset of resources proposed as a common standard for tool
+    repositories. Implements TRS [1.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/1.0.0)
+    and is considered final (not subject to change)
+  name: GA4GHV1

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -2582,27 +2582,6 @@ paths:
           description: "successful operation"
       security:
       - BEARER: []
-  /entries/{entryId}/verifiedPlatforms:
-    get:
-      tags:
-      - "entries"
-      operationId: "getVerifiedPlatforms"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "entryId"
-        in: "path"
-        required: true
-        type: "integer"
-        format: "int64"
-      responses:
-        200:
-          description: "successful operation"
-          headers: {}
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/VersionVerifiedPlatform"
   /entries/{id}/aliases:
     post:
       tags:
@@ -8297,16 +8276,6 @@ definitions:
         type: "string"
         position: 24
     description: "Base class for versions of entries in the Dockstore"
-  VersionVerifiedPlatform:
-    type: "object"
-    properties:
-      metadata:
-        type: "string"
-      source:
-        type: "string"
-      versionId:
-        type: "integer"
-        format: "int64"
   Workflow:
     type: "object"
     required:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -2582,6 +2582,32 @@ paths:
           description: "successful operation"
       security:
       - BEARER: []
+  /entries/{entryId}/verifiedPlatforms:
+    get:
+      tags:
+      - "entries"
+      operationId: "getVerifiedPlatforms"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/User"
+      - name: "entryId"
+        in: "path"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          headers: {}
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/VersionVerifiedPlatform"
   /entries/{id}/aliases:
     post:
       tags:
@@ -7203,6 +7229,20 @@ definitions:
         format: "date-time"
         position: 6
         description: "Timestamp at which the notification was last updated"
+  Optional:
+    type: "object"
+    properties:
+      empty:
+        type: "boolean"
+      present:
+        type: "boolean"
+  OptionalUser:
+    type: "object"
+    properties:
+      empty:
+        type: "boolean"
+      present:
+        type: "boolean"
   Organization:
     type: "object"
     required:
@@ -8276,6 +8316,16 @@ definitions:
         type: "string"
         position: 24
     description: "Base class for versions of entries in the Dockstore"
+  VersionVerifiedPlatform:
+    type: "object"
+    properties:
+      metadata:
+        type: "string"
+      source:
+        type: "string"
+      versionId:
+        type: "integer"
+        format: "int64"
   Workflow:
     type: "object"
     required:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -2590,11 +2590,6 @@ paths:
       produces:
       - "application/json"
       parameters:
-      - in: "body"
-        name: "body"
-        required: false
-        schema:
-          $ref: "#/definitions/User"
       - name: "entryId"
         in: "path"
         required: true
@@ -7229,20 +7224,6 @@ definitions:
         format: "date-time"
         position: 6
         description: "Timestamp at which the notification was last updated"
-  Optional:
-    type: "object"
-    properties:
-      empty:
-        type: "boolean"
-      present:
-        type: "boolean"
-  OptionalUser:
-    type: "object"
-    properties:
-      empty:
-        type: "boolean"
-      present:
-        type: "boolean"
   Organization:
     type: "object"
     required:


### PR DESCRIPTION
After talking to Charles, decided to breakdown #3455 further. 
This PR creates a new endpoint that returns which versions (plus relevant info) of an entry that have verified by source information. The UI needs this to fill out the verified platforms column under the versions tab. 

I have a branch in the UI that's working with this endpoint and the workflow pages seem to be working with lazy loaded sourcefiles. However, more work needs to be done to get tools on the same page and other issues may arise so I won't make PR for that yet till I do more webservice changes.

Future work
- Create a column in the tool db to store the descriptor type and fill all the rows. Right now it's a column that gets calculated every time we return a tool and it uses sourcefiles to perform the calculation, so that needs to be changed before switching to lazy. #3632
- Add JsonIgnore to sourcefile columns in Version.java and see what else it breaks in the UI and fix.
- Finally switch to lazy load/write tests for this endpoint and potentially any others created.