### PR TITLE
Feature/seab 1164/remove orphan version metadata

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -144,7 +144,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     // Warning: this is eagerly loaded because of two reasons:
     // the 4 @ApiModelProperty that uses version metadata
     // This OneToOne
-    @OneToOne(cascade = CascadeType.ALL, mappedBy = "parent")
+    @OneToOne(cascade = CascadeType.ALL, mappedBy = "parent", orphanRemoval = true)
     @Cascade(org.hibernate.annotations.CascadeType.ALL)
     @PrimaryKeyJoinColumn
     private VersionMetadata versionMetadata = new VersionMetadata();

--- a/dockstore-webservice/src/main/resources/migrations.1.10.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.10.0.xml
@@ -60,4 +60,7 @@
         </createTable>
         <addForeignKeyConstraint baseColumnNames="version_metadata_id" baseTableName="parsed_information" constraintName="version_metadata_parsed_information_fk_constraint" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="version_metadata"/>
     </changeSet>
+    <changeSet id="removeOrphanVersionMetadata" author="gluu">
+        <sql dbms="postgresql">delete from version_metadata vm where vm.id not in (select wv.id from workflowversion wv union select t.id from tag t);</sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
For https://ucsc-cgl.atlassian.net/browse/SEAB-1164 , see comments in it for details.

We currently have no constraint to prevent orphans, but the orphans do not appear to be created in a normal manner anyways

Adding a real constraint to prevent orphans does not appear to be easily do-able right now.

Just removing orphans in migration for now. Also adding `orphanRemoval = true` just in case.

Probably need to create another issue for adding an actual constraint.