### PR TITLE
Fix/3619/add user to dockstore workflows performance

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -74,6 +74,7 @@ import org.hibernate.annotations.Check;
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findByGitUrl", query = "SELECT c FROM Workflow c WHERE c.gitUrl = :gitUrl ORDER BY gitUrl"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findPublishedByOrganization", query = "SELECT c FROM Workflow c WHERE lower(c.organization) = lower(:organization) AND c.isPublished = true"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findByOrganization", query = "SELECT c FROM Workflow c WHERE lower(c.organization) = lower(:organization) AND c.sourceControl = :sourceControl"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findByOrganizationWithoutUser", query = "SELECT c FROM Workflow c WHERE lower(c.organization) = lower(:organization) AND c.sourceControl = :sourceControl AND :user not in elements(c.users)"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findWorkflowByWorkflowVersionId", query = "SELECT c FROM Workflow c, Version v WHERE v.id = :workflowVersionId AND c.id = v.parent"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.getEntriesByUserId", query = "SELECT w FROM Workflow w WHERE w.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.getPublishedEntriesByUserId", query = "SELECT w FROM Workflow w WHERE w.isPublished = true AND w.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -31,6 +31,7 @@ import javax.persistence.criteria.Root;
 import io.dockstore.common.SourceControl;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.SourceControlConverter;
+import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
 import org.apache.http.HttpStatus;
 import org.hibernate.SessionFactory;
@@ -242,6 +243,13 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
     public List<Workflow> findByOrganization(SourceControl sourceControl, String organization) {
         return list(namedQuery("io.dockstore.webservice.core.Workflow.findByOrganization")
                 .setParameter("organization", organization)
+                .setParameter("sourceControl", sourceControl));
+    }
+
+    public List<Workflow> findByOrganizationWithoutUser(SourceControl sourceControl, String organization, User user) {
+        return list(namedQuery("io.dockstore.webservice.core.Workflow.findByOrganizationWithoutUser")
+                .setParameter("organization", organization)
+                .setParameter("user", user)
                 .setParameter("sourceControl", sourceControl));
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -813,11 +813,10 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
             Set<String> organizations = gitUrlToRepositoryId.values().stream().map(repository -> repository.split("/")[0]).collect(Collectors.toSet());
 
             organizations.forEach(organization -> {
-                List<Workflow> workflows = workflowDAO.findByOrganization(token.getTokenSource().getSourceControl(), organization);
-                workflows.forEach(workflow -> workflow.getUsers().add(user));
+                List<Workflow> workflowsWithoutuser = workflowDAO.findByOrganizationWithoutUser(token.getTokenSource().getSourceControl(), organization, user);
+                workflowsWithoutuser.forEach(workflow -> workflow.addUser(user));
             });
         });
-
         return convertMyWorkflowsToWorkflow(this.bioWorkflowDAO.findUserBioWorkflows(user.getId()));
     }
 


### PR DESCRIPTION
For #3619 



Main changes:
- Use optmized query to get myworkflows
- Don't grab all workflows (just grab the ones that user is not a part of)

Notes:
The main chunk of statements is from getting the workflows of the organizations that the user doesn't belong to (but belong to the organization)
Didn't use JPQL to add user to workflow because it should be drastically reduced once workflowversion is lazyloaded (defeats the purpose of Hibernate otherwise)
Could not definitively tell based on visualvm and intellij the memory used before and after (and whether there is a problem in the first place)

For me
Before:
```
INFO  [2020-07-06 21:44:25,403] org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: Session Metrics {
    58300 nanoseconds spent acquiring 2 JDBC connections;
    56600 nanoseconds spent releasing 2 JDBC connections;
    101177300 nanoseconds spent preparing 10989 JDBC statements;
    9696065500 nanoseconds spent executing 10989 JDBC statements;
    0 nanoseconds spent executing 0 JDBC batches;
    0 nanoseconds spent performing 0 L2C puts;
    0 nanoseconds spent performing 0 L2C hits;
    0 nanoseconds spent performing 0 L2C misses;
    2088400 nanoseconds spent executing 1 flushes (flushing a total of 219 entities and 517 collections);
    199596100 nanoseconds spent executing 11 partial-flushes (flushing a total of 16377 entities and 16377 collections)
```

After:
```
INFO  [2020-07-07 15:29:35,035] org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: Session Metrics {
    64100 nanoseconds spent acquiring 2 JDBC connections;
    48700 nanoseconds spent releasing 2 JDBC connections;
    27543800 nanoseconds spent preparing 1588 JDBC statements;
    1558498900 nanoseconds spent executing 1588 JDBC statements;
    0 nanoseconds spent executing 0 JDBC batches;
    0 nanoseconds spent performing 0 L2C puts;
    0 nanoseconds spent performing 0 L2C hits;
    0 nanoseconds spent performing 0 L2C misses;
    11204800 nanoseconds spent executing 1 flushes (flushing a total of 1283 entities and 1935 collections);
    139426000 nanoseconds spent executing 13 partial-flushes (flushing a total of 9040 entities and 9040 collections)
}
```

