### PR TITLE
Store actual error message for lambda

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -323,12 +323,16 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             lambdaEventDAO.create(lambdaEvent);
             return workflows;
         } catch (CustomWebApplicationException | ClassCastException | DockstoreYamlHelper.DockstoreYamlException ex) {
-            String msg = "User " + username + ": Error handling push event for repository " + repository + " and reference " + gitReference + "\n" + ex.getMessage();
+            String errorMessage = ex.getMessage();
+            if (ex instanceof CustomWebApplicationException) {
+                errorMessage = ((CustomWebApplicationException)ex).getErrorMessage();
+            }
+            String msg = "User " + username + ": Error handling push event for repository " + repository + " and reference " + gitReference + "\n" + errorMessage;
             LOG.info(msg, ex);
             sessionFactory.getCurrentSession().clear();
             LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, username, LambdaEvent.LambdaEventType.PUSH);
             lambdaEvent.setSuccess(false);
-            lambdaEvent.setMessage(ex.getMessage());
+            lambdaEvent.setMessage(errorMessage);
             lambdaEventDAO.create(lambdaEvent);
             sessionFactory.getCurrentSession().getTransaction().commit();
             throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -323,10 +323,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             lambdaEventDAO.create(lambdaEvent);
             return workflows;
         } catch (CustomWebApplicationException | ClassCastException | DockstoreYamlHelper.DockstoreYamlException ex) {
-            String errorMessage = ex.getMessage();
-            if (ex instanceof CustomWebApplicationException) {
-                errorMessage = ((CustomWebApplicationException)ex).getErrorMessage();
-            }
+            String errorMessage = ex instanceof CustomWebApplicationException ? ((CustomWebApplicationException)ex).getErrorMessage() : ex.getMessage();
             String msg = "User " + username + ": Error handling push event for repository " + repository + " and reference " + gitReference + "\n" + errorMessage;
             LOG.info(msg, ex);
             sessionFactory.getCurrentSession().clear();


### PR DESCRIPTION
Seems like our code wasn't properly grabbing exception messages if the exception was of type CustomWebApplicationException. This caused the message for the lambda failures to simply say HTTP 418. Now they are the actual errors.
https://github.com/dockstore/dockstore/issues/3678

Seems like there is a known test failure (though not related to my changes)