### PR TITLE
TRS tools endpoint - exclude null values for provided parameters

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -320,6 +320,10 @@ public class SwaggerClientIT extends BaseIT {
         assertEquals(1, tools.size());
         tools = toolApi.toolsGet(QUAY_IO_TEST_ORG_TEST6, Registry.DOCKER_HUB.getDockerPath(), null, null, null, null, null, null, null);
         assertEquals(0, tools.size());
+        tools = toolApi.toolsGet(null, Registry.QUAY_IO.getDockerPath(), null, null, null, null, null, null, null);
+        assertEquals(1, tools.size());
+        tools = toolApi.toolsGet(null, null, null, null, null, "Foo", null, null, null);
+        assertEquals(0, tools.size());
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -296,16 +296,16 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
             if (c instanceof Tool) {
                 Tool tool = (Tool)c;
                 // check each criteria. This sucks. Can we do this better with reflection? Or should we pre-convert?
-                if (registry != null && tool.getRegistry() != null && !tool.getRegistry().contains(registry)) {
+                if (registry != null && (tool.getRegistry() == null || !tool.getRegistry().contains(registry))) {
                     continue;
                 }
-                if (organization != null && tool.getNamespace() != null && !tool.getNamespace().contains(organization)) {
+                if (organization != null && (tool.getNamespace() == null || !tool.getNamespace().contains(organization))) {
                     continue;
                 }
-                if (name != null && tool.getName() != null && !tool.getName().contains(name)) {
+                if (name != null && (tool.getName() == null || !tool.getName().contains(name))) {
                     continue;
                 }
-                if (toolname != null && tool.getToolname() != null && !tool.getToolname().contains(toolname)) {
+                if (toolname != null && (tool.getToolname() == null || !tool.getToolname().contains(toolname))) {
                     continue;
                 }
                 if (checker != null && checker) {
@@ -313,20 +313,20 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
                     continue;
                 }
             }
-            // filters just for tools
+            // filters just for workflows
             if (c instanceof Workflow) {
                 Workflow workflow = (Workflow)c;
                 // check each criteria. This sucks. Can we do this better with reflection? Or should we pre-convert?
-                if (registry != null && workflow.getSourceControl() != null && !workflow.getSourceControl().toString().contains(registry)) {
+                if (registry != null && (workflow.getSourceControl() == null || !workflow.getSourceControl().toString().contains(registry))) {
                     continue;
                 }
-                if (organization != null && workflow.getOrganization() != null && !workflow.getOrganization().contains(organization)) {
+                if (organization != null && (workflow.getOrganization() == null || !workflow.getOrganization().contains(organization))) {
                     continue;
                 }
-                if (name != null && workflow.getRepository() != null && !workflow.getRepository().contains(name)) {
+                if (name != null && (workflow.getRepository() == null || !workflow.getRepository().contains(name))) {
                     continue;
                 }
-                if (toolname != null && workflow.getWorkflowName() != null && !workflow.getWorkflowName().contains(toolname)) {
+                if (toolname != null && (workflow.getWorkflowName() == null || !workflow.getWorkflowName().contains(toolname))) {
                     continue;
                 }
                 if (checker != null && workflow.isIsChecker() != checker) {
@@ -334,10 +334,10 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
                 }
             }
             // common filters between tools and workflows
-            if (description != null && c.getDescription() != null && !c.getDescription().contains(description)) {
+            if (description != null && (c.getDescription() == null || !c.getDescription().contains(description))) {
                 continue;
             }
-            if (author != null && c.getAuthor() != null && !c.getAuthor().contains(author)) {
+            if (author != null && (c.getAuthor() == null || !c.getAuthor().contains(author))) {
                 continue;
             }
             // if passing, for each container that matches the criteria, convert to standardised format and return


### PR DESCRIPTION
Main issue: #3660

With this change, results with `null` values in fields specified by request query parameters become excluded.

In the provided example
`curl -X GET "https://staging.dockstore.org/api/ga4gh/trs/v2/tools?description=Foo" -H "accept: application/json"`
only the 2 entries with descriptions containing `Foo` are returned instead of those and all entries with `null` descriptions.