### PR TITLE
Gather remaining GitHub emails

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -613,7 +613,7 @@ public class UserResourceIT extends BaseIT {
         io.dockstore.openapi.client.model.User admin = adminApi.getUser();
         io.dockstore.openapi.client.model.Profile userProfile = userApi.getUser().getUserProfiles().get("github.com");
 
-        // Delete all of the tokens for every user
+        // Delete all of the tokens (except for Dockstore tokens) for every user
         testingPostgres.runUpdateStatement("DELETE FROM token WHERE tokensource <> 'dockstore'");
 
         assertNull(userProfile.getEmail());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -614,7 +614,7 @@ public class UserResourceIT extends BaseIT {
         io.dockstore.openapi.client.model.Profile userProfile = userApi.getUser().getUserProfiles().get("github.com");
 
         // Delete all of the tokens for every user
-        testingPostgres.runUpdateStatement("DELETE FROM token");
+        testingPostgres.runUpdateStatement("DELETE FROM token WHERE tokensource <> 'dockstore'");
 
         assertNull(userProfile.getEmail());
         assertNull(userProfile.getAvatarURL());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -562,4 +562,71 @@ public class UserResourceIT extends BaseIT {
             assertEquals(HttpStatus.SC_FORBIDDEN, ex.getCode());
         }
     }
+
+    /**
+     * Tests the endpoint used to sync all users' Github information called by a user who has a valid GitHub token
+     * and one user who has a missing or outdated GitHub token
+     */
+    @Test
+    public void testUpdateUserMetadataWithTokens() {
+        io.dockstore.openapi.client.ApiClient adminWebClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        io.dockstore.openapi.client.ApiClient userWebClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        io.dockstore.openapi.client.api.UsersApi adminApi = new io.dockstore.openapi.client.api.UsersApi(adminWebClient);
+        io.dockstore.openapi.client.api.UsersApi userApi = new io.dockstore.openapi.client.api.UsersApi(userWebClient);
+        io.dockstore.openapi.client.model.User admin = adminApi.getUser();
+        io.dockstore.openapi.client.model.Profile userProfile = userApi.getUser().getUserProfiles().get("github.com");
+
+        // Should add a test above this to check that the API call should pass once the admin tokens are up to date
+        // Testing that the updateLoggedInUserMetadata() should fail if GitHub tokens are expired or absent
+        testingPostgres.runUpdateStatement(String.format("DELETE FROM token WHERE userid = %d", admin.getId()));
+        try {
+            adminApi.updateLoggedInUserMetadata("github.com");
+            fail("API call should fail and throw an error when no GitHub tokens are found or if tokens are out of date");
+        } catch (io.dockstore.openapi.client.ApiException ex) {
+            assertEquals(HttpStatus.SC_FORBIDDEN, ex.getCode());
+        }
+
+        // DockstoreUser2's profile elements should be initially set to null since the GitHub metadata isn't synced yet
+        assertNull(userProfile.getEmail());
+        assertNull(userProfile.getAvatarURL());
+        assertNull(userProfile.getLocation());
+
+        // The API call updateUserMetadata() should not throw an error and exit if any users' tokens are out of date or absent
+        // Additionally, the API call should go through and sync DockstoreTestUser2's GitHub data
+        userApi.updateUserMetadata();
+
+        userProfile = userApi.getUser().getUserProfiles().get("github.com");
+        assertEquals("dockstore.test.user2@gmail.com", userProfile.getEmail());
+        assertEquals("https://avatars1.githubusercontent.com/u/17859829?v=4", userProfile.getAvatarURL());
+        assertEquals("Toronto", userProfile.getLocation());
+    }
+
+    /**
+     * Tests the endpoint while all users have no valid GitHub token and the caller also does not have a valid token
+     */
+    @Test
+    public void testUpdateUserMetadataWithoutTokens() {
+        io.dockstore.openapi.client.ApiClient adminWebClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        io.dockstore.openapi.client.ApiClient userWebClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        io.dockstore.openapi.client.api.UsersApi adminApi = new io.dockstore.openapi.client.api.UsersApi(adminWebClient);
+        io.dockstore.openapi.client.api.UsersApi userApi = new io.dockstore.openapi.client.api.UsersApi(userWebClient);
+        io.dockstore.openapi.client.model.User admin = adminApi.getUser();
+        io.dockstore.openapi.client.model.Profile userProfile = userApi.getUser().getUserProfiles().get("github.com");
+
+        // Delete all of the tokens for every user
+        testingPostgres.runUpdateStatement("DELETE FROM token");
+
+        assertNull(userProfile.getEmail());
+        assertNull(userProfile.getAvatarURL());
+        assertNull(userProfile.getLocation());
+
+        // Call the API method while the caller has no token
+        // An error should not be thrown and the call should pass, but every user should not have their GitHub information synced
+        userApi.updateUserMetadata();
+
+        userProfile = userApi.getUser().getUserProfiles().get("github.com");
+        assertNull(userProfile.getEmail());
+        assertNull(userProfile.getAvatarURL());
+        assertNull(userProfile.getLocation());
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -233,7 +233,11 @@ public class User implements Principal, Comparable<User>, Serializable {
      * @param tokenDAO The TokenDAO to access the user's tokens
      */
     public void updateUserMetadata(final TokenDAO tokenDAO) {
-        updateUserMetadata(tokenDAO, null);
+        updateUserMetadata(tokenDAO, null, true);
+    }
+
+    public void updateUserMetadata(final TokenDAO tokenDAO, boolean throwException) {
+        updateUserMetadata(tokenDAO, null, throwException);
     }
 
     /**
@@ -243,22 +247,22 @@ public class User implements Principal, Comparable<User>, Serializable {
      * @param tokenDAO The TokenDAO to access the user's tokens
      * @param source   The source to update the user's profile (GITHUB_COM, GOOGLE_COM, NULL)
      */
-    public void updateUserMetadata(final TokenDAO tokenDAO, TokenType source) {
+    public void updateUserMetadata(final TokenDAO tokenDAO, TokenType source, boolean throwException) {
         if (source == null) {
-            if (!updateGoogleMetadata(tokenDAO) && !updateGithubMetadata(tokenDAO)) {
+            if (!updateGoogleMetadata(tokenDAO) && !updateGithubMetadata(tokenDAO) && throwException) {
                 throw new CustomWebApplicationException(
                         "No GitHub or Google token found.  Please link a GitHub or Google token to your account.", HttpStatus.SC_FORBIDDEN);
             }
         } else {
             switch (source) {
             case GOOGLE_COM:
-                if (!updateGoogleMetadata(tokenDAO)) {
+                if (!updateGoogleMetadata(tokenDAO) && throwException) {
                     throw new CustomWebApplicationException("No Google token found.  Please link a Google token to your account.",
                             HttpStatus.SC_FORBIDDEN);
                 }
                 break;
             case GITHUB_COM:
-                if (!updateGithubMetadata(tokenDAO)) {
+                if (!updateGithubMetadata(tokenDAO) && throwException) {
                     throw new CustomWebApplicationException("No GitHub token found.  Please link a GitHub token to your account.",
                             HttpStatus.SC_FORBIDDEN);
                 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -244,8 +244,9 @@ public class User implements Principal, Comparable<User>, Serializable {
      * Updates the given user's profile with metadata depending on the source
      * If no source is specified try updating both
      *
-     * @param tokenDAO The TokenDAO to access the user's tokens
-     * @param source   The source to update the user's profile (GITHUB_COM, GOOGLE_COM, NULL)
+     * @param tokenDAO          The TokenDAO to access the user's tokens
+     * @param source            The source to update the user's profile (GITHUB_COM, GOOGLE_COM, NULL)
+     * @param throwException    The option to throw an error and stop the API call from processing if tokens are not valid
      */
     public void updateUserMetadata(final TokenDAO tokenDAO, TokenType source, boolean throwException) {
         try {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -730,7 +730,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     public List<User> updateUserMetadata(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user) {
         List<User> users = userDAO.findAll();
         for (User u : users) {
-            u.updateUserMetadata(tokenDAO);
+            u.updateUserMetadata(tokenDAO, false);
         }
 
         return userDAO.findAll();
@@ -753,7 +753,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
         if (source.equals(TokenType.GOOGLE_COM)) {
             updateGoogleAccessToken(user.getId());
         }
-        dbuser.updateUserMetadata(tokenDAO, source);
+        dbuser.updateUserMetadata(tokenDAO, source, true);
         return dbuser;
     }
 

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -694,15 +694,13 @@ components:
             - SWL
             - NFL
             - service
-            - cwl
-            - wdl
+            
+            
           type: string
         hasHTTPImports:
           type: boolean
         hasLocalImports:
           type: boolean
-      required:
-        - descriptorLanguage
       type: object
     Permission:
       properties:
@@ -1422,7 +1420,6 @@ components:
           items:
             $ref: '#/components/schemas/ParsedInformation'
           type: array
-          uniqueItems: true
       type: object
     VersionVerifiedPlatform:
       properties:
@@ -1469,8 +1466,8 @@ components:
             - SWL
             - NFL
             - service
-            - cwl
-            - wdl
+            
+            
           type: string
         descriptorTypeSubclass:
           enum:
@@ -1749,7 +1746,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WorkflowVersion'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -3634,7 +3631,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -4498,7 +4495,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Collection'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -6487,7 +6484,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Workflow'
           description: default response
       security:
         - bearer: []
@@ -6513,7 +6510,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -7271,8 +7271,6 @@ definitions:
         format: "int64"
   ParsedInformation:
     type: "object"
-    required:
-    - "descriptorLanguage"
     properties:
       descriptorLanguage:
         type: "string"
@@ -8242,7 +8240,6 @@ definitions:
         format: "int64"
       parsedInformationSet:
         type: "array"
-        uniqueItems: true
         items:
           $ref: "#/definitions/ParsedInformation"
   Workflow:


### PR DESCRIPTION
SEAB-1532

The API method updateUserMetadata() will no longer throw an error
when no GitHub or Google tokens are found to ensure that the metadata
is updated for users with tokens

Included a new updateUserMetadata() signature that is only affiliated
with the endpoint /users/updateUserMetadata

Included a boolean parameter to the main updateUserMetadata() method
to toggle the option to throw an error when no GitHub or Google tokens
are found

Added a check in the if-statements of the main updateUserMetadata()
method to see if errors should be thrown if tokens do not exist

Refactored existing calls to updateUserMetadata() to include a boolean
parameter