### PR TITLE
Feature/3088/checker workflow stub

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
@@ -45,8 +45,10 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Confidential tests for checker workflows
@@ -174,9 +176,17 @@ public class CheckerWorkflowIT extends BaseIT {
         // Should not be able to directly publish the checker
         try {
             workflowApi.publish(refreshedEntry.getCheckerId(), publishRequest);
-            Assert.fail("Should not reach this statement.");
+            fail("Should not reach this statement.");
         } catch (ApiException ex) {
             assertEquals(ex.getCode(), HttpStatus.SC_BAD_REQUEST);
+        }
+
+        // Should not be able to restub the checker
+        try {
+            workflowApi.restub(refreshedEntry.getCheckerId());
+            fail("Should not reach this statement.");
+        } catch (ApiException e) {
+            assertEquals(e.getCode(), HttpStatus.SC_BAD_REQUEST);
         }
     }
 
@@ -268,6 +278,17 @@ public class CheckerWorkflowIT extends BaseIT {
                 }
             }
         }
+        // Try to restub parent workflow
+        if (workflow) {
+            Workflow restub = workflowApi.restub(baseEntryId);
+            assertNull("No checker associated with the workflow", restub.getCheckerId());
+            try {
+                workflowApi.getWorkflow(checkerWorkflowBase.getCheckerId(), null);
+                fail("Should not reach this statement");
+            } catch (ApiException e) {
+                assertEquals(e.getCode(), HttpStatus.SC_BAD_REQUEST);
+            }
+        }
     }
 
     /**
@@ -357,7 +378,7 @@ public class CheckerWorkflowIT extends BaseIT {
         // Should not be able to directly publish the checker
         try {
             workflowApi.publish(refreshedEntry.getCheckerId(), publishRequest);
-            Assert.fail("Should not reach this statement.");
+            fail("Should not reach this statement.");
         } catch (ApiException ex) {
             assertEquals(ex.getCode(), HttpStatus.SC_BAD_REQUEST);
         }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
@@ -172,20 +172,18 @@ public class CheckerWorkflowIT extends BaseIT {
         final long count9 = testingPostgres.runSelectStatement("select count(*) from tool where ispublished = true", long.class);
         assertEquals("the tool should not be published, there are " + count9, 0, count9);
 
-        // Should not be able to directly publish the checker
         try {
             workflowApi.publish(refreshedEntry.getCheckerId(), publishRequest);
-            fail("Should not reach this statement.");
-        } catch (ApiException ex) {
-            assertEquals(ex.getCode(), HttpStatus.SC_BAD_REQUEST);
+            fail("Should not be able to directly publish the checker");
+        } catch (ApiException e) {
+            assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
         }
 
-        // Should not be able to restub the checker
         try {
             workflowApi.restub(refreshedEntry.getCheckerId());
-            fail("Should not reach this statement.");
+            fail("Should not be able to restub the checker");
         } catch (ApiException e) {
-            assertEquals(e.getCode(), HttpStatus.SC_BAD_REQUEST);
+            assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
         }
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
@@ -45,7 +45,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -276,17 +275,6 @@ public class CheckerWorkflowIT extends BaseIT {
                 if (workflowItem.getOrganization().equalsIgnoreCase(stubCheckerWorkflow.getOrganization())) {
                     workflowApi.refresh(workflowItem.getId());
                 }
-            }
-        }
-        // Try to restub parent workflow
-        if (workflow) {
-            Workflow restub = workflowApi.restub(baseEntryId);
-            assertNull("No checker associated with the workflow", restub.getCheckerId());
-            try {
-                workflowApi.getWorkflow(checkerWorkflowBase.getCheckerId(), null);
-                fail("Should not reach this statement");
-            } catch (ApiException e) {
-                assertEquals(e.getCode(), HttpStatus.SC_BAD_REQUEST);
             }
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -233,6 +233,10 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             throw new CustomWebApplicationException("A workflow must be unpublished to restub.", HttpStatus.SC_BAD_REQUEST);
         }
 
+        if (workflow.isIsChecker()) {
+            throw new CustomWebApplicationException("A checker workflow cannot be restubed.", HttpStatus.SC_BAD_REQUEST);
+        }
+
         checkNotHosted(workflow);
         checkCanWriteWorkflow(user, workflow);
 


### PR DESCRIPTION
Can no longer restub checker workflows.
https://github.com/dockstore/dockstore/issues/3088

Note that if you restub a parent workflow, it removes the association with the checker, but the checker is not deleted. Will need to investigate this more when we start working on archiving and what not.