### PR TITLE
Don't hide default versions and vice versa

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -260,9 +260,9 @@ public class GeneralWorkflowIT extends BaseIT {
 
         // Update workflow
         Optional<WorkflowVersion> workflowVersion = workflow.getWorkflowVersions().stream()
-            .filter(version -> Objects.equals(version.getName(), "master")).findFirst();
+            .filter(version -> Objects.equals(version.getName(), "testCWL")).findFirst();
         if (workflowVersion.isEmpty()) {
-            fail("Master version should exist");
+            fail("testCWL version should exist");
         }
 
         List<WorkflowVersion> workflowVersions = new ArrayList<>();
@@ -273,7 +273,7 @@ public class GeneralWorkflowIT extends BaseIT {
         workflowsApi.updateWorkflowVersion(workflow.getId(), workflowVersions);
 
         final long count = testingPostgres.runSelectStatement(
-            "select count(*) from workflowversion wv, version_metadata vm where wv.name = 'master' and vm.hidden = 't' and wv.workflowpath = '/Dockstore2.wdl' and wv.id = vm.id",
+            "select count(*) from workflowversion wv, version_metadata vm where wv.name = 'testCWL' and vm.hidden = 't' and wv.workflowpath = '/Dockstore2.wdl' and wv.id = vm.id",
             long.class);
         assertEquals("there should be 1 matching workflow version, there is " + count, 1, count);
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -99,6 +99,7 @@ import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
+import static io.dockstore.common.DescriptorLanguage.CWL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -1071,6 +1072,72 @@ public class WorkflowIT extends BaseIT {
         verifyTRSImageConversion(versions, "1.0", 3);
     }
 
+    @Test
+    public void testHiddenAndDefaultVersions() {
+        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowsApi = new WorkflowsApi(webClient);
+        HostedApi hostedApi = new HostedApi(webClient);
+        Workflow workflow = workflowsApi.manualRegister("github", DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "/Dockstore.wdl", "", DescriptorLanguage.WDL.toString(), "/test.json");
+
+        workflow = workflowsApi.refresh(workflow.getId());
+        List<WorkflowVersion> workflowVersions = workflow.getWorkflowVersions();
+        WorkflowVersion version = workflowVersions.get(0);
+        version.setHidden(true);
+        workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(version));
+
+        try {
+            workflow = workflowsApi.updateWorkflowDefaultVersion(workflow.getId(), version.getName());
+            fail("Shouldn't be able to set the default version to one that is hidden.");
+        } catch (ApiException ex) {
+            Assert.assertEquals("You can not set the default version to a hidden version.", ex.getMessage());
+        }
+
+        // Set the default version to a non-hidden version
+        version.setHidden(false);
+        workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(version));
+        workflow = workflowsApi.updateWorkflowDefaultVersion(workflow.getId(), version.getName());
+
+        // Should not be able to hide a default version
+        version.setHidden(true);
+        try {
+            workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(version));
+            fail("Should not be able to hide a default version");
+        } catch (ApiException ex) {
+            Assert.assertEquals("You cannot hide the default version.", ex.getMessage());
+        }
+
+        // Test same for hosted workflows
+        Workflow hostedWorkflow = hostedApi.createHostedWorkflow("awesomeTool", null, CWL.getShortName(), null, null);
+        SourceFile file = new SourceFile();
+        file.setContent("cwlVersion: v1.0\n" + "class: Workflow");
+        file.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
+        file.setPath("/Dockstore.cwl");
+        file.setAbsolutePath("/Dockstore.cwl");
+        hostedWorkflow = hostedApi.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file));
+
+        WorkflowVersion hostedVersion = hostedWorkflow.getWorkflowVersions().get(0);
+        hostedVersion.setHidden(true);
+        try {
+            workflowsApi.updateWorkflowVersion(hostedWorkflow.getId(), Collections.singletonList(hostedVersion));
+            fail("Shouldn't be able to hide the default version.");
+        } catch (ApiException ex) {
+            Assert.assertEquals("You cannot hide the default version.", ex.getMessage());
+        }
+
+        file.setContent("cwlVersion: v1.0\n\n" + "class: Workflow");
+        hostedWorkflow = hostedApi.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file));
+        hostedVersion = hostedWorkflow.getWorkflowVersions().stream().filter(v -> v.getName().equals("1")).findFirst().get();
+        hostedVersion.setHidden(true);
+        workflowsApi.updateWorkflowVersion(hostedWorkflow.getId(), Collections.singletonList(hostedVersion));
+
+        try {
+            workflowsApi.updateWorkflowDefaultVersion(hostedWorkflow.getId(), hostedVersion.getName());
+            fail("Shouldn't be able to set the default version to one that is hidden.");
+        } catch (ApiException ex) {
+            Assert.assertEquals("You can not set the default version to a hidden version.", ex.getMessage());
+        }
+    }
+
     /**
     * Tests the a checksum is calculated for workflow sourcefiles on refresh or snapshot. Also checks that trs endpoints convert correctly.
     * */
@@ -1081,7 +1148,7 @@ public class WorkflowIT extends BaseIT {
         WorkflowsApi workflowsApi = new WorkflowsApi(webClient);
         final io.dockstore.openapi.client.ApiClient openAPIClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openAPIClient);
-        Workflow workflow = workflowsApi.manualRegister("github", DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "/Dockstore.wdl", "", "wdl", "/test.json");
+        Workflow workflow = workflowsApi.manualRegister("github", DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "/Dockstore.wdl", "", DescriptorLanguage.WDL.toString(), "/test.json");
 
         workflow = workflowsApi.refresh(workflow.getId());
         List<WorkflowVersion> workflowVersions = workflow.getWorkflowVersions();
@@ -1099,7 +1166,7 @@ public class WorkflowIT extends BaseIT {
         assertTrue(testedWDL);
 
         // Test grabbing checksum on snapshot
-        Workflow workflow2 = manualRegisterAndPublish(workflowsApi, "dockstore-testing/hello_world", "", "cwl", SourceControl.GITHUB, "/hello_world.cwl", true);
+        Workflow workflow2 = manualRegisterAndPublish(workflowsApi, "dockstore-testing/hello_world", "", DescriptorLanguage.CWL.toString(), SourceControl.GITHUB, "/hello_world.cwl", true);
         WorkflowVersion snapshotVersion = workflow2.getWorkflowVersions().stream().filter(v -> v.getName().equals("1.0.1")).findFirst().get();
         assertNotNull(snapshotVersion.getSourceFiles());
         snapshotVersion.setFrozen(true);
@@ -1110,7 +1177,7 @@ public class WorkflowIT extends BaseIT {
         workflowsApi.refresh(workflow2.getId());
 
         // Test TRS conversion
-        io.dockstore.openapi.client.model.FileWrapper fileWrapper = ga4Ghv20Api.toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/github.com/dockstore-testing/hello_world", "1.0.1");
+        io.dockstore.openapi.client.model.FileWrapper fileWrapper = ga4Ghv20Api.toolsIdVersionsVersionIdTypeDescriptorGet(DescriptorLanguage.CWL.toString(), "#workflow/github.com/dockstore-testing/hello_world", "1.0.1");
         verifyTRSSourcefileConversion(fileWrapper);
 
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -61,8 +61,10 @@ import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Ordering;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.EntryType;
+import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.helpers.EntryStarredSerializer;
 import io.swagger.annotations.ApiModelProperty;
+import org.apache.http.HttpStatus;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -505,6 +507,9 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     public boolean checkAndSetDefaultVersion(String newDefaultVersion) {
         for (T version : this.getWorkflowVersions()) {
             if (Objects.equals(newDefaultVersion, version.getName())) {
+                if (version.isHidden()) {
+                    throw new CustomWebApplicationException("You can not set the default version to a hidden version.", HttpStatus.SC_BAD_REQUEST);
+                }
                 this.setActualDefaultVersion(version);
                 this.syncMetadataWithDefault();
                 return true;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -365,6 +365,10 @@ public abstract class SourceCodeRepoInterface {
                             String reference = workflowVersion.getReference();
                             return branch.equals(reference);
                         }).findFirst();
+                // if the main branch is set to hidden, get the latest, non hidden version instead
+                if (firstWorkflowVersion.isPresent() && firstWorkflowVersion.get().isHidden()) {
+                    firstWorkflowVersion = workflowVersions.stream().filter(version -> !version.isHidden()).max(Comparator.comparing(Version::getDate));
+                }
                 firstWorkflowVersion.ifPresentOrElse(version -> entry.checkAndSetDefaultVersion(version.getName()), () -> {
                     if (!workflowVersions.isEmpty()) {
                         Version newestVersion = Collections.max(workflowVersions, Comparator.comparingLong(s -> s.getDate().getTime()));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoTagResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoTagResource.java
@@ -125,6 +125,9 @@ public class DockerRepoTagResource implements AuthenticatedResourceInterface, En
 
         for (Tag tag : tags) {
             if (mapOfExistingTags.containsKey(tag.getId())) {
+                if (tool.getActualDefaultVersion() != null && tool.getActualDefaultVersion().getId() == tag.getId() && tag.isHidden()) {
+                    throw new CustomWebApplicationException("You cannot hide the default version.", HttpStatus.SC_BAD_REQUEST);
+                }
                 // remove existing copy and add the new one
                 Tag existingTag = mapOfExistingTags.get(tag.getId());
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1392,6 +1392,9 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
         for (WorkflowVersion version : workflowVersions) {
             if (mapOfExistingWorkflowVersions.containsKey(version.getId())) {
+                if (w.getActualDefaultVersion() != null && w.getActualDefaultVersion().getId() == version.getId() && version.isHidden()) {
+                    throw new CustomWebApplicationException("You cannot hide the default version.", HttpStatus.SC_BAD_REQUEST);
+                }
                 // remove existing copy and add the new one
                 WorkflowVersion existingTag = mapOfExistingWorkflowVersions.get(version.getId());
 

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -694,15 +694,13 @@ components:
             - SWL
             - NFL
             - service
-            - cwl
-            - wdl
+            
+            
           type: string
         hasHTTPImports:
           type: boolean
         hasLocalImports:
           type: boolean
-      required:
-        - descriptorLanguage
       type: object
     Permission:
       properties:
@@ -1422,7 +1420,6 @@ components:
           items:
             $ref: '#/components/schemas/ParsedInformation'
           type: array
-          uniqueItems: true
       type: object
     VersionVerifiedPlatform:
       properties:
@@ -1469,8 +1466,8 @@ components:
             - SWL
             - NFL
             - service
-            - cwl
-            - wdl
+            
+            
           type: string
         descriptorTypeSubclass:
           enum:
@@ -2446,7 +2443,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tool'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []
@@ -4626,7 +4623,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organization'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -6513,7 +6510,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1746,7 +1746,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WorkflowVersion'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -2443,7 +2443,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Tool'
           description: default response
       security:
         - bearer: []
@@ -3631,7 +3631,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -6484,7 +6484,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Workflow'
           description: default response
       security:
         - bearer: []

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -7271,8 +7271,6 @@ definitions:
         format: "int64"
   ParsedInformation:
     type: "object"
-    required:
-    - "descriptorLanguage"
     properties:
       descriptorLanguage:
         type: "string"
@@ -8242,7 +8240,6 @@ definitions:
         format: "int64"
       parsedInformationSet:
         type: "array"
-        uniqueItems: true
         items:
           $ref: "#/definitions/ParsedInformation"
   Workflow:


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-1360

Elastic search keeps the sourcefiles for the default version, but before we could have the default version be hidden. So this PR doesn't let you hide a default version nor make a hidden version the default version.