### PR TITLE
Support GALAXY subclass in .dockstore.yml

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
@@ -20,10 +20,20 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
+import io.dockstore.common.DescriptorLanguage;
+
 /**
  * A workflow as described in a .dockstore.yml
  */
 public class YamlWorkflow {
+
+    /**
+     * Subclass was originally GXFORMAT2, should have been GALAXY.
+     * Allow GALAXY, but continue to support GXFORMAT2, and keep it
+     * as GXFORMAT2 in the object for other classes already relying on that
+     */
+    private static final String NEW_GALAXY_SUBCLASS = "GALAXY";
+
     private String name;
     @NotNull
     private String subclass;
@@ -31,6 +41,7 @@ public class YamlWorkflow {
     private String primaryDescriptorPath;
 
     private List<String> testParameterFiles = new ArrayList<>();
+
 
     public String getName() {
         return name;
@@ -41,6 +52,9 @@ public class YamlWorkflow {
     }
 
     public String getSubclass() {
+        if (NEW_GALAXY_SUBCLASS.equalsIgnoreCase(subclass)) {
+            return DescriptorLanguage.GXFORMAT2.getShortName();
+        }
         return subclass;
     }
 

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -37,6 +37,7 @@ public class DockstoreYamlTest {
     private static final String DOCKSTORE10_YAML = FixtureHelpers.fixture("fixtures/dockstore10.yml");
     private static final String DOCKSTORE11_YAML = FixtureHelpers.fixture("fixtures/dockstore11.yml");
     private static final String DOCKSTORE12_YAML = FixtureHelpers.fixture("fixtures/dockstore12.yml");
+    private static final String DOCKSTORE_GALAXY_YAML = FixtureHelpers.fixture("fixtures/dockstoreGalaxy.yml");
 
     @Rule
     public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
@@ -180,6 +181,21 @@ public class DockstoreYamlTest {
         assertEquals(3, workflows.size());
         assertEquals(1, workflows.stream().filter(w -> "CWL".equals(w.getSubclass())).count());
         assertEquals(1, workflows.stream().filter(w -> "cwl".equals(w.getSubclass())).count());
+    }
+
+    /**
+     * Subclass in .dockstore.yml for Galaxy was `GXFORMAT2`; should be `GALAXY`.
+     * Fixture has 2 of each, with different cases; make sure they all appear as `GXFORMAT2`, which our
+     * other code relies on.
+     *
+     * https://github.com/dockstore/dockstore/issues/3686
+     *
+     * @throws DockstoreYamlHelper.DockstoreYamlException
+     */
+    @Test
+    public void testGalaxySubclass() throws DockstoreYamlHelper.DockstoreYamlException {
+        final List<YamlWorkflow> workflows = DockstoreYamlHelper.readAsDockstoreYaml12(DOCKSTORE_GALAXY_YAML).getWorkflows();
+        assertEquals(4, workflows.stream().filter(w -> w.getSubclass().equalsIgnoreCase("gxformat2")).count());
     }
 
 }

--- a/dockstore-common/src/test/resources/fixtures/dockstoreGalaxy.yml
+++ b/dockstore-common/src/test/resources/fixtures/dockstoreGalaxy.yml
@@ -1,0 +1,14 @@
+version: 1.2
+workflows:
+  -  name: foobar
+     subclass: gxformat2
+     primaryDescriptorPath: /Dockstore2.ga
+  -  name: foobar2
+     subclass: galaxy
+     primaryDescriptorPath: /Dockstore.ga
+  -  name: foobar3
+     subclass: GXFORMAT2
+     primaryDescriptorPath: /Dockstore.ga
+  -  name: foobar4
+     subclass: GALAXY
+     primaryDescriptorPath: /Dockstore.ga

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -305,7 +305,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
 
         final HttpClient httpClient = new HttpClientBuilder(environment).using(configuration.getHttpClientConfiguration()).build(getName());
 
-        final PermissionsInterface authorizer = PermissionsFactory.getAuthorizer(tokenDAO, configuration);
+        final PermissionsInterface authorizer = PermissionsFactory.createAuthorizer(tokenDAO, configuration);
 
         final EntryResource entryResource = new EntryResource(toolDAO, configuration);
         environment.jersey().register(entryResource);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsFactory.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsFactory.java
@@ -8,29 +8,22 @@ import org.slf4j.LoggerFactory;
 
 public final class PermissionsFactory {
 
-    private static PermissionsInterface permissionsInterface;
-
     private static final Logger LOG = LoggerFactory.getLogger(PermissionsFactory.class);
 
     private PermissionsFactory() {
     }
 
-    public static PermissionsInterface getAuthorizer(TokenDAO tokenDAO, DockstoreWebserviceConfiguration configuration) {
-        synchronized (PermissionsFactory.class) {
-            if (permissionsInterface == null) {
-                String authorizerType = configuration.getAuthorizerType();
-                if ("sam".equalsIgnoreCase(authorizerType)) {
-                    permissionsInterface = new SamPermissionsImpl(tokenDAO, configuration);
-                    LOG.info("Using SAM for sharing");
-                } else if ("inmemory".equalsIgnoreCase(authorizerType)) {
-                    permissionsInterface = new InMemoryPermissionsImpl();
-                    LOG.info("Using InMemoryPermissionsImpl for sharing");
-                } else {
-                    permissionsInterface = new NoOpPermissionsImpl();
-                    LOG.info("Using NoOpPermissionsImpl for sharing");
-                }
-            }
-            return permissionsInterface;
+    public static PermissionsInterface createAuthorizer(TokenDAO tokenDAO, DockstoreWebserviceConfiguration configuration) {
+        String authorizerType = configuration.getAuthorizerType();
+        if ("sam".equalsIgnoreCase(authorizerType)) {
+            LOG.info("Using SAM for sharing");
+            return new SamPermissionsImpl(tokenDAO, configuration);
+        } else if ("inmemory".equalsIgnoreCase(authorizerType)) {
+            LOG.info("Using InMemoryPermissionsImpl for sharing");
+            return new InMemoryPermissionsImpl();
+        } else {
+            LOG.info("Using NoOpPermissionsImpl for sharing");
+            return new NoOpPermissionsImpl();
         }
     }
 }


### PR DESCRIPTION
#3686

Continue to support GXFORMAT2 for backwards-compatiblity,
and continue to expose GXFORMAT2 in the object for code
that already relies on that.

There is probably a more elegant solution with snakeyaml,
but it wasn't immediately obvious, and this should work.

