### PR TITLE
Feature/seab 1401/collect emails

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/Hoverfly.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/Hoverfly.java
@@ -73,6 +73,7 @@ public final class Hoverfly {
     private static final String GITHUB_COMMIT = fixture(("fixtures/GitHubCommit.json"));
     private static final String GITHUB_CONTENTS = fixture("fixtures/GitHubContents.json");
     private static final String GITHUB_DOCKSTORE_YML_CONTENT = fixture("fixtures/GitHubFileContent.json");
+    private static final String GITHUB_EMAIL = fixture("fixtures/GitHubEmail.json");
     private static final String EMPTY_JSON_ARRAY = "[]";
 
     /**
@@ -181,7 +182,9 @@ public final class Hoverfly {
 
             .get("/rate_limit").willReturn(success(GITHUB_RATE_LIMIT, MediaType.APPLICATION_JSON))
 
-            .get("/user/orgs").willReturn(success(GITHUB_ORGANIZATIONS, MediaType.APPLICATION_JSON)));
+            .get("/user/orgs").willReturn(success(GITHUB_ORGANIZATIONS, MediaType.APPLICATION_JSON))
+
+            .get("/user/emails").willReturn(success(GITHUB_EMAIL, MediaType.APPLICATION_JSON)));
     private Hoverfly() {
         // utility class
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -38,6 +38,7 @@ import io.swagger.client.model.Collection;
 import io.swagger.client.model.EntryUpdateTime;
 import io.swagger.client.model.Organization;
 import io.swagger.client.model.OrganizationUpdateTime;
+import io.swagger.client.model.Profile;
 import io.swagger.client.model.Repository;
 import io.swagger.client.model.User;
 import io.swagger.client.model.Workflow;
@@ -483,6 +484,33 @@ public class UserResourceIT extends BaseIT {
         collection.setDescription("this is the description");
 
         return collection;
+    }
+
+    @Test
+    public void testUpdateUserMetadataFromGithub() {
+        ApiClient client = getWebClient(USER_2_USERNAME, testingPostgres);
+        UsersApi usersApi = new UsersApi(client);
+        Profile userProfile = usersApi.getUser().getUserProfiles().get("github.com");
+
+        assertEquals("", userProfile.getName());
+        assertNull(userProfile.getEmail());
+        assertNull(userProfile.getAvatarURL());
+        assertNull(userProfile.getBio());
+        assertNull(userProfile.getLocation());
+        assertNull(userProfile.getCompany());
+        assertEquals("DockstoreTestUser2", userProfile.getUsername());
+
+        final User user = usersApi.updateLoggedInUserMetadata("github.com");
+        userProfile = usersApi.getUser().getUserProfiles().get("github.com");
+
+        System.out.println(usersApi.getUser().getUserProfiles().get("github.com"));
+        assertNull(userProfile.getName());
+        assertEquals("dockstore.test.user2@gmail.com", userProfile.getEmail());
+        assertEquals("https://avatars1.githubusercontent.com/u/17859829?v=4", userProfile.getAvatarURL());
+        assertEquals("", userProfile.getBio());
+        assertEquals("Toronto", userProfile.getLocation());
+        assertNull(userProfile.getCompany());
+        assertEquals("DockstoreTestUser2", userProfile.getUsername());
     }
 
 }

--- a/dockstore-integration-testing/src/test/resources/fixtures/GitHubEmail.json
+++ b/dockstore-integration-testing/src/test/resources/fixtures/GitHubEmail.json
@@ -1,0 +1,7 @@
+[
+  {
+    "email": "octocat@github.com",
+    "primary": true,
+    "verified": true
+  }
+]

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -886,7 +886,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         return null;
     }
 
-    public String getEmail(GHMyself myself) throws IOException {
+    private String getEmail(GHMyself myself) throws IOException {
         for (GHEmail email: myself.getEmails2()) {
             if (email.isPrimary()) {
                 return email.getEmail();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -67,6 +67,7 @@ import org.kohsuke.github.AbuseLimitHandler;
 import org.kohsuke.github.GHBranch;
 import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHEmail;
 import org.kohsuke.github.GHFileNotFoundException;
 import org.kohsuke.github.GHMyself;
 import org.kohsuke.github.GHRateLimit;
@@ -885,6 +886,15 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         return null;
     }
 
+    public String getEmail(GHMyself myself) throws IOException {
+        for (GHEmail email: myself.getEmails2()) {
+            if (email.isPrimary()) {
+                return email.getEmail();
+            }
+        }
+        return null;
+    }
+
     /**
      * Updates a user object with metadata from GitHub
      * @param user the user to be updated
@@ -895,7 +905,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             GHMyself myself = github.getMyself();
             User.Profile profile = new User.Profile();
             profile.name = myself.getName();
-            profile.email = myself.getEmail();
+            profile.email = getEmail(myself);
             profile.avatarURL = myself.getAvatarUrl();
             profile.bio = myself.getBlog();  // ? not sure about this mapping in the new api
             profile.location = myself.getLocation();


### PR DESCRIPTION
Collect User Emails From GitHub

SEAB#1401

Implemented a getEmail() method that goes through every single email
from a GitHub user (regardless if they have private email turned on/off)
and returns their primary email

Created a integration test to verify that the fields of object Profile
is correct after updating the logged in user's metadata

Included a new fixture 'GitHubEmail.json' for Hoverfly

Implemented a new case for Hoverfly to check for the new endpoint
'/user/emails'
