### PR TITLE
Set batch size for associations

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -63,6 +63,7 @@ import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.EntryType;
 import io.dockstore.webservice.helpers.EntryStarredSerializer;
 import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -120,12 +121,14 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     @JoinTable(name = "entry_label", joinColumns = @JoinColumn(name = "entryid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "labelid", referencedColumnName = "id"))
     @ApiModelProperty(value = "Labels (i.e. meta tags) for describing the purpose and contents of containers", position = 3)
     @OrderBy("id")
+    @BatchSize(size = 25)
     private SortedSet<Label> labels = new TreeSet<>();
 
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "user_entry", inverseJoinColumns = @JoinColumn(name = "userid", nullable = false, updatable = false, referencedColumnName = "id"), joinColumns = @JoinColumn(name = "entryid", nullable = false, updatable = false, referencedColumnName = "id"))
     @ApiModelProperty(value = "This indicates the users that have control over this entry, dockstore specific", required = false, position = 4)
     @OrderBy("id")
+    @BatchSize(size = 25)
     private SortedSet<User> users;
 
     @ManyToMany(fetch = FetchType.EAGER)
@@ -133,6 +136,7 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     @ApiModelProperty(value = "This indicates the users that have starred this entry, dockstore specific", required = false, position = 5)
     @JsonSerialize(using = EntryStarredSerializer.class)
     @OrderBy("id")
+    @BatchSize(size = 25)
     private SortedSet<User> starredUsers;
 
     @Column
@@ -170,6 +174,7 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     @JoinTable(name = "entry_alias", joinColumns = @JoinColumn(name = "id"), uniqueConstraints = @UniqueConstraint(name = "unique_entry_aliases", columnNames = { "alias" }))
     @MapKeyColumn(name = "alias", columnDefinition = "text")
     @ApiModelProperty(value = "aliases can be used as an alternate unique id for entries")
+    @BatchSize(size = 25)
     private Map<String, Alias> aliases = new HashMap<>();
 
     // database timestamps

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -49,6 +49,7 @@ import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.helpers.ZipSourceFileHelper;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.slf4j.Logger;
@@ -113,6 +114,7 @@ public class SourceFile implements Comparable<SourceFile> {
         "id", "source" }))
     @MapKeyColumn(name = "source", columnDefinition = "text")
     @ApiModelProperty(value = "maps from platform to whether an entry successfully ran on it using this test json")
+    @BatchSize(size = 25)
     private Map<String, VerificationInformation> verifiedBySource = new HashMap<>();
 
     public Map<String, VerificationInformation> getVerifiedBySource() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -50,6 +50,7 @@ import io.dockstore.common.Registry;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.Check;
@@ -151,6 +152,7 @@ public class Tool extends Entry<Tool, Tag> {
     @JsonAlias({ "tags", "workflowVersions"})
     @OrderBy("id")
     @Cascade(CascadeType.DETACH)
+    @BatchSize(size = 25)
     private final SortedSet<Tag> workflowVersions;
 
     @JsonIgnore

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -57,6 +57,7 @@ import io.dockstore.webservice.CustomWebApplicationException;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.apache.http.HttpStatus;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -129,6 +130,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @ApiModelProperty(value = "Cached files for each version. Includes Dockerfile and Descriptor files", position = 6)
     @Cascade(org.hibernate.annotations.CascadeType.DETACH)
     @OrderBy("path")
+    @BatchSize(size = 25)
     private final SortedSet<SourceFile> sourceFiles;
 
     @Column
@@ -165,23 +167,27 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @JoinTable(name = "version_input_fileformat", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "fileformatid", referencedColumnName = "id"))
     @ApiModelProperty(value = "File formats for describing the input file formats of versions (tag/workflowVersion)", position = 12)
     @OrderBy("id")
+    @BatchSize(size = 25)
     private SortedSet<FileFormat> inputFileFormats = new TreeSet<>();
 
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "version_output_fileformat", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "fileformatid", referencedColumnName = "id"))
     @ApiModelProperty(value = "File formats for describing the output file formats of versions (tag/workflowVersion)", position = 13)
     @OrderBy("id")
+    @BatchSize(size = 25)
     private SortedSet<FileFormat> outputFileFormats = new TreeSet<>();
 
     @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
     @JoinTable(name = "version_validation", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "validationid", referencedColumnName = "id"))
     @ApiModelProperty(value = "Cached validations for each version.", position = 14)
     @OrderBy("type")
+    @BatchSize(size = 25)
     private final SortedSet<Validation> validations;
 
     @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
     @JoinTable(name = "entry_version_image", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "imageid", referencedColumnName = "id"))
     @ApiModelProperty(value = "The images that belong to this version", position = 15)
+    @BatchSize(size = 25)
     private Set<Image> images = new HashSet<>();
 
     public Version() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -46,6 +46,7 @@ import io.dockstore.common.DescriptorLanguageSubclass;
 import io.dockstore.common.SourceControl;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.Check;
@@ -128,6 +129,7 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
     @ApiModelProperty(value = "Implementation specific tracking of valid build workflowVersions for the docker container", position = 21)
     @OrderBy("id")
     @Cascade({ CascadeType.DETACH, CascadeType.SAVE_UPDATE })
+    @BatchSize(size = 25)
     private final SortedSet<WorkflowVersion> workflowVersions;
 
     @JsonIgnore

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -24,8 +24,8 @@ components:
           type: object
       type: object
     Checksum:
-      description: A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes.  This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
-      example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182, type=sha256}]'
+      description: 'A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes. '
+      example: '[{checksum=ea2a5db69bd20a42976838790bc29294df3af02b, type=sha1}]'
       properties:
         checksum:
           description: 'The hex-string encoded checksum for the data. '
@@ -1705,7 +1705,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/WorkflowVersion'
           description: default response
       security:
         - bearer: []
@@ -2402,7 +2402,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Tool'
           description: default response
       security:
         - bearer: []
@@ -2428,7 +2428,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Tool'
           description: default response
       security:
         - bearer: []
@@ -3655,7 +3655,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tool'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []
@@ -6626,7 +6626,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []


### PR DESCRIPTION
#2125

Instead of fetching each association row one-by-one,
fetches them in batches. For example, if a entry has
10 versions, the 10 versions will be fetched in one SQL
statement when batch size is >= 10. If batch size is not
set, the 10 versions are fetched with 10 SQL statements.

Ran various experiments locally with 714 published tools and workflows,
hitting `localhost:8080/ga4gh/trs/v2/tools`

| Batch Size    |           Time to Complete   |         Number of SQL statements |
| -----------   | -------------------------  | -------------------------------- |
| Not Set        |                     178s                |                     83,267                     |
| 10                 |                       62s               |                     74,627                     |
| 20                |                       45s              |                        5,880                     |
| 25                |                       41s               |                        5,043                   |
| 100              |                        34s             |                         2,460                   |
| 1,000           |                             33s          |        1,591                                          |

Max heap size was essentially the same in all scenarios; it just went up more quickly when it  took less time to finish, obviously.

Went with 25. Why didn't I just go with a higher number? Found [a post](https://prasanthmathialagan.wordpress.com/2017/04/20/beware-of-hibernate-batch-fetching/) about setting it too high, even though it was for an older version of Hibernate. So went with a lower number for now just to be safe.

I don't see this as the ultimate solution, but it seems like an easy/safe 4x speed gain, which could even be applied to hotfix, if we so choose.