### PR TITLE
use getters for Tag compareTo()

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -50,7 +50,7 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
     @Column
     @JsonProperty("last_built")
     @ApiModelProperty(value = "For automated tools: The last time the container backing this tool version was built. For hosted: N/A", position = 101)
-    Date lastBuilt;
+    private Date lastBuilt;
 
     @Column
     @JsonProperty("image_id")
@@ -235,19 +235,19 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, reference);
+        return Objects.hash(id, this.getName(), this.getReference());
     }
 
     @Override
     public int compareTo(@NotNull Tag that) {
-        return ComparisonChain.start().compare(this.name, that.getName(), Ordering.natural().nullsFirst())
-            .compare(this.reference, that.getReference(), Ordering.natural().nullsFirst())
-            .compare(this.lastBuilt, that.getLastBuilt(), Ordering.natural().nullsFirst()).result();
+        return ComparisonChain.start().compare(this.getName(), that.getName(), Ordering.natural().nullsFirst())
+            .compare(this.getReference(), that.getReference(), Ordering.natural().nullsFirst())
+            .compare(this.getLastBuilt(), that.getLastBuilt(), Ordering.natural().nullsFirst()).result();
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("id", id).add("name", name).add("reference", reference).add("imageId", imageId)
+        return MoreObjects.toStringHelper(this).add("id", id).add("name", this.getName()).add("reference", this.getReference()).add("imageId", imageId)
             .add("dockerfilePath", dockerfilePath).toString();
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -240,9 +240,9 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
 
     @Override
     public int compareTo(@NotNull Tag that) {
-        return ComparisonChain.start().compare(this.name, that.name, Ordering.natural().nullsFirst())
-            .compare(this.reference, reference, Ordering.natural().nullsFirst())
-            .compare(this.lastBuilt, that.lastBuilt, Ordering.natural().nullsFirst()).result();
+        return ComparisonChain.start().compare(this.name, that.getName(), Ordering.natural().nullsFirst())
+            .compare(this.reference, that.getReference(), Ordering.natural().nullsFirst())
+            .compare(this.lastBuilt, that.getLastBuilt(), Ordering.natural().nullsFirst()).result();
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -97,11 +97,11 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     @Column
     @ApiModelProperty(value = "git commit/tag/branch", required = true, position = 1)
-    protected String reference;
+    private String reference;
 
     @Column
     @ApiModelProperty(value = "Implementation specific, can be a quay.io or docker hub tag name", required = true, position = 2)
-    protected String name;
+    private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parentid", nullable = false)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -163,7 +163,7 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, reference);
+        return Objects.hash(this.getName(), this.getReference());
     }
 
     @Override
@@ -174,7 +174,7 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("id", id).add("name", name).add("reference", reference).toString();
+        return MoreObjects.toStringHelper(this).add("id", id).add("name", this.getName()).add("reference", this.getReference()).toString();
     }
 
     public Service.SubClass getSubClass() {


### PR DESCRIPTION
Main issue: #3663

`addTags()` fails to catch duplicate adds of tags matching the original tag (default: `latest`) created when registering a tool with `registerManual()`, leading to the `unique_tag_names` SQL error. https://github.com/dockstore/dockstore/blob/develop/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoTagResource.java#L174

With the debugger I narrowed down the cause of this to `Tag::compareTo()` where `that.name`, `that.reference`, & `that.lastBuilt` all resolving to `null` for some reason. Using the getters for `that` appears to fix this.

Honestly I couldn't explain why this makes a difference, but I've verified using the debugger & reproducing the original issue using the CLI.

**Expected behaviour:**
```
$ dockstore tool manual_publish --name test --namespace GFJHogue --git-url git@github.com:GFJHogue/dockstore-tool-bamstats.git --git-reference develop
Successfully published DOCKER_HUB/GFJHogue/test
$ dockstore tool version_tag add --entry registry.hub.docker.com/GFJHogue/test --name latest --git-reference develop --image-id test
14:44:48.649 [main] ERROR io.dockstore.client.cli.ArgumentUtility - Could not find container
14:44:48.652 [main] ERROR io.dockstore.client.cli.ArgumentUtility - io.swagger.client.ApiException: Rollback of tag creation due to duplicate name
        at io.swagger.client.ApiClient.invokeAPI(ApiClient.java:718)
        at io.swagger.client.api.ContainertagsApi.addTagsWithHttpInfo(ContainertagsApi.java:96)
        at io.swagger.client.api.ContainertagsApi.addTags(ContainertagsApi.java:47)
        at io.dockstore.client.cli.nested.ToolClient.versionTag(ToolClient.java:837)
        at io.dockstore.client.cli.nested.ToolClient.processEntrySpecificCommands(ToolClient.java:113)
        at io.dockstore.client.cli.nested.AbstractEntryClient.processEntryCommands(AbstractEntryClient.java:237)
        at io.dockstore.client.cli.Client.run(Client.java:715)
        at io.dockstore.client.cli.Client.main(Client.java:614)
```