### PR TITLE
3487/smart refresh

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -191,7 +191,7 @@ public class BasicIT extends BaseIT {
         // refresh a specific workflow
         Workflow workflow = workflowsApi
                 .getWorkflowByPath(SourceControl.GITHUB.toString() + "/DockstoreTestUser/dockstore-whalesay-wdl", "", false);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         assertFalse(workflow.getWorkflowVersions().isEmpty());
     }
 
@@ -232,14 +232,14 @@ public class BasicIT extends BaseIT {
         // refresh a specific workflow
         Workflow workflow = workflowsApi
             .getWorkflowByPath(SourceControl.GITHUB.toString() + "/DockstoreTestUser/dockstore-whalesay-wdl", "", false);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // artificially create an invalid version
         testingPostgres.runUpdateStatement("update workflowversion set name = 'test'");
         testingPostgres.runUpdateStatement("update workflowversion set reference = 'test'");
 
         // refresh individual workflow
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // check that the version was deleted
         final long updatedWorkflowVersionCount = testingPostgres.runSelectStatement("select count(*) from workflowversion", long.class);
@@ -263,7 +263,7 @@ public class BasicIT extends BaseIT {
 
         // refresh without github token
         try {
-            workflow = workflowsApi.refresh(workflow.getId(), true);
+            workflow = workflowsApi.refresh(workflow.getId(), false);
         } catch (ApiException e) {
             assertTrue(e.getMessage().contains("No GitHub or Google token found"));
         }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -191,7 +191,7 @@ public class BasicIT extends BaseIT {
         // refresh a specific workflow
         Workflow workflow = workflowsApi
                 .getWorkflowByPath(SourceControl.GITHUB.toString() + "/DockstoreTestUser/dockstore-whalesay-wdl", "", false);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         assertFalse(workflow.getWorkflowVersions().isEmpty());
     }
 
@@ -232,14 +232,14 @@ public class BasicIT extends BaseIT {
         // refresh a specific workflow
         Workflow workflow = workflowsApi
             .getWorkflowByPath(SourceControl.GITHUB.toString() + "/DockstoreTestUser/dockstore-whalesay-wdl", "", false);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         // artificially create an invalid version
         testingPostgres.runUpdateStatement("update workflowversion set name = 'test'");
         testingPostgres.runUpdateStatement("update workflowversion set reference = 'test'");
 
         // refresh individual workflow
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         // check that the version was deleted
         final long updatedWorkflowVersionCount = testingPostgres.runSelectStatement("select count(*) from workflowversion", long.class);
@@ -263,7 +263,7 @@ public class BasicIT extends BaseIT {
 
         // refresh without github token
         try {
-            workflow = workflowsApi.refresh(workflow.getId());
+            workflow = workflowsApi.refresh(workflow.getId(), true);
         } catch (ApiException e) {
             assertTrue(e.getMessage().contains("No GitHub or Google token found"));
         }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
@@ -525,7 +525,7 @@ public class CRUDClientIT extends BaseIT {
         Workflow hostedWorkflow = hostedApi
             .createHostedWorkflow("awesomeTool", null, DescriptorLanguage.CWL.toString().toLowerCase(), null, null);
         thrown.expect(ApiException.class);
-        workflowApi.refresh(hostedWorkflow.getId());
+        workflowApi.refresh(hostedWorkflow.getId(), true);
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
@@ -525,7 +525,7 @@ public class CRUDClientIT extends BaseIT {
         Workflow hostedWorkflow = hostedApi
             .createHostedWorkflow("awesomeTool", null, DescriptorLanguage.CWL.toString().toLowerCase(), null, null);
         thrown.expect(ApiException.class);
-        workflowApi.refresh(hostedWorkflow.getId(), true);
+        workflowApi.refresh(hostedWorkflow.getId(), false);
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
@@ -218,7 +218,7 @@ public class CheckerWorkflowIT extends BaseIT {
             Workflow githubWorkflow = workflowApi
                 .manualRegister("github", "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl", "", "cwl", "/testcwl.json");
             // Refresh the workflow
-            baseEntryId = workflowApi.refresh(githubWorkflow.getId()).getId();
+            baseEntryId = workflowApi.refresh(githubWorkflow.getId(), true).getId();
         } else {
             // Manually register a tool
             DockstoreTool newTool = new DockstoreTool();
@@ -259,12 +259,12 @@ public class CheckerWorkflowIT extends BaseIT {
                 .manualRegister("github", "DockstoreTestUser2/dockstore_workflow_cnv", "/workflow/cnv.cwl", "", "cwl", "/test.json"));
         if (all) {
             for (Workflow workflowItem : workflows) {
-                workflowApi.refresh(workflowItem.getId());
+                workflowApi.refresh(workflowItem.getId(), true);
             }
         } else {
             for (Workflow workflowItem : workflows) {
                 if (workflowItem.getOrganization().equalsIgnoreCase(stubCheckerWorkflow.getOrganization())) {
-                    workflowApi.refresh(workflowItem.getId());
+                    workflowApi.refresh(workflowItem.getId(), true);
                 }
             }
         }
@@ -297,7 +297,7 @@ public class CheckerWorkflowIT extends BaseIT {
         assertEquals("No workflows are in full mode, there are " + count, 0, count);
 
         // Refresh the workflow
-        workflowApi.refresh(githubWorkflow.getId());
+        workflowApi.refresh(githubWorkflow.getId(), true);
 
         final long count2 = testingPostgres
             .runSelectStatement("select count(*) from workflow where mode = '" + Workflow.ModeEnum.FULL + "'", long.class);
@@ -307,7 +307,7 @@ public class CheckerWorkflowIT extends BaseIT {
         workflowApi.registerCheckerWorkflow("/checker-workflow-wrapping-workflow.cwl", githubWorkflow.getId(), "cwl", null);
 
         // Refresh workflow
-        Workflow refreshedEntry = workflowApi.refresh(githubWorkflow.getId());
+        Workflow refreshedEntry = workflowApi.refresh(githubWorkflow.getId(), true);
 
         // Should be able to download zip for first version
         Workflow checkerWorkflow = workflowApi.getWorkflow(refreshedEntry.getCheckerId(), null);
@@ -390,7 +390,7 @@ public class CheckerWorkflowIT extends BaseIT {
         assertEquals("No workflows are in full mode, there are " + count, 0, count);
 
         // Refresh the workflow
-        workflowApi.refresh(githubWorkflow.getId());
+        workflowApi.refresh(githubWorkflow.getId(), true);
 
         final long count2 = testingPostgres
             .runSelectStatement("select count(*) from workflow where mode = '" + Workflow.ModeEnum.FULL + "'", long.class);
@@ -400,7 +400,7 @@ public class CheckerWorkflowIT extends BaseIT {
         workflowApi.registerCheckerWorkflow("/checker-workflow-wrapping-workflow.wdl", githubWorkflow.getId(), "wdl", null);
 
         // Refresh workflow
-        workflowApi.refresh(githubWorkflow.getId());
+        workflowApi.refresh(githubWorkflow.getId(), true);
 
         // Checker workflow should refresh
         final long count3 = testingPostgres

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
@@ -218,7 +218,7 @@ public class CheckerWorkflowIT extends BaseIT {
             Workflow githubWorkflow = workflowApi
                 .manualRegister("github", "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl", "", "cwl", "/testcwl.json");
             // Refresh the workflow
-            baseEntryId = workflowApi.refresh(githubWorkflow.getId(), true).getId();
+            baseEntryId = workflowApi.refresh(githubWorkflow.getId(), false).getId();
         } else {
             // Manually register a tool
             DockstoreTool newTool = new DockstoreTool();
@@ -259,12 +259,12 @@ public class CheckerWorkflowIT extends BaseIT {
                 .manualRegister("github", "DockstoreTestUser2/dockstore_workflow_cnv", "/workflow/cnv.cwl", "", "cwl", "/test.json"));
         if (all) {
             for (Workflow workflowItem : workflows) {
-                workflowApi.refresh(workflowItem.getId(), true);
+                workflowApi.refresh(workflowItem.getId(), false);
             }
         } else {
             for (Workflow workflowItem : workflows) {
                 if (workflowItem.getOrganization().equalsIgnoreCase(stubCheckerWorkflow.getOrganization())) {
-                    workflowApi.refresh(workflowItem.getId(), true);
+                    workflowApi.refresh(workflowItem.getId(), false);
                 }
             }
         }
@@ -297,7 +297,7 @@ public class CheckerWorkflowIT extends BaseIT {
         assertEquals("No workflows are in full mode, there are " + count, 0, count);
 
         // Refresh the workflow
-        workflowApi.refresh(githubWorkflow.getId(), true);
+        workflowApi.refresh(githubWorkflow.getId(), false);
 
         final long count2 = testingPostgres
             .runSelectStatement("select count(*) from workflow where mode = '" + Workflow.ModeEnum.FULL + "'", long.class);
@@ -307,7 +307,7 @@ public class CheckerWorkflowIT extends BaseIT {
         workflowApi.registerCheckerWorkflow("/checker-workflow-wrapping-workflow.cwl", githubWorkflow.getId(), "cwl", null);
 
         // Refresh workflow
-        Workflow refreshedEntry = workflowApi.refresh(githubWorkflow.getId(), true);
+        Workflow refreshedEntry = workflowApi.refresh(githubWorkflow.getId(), false);
 
         // Should be able to download zip for first version
         Workflow checkerWorkflow = workflowApi.getWorkflow(refreshedEntry.getCheckerId(), null);
@@ -390,7 +390,7 @@ public class CheckerWorkflowIT extends BaseIT {
         assertEquals("No workflows are in full mode, there are " + count, 0, count);
 
         // Refresh the workflow
-        workflowApi.refresh(githubWorkflow.getId(), true);
+        workflowApi.refresh(githubWorkflow.getId(), false);
 
         final long count2 = testingPostgres
             .runSelectStatement("select count(*) from workflow where mode = '" + Workflow.ModeEnum.FULL + "'", long.class);
@@ -400,7 +400,7 @@ public class CheckerWorkflowIT extends BaseIT {
         workflowApi.registerCheckerWorkflow("/checker-workflow-wrapping-workflow.wdl", githubWorkflow.getId(), "wdl", null);
 
         // Refresh workflow
-        workflowApi.refresh(githubWorkflow.getId(), true);
+        workflowApi.refresh(githubWorkflow.getId(), false);
 
         // Checker workflow should refresh
         final long count3 = testingPostgres

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
@@ -67,7 +67,7 @@ public class DAGWorkflowTestIT extends BaseIT {
         Assert.assertEquals(githubWorkflow.getWorkflowName(), testWorkflowName);
 
         // Publish github workflow
-        Workflow refresh = workflowApi.refresh(githubWorkflow.getId());
+        Workflow refresh = workflowApi.refresh(githubWorkflow.getId(), true);
 
         // This checks if a workflow whose default name is test-workflow remains as test-workflow and not null or empty string after refresh
         Assert.assertEquals(refresh.getWorkflowName(), testWorkflowName);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
@@ -67,7 +67,7 @@ public class DAGWorkflowTestIT extends BaseIT {
         Assert.assertEquals(githubWorkflow.getWorkflowName(), testWorkflowName);
 
         // Publish github workflow
-        Workflow refresh = workflowApi.refresh(githubWorkflow.getId(), true);
+        Workflow refresh = workflowApi.refresh(githubWorkflow.getId(), false);
 
         // This checks if a workflow whose default name is test-workflow remains as test-workflow and not null or empty string after refresh
         Assert.assertEquals(refresh.getWorkflowName(), testWorkflowName);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedNextflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedNextflowIT.java
@@ -77,7 +77,7 @@ public class ExtendedNextflowIT extends BaseIT {
         workflowApi.updateWorkflow(workflowByPathGithub.getId(), workflowByPathGithub);
 
         workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_WORKFLOW, null, false);
-        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), true);
+        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), false);
 
         // Tests that nf-core nextflow.config files can be parsed
         List<SourceFile> sourceFileList = new ArrayList<>(
@@ -103,7 +103,7 @@ public class ExtendedNextflowIT extends BaseIT {
         // get workflow stubs
         Workflow workflow = workflowApi.manualRegister(SourceControl.BITBUCKET.name(), "dockstore_testuser2/ampa-nf", "/nextflow.config", "",
                 DescriptorLanguage.NEXTFLOW.getLowerShortName(), "/foo.json");
-        workflowApi.refresh(workflow.getId(), true);
+        workflowApi.refresh(workflow.getId(), false);
 
         // do targeted refresh, should promote workflow to fully-fleshed out workflow
         Workflow workflowByPathBitbucket = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_BITBUCKET_WORKFLOW, null, false);
@@ -112,7 +112,7 @@ public class ExtendedNextflowIT extends BaseIT {
         workflowByPathBitbucket.setDescriptorType(Workflow.DescriptorTypeEnum.NFL);
         workflowApi.updateWorkflow(workflowByPathBitbucket.getId(), workflowByPathBitbucket);
         workflowByPathBitbucket = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_BITBUCKET_WORKFLOW, null, false);
-        final Workflow bitbucketWorkflow = workflowApi.refresh(workflowByPathBitbucket.getId(), true);
+        final Workflow bitbucketWorkflow = workflowApi.refresh(workflowByPathBitbucket.getId(), false);
         Workflow byPathWorkflow = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_BITBUCKET_WORKFLOW, null, false);
         // There are 3 versions: master, v1.0, and v2.0
         // master and v2.0 has a nextflow.config file that has description and author, v1.0 does not
@@ -123,7 +123,7 @@ public class ExtendedNextflowIT extends BaseIT {
         testingPostgres.runUpdateStatement("update version_metadata set email='bad_potato'");
         testingPostgres.runUpdateStatement("update version_metadata set author='bad_potato'");
         testingPostgres.runUpdateStatement("update version_metadata set description='bad_potato'");
-        final Workflow refreshedBitbucketWorkflow = workflowApi.refresh(workflowByPathBitbucket.getId(), true);
+        final Workflow refreshedBitbucketWorkflow = workflowApi.refresh(workflowByPathBitbucket.getId(), false);
         byPathWorkflow = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_BITBUCKET_WORKFLOW, null, false);
         // This tests if it can fix outdated metadata
         testWorkflowVersionMetadata(refreshedBitbucketWorkflow);
@@ -172,7 +172,7 @@ public class ExtendedNextflowIT extends BaseIT {
         Workflow workflow = workflowApi
                 .manualRegister(SourceControl.BITBUCKET.name(), "dockstore_testuser2/kallisto-nf", "/nextflow.config", "",
                         DescriptorLanguage.NEXTFLOW.getLowerShortName(), "/foo.json");
-        workflowApi.refresh(workflow.getId(), true);
+        workflowApi.refresh(workflow.getId(), false);
 
         // do targeted refresh, should promote workflow to fully-fleshed out workflow
         Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_BINARY_WORKFLOW, null, false);
@@ -182,7 +182,7 @@ public class ExtendedNextflowIT extends BaseIT {
         workflowApi.updateWorkflow(workflowByPathGithub.getId(), workflowByPathGithub);
 
         workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_BINARY_WORKFLOW, null, false);
-        final Workflow bitbucketWorkflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
+        final Workflow bitbucketWorkflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
         Assert.assertTrue("Should have gotten the description from README", bitbucketWorkflow.getDescription().contains("A Nextflow implementation of Kallisto & Sleuth RNA-Seq Tools"));
         List<SourceFile> sourceFileList = new ArrayList<>(
             bitbucketWorkflow.getWorkflowVersions().stream().filter(version -> version.getName().equals("v1.0")).findFirst().get()

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedNextflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedNextflowIT.java
@@ -123,7 +123,7 @@ public class ExtendedNextflowIT extends BaseIT {
         testingPostgres.runUpdateStatement("update version_metadata set email='bad_potato'");
         testingPostgres.runUpdateStatement("update version_metadata set author='bad_potato'");
         testingPostgres.runUpdateStatement("update version_metadata set description='bad_potato'");
-        final Workflow refreshedBitbucketWorkflow = workflowApi.refresh(workflowByPathBitbucket.getId(), false);
+        final Workflow refreshedBitbucketWorkflow = workflowApi.refresh(workflowByPathBitbucket.getId(), true);
         byPathWorkflow = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_BITBUCKET_WORKFLOW, null, false);
         // This tests if it can fix outdated metadata
         testWorkflowVersionMetadata(refreshedBitbucketWorkflow);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedNextflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedNextflowIT.java
@@ -77,7 +77,7 @@ public class ExtendedNextflowIT extends BaseIT {
         workflowApi.updateWorkflow(workflowByPathGithub.getId(), workflowByPathGithub);
 
         workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_WORKFLOW, null, false);
-        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId());
+        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), true);
 
         // Tests that nf-core nextflow.config files can be parsed
         List<SourceFile> sourceFileList = new ArrayList<>(
@@ -103,7 +103,7 @@ public class ExtendedNextflowIT extends BaseIT {
         // get workflow stubs
         Workflow workflow = workflowApi.manualRegister(SourceControl.BITBUCKET.name(), "dockstore_testuser2/ampa-nf", "/nextflow.config", "",
                 DescriptorLanguage.NEXTFLOW.getLowerShortName(), "/foo.json");
-        workflowApi.refresh(workflow.getId());
+        workflowApi.refresh(workflow.getId(), true);
 
         // do targeted refresh, should promote workflow to fully-fleshed out workflow
         Workflow workflowByPathBitbucket = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_BITBUCKET_WORKFLOW, null, false);
@@ -112,7 +112,7 @@ public class ExtendedNextflowIT extends BaseIT {
         workflowByPathBitbucket.setDescriptorType(Workflow.DescriptorTypeEnum.NFL);
         workflowApi.updateWorkflow(workflowByPathBitbucket.getId(), workflowByPathBitbucket);
         workflowByPathBitbucket = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_BITBUCKET_WORKFLOW, null, false);
-        final Workflow bitbucketWorkflow = workflowApi.refresh(workflowByPathBitbucket.getId());
+        final Workflow bitbucketWorkflow = workflowApi.refresh(workflowByPathBitbucket.getId(), true);
         Workflow byPathWorkflow = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_BITBUCKET_WORKFLOW, null, false);
         // There are 3 versions: master, v1.0, and v2.0
         // master and v2.0 has a nextflow.config file that has description and author, v1.0 does not
@@ -123,7 +123,7 @@ public class ExtendedNextflowIT extends BaseIT {
         testingPostgres.runUpdateStatement("update version_metadata set email='bad_potato'");
         testingPostgres.runUpdateStatement("update version_metadata set author='bad_potato'");
         testingPostgres.runUpdateStatement("update version_metadata set description='bad_potato'");
-        final Workflow refreshedBitbucketWorkflow = workflowApi.refresh(workflowByPathBitbucket.getId());
+        final Workflow refreshedBitbucketWorkflow = workflowApi.refresh(workflowByPathBitbucket.getId(), true);
         byPathWorkflow = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_BITBUCKET_WORKFLOW, null, false);
         // This tests if it can fix outdated metadata
         testWorkflowVersionMetadata(refreshedBitbucketWorkflow);
@@ -172,7 +172,7 @@ public class ExtendedNextflowIT extends BaseIT {
         Workflow workflow = workflowApi
                 .manualRegister(SourceControl.BITBUCKET.name(), "dockstore_testuser2/kallisto-nf", "/nextflow.config", "",
                         DescriptorLanguage.NEXTFLOW.getLowerShortName(), "/foo.json");
-        workflowApi.refresh(workflow.getId());
+        workflowApi.refresh(workflow.getId(), true);
 
         // do targeted refresh, should promote workflow to fully-fleshed out workflow
         Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_BINARY_WORKFLOW, null, false);
@@ -182,7 +182,7 @@ public class ExtendedNextflowIT extends BaseIT {
         workflowApi.updateWorkflow(workflowByPathGithub.getId(), workflowByPathGithub);
 
         workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER_NEXTFLOW_BINARY_WORKFLOW, null, false);
-        final Workflow bitbucketWorkflow = workflowApi.refresh(workflowByPathGithub.getId());
+        final Workflow bitbucketWorkflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
         Assert.assertTrue("Should have gotten the description from README", bitbucketWorkflow.getDescription().contains("A Nextflow implementation of Kallisto & Sleuth RNA-Seq Tools"));
         List<SourceFile> sourceFileList = new ArrayList<>(
             bitbucketWorkflow.getWorkflowVersions().stream().filter(version -> version.getName().equals("v1.0")).findFirst().get()

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSIT.java
@@ -118,7 +118,7 @@ public class ExtendedTRSIT extends BaseIT {
             workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
 
             // refresh and publish the workflow
-            final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId());
+            final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
             workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
         }
 
@@ -159,7 +159,7 @@ public class ExtendedTRSIT extends BaseIT {
             // refresh as the owner
             WorkflowsApi workflowApi = new WorkflowsApi(registeringUser);
             // refresh should not destroy verification data
-            workflowApi.refresh(workflowByPathGithub.getId());
+            workflowApi.refresh(workflowByPathGithub.getId(), true);
             Map<String, Object> stringObjectMap = extendedGa4GhApi
                 .toolsIdVersionsVersionIdTypeTestsPost("CWL", id, "master", defaultTestParameterFilePath, CRUMMY_PLATFORM, "1.0.0",
                     "new metadata", true);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSIT.java
@@ -118,7 +118,7 @@ public class ExtendedTRSIT extends BaseIT {
             workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
 
             // refresh and publish the workflow
-            final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
+            final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
             workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
         }
 
@@ -159,7 +159,7 @@ public class ExtendedTRSIT extends BaseIT {
             // refresh as the owner
             WorkflowsApi workflowApi = new WorkflowsApi(registeringUser);
             // refresh should not destroy verification data
-            workflowApi.refresh(workflowByPathGithub.getId(), true);
+            workflowApi.refresh(workflowByPathGithub.getId(), false);
             Map<String, Object> stringObjectMap = extendedGa4GhApi
                 .toolsIdVersionsVersionIdTypeTestsPost("CWL", id, "master", defaultTestParameterFilePath, CRUMMY_PLATFORM, "1.0.0",
                     "new metadata", true);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -225,7 +225,7 @@ public class GeneralWorkflowIT extends BaseIT {
         assertEquals("there should be 4 versions, there are " + count4, 4, count4);
 
         // attempt to publish it
-        workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(false));
+        workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
 
         final long count5 = testingPostgres.runSelectStatement("select count(*) from workflow where ispublished='t'", long.class);
         assertEquals("there should be 1 published entry, there are " + count5, 1, count5);
@@ -794,7 +794,8 @@ public class GeneralWorkflowIT extends BaseIT {
         assertEquals("there should be 1 full workflows, there are " + count3, 1, count3);
 
         // Change path for each version so that it is invalid
-        testingPostgres.runUpdateStatement("UPDATE workflowversion SET workflowpath='thisisnotarealpath.cwl', dirtybit=true");
+        workflow.setWorkflowPath("thisisnotarealpath.cwl");
+        workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // Workflow has no valid versions so you cannot publish
@@ -819,7 +820,8 @@ public class GeneralWorkflowIT extends BaseIT {
         workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(false));
 
         // Set paths to invalid
-        testingPostgres.runUpdateStatement("UPDATE workflowversion SET workflowpath='thisisnotarealpath.wdl', dirtybit=true");
+        workflow.setWorkflowPath("thisisnotarealpath.wdl");
+        workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // Check that versions are invalid

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -100,7 +100,7 @@ public class GeneralWorkflowIT extends BaseIT {
         assertEquals(Workflow.ModeEnum.STUB, workflow.getMode());
 
         // Refresh
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         assertEquals(Workflow.ModeEnum.FULL, workflow.getMode());
 
         // Publish
@@ -125,7 +125,7 @@ public class GeneralWorkflowIT extends BaseIT {
 
         // refresh individual that is valid
         Workflow workflow = workflowsApi.getWorkflowByPath("github.com/DockstoreTestUser2/hello-dockstore-workflow", "", false);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         // check that valid is valid and full
         final long count = testingPostgres.runSelectStatement("select count(*) from workflow where ispublished='t'", long.class);
@@ -153,18 +153,18 @@ public class GeneralWorkflowIT extends BaseIT {
         workflow = workflowsApi.restub(workflow.getId());
 
         // Refresh a single version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "master");
+        workflow = workflowsApi.refreshVersion(workflow.getId(), "master", true);
         assertEquals("Should only have one version", 1, workflow.getWorkflowVersions().size());
         assertTrue("Should have master version", workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "master")));
         assertEquals("Should no longer be a stub workflow", Workflow.ModeEnum.FULL, workflow.getMode());
 
         // Refresh another version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "testCWL");
+        workflow = workflowsApi.refreshVersion(workflow.getId(), "testCWL", true);
         assertEquals("Should now have two versions", 2, workflow.getWorkflowVersions().size());
         assertTrue("Should have testCWL version", workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "testCWL")));
 
         try {
-            workflowsApi.refreshVersion(workflow.getId(), "fakeVersion");
+            workflowsApi.refreshVersion(workflow.getId(), "fakeVersion", true);
             fail("Should not be able to refresh a version that does not exist");
         } catch (ApiException ex) {
             assertEquals(HttpStatus.BAD_REQUEST_400, ex.getCode());
@@ -336,7 +336,7 @@ public class GeneralWorkflowIT extends BaseIT {
         final long count = testingPostgres.runSelectStatement("select count(*) from workflow where descriptortype = 'wdl'", long.class);
         assertEquals("there should be 1 wdl workflow, there are " + count, 1, count);
 
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         workflow.setDescriptorType(Workflow.DescriptorTypeEnum.CWL);
         try {
             workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
@@ -370,7 +370,7 @@ public class GeneralWorkflowIT extends BaseIT {
         updateWorkflowVersion.setWorkflowPath("/newdescriptor.cwl");
         workflowVersions.add(updateWorkflowVersion);
         workflowVersions = workflowsApi.updateWorkflowVersion(workflow.getId(), workflowVersions);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         final long count = testingPostgres
             .runSelectStatement("select count(*) from workflowversion where name = 'master' and workflowpath = '/newdescriptor.cwl'",
@@ -421,7 +421,7 @@ public class GeneralWorkflowIT extends BaseIT {
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
 
         // Refresh workflow
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         // Publish workflow
         workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
@@ -433,18 +433,18 @@ public class GeneralWorkflowIT extends BaseIT {
         workflow = workflowsApi.restub(workflow.getId());
 
         // Refresh a single version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "master");
+        workflow = workflowsApi.refreshVersion(workflow.getId(), "master", true);
         assertEquals("Should only have one version", 1, workflow.getWorkflowVersions().size());
         assertTrue("Should have master version", workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "master")));
         assertEquals("Should no longer be a stub workflow", Workflow.ModeEnum.FULL, workflow.getMode());
 
         // Refresh another version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "cwl_import");
+        workflow = workflowsApi.refreshVersion(workflow.getId(), "cwl_import", true);
         assertEquals("Should now have two versions", 2, workflow.getWorkflowVersions().size());
         assertTrue("Should have cwl_import version", workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "cwl_import")));
 
         try {
-            workflowsApi.refreshVersion(workflow.getId(), "fakeVersion");
+            workflowsApi.refreshVersion(workflow.getId(), "fakeVersion", true);
             fail("Should not be able to refresh a version that does not exist");
         } catch (ApiException ex) {
             assertEquals(HttpStatus.BAD_REQUEST_400, ex.getCode());
@@ -465,12 +465,12 @@ public class GeneralWorkflowIT extends BaseIT {
                 "/test.json");
 
         // Publish github workflow
-        Workflow workflow = workflowsApi.refresh(githubWorkflow.getId());
+        Workflow workflow = workflowsApi.refresh(githubWorkflow.getId(), true);
 
         //update the default workflow path to be hello.cwl , the workflow path in workflow versions should also be changes
         workflow.setWorkflowPath("/hello.cwl");
         workflowsApi.updateWorkflowPath(githubWorkflow.getId(), workflow);
-        workflowsApi.refresh(githubWorkflow.getId());
+        workflowsApi.refresh(githubWorkflow.getId(), true);
 
         //check if the workflow versions have the same workflow path or not in the database
         final String masterpath = testingPostgres
@@ -494,7 +494,7 @@ public class GeneralWorkflowIT extends BaseIT {
             .manualRegister("github", "DockstoreTestUser2/test_lastmodified", "/wrongpath.wdl", "test-update-workflow", "wdl",
                 "/wrong-test.json");
 
-        Workflow workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId());
+        Workflow workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId(), true);
         WorkflowVersion master = workflowBeforeFreezing.getWorkflowVersions().stream().filter(v -> v.getName().equals("master")).findFirst()
             .get();
         master.setFrozen(true);
@@ -523,7 +523,7 @@ public class GeneralWorkflowIT extends BaseIT {
             .manualRegister("github", "DockstoreTestUser2/test_lastmodified", "/hello.wdl", "test-update-workflow", "wdl", "/test.json");
 
         // Publish github workflow
-        Workflow workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId());
+        Workflow workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId(), true);
         WorkflowVersion master = workflowBeforeFreezing.getWorkflowVersions().stream().filter(v -> v.getName().equals("master")).findFirst()
             .get();
         master.setFrozen(true);
@@ -535,7 +535,7 @@ public class GeneralWorkflowIT extends BaseIT {
         // try various operations that should be disallowed
 
         // cannot modify version properties, like unfreezing for now
-        workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId());
+        workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId(), true);
         master = workflowBeforeFreezing.getWorkflowVersions().stream().filter(v -> v.getName().equals("master")).findFirst().get();
         master.setFrozen(false);
         List<WorkflowVersion> workflowVersions = workflowsApi
@@ -553,7 +553,7 @@ public class GeneralWorkflowIT extends BaseIT {
         assertEquals(WorkflowVersion.DoiStatusEnum.REQUESTED, master.getDoiStatus());
 
         // refresh should skip over the frozen version
-        final Workflow refresh = workflowsApi.refresh(githubWorkflow.getId());
+        final Workflow refresh = workflowsApi.refresh(githubWorkflow.getId(), true);
         master = refresh.getWorkflowVersions().stream().filter(v -> v.getName().equals("master")).findFirst().get();
 
         // cannot modify sourcefiles for a frozen version
@@ -620,11 +620,11 @@ public class GeneralWorkflowIT extends BaseIT {
         Assert.assertEquals("manualRegisterAndPublish does a refresh, it should automatically set the default version", "master", workflow.getDefaultVersion());
         workflow = workflowsApi.updateWorkflowDefaultVersion(workflow.getId(), "testBoth");
         Assert.assertEquals("Should be able to overwrite previous default version", "testBoth", workflow.getDefaultVersion());
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertEquals("Refresh should not have set it back to the automatic one", "testBoth", workflow.getDefaultVersion());
         // Mimic version on Dockstore no longer present on GitHub
         testingPostgres.runUpdateStatement("UPDATE workflowversion SET name = 'deletedGitHubBranch', reference ='deletedGitHubBranch' where name='testBoth'");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertEquals("the old default was deleted during refresh, it should automatically set the default version again", "master", workflow.getDefaultVersion());
     }
 
@@ -659,7 +659,7 @@ public class GeneralWorkflowIT extends BaseIT {
         Assert.assertNull(workflow.getEmail());
         // Update workflow with version with metadata
         workflow = workflowsApi.updateWorkflowDefaultVersion(workflow.getId(), "testBoth");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         // Assert default version is updated and author and email are set
         final long count3 = testingPostgres
@@ -708,7 +708,7 @@ public class GeneralWorkflowIT extends BaseIT {
 
         // Change path for each version so that it is invalid
         testingPostgres.runUpdateStatement("UPDATE workflowversion SET workflowpath='thisisnotarealpath.cwl', dirtybit=true");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         // Workflow has no valid versions so you cannot publish
 
@@ -723,7 +723,7 @@ public class GeneralWorkflowIT extends BaseIT {
         workflow.setWorkflowPath("/Dockstore.wdl");
         workflow.setDescriptorType(Workflow.DescriptorTypeEnum.WDL);
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         // Can now publish workflow
         workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
@@ -733,7 +733,7 @@ public class GeneralWorkflowIT extends BaseIT {
 
         // Set paths to invalid
         testingPostgres.runUpdateStatement("UPDATE workflowversion SET workflowpath='thisisnotarealpath.wdl', dirtybit=true");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         // Check that versions are invalid
         final long count5 = testingPostgres.runSelectStatement("select count(*) from workflowversion where valid='f'", long.class);
@@ -776,7 +776,7 @@ public class GeneralWorkflowIT extends BaseIT {
         updateWorkflowVersion.setWorkflowPath("/Dockstoredirty.cwl");
         workflowVersions.add(updateWorkflowVersion);
         workflowVersions = workflowsApi.updateWorkflowVersion(workflow.getId(), workflowVersions);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         // There should be on dirty bit
         final long count1 = testingPostgres.runSelectStatement("select count(*) from workflowversion where dirtybit = true", long.class);
@@ -785,7 +785,7 @@ public class GeneralWorkflowIT extends BaseIT {
         // Update default cwl
         workflow.setWorkflowPath("/Dockstoreclean.cwl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
-        workflowsApi.refresh(workflow.getId());
+        workflowsApi.refresh(workflow.getId(), true);
 
         // There should be 3 versions with new cwl
         final long count2 = testingPostgres
@@ -828,7 +828,7 @@ public class GeneralWorkflowIT extends BaseIT {
         updateWorkflowVersion.setWorkflowPath("/Dockstoredirty.cwl");
         workflowVersions.add(updateWorkflowVersion);
         workflowVersions = workflowsApi.updateWorkflowVersion(workflow.getId(), workflowVersions);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         // There should be on dirty bit
         final long count1 = testingPostgres.runSelectStatement("select count(*) from workflowversion where dirtybit = true", long.class);
@@ -837,7 +837,7 @@ public class GeneralWorkflowIT extends BaseIT {
         // Update default cwl
         workflow.setWorkflowPath("/Dockstoreclean.cwl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
-        workflowsApi.refresh(workflow.getId());
+        workflowsApi.refresh(workflow.getId(), true);
 
         // There should be 3 versions with new cwl
         final long count2 = testingPostgres
@@ -906,7 +906,7 @@ public class GeneralWorkflowIT extends BaseIT {
         assertEquals("The given workflow shouldn't have any contact info", 1, count6);
 
         workflow = workflowsApi.updateWorkflowDefaultVersion(workflow.getId(), "test");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         final long count7 = testingPostgres.runSelectStatement(
             "select count(*) from workflow where defaultversion = 'test' and author is null and email is null and description is null",
@@ -932,18 +932,18 @@ public class GeneralWorkflowIT extends BaseIT {
         workflow = workflowsApi.restub(workflow.getId());
 
         // Refresh a single version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "master");
+        workflow = workflowsApi.refreshVersion(workflow.getId(), "master", true);
         assertEquals("Should only have one version", 1, workflow.getWorkflowVersions().size());
         assertTrue("Should have master version", workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "master")));
         assertEquals("Should no longer be a stub workflow", Workflow.ModeEnum.FULL, workflow.getMode());
 
         // Refresh another version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "test");
+        workflow = workflowsApi.refreshVersion(workflow.getId(), "test", true);
         assertEquals("Should now have two versions", 2, workflow.getWorkflowVersions().size());
         assertTrue("Should have test version", workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "test")));
 
         try {
-            workflowsApi.refreshVersion(workflow.getId(), "fakeVersion");
+            workflowsApi.refreshVersion(workflow.getId(), "fakeVersion", true);
             fail("Should not be able to refresh a version that does not exist");
         } catch (ApiException ex) {
             assertEquals(HttpStatus.BAD_REQUEST_400, ex.getCode());
@@ -1090,7 +1090,7 @@ public class GeneralWorkflowIT extends BaseIT {
         } catch (ApiException e) {
             assertEquals("Should have returned a 404 when deleting non-existent file", HttpStatus.NOT_FOUND_404, e.getCode());
         }
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         final long count2 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type like '%_TEST_JSON'", long.class);
         assertEquals("there should be two sourcefiles that are test parameter files, there are " + count2, 2, count2);
@@ -1102,7 +1102,7 @@ public class GeneralWorkflowIT extends BaseIT {
         toDelete.clear();
         toDelete.add("test2.cwl.json");
         workflowsApi.deleteTestParameterFiles(workflow.getId(), toDelete, "master");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         final long count3 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type like '%_TEST_JSON'", long.class);
         assertEquals("there should be one sourcefile that is a test parameter file, there are " + count3, 1, count3);
 
@@ -1110,7 +1110,7 @@ public class GeneralWorkflowIT extends BaseIT {
         toAdd.clear();
         toAdd.add("test.wdl.json");
         workflowsApi.addTestParameterFiles(workflow.getId(), toAdd, "", "wdltest");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         final long count4 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type='CWL_TEST_JSON'", long.class);
         assertEquals("there should be two sourcefiles that are cwl test parameter files, there are " + count4, 2, count4);
 
@@ -1121,7 +1121,7 @@ public class GeneralWorkflowIT extends BaseIT {
         workflow.setDescriptorType(Workflow.DescriptorTypeEnum.WDL);
         workflow.setWorkflowPath("Dockstore.wdl");
         workflowsApi.updateWorkflow(workflow.getId(), workflow);
-        workflowsApi.refresh(workflow.getId());
+        workflowsApi.refresh(workflow.getId(), true);
 
         // Should be no sourcefiles
         final long count5 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type like '%_TEST_JSON'", long.class);
@@ -1131,7 +1131,7 @@ public class GeneralWorkflowIT extends BaseIT {
         toAdd.clear();
         toAdd.add("test.wdl.json");
         workflowsApi.addTestParameterFiles(workflow.getId(), toAdd, "", "wdltest");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         final long count6 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type='WDL_TEST_JSON'", long.class);
         assertEquals("there should be one sourcefile that is a wdl test parameter file, there are " + count6, 1, count6);
     }
@@ -1168,7 +1168,7 @@ public class GeneralWorkflowIT extends BaseIT {
         Workflow githubWorkflow = workflowsApi
             .manualRegister("github", "DockstoreTestUser2/test_lastmodified", "/hello.wdl", "test-update-workflow", "wdl", "/test.json");
 
-        Workflow workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId());
+        Workflow workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId(), true);
         WorkflowVersion master = workflowBeforeFreezing.getWorkflowVersions().stream().filter(v -> v.getName().equals("master")).findFirst()
             .get();
 
@@ -1197,6 +1197,6 @@ public class GeneralWorkflowIT extends BaseIT {
         }
 
         // Should be able to refresh a workflow with a frozen version without throwing an error
-        workflowsApi.refresh(githubWorkflow.getId());
+        workflowsApi.refresh(githubWorkflow.getId(), true);
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -251,7 +251,7 @@ public class GeneralWorkflowIT extends BaseIT {
         assertTrue("Should have testCWL version", workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "testCWL")));
 
         try {
-            workflowsApi.refreshVersion(workflow.getId(), "fakeVersion", true);
+            workflowsApi.refreshVersion(workflow.getId(), "fakeVersion", false);
             fail("Should not be able to refresh a version that does not exist");
         } catch (ApiException ex) {
             assertEquals(HttpStatus.BAD_REQUEST_400, ex.getCode());
@@ -520,18 +520,18 @@ public class GeneralWorkflowIT extends BaseIT {
         workflow = workflowsApi.restub(workflow.getId());
 
         // Refresh a single version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "master", true);
+        workflow = workflowsApi.refreshVersion(workflow.getId(), "master", false);
         assertEquals("Should only have one version", 1, workflow.getWorkflowVersions().size());
         assertTrue("Should have master version", workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "master")));
         assertEquals("Should no longer be a stub workflow", Workflow.ModeEnum.FULL, workflow.getMode());
 
         // Refresh another version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "cwl_import", true);
+        workflow = workflowsApi.refreshVersion(workflow.getId(), "cwl_import", false);
         assertEquals("Should now have two versions", 2, workflow.getWorkflowVersions().size());
         assertTrue("Should have cwl_import version", workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "cwl_import")));
 
         try {
-            workflowsApi.refreshVersion(workflow.getId(), "fakeVersion", true);
+            workflowsApi.refreshVersion(workflow.getId(), "fakeVersion", false);
             fail("Should not be able to refresh a version that does not exist");
         } catch (ApiException ex) {
             assertEquals(HttpStatus.BAD_REQUEST_400, ex.getCode());
@@ -1019,18 +1019,18 @@ public class GeneralWorkflowIT extends BaseIT {
         workflow = workflowsApi.restub(workflow.getId());
 
         // Refresh a single version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "master", true);
+        workflow = workflowsApi.refreshVersion(workflow.getId(), "master", false);
         assertEquals("Should only have one version", 1, workflow.getWorkflowVersions().size());
         assertTrue("Should have master version", workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "master")));
         assertEquals("Should no longer be a stub workflow", Workflow.ModeEnum.FULL, workflow.getMode());
 
         // Refresh another version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "test", true);
+        workflow = workflowsApi.refreshVersion(workflow.getId(), "test", false);
         assertEquals("Should now have two versions", 2, workflow.getWorkflowVersions().size());
         assertTrue("Should have test version", workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "test")));
 
         try {
-            workflowsApi.refreshVersion(workflow.getId(), "fakeVersion", true);
+            workflowsApi.refreshVersion(workflow.getId(), "fakeVersion", false);
             fail("Should not be able to refresh a version that does not exist");
         } catch (ApiException ex) {
             assertEquals(HttpStatus.BAD_REQUEST_400, ex.getCode());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -100,7 +100,7 @@ public class GeneralWorkflowIT extends BaseIT {
         assertEquals(Workflow.ModeEnum.STUB, workflow.getMode());
 
         // Refresh
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         assertEquals(Workflow.ModeEnum.FULL, workflow.getMode());
 
         // Publish

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -112,6 +112,93 @@ public class GeneralWorkflowIT extends BaseIT {
     }
 
     /**
+     * This tests that smart refresh correctly refreshes the right versions based on some scenarios for GitHub
+     */
+    @Test
+    public void testSmartRefreshGitHub() {
+        commonSmartRefreshTest(SourceControl.GITHUB, "DockstoreTestUser2/hello-dockstore-workflow", "testBoth");
+    }
+
+    /**
+     * This tests that smart refresh correctly refreshes the right versions based on some scenarios for Gitlab
+     */
+    @Test
+    public void testSmartRefreshGitlab() {
+        commonSmartRefreshTest(SourceControl.GITLAB, "dockstore.test.user2/dockstore-workflow-example", "master");
+    }
+
+    /**
+     * This tests that smart refresh correctly refreshes the right versions based on some scenarios for BitBucket
+     */
+    @Test
+    public void testSmartRefreshBitbucket() {
+        commonSmartRefreshTest(SourceControl.BITBUCKET, "dockstore_testuser2/dockstore-workflow", "cwl_import");
+    }
+
+    private void commonSmartRefreshTest(SourceControl sourceControl, String workflowPath, String versionOfInterest) {
+        ApiClient client = getWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowsApi = new WorkflowsApi(client);
+
+        String correctDescriptorPath = "/Dockstore.cwl";
+        String incorrectDescriptorPath = "/Dockstore2.cwl";
+
+        String fullPath = sourceControl.toString() + "/" + workflowPath;
+
+        // Add workflow
+        workflowsApi.manualRegister(sourceControl.name(), workflowPath, correctDescriptorPath, "",
+                DescriptorLanguage.CWL.getLowerShortName(), "");
+
+        // Smart refresh individual that is valid (should add versions that doesn't exist)
+        Workflow workflow = workflowsApi.getWorkflowByPath(fullPath, "", false);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
+
+        // All versions should be synced
+        workflow.getWorkflowVersions().forEach(workflowVersion -> assertTrue(workflowVersion.isSynced()));
+
+        // When the commit ID is null, a refresh should occur
+        WorkflowVersion oldVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> Objects.equals(workflowVersion.getName(), versionOfInterest)).findFirst().get();
+        testingPostgres.runUpdateStatement("update workflowversion set commitid = NULL where name = '" + versionOfInterest + "'");
+        workflow = workflowsApi.refresh(workflow.getId(), false);
+        WorkflowVersion updatedVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> Objects.equals(workflowVersion.getName(), versionOfInterest)).findFirst().get();
+        assertNotNull(updatedVersion.getCommitID());
+        assertNotEquals(versionOfInterest + " version should be updated (different dbupdatetime)", oldVersion.getDbUpdateDate(), updatedVersion.getDbUpdateDate());
+
+        // When the commit ID is different, a refresh should occur
+        oldVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> Objects.equals(workflowVersion.getName(), versionOfInterest)).findFirst().get();
+        testingPostgres.runUpdateStatement("update workflowversion set commitid = 'dj90jd9jd230d3j9' where name = '" + versionOfInterest + "'");
+        workflow = workflowsApi.refresh(workflow.getId(), false);
+        updatedVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> Objects.equals(workflowVersion.getName(), versionOfInterest)).findFirst().get();
+        assertNotNull(updatedVersion.getCommitID());
+        assertNotEquals(versionOfInterest + " version should be updated (different dbupdatetime)", oldVersion.getDbUpdateDate(), updatedVersion.getDbUpdateDate());
+
+        // Updating the workflow should make the version not synced, a refresh should refresh all versions
+        workflow.setWorkflowPath(incorrectDescriptorPath);
+        workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
+        workflow.getWorkflowVersions().forEach(workflowVersion -> assertTrue(!workflowVersion.isSynced()));
+        workflow = workflowsApi.refresh(workflow.getId(), false);
+
+        // All versions should be synced and updated
+        workflow.getWorkflowVersions().forEach(workflowVersion -> assertTrue(workflowVersion.isSynced()));
+        workflow.getWorkflowVersions().forEach(workflowVersion -> Objects.equals(workflowVersion.getWorkflowPath(), incorrectDescriptorPath));
+
+        // Update the version to have the correct path
+        WorkflowVersion testBothVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> Objects.equals(workflowVersion.getName(), versionOfInterest)).findFirst().get();
+        testBothVersion.setWorkflowPath(correctDescriptorPath);
+        List<WorkflowVersion> versions = new ArrayList<>();
+        versions.add(testBothVersion);
+        workflowsApi.updateWorkflowVersion(workflow.getId(), versions);
+
+        // Refresh should only update the version that is not synced
+        workflow = workflowsApi.getWorkflow(workflow.getId(), "");
+        testBothVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> Objects.equals(workflowVersion.getName(), versionOfInterest)).findFirst().get();
+        assertTrue("Version should not be synced", !testBothVersion.isSynced());
+        workflow = workflowsApi.refresh(workflow.getId(), false);
+        testBothVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> Objects.equals(workflowVersion.getName(), versionOfInterest)).findFirst().get();
+        assertTrue("Version should now be synced", testBothVersion.isSynced());
+        assertEquals("Workflow version path should be set", correctDescriptorPath, testBothVersion.getWorkflowPath());
+    }
+
+    /**
      * This test checks that refresh all workflows (with a mix of stub and full) and refresh individual.  It then tries to publish them
      */
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -212,7 +212,7 @@ public class GeneralWorkflowIT extends BaseIT {
 
         // refresh individual that is valid
         Workflow workflow = workflowsApi.getWorkflowByPath("github.com/DockstoreTestUser2/hello-dockstore-workflow", "", false);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // check that valid is valid and full
         final long count = testingPostgres.runSelectStatement("select count(*) from workflow where ispublished='t'", long.class);
@@ -225,7 +225,7 @@ public class GeneralWorkflowIT extends BaseIT {
         assertEquals("there should be 4 versions, there are " + count4, 4, count4);
 
         // attempt to publish it
-        workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(false));
 
         final long count5 = testingPostgres.runSelectStatement("select count(*) from workflow where ispublished='t'", long.class);
         assertEquals("there should be 1 published entry, there are " + count5, 1, count5);
@@ -240,13 +240,13 @@ public class GeneralWorkflowIT extends BaseIT {
         workflow = workflowsApi.restub(workflow.getId());
 
         // Refresh a single version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "master", true);
+        workflow = workflowsApi.refreshVersion(workflow.getId(), "master", false);
         assertEquals("Should only have one version", 1, workflow.getWorkflowVersions().size());
         assertTrue("Should have master version", workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "master")));
         assertEquals("Should no longer be a stub workflow", Workflow.ModeEnum.FULL, workflow.getMode());
 
         // Refresh another version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "testCWL", true);
+        workflow = workflowsApi.refreshVersion(workflow.getId(), "testCWL", false);
         assertEquals("Should now have two versions", 2, workflow.getWorkflowVersions().size());
         assertTrue("Should have testCWL version", workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "testCWL")));
 
@@ -423,7 +423,7 @@ public class GeneralWorkflowIT extends BaseIT {
         final long count = testingPostgres.runSelectStatement("select count(*) from workflow where descriptortype = 'wdl'", long.class);
         assertEquals("there should be 1 wdl workflow, there are " + count, 1, count);
 
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         workflow.setDescriptorType(Workflow.DescriptorTypeEnum.CWL);
         try {
             workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
@@ -457,7 +457,7 @@ public class GeneralWorkflowIT extends BaseIT {
         updateWorkflowVersion.setWorkflowPath("/newdescriptor.cwl");
         workflowVersions.add(updateWorkflowVersion);
         workflowVersions = workflowsApi.updateWorkflowVersion(workflow.getId(), workflowVersions);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         final long count = testingPostgres
             .runSelectStatement("select count(*) from workflowversion where name = 'master' and workflowpath = '/newdescriptor.cwl'",
@@ -508,7 +508,7 @@ public class GeneralWorkflowIT extends BaseIT {
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
 
         // Refresh workflow
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // Publish workflow
         workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
@@ -552,12 +552,12 @@ public class GeneralWorkflowIT extends BaseIT {
                 "/test.json");
 
         // Publish github workflow
-        Workflow workflow = workflowsApi.refresh(githubWorkflow.getId(), true);
+        Workflow workflow = workflowsApi.refresh(githubWorkflow.getId(), false);
 
         //update the default workflow path to be hello.cwl , the workflow path in workflow versions should also be changes
         workflow.setWorkflowPath("/hello.cwl");
         workflowsApi.updateWorkflowPath(githubWorkflow.getId(), workflow);
-        workflowsApi.refresh(githubWorkflow.getId(), true);
+        workflowsApi.refresh(githubWorkflow.getId(), false);
 
         //check if the workflow versions have the same workflow path or not in the database
         final String masterpath = testingPostgres
@@ -581,7 +581,7 @@ public class GeneralWorkflowIT extends BaseIT {
             .manualRegister("github", "DockstoreTestUser2/test_lastmodified", "/wrongpath.wdl", "test-update-workflow", "wdl",
                 "/wrong-test.json");
 
-        Workflow workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId(), true);
+        Workflow workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId(), false);
         WorkflowVersion master = workflowBeforeFreezing.getWorkflowVersions().stream().filter(v -> v.getName().equals("master")).findFirst()
             .get();
         master.setFrozen(true);
@@ -610,7 +610,7 @@ public class GeneralWorkflowIT extends BaseIT {
             .manualRegister("github", "DockstoreTestUser2/test_lastmodified", "/hello.wdl", "test-update-workflow", "wdl", "/test.json");
 
         // Publish github workflow
-        Workflow workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId(), true);
+        Workflow workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId(), false);
         WorkflowVersion master = workflowBeforeFreezing.getWorkflowVersions().stream().filter(v -> v.getName().equals("master")).findFirst()
             .get();
         master.setFrozen(true);
@@ -622,7 +622,7 @@ public class GeneralWorkflowIT extends BaseIT {
         // try various operations that should be disallowed
 
         // cannot modify version properties, like unfreezing for now
-        workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId(), true);
+        workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId(), false);
         master = workflowBeforeFreezing.getWorkflowVersions().stream().filter(v -> v.getName().equals("master")).findFirst().get();
         master.setFrozen(false);
         List<WorkflowVersion> workflowVersions = workflowsApi
@@ -640,7 +640,7 @@ public class GeneralWorkflowIT extends BaseIT {
         assertEquals(WorkflowVersion.DoiStatusEnum.REQUESTED, master.getDoiStatus());
 
         // refresh should skip over the frozen version
-        final Workflow refresh = workflowsApi.refresh(githubWorkflow.getId(), true);
+        final Workflow refresh = workflowsApi.refresh(githubWorkflow.getId(), false);
         master = refresh.getWorkflowVersions().stream().filter(v -> v.getName().equals("master")).findFirst().get();
 
         // cannot modify sourcefiles for a frozen version
@@ -707,11 +707,11 @@ public class GeneralWorkflowIT extends BaseIT {
         Assert.assertEquals("manualRegisterAndPublish does a refresh, it should automatically set the default version", "master", workflow.getDefaultVersion());
         workflow = workflowsApi.updateWorkflowDefaultVersion(workflow.getId(), "testBoth");
         Assert.assertEquals("Should be able to overwrite previous default version", "testBoth", workflow.getDefaultVersion());
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertEquals("Refresh should not have set it back to the automatic one", "testBoth", workflow.getDefaultVersion());
         // Mimic version on Dockstore no longer present on GitHub
         testingPostgres.runUpdateStatement("UPDATE workflowversion SET name = 'deletedGitHubBranch', reference ='deletedGitHubBranch' where name='testBoth'");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertEquals("the old default was deleted during refresh, it should automatically set the default version again", "master", workflow.getDefaultVersion());
     }
 
@@ -746,7 +746,7 @@ public class GeneralWorkflowIT extends BaseIT {
         Assert.assertNull(workflow.getEmail());
         // Update workflow with version with metadata
         workflow = workflowsApi.updateWorkflowDefaultVersion(workflow.getId(), "testBoth");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // Assert default version is updated and author and email are set
         final long count3 = testingPostgres
@@ -795,7 +795,7 @@ public class GeneralWorkflowIT extends BaseIT {
 
         // Change path for each version so that it is invalid
         testingPostgres.runUpdateStatement("UPDATE workflowversion SET workflowpath='thisisnotarealpath.cwl', dirtybit=true");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // Workflow has no valid versions so you cannot publish
 
@@ -810,7 +810,7 @@ public class GeneralWorkflowIT extends BaseIT {
         workflow.setWorkflowPath("/Dockstore.wdl");
         workflow.setDescriptorType(Workflow.DescriptorTypeEnum.WDL);
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // Can now publish workflow
         workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
@@ -820,7 +820,7 @@ public class GeneralWorkflowIT extends BaseIT {
 
         // Set paths to invalid
         testingPostgres.runUpdateStatement("UPDATE workflowversion SET workflowpath='thisisnotarealpath.wdl', dirtybit=true");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // Check that versions are invalid
         final long count5 = testingPostgres.runSelectStatement("select count(*) from workflowversion where valid='f'", long.class);
@@ -863,7 +863,7 @@ public class GeneralWorkflowIT extends BaseIT {
         updateWorkflowVersion.setWorkflowPath("/Dockstoredirty.cwl");
         workflowVersions.add(updateWorkflowVersion);
         workflowVersions = workflowsApi.updateWorkflowVersion(workflow.getId(), workflowVersions);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // There should be on dirty bit
         final long count1 = testingPostgres.runSelectStatement("select count(*) from workflowversion where dirtybit = true", long.class);
@@ -872,7 +872,7 @@ public class GeneralWorkflowIT extends BaseIT {
         // Update default cwl
         workflow.setWorkflowPath("/Dockstoreclean.cwl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
-        workflowsApi.refresh(workflow.getId(), true);
+        workflowsApi.refresh(workflow.getId(), false);
 
         // There should be 3 versions with new cwl
         final long count2 = testingPostgres
@@ -915,7 +915,7 @@ public class GeneralWorkflowIT extends BaseIT {
         updateWorkflowVersion.setWorkflowPath("/Dockstoredirty.cwl");
         workflowVersions.add(updateWorkflowVersion);
         workflowVersions = workflowsApi.updateWorkflowVersion(workflow.getId(), workflowVersions);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // There should be on dirty bit
         final long count1 = testingPostgres.runSelectStatement("select count(*) from workflowversion where dirtybit = true", long.class);
@@ -924,7 +924,7 @@ public class GeneralWorkflowIT extends BaseIT {
         // Update default cwl
         workflow.setWorkflowPath("/Dockstoreclean.cwl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
-        workflowsApi.refresh(workflow.getId(), true);
+        workflowsApi.refresh(workflow.getId(), false);
 
         // There should be 3 versions with new cwl
         final long count2 = testingPostgres
@@ -993,7 +993,7 @@ public class GeneralWorkflowIT extends BaseIT {
         assertEquals("The given workflow shouldn't have any contact info", 1, count6);
 
         workflow = workflowsApi.updateWorkflowDefaultVersion(workflow.getId(), "test");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         final long count7 = testingPostgres.runSelectStatement(
             "select count(*) from workflow where defaultversion = 'test' and author is null and email is null and description is null",
@@ -1177,7 +1177,7 @@ public class GeneralWorkflowIT extends BaseIT {
         } catch (ApiException e) {
             assertEquals("Should have returned a 404 when deleting non-existent file", HttpStatus.NOT_FOUND_404, e.getCode());
         }
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         final long count2 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type like '%_TEST_JSON'", long.class);
         assertEquals("there should be two sourcefiles that are test parameter files, there are " + count2, 2, count2);
@@ -1189,7 +1189,7 @@ public class GeneralWorkflowIT extends BaseIT {
         toDelete.clear();
         toDelete.add("test2.cwl.json");
         workflowsApi.deleteTestParameterFiles(workflow.getId(), toDelete, "master");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         final long count3 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type like '%_TEST_JSON'", long.class);
         assertEquals("there should be one sourcefile that is a test parameter file, there are " + count3, 1, count3);
 
@@ -1197,7 +1197,7 @@ public class GeneralWorkflowIT extends BaseIT {
         toAdd.clear();
         toAdd.add("test.wdl.json");
         workflowsApi.addTestParameterFiles(workflow.getId(), toAdd, "", "wdltest");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         final long count4 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type='CWL_TEST_JSON'", long.class);
         assertEquals("there should be two sourcefiles that are cwl test parameter files, there are " + count4, 2, count4);
 
@@ -1208,7 +1208,7 @@ public class GeneralWorkflowIT extends BaseIT {
         workflow.setDescriptorType(Workflow.DescriptorTypeEnum.WDL);
         workflow.setWorkflowPath("Dockstore.wdl");
         workflowsApi.updateWorkflow(workflow.getId(), workflow);
-        workflowsApi.refresh(workflow.getId(), true);
+        workflowsApi.refresh(workflow.getId(), false);
 
         // Should be no sourcefiles
         final long count5 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type like '%_TEST_JSON'", long.class);
@@ -1218,7 +1218,7 @@ public class GeneralWorkflowIT extends BaseIT {
         toAdd.clear();
         toAdd.add("test.wdl.json");
         workflowsApi.addTestParameterFiles(workflow.getId(), toAdd, "", "wdltest");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         final long count6 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type='WDL_TEST_JSON'", long.class);
         assertEquals("there should be one sourcefile that is a wdl test parameter file, there are " + count6, 1, count6);
     }
@@ -1255,7 +1255,7 @@ public class GeneralWorkflowIT extends BaseIT {
         Workflow githubWorkflow = workflowsApi
             .manualRegister("github", "DockstoreTestUser2/test_lastmodified", "/hello.wdl", "test-update-workflow", "wdl", "/test.json");
 
-        Workflow workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId(), true);
+        Workflow workflowBeforeFreezing = workflowsApi.refresh(githubWorkflow.getId(), false);
         WorkflowVersion master = workflowBeforeFreezing.getWorkflowVersions().stream().filter(v -> v.getName().equals("master")).findFirst()
             .get();
 
@@ -1284,6 +1284,6 @@ public class GeneralWorkflowIT extends BaseIT {
         }
 
         // Should be able to refresh a workflow with a frozen version without throwing an error
-        workflowsApi.refresh(githubWorkflow.getId(), true);
+        workflowsApi.refresh(githubWorkflow.getId(), false);
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowRegressionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowRegressionIT.java
@@ -300,13 +300,13 @@ public class GeneralWorkflowRegressionIT extends BaseIT {
                 "/test.json");
 
         // Publish github workflow
-        Workflow workflow = workflowApi.refresh(githubWorkflow.getId());
+        Workflow workflow = workflowApi.refresh(githubWorkflow.getId(), true);
 
         Assert.assertTrue("Description should fall back to README file.", workflow.getDescription().contains("this is a readme file"));
         //update the default workflow path to be hello.cwl , the workflow path in workflow versions should also be changes
         workflow.setWorkflowPath("/hello.cwl");
         workflowApi.updateWorkflowPath(githubWorkflow.getId(), workflow);
-        workflowApi.refresh(githubWorkflow.getId());
+        workflowApi.refresh(githubWorkflow.getId(), true);
 
         // Set up DB
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowRegressionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowRegressionIT.java
@@ -300,13 +300,13 @@ public class GeneralWorkflowRegressionIT extends BaseIT {
                 "/test.json");
 
         // Publish github workflow
-        Workflow workflow = workflowApi.refresh(githubWorkflow.getId(), true);
+        Workflow workflow = workflowApi.refresh(githubWorkflow.getId(), false);
 
         Assert.assertTrue("Description should fall back to README file.", workflow.getDescription().contains("this is a readme file"));
         //update the default workflow path to be hello.cwl , the workflow path in workflow versions should also be changes
         workflow.setWorkflowPath("/hello.cwl");
         workflowApi.updateWorkflowPath(githubWorkflow.getId(), workflow);
-        workflowApi.refresh(githubWorkflow.getId(), true);
+        workflowApi.refresh(githubWorkflow.getId(), false);
 
         // Set up DB
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -63,7 +63,7 @@ public class ToolsWorkflowTestIT extends BaseIT {
         Assert.assertEquals(githubWorkflow.getWorkflowName(), testWorkflowName);
 
         // Publish github workflow
-        Workflow refresh = workflowApi.refresh(githubWorkflow.getId(), true);
+        Workflow refresh = workflowApi.refresh(githubWorkflow.getId(), false);
 
         // This checks if a workflow whose default name is test-workflow remains as test-workflow and not null or empty string after refresh
         Assert.assertEquals(refresh.getWorkflowName(), testWorkflowName);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -63,7 +63,7 @@ public class ToolsWorkflowTestIT extends BaseIT {
         Assert.assertEquals(githubWorkflow.getWorkflowName(), testWorkflowName);
 
         // Publish github workflow
-        Workflow refresh = workflowApi.refresh(githubWorkflow.getId());
+        Workflow refresh = workflowApi.refresh(githubWorkflow.getId(), true);
 
         // This checks if a workflow whose default name is test-workflow remains as test-workflow and not null or empty string after refresh
         Assert.assertEquals(refresh.getWorkflowName(), testWorkflowName);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
@@ -144,58 +144,58 @@ public class ValidationIT extends BaseIT {
         // Register a workflow
         Workflow workflow = workflowsApi
             .manualRegister("GitHub", "DockstoreTestUser2/TestEntryValidation", "/validWorkflow.wdl", "testname", "wdl", "/test.json");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
 
         // change to empty wdl - should be invalid
         workflow.setWorkflowPath("empty.wdl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change to missing import - should be invalid
         workflow.setWorkflowPath("/missingImport.wdl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change to missing workflow section - should be invalid
         workflow.setWorkflowPath("/missingWorkflowSection.wdl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change to valid tool - should be valid
         workflow.setWorkflowPath("/validTool.wdl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
 
         // change back to valid workflow - should be valid
         workflow.setWorkflowPath("/validWorkflow.wdl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
 
         // add invalid test json - should be invalid
         List<String> testParameterFiles = new ArrayList<>();
         testParameterFiles.add("/invalidJson.json");
         workflowsApi.addTestParameterFiles(workflow.getId(), testParameterFiles, "", "master");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
         workflowsApi.deleteTestParameterFiles(workflow.getId(), testParameterFiles, "master");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         // add valid test json - should again be valid
         testParameterFiles = new ArrayList<>();
         testParameterFiles.add("/valid.json");
         workflowsApi.addTestParameterFiles(workflow.getId(), testParameterFiles, "", "master");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
     }
 
@@ -212,51 +212,51 @@ public class ValidationIT extends BaseIT {
         workflowsApi.getApiClient().setDebugging(true);
         Workflow workflow = workflowsApi
             .manualRegister("GitHub", "DockstoreTestUser2/TestEntryValidation", "/validWorkflow.cwl", "testname", "cwl", "/test.json");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
 
         // change to empty cwl - should be invalid
         workflow.setWorkflowPath("/empty.cwl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change to wrong version - should be invalid
         workflow.setWorkflowPath("/wrongVersion.cwl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change to tool - should be invalid
         workflow.setWorkflowPath("/validTool.cwl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change back to valid workflow - should be valid
         workflow.setWorkflowPath("/validWorkflow.cwl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
 
         // add invalid test json - should be invalid
         List<String> testParameterFiles = new ArrayList<>();
         testParameterFiles.add("/invalidJson.json");
         workflowsApi.addTestParameterFiles(workflow.getId(), testParameterFiles, "", "master");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
         workflowsApi.deleteTestParameterFiles(workflow.getId(), testParameterFiles, "master");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         // add valid test json - should again be valid
         testParameterFiles = new ArrayList<>();
         testParameterFiles.add("/valid.json");
         workflowsApi.addTestParameterFiles(workflow.getId(), testParameterFiles, "", "master");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ValidationIT.java
@@ -144,58 +144,58 @@ public class ValidationIT extends BaseIT {
         // Register a workflow
         Workflow workflow = workflowsApi
             .manualRegister("GitHub", "DockstoreTestUser2/TestEntryValidation", "/validWorkflow.wdl", "testname", "wdl", "/test.json");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
 
         // change to empty wdl - should be invalid
         workflow.setWorkflowPath("empty.wdl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change to missing import - should be invalid
         workflow.setWorkflowPath("/missingImport.wdl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change to missing workflow section - should be invalid
         workflow.setWorkflowPath("/missingWorkflowSection.wdl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change to valid tool - should be valid
         workflow.setWorkflowPath("/validTool.wdl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
 
         // change back to valid workflow - should be valid
         workflow.setWorkflowPath("/validWorkflow.wdl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
 
         // add invalid test json - should be invalid
         List<String> testParameterFiles = new ArrayList<>();
         testParameterFiles.add("/invalidJson.json");
         workflowsApi.addTestParameterFiles(workflow.getId(), testParameterFiles, "", "master");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
         workflowsApi.deleteTestParameterFiles(workflow.getId(), testParameterFiles, "master");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // add valid test json - should again be valid
         testParameterFiles = new ArrayList<>();
         testParameterFiles.add("/valid.json");
         workflowsApi.addTestParameterFiles(workflow.getId(), testParameterFiles, "", "master");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
     }
 
@@ -212,51 +212,51 @@ public class ValidationIT extends BaseIT {
         workflowsApi.getApiClient().setDebugging(true);
         Workflow workflow = workflowsApi
             .manualRegister("GitHub", "DockstoreTestUser2/TestEntryValidation", "/validWorkflow.cwl", "testname", "cwl", "/test.json");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
 
         // change to empty cwl - should be invalid
         workflow.setWorkflowPath("/empty.cwl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change to wrong version - should be invalid
         workflow.setWorkflowPath("/wrongVersion.cwl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change to tool - should be invalid
         workflow.setWorkflowPath("/validTool.cwl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
 
         // change back to valid workflow - should be valid
         workflow.setWorkflowPath("/validWorkflow.cwl");
         workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         workflowsApi.updateWorkflowPath(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
 
         // add invalid test json - should be invalid
         List<String> testParameterFiles = new ArrayList<>();
         testParameterFiles.add("/invalidJson.json");
         workflowsApi.addTestParameterFiles(workflow.getId(), testParameterFiles, "", "master");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertFalse(isWorkflowVersionValid(workflow, "master"));
         workflowsApi.deleteTestParameterFiles(workflow.getId(), testParameterFiles, "master");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // add valid test json - should again be valid
         testParameterFiles = new ArrayList<>();
         testParameterFiles.add("/valid.json");
         workflowsApi.addTestParameterFiles(workflow.getId(), testParameterFiles, "", "master");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         Assert.assertTrue("Should be valid", isWorkflowVersionValid(workflow, "master"));
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -194,7 +194,7 @@ public class WorkflowIT extends BaseIT {
         assertEquals(Workflow.ModeEnum.STUB, workflow.getMode());
 
         // Refresh
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         assertEquals(Workflow.ModeEnum.FULL, workflow.getMode());
 
         // Publish
@@ -253,9 +253,9 @@ public class WorkflowIT extends BaseIT {
 
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, null, false);
-        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), true);
+        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), false);
         final Workflow workflowByPathBitbucket = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_DOCKSTORE_WORKFLOW, null, false);
-        final Workflow refreshBitbucket = workflowApi.refresh(workflowByPathBitbucket.getId(), true);
+        final Workflow refreshBitbucket = workflowApi.refresh(workflowByPathBitbucket.getId(), false);
 
         // tests for reference type for bitbucket workflows
         assertTrue("should see at least 4 branches", refreshBitbucket.getWorkflowVersions().stream()
@@ -356,7 +356,7 @@ public class WorkflowIT extends BaseIT {
         assertFalse(branchToolJson.isEmpty());
         assertEquals(branchToolJsonFromApi, branchToolJson);
 
-        workflow = workflowApi.refresh(workflow.getId(), true);
+        workflow = workflowApi.refresh(workflow.getId(), false);
         branchToolJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
         assertNull(branchToolJson);
 
@@ -368,7 +368,7 @@ public class WorkflowIT extends BaseIT {
         assertEquals(tagToolJsonFromApi, tagToolJson);
 
         workflowApi.getTableToolContent(workflow.getId(), branchVersion.getId());
-        workflow = workflowApi.refreshVersion(workflow.getId(), tagVersion.getName(), true);
+        workflow = workflowApi.refreshVersion(workflow.getId(), tagVersion.getName(), false);
         tagToolJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", tagVersion.getId()), String.class);
         assertNull(tagToolJson);
         branchToolJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
@@ -381,7 +381,7 @@ public class WorkflowIT extends BaseIT {
         assertFalse(branchDagJson.isEmpty());
         assertEquals(branchDagJsonFromApi, branchDagJson);
 
-        workflow = workflowApi.refresh(workflow.getId(), true);
+        workflow = workflowApi.refresh(workflow.getId(), false);
         branchDagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
         assertNull(branchDagJson);
 
@@ -393,7 +393,7 @@ public class WorkflowIT extends BaseIT {
         assertEquals(tagDagJsonFromApi, tagDagJson);
 
         workflowApi.getWorkflowDag(workflow.getId(), branchVersion.getId());
-        workflowApi.refreshVersion(workflow.getId(), tagVersion.getName(), true);
+        workflowApi.refreshVersion(workflow.getId(), tagVersion.getName(), false);
         tagDagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", tagVersion.getId()), String.class);
         assertNull(tagDagJson);
         branchDagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
@@ -402,7 +402,7 @@ public class WorkflowIT extends BaseIT {
         // Test json is cleared after an organization refresh
         UsersApi usersApi = new UsersApi(webClient);
         long userId = 1;
-        workflow = workflowApi.refresh(workflow.getId(), true);
+        workflow = workflowApi.refresh(workflow.getId(), false);
 
         final List<Workflow> workflows = usersApi.userWorkflows(userId);
         branchDagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
@@ -433,7 +433,7 @@ public class WorkflowIT extends BaseIT {
         Workflow workflow = workflowApi
             .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
                 "test", "cwl", null);
-        Workflow refresh = workflowApi.refresh(workflow.getId(), true);
+        Workflow refresh = workflowApi.refresh(workflow.getId(), false);
         Long workflowId = refresh.getId();
         WorkflowVersion workflowVersion = refresh.getWorkflowVersions().get(0);
         Long versionId = workflowVersion.getId();
@@ -489,7 +489,7 @@ public class WorkflowIT extends BaseIT {
         Workflow workflow = ownerWorkflowApi
             .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
                 "test", "cwl", null);
-        Workflow refresh = ownerWorkflowApi.refresh(workflow.getId(), true);
+        Workflow refresh = ownerWorkflowApi.refresh(workflow.getId(), false);
         Long workflowId = refresh.getId();
         Long versionId = refresh.getWorkflowVersions().get(0).getId();
 
@@ -607,10 +607,10 @@ public class WorkflowIT extends BaseIT {
         Workflow workflow = workflowApi
             .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
                 "test", "cwl", null);
-        Workflow refresh = workflowApi.refresh(workflow.getId(), true);
+        Workflow refresh = workflowApi.refresh(workflow.getId(), false);
         assertFalse(refresh.isIsPublished());
         workflowApi.registerCheckerWorkflow("checker-workflow-wrapping-workflow.cwl", workflow.getId(), "cwl", "checker-input-cwl.json");
-        workflowApi.refresh(workflow.getId(), true);
+        workflowApi.refresh(workflow.getId(), false);
 
         final String fileWithIncorrectCredentials = ResourceHelpers.resourceFilePath("config_file.txt");
         final String fileWithCorrectCredentials = ResourceHelpers.resourceFilePath("config_file2.txt");
@@ -654,7 +654,7 @@ public class WorkflowIT extends BaseIT {
         workflowApi.updateWorkflow(workflowByPathGithub.getId(), workflowByPathGithub);
 
         workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_NEXTFLOW_LIB_WORKFLOW, null, false);
-        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), true);
+        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), false);
 
         assertSame("github workflow is not in full mode", refreshGithub.getMode(), Workflow.ModeEnum.FULL);
 
@@ -703,7 +703,7 @@ public class WorkflowIT extends BaseIT {
         workflowApi.updateWorkflow(workflowByPathGithub.getId(), workflowByPathGithub);
 
         workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_INCLUDECONFIG_WORKFLOW, null, false);
-        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), true);
+        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), false);
 
         assertEquals("workflow does not include expected config included files", 3,
             refreshGithub.getWorkflowVersions().stream().filter(version -> version.getName().equals("master")).findFirst().get()
@@ -724,7 +724,7 @@ public class WorkflowIT extends BaseIT {
         workflowApi.updateWorkflow(workflowByPathGithub.getId(), workflowByPathGithub);
 
         workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_NEXTFLOW_DOCKER_WORKFLOW, null, false);
-        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), true);
+        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), false);
 
         assertSame("github workflow is not in full mode", refreshGithub.getMode(), Workflow.ModeEnum.FULL);
         Optional<WorkflowVersion> first = refreshGithub.getWorkflowVersions().stream().filter(version -> version.getName().equals("1.0"))
@@ -781,7 +781,7 @@ public class WorkflowIT extends BaseIT {
         mtaNf.setWorkflowPath("/nextflow.config");
         mtaNf.setDescriptorType(DescriptorTypeEnum.NFL);
         workflowApi.updateWorkflow(mtaNf.getId(), mtaNf);
-        workflowApi.refresh(mtaNf.getId(), true);
+        workflowApi.refresh(mtaNf.getId(), false);
         // publish this way? (why is the auto-generated variable private?)
         workflowApi.publish(mtaNf.getId(), SwaggerUtility.createPublishRequest(true));
         mtaNf = workflowApi.getWorkflow(mtaNf.getId(), null);
@@ -876,7 +876,7 @@ public class WorkflowIT extends BaseIT {
 
         final Workflow workflowByPath = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, null, false);
         // refresh targeted
-        workflowApi.refresh(workflowByPath.getId(), true);
+        workflowApi.refresh(workflowByPath.getId(), false);
 
         // publish one
         final PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
@@ -894,7 +894,7 @@ public class WorkflowIT extends BaseIT {
             "github.com/DockstoreTestUser2/dockstore-whalesay-imports", "github.com/DockstoreTestUser2/parameter_test_workflow")
             .forEach(path -> {
                 Workflow workflow = workflowApi.getWorkflowByPath(path, null, false);
-                workflowApi.refresh(workflow.getId(), true);
+                workflowApi.refresh(workflow.getId(), false);
                 workflowApi.publish(workflow.getId(), publishRequest);
             });
         List<Workflow> workflows = workflowApi.allPublishedWorkflows(null, null, null, null, null, false);
@@ -946,7 +946,7 @@ public class WorkflowIT extends BaseIT {
         assertEquals("There should be two workflows with name altname, there are " + count2, 2, count2);
 
         // Publish github workflow
-        workflowApi.refresh(githubWorkflow.getId(), true);
+        workflowApi.refresh(githubWorkflow.getId(), false);
         workflowApi.publish(githubWorkflow.getId(), publishRequest);
 
         // Assert some things
@@ -958,7 +958,7 @@ public class WorkflowIT extends BaseIT {
         final long count4 = testingPostgres.runSelectStatement("select count(*) from workflowversion where valid = 't'", long.class);
         assertEquals("There should be 2 valid version tags, there are " + count4, 2, count4);
 
-        workflowApi.refresh(bitbucketWorkflow.getId(), true);
+        workflowApi.refresh(bitbucketWorkflow.getId(), false);
         thrown.expect(ApiException.class);
         // Publish bitbucket workflow, will fail now since the workflow test case is actually invalid now
         workflowApi.publish(bitbucketWorkflow.getId(), publishRequest);
@@ -1006,7 +1006,7 @@ public class WorkflowIT extends BaseIT {
         Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openAPIClient);
         Workflow workflow = workflowsApi.manualRegister("github", DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "/Dockstore.wdl", "", "wdl", "/test.json");
 
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
         List<WorkflowVersion> workflowVersions = workflow.getWorkflowVersions();
         assertFalse(workflowVersions.isEmpty());
         boolean testedWDL = false;
@@ -1030,7 +1030,7 @@ public class WorkflowIT extends BaseIT {
         verifySourcefileChecksumsSaved(snapshotVersion);
 
         // Make sure refresh does not error.
-        workflowsApi.refresh(workflow2.getId(), true);
+        workflowsApi.refresh(workflow2.getId(), false);
 
         // Test TRS conversion
         io.dockstore.openapi.client.model.FileWrapper fileWrapper = ga4Ghv20Api.toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/github.com/dockstore-testing/hello_world", "1.0.1");
@@ -1212,7 +1212,7 @@ public class WorkflowIT extends BaseIT {
         assertEquals("No workflows are in full mode", 0, count);
 
         // Refresh the workflow
-        workflowApi.refresh(githubWorkflow.getId(), true);
+        workflowApi.refresh(githubWorkflow.getId(), false);
 
         // Confirm that correct number of sourcefiles are found
         githubWorkflow = workflowApi.getWorkflow(githubWorkflow.getId(), null);
@@ -1248,7 +1248,7 @@ public class WorkflowIT extends BaseIT {
                 "/examples/chksum_seqval_wf_interleaved_fq.json");
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_MORE_IMPORT_STRUCTURE, null, false);
 
-        workflowApi.refresh(workflowByPathGithub.getId(), true);
+        workflowApi.refresh(workflowByPathGithub.getId(), false);
         workflowApi.publish(workflowByPathGithub.getId(), SwaggerUtility.createPublishRequest(true));
 
         // check on URLs for workflows via ga4gh calls
@@ -1276,7 +1276,7 @@ public class WorkflowIT extends BaseIT {
                         "");
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath("github.com/dockstore-testing/viral-pipelines", null, false);
 
-        workflowApi.refresh(workflowByPathGithub.getId(), true);
+        workflowApi.refresh(workflowByPathGithub.getId(), false);
         workflowApi.publish(workflowByPathGithub.getId(), SwaggerUtility.createPublishRequest(true));
 
         // check on URLs for workflows via ga4gh calls
@@ -1421,7 +1421,7 @@ public class WorkflowIT extends BaseIT {
         // This checks if a workflow whose default name was manually registered as an empty string would become null
         assertNull(workflowByPathGithub.getWorkflowName());
 
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
 
         // This checks if a workflow whose default name is null would remain as null after refresh
         assertNull(workflow.getWorkflowName());
@@ -1449,7 +1449,7 @@ public class WorkflowIT extends BaseIT {
         // This checks if a workflow whose default name was manually registered as an empty string would become null
         assertNull(workflowByPathGithub.getWorkflowName());
 
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
 
         // Test that the secondary file's input file formats are recognized (secondary file is varscan_cnv.cwl)
         List<FileFormat> fileFormats = workflow.getInputFileFormats();
@@ -1484,7 +1484,7 @@ public class WorkflowIT extends BaseIT {
         List<WorkflowVersion> workflowVersions = workflow.getWorkflowVersions();
         workflowVersions.stream().filter(v -> v.getName().equals("rootTest")).findFirst().get().setWorkflowPath("/cnv.cwl");
         workflowApi.updateWorkflowVersion(workflow.getId(), workflowVersions);
-        workflowApi.refresh(workflowByPathGithub.getId(), true);
+        workflowApi.refresh(workflowByPathGithub.getId(), false);
         final List<SourceFile> newMasterImports = workflowApi
             .secondaryDescriptors(workflow.getId(), "master", DescriptorLanguage.CWL.toString());
         assertEquals("should find 3 imports, found " + newMasterImports.size(), 3, newMasterImports.size());
@@ -1525,7 +1525,7 @@ public class WorkflowIT extends BaseIT {
         WorkflowsApi workflowApi = new WorkflowsApi(getWebClient(USER_2_USERNAME, testingPostgres));
         workflowApi.manualRegister("github", "DockstoreTestUser2/dockstore_workflow_cnv", "/workflow/cnv.cwl", "", "cwl", "/test.json");
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
-        workflowApi.refresh(workflowByPathGithub.getId(), true);
+        workflowApi.refresh(workflowByPathGithub.getId(), false);
 
         // should not be able to get content normally
         Ga4GhApi anonymousGa4Ghv2Api = new Ga4GhApi(CommonTestUtilities.getWebClient(false, null, testingPostgres));
@@ -1596,12 +1596,12 @@ public class WorkflowIT extends BaseIT {
         workflowApi.manualRegister("github", "DockstoreTestUser2/dockstore_workflow_cnv", "/workflow/cnv.cwl", "", "cwl", "/test.json");
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
         workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
 
         Workflow md5workflow = workflowApi.manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker",
             "/checker-workflow-wrapping-workflow.cwl", "test", "cwl", null);
-        workflowApi.refresh(md5workflow.getId(), true);
+        workflowApi.refresh(md5workflow.getId(), false);
         workflowApi.publish(md5workflow.getId(), SwaggerUtility.createPublishRequest(true));
 
         // give the workflow a few aliases
@@ -1655,7 +1655,7 @@ public class WorkflowIT extends BaseIT {
         workflowApi.manualRegister("github", "DockstoreTestUser2/gdc-dnaseq-cwl", "/workflows/dnaseq/transform.cwl", "", "cwl",
             "/workflows/dnaseq/transform.cwl.json");
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_GDC_DNASEQ_CWL_WORKFLOW, null, false);
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
 
         Assert.assertEquals("should have 2 version", 2, workflow.getWorkflowVersions().size());
         Optional<WorkflowVersion> workflowVersion = workflow.getWorkflowVersions().stream()
@@ -1785,7 +1785,7 @@ public class WorkflowIT extends BaseIT {
         // Register and refresh workflow
         Workflow workflow = ownerWorkflowApi.manualRegister(SourceControl.GITHUB.getFriendlyName(), "dockstore-testing/gatk-sv-clinical", "/GATKSVPipelineClinical.wdl",
                 "test", "wdl", "/test.json");
-        return ownerWorkflowApi.refresh(workflow.getId(), true);
+        return ownerWorkflowApi.refresh(workflow.getId(), false);
     }
     
     @Test
@@ -1796,7 +1796,7 @@ public class WorkflowIT extends BaseIT {
                 "/workflow/cnv.cwl", "", "cwl", "/test.json");
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
         workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
 
         Assert.assertTrue(workflow.getWorkflowVersions().stream().anyMatch(versions -> "master".equals(versions.getName())));
@@ -1846,7 +1846,7 @@ public class WorkflowIT extends BaseIT {
                 "/workflow/cnv.cwl", "", "cwl", "/test.json");
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
         workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
 
         Assert.assertTrue(workflow.getWorkflowVersions().stream().anyMatch(versions -> "master".equals(versions.getName())));
@@ -1952,7 +1952,7 @@ public class WorkflowIT extends BaseIT {
         // Sourcefiles for workflowversions
         Workflow workflow = workflowsApi
                 .manualRegister(SourceControl.GITHUB.getFriendlyName(), DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "/Dockstore.cwl", "", "cwl", "/test.json");
-        workflow = workflowsApi.refresh(workflow.getId(), true);
+        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         WorkflowVersion workflowVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion1 -> workflowVersion1.getName().equals("testCWL")).findFirst().get();
 
@@ -1977,7 +1977,7 @@ public class WorkflowIT extends BaseIT {
         Workflow workflow2 = workflowsApi
                 .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
                         "test", "cwl", null);
-        workflow2 = workflowsApi.refresh(workflow2.getId(), true);
+        workflow2 = workflowsApi.refresh(workflow2.getId(), false);
         WorkflowVersion workflow2Version = workflow2.getWorkflowVersions().get(0);
         boolean throwsError = false;
         try {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -1770,7 +1770,7 @@ public class WorkflowIT extends BaseIT {
                 "/cwl/v1.1/wc-job.json");
         final Workflow workflowByPathGithub2 = userWorkflowsApi
             .getWorkflowByPath("github.com/dockstore-testing/Workflows-For-CI/count-lines1-wf", null, false);
-        final Workflow workflow2 = userWorkflowsApi.refresh(workflowByPathGithub2.getId(), true);
+        final Workflow workflow2 = userWorkflowsApi.refresh(workflowByPathGithub2.getId(), false);
         Assert.assertTrue(workflow.getWorkflowVersions().stream().anyMatch(versions -> "master".equals(versions.getName())));
         Optional<WorkflowVersion> optionalWorkflowVersion2 = workflow2.getWorkflowVersions().stream()
             .filter(version -> "master".equalsIgnoreCase(version.getName())).findFirst();

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -194,7 +194,7 @@ public class WorkflowIT extends BaseIT {
         assertEquals(Workflow.ModeEnum.STUB, workflow.getMode());
 
         // Refresh
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         assertEquals(Workflow.ModeEnum.FULL, workflow.getMode());
 
         // Publish
@@ -253,9 +253,9 @@ public class WorkflowIT extends BaseIT {
 
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, null, false);
-        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId());
+        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), true);
         final Workflow workflowByPathBitbucket = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_DOCKSTORE_WORKFLOW, null, false);
-        final Workflow refreshBitbucket = workflowApi.refresh(workflowByPathBitbucket.getId());
+        final Workflow refreshBitbucket = workflowApi.refresh(workflowByPathBitbucket.getId(), true);
 
         // tests for reference type for bitbucket workflows
         assertTrue("should see at least 4 branches", refreshBitbucket.getWorkflowVersions().stream()
@@ -356,7 +356,7 @@ public class WorkflowIT extends BaseIT {
         assertFalse(branchToolJson.isEmpty());
         assertEquals(branchToolJsonFromApi, branchToolJson);
 
-        workflow = workflowApi.refresh(workflow.getId());
+        workflow = workflowApi.refresh(workflow.getId(), true);
         branchToolJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
         assertNull(branchToolJson);
 
@@ -368,7 +368,7 @@ public class WorkflowIT extends BaseIT {
         assertEquals(tagToolJsonFromApi, tagToolJson);
 
         workflowApi.getTableToolContent(workflow.getId(), branchVersion.getId());
-        workflow = workflowApi.refreshVersion(workflow.getId(), tagVersion.getName());
+        workflow = workflowApi.refreshVersion(workflow.getId(), tagVersion.getName(), true);
         tagToolJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", tagVersion.getId()), String.class);
         assertNull(tagToolJson);
         branchToolJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
@@ -381,7 +381,7 @@ public class WorkflowIT extends BaseIT {
         assertFalse(branchDagJson.isEmpty());
         assertEquals(branchDagJsonFromApi, branchDagJson);
 
-        workflow = workflowApi.refresh(workflow.getId());
+        workflow = workflowApi.refresh(workflow.getId(), true);
         branchDagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
         assertNull(branchDagJson);
 
@@ -393,7 +393,7 @@ public class WorkflowIT extends BaseIT {
         assertEquals(tagDagJsonFromApi, tagDagJson);
 
         workflowApi.getWorkflowDag(workflow.getId(), branchVersion.getId());
-        workflowApi.refreshVersion(workflow.getId(), tagVersion.getName());
+        workflowApi.refreshVersion(workflow.getId(), tagVersion.getName(), true);
         tagDagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", tagVersion.getId()), String.class);
         assertNull(tagDagJson);
         branchDagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
@@ -402,7 +402,7 @@ public class WorkflowIT extends BaseIT {
         // Test json is cleared after an organization refresh
         UsersApi usersApi = new UsersApi(webClient);
         long userId = 1;
-        workflow = workflowApi.refresh(workflow.getId());
+        workflow = workflowApi.refresh(workflow.getId(), true);
 
         final List<Workflow> workflows = usersApi.userWorkflows(userId);
         branchDagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
@@ -433,7 +433,7 @@ public class WorkflowIT extends BaseIT {
         Workflow workflow = workflowApi
             .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
                 "test", "cwl", null);
-        Workflow refresh = workflowApi.refresh(workflow.getId());
+        Workflow refresh = workflowApi.refresh(workflow.getId(), true);
         Long workflowId = refresh.getId();
         WorkflowVersion workflowVersion = refresh.getWorkflowVersions().get(0);
         Long versionId = workflowVersion.getId();
@@ -489,7 +489,7 @@ public class WorkflowIT extends BaseIT {
         Workflow workflow = ownerWorkflowApi
             .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
                 "test", "cwl", null);
-        Workflow refresh = ownerWorkflowApi.refresh(workflow.getId());
+        Workflow refresh = ownerWorkflowApi.refresh(workflow.getId(), true);
         Long workflowId = refresh.getId();
         Long versionId = refresh.getWorkflowVersions().get(0).getId();
 
@@ -607,10 +607,10 @@ public class WorkflowIT extends BaseIT {
         Workflow workflow = workflowApi
             .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
                 "test", "cwl", null);
-        Workflow refresh = workflowApi.refresh(workflow.getId());
+        Workflow refresh = workflowApi.refresh(workflow.getId(), true);
         assertFalse(refresh.isIsPublished());
         workflowApi.registerCheckerWorkflow("checker-workflow-wrapping-workflow.cwl", workflow.getId(), "cwl", "checker-input-cwl.json");
-        workflowApi.refresh(workflow.getId());
+        workflowApi.refresh(workflow.getId(), true);
 
         final String fileWithIncorrectCredentials = ResourceHelpers.resourceFilePath("config_file.txt");
         final String fileWithCorrectCredentials = ResourceHelpers.resourceFilePath("config_file2.txt");
@@ -654,7 +654,7 @@ public class WorkflowIT extends BaseIT {
         workflowApi.updateWorkflow(workflowByPathGithub.getId(), workflowByPathGithub);
 
         workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_NEXTFLOW_LIB_WORKFLOW, null, false);
-        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId());
+        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), true);
 
         assertSame("github workflow is not in full mode", refreshGithub.getMode(), Workflow.ModeEnum.FULL);
 
@@ -703,7 +703,7 @@ public class WorkflowIT extends BaseIT {
         workflowApi.updateWorkflow(workflowByPathGithub.getId(), workflowByPathGithub);
 
         workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_INCLUDECONFIG_WORKFLOW, null, false);
-        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId());
+        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), true);
 
         assertEquals("workflow does not include expected config included files", 3,
             refreshGithub.getWorkflowVersions().stream().filter(version -> version.getName().equals("master")).findFirst().get()
@@ -724,7 +724,7 @@ public class WorkflowIT extends BaseIT {
         workflowApi.updateWorkflow(workflowByPathGithub.getId(), workflowByPathGithub);
 
         workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_NEXTFLOW_DOCKER_WORKFLOW, null, false);
-        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId());
+        final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), true);
 
         assertSame("github workflow is not in full mode", refreshGithub.getMode(), Workflow.ModeEnum.FULL);
         Optional<WorkflowVersion> first = refreshGithub.getWorkflowVersions().stream().filter(version -> version.getName().equals("1.0"))
@@ -781,7 +781,7 @@ public class WorkflowIT extends BaseIT {
         mtaNf.setWorkflowPath("/nextflow.config");
         mtaNf.setDescriptorType(DescriptorTypeEnum.NFL);
         workflowApi.updateWorkflow(mtaNf.getId(), mtaNf);
-        workflowApi.refresh(mtaNf.getId());
+        workflowApi.refresh(mtaNf.getId(), true);
         // publish this way? (why is the auto-generated variable private?)
         workflowApi.publish(mtaNf.getId(), SwaggerUtility.createPublishRequest(true));
         mtaNf = workflowApi.getWorkflow(mtaNf.getId(), null);
@@ -876,7 +876,7 @@ public class WorkflowIT extends BaseIT {
 
         final Workflow workflowByPath = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, null, false);
         // refresh targeted
-        workflowApi.refresh(workflowByPath.getId());
+        workflowApi.refresh(workflowByPath.getId(), true);
 
         // publish one
         final PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
@@ -894,7 +894,7 @@ public class WorkflowIT extends BaseIT {
             "github.com/DockstoreTestUser2/dockstore-whalesay-imports", "github.com/DockstoreTestUser2/parameter_test_workflow")
             .forEach(path -> {
                 Workflow workflow = workflowApi.getWorkflowByPath(path, null, false);
-                workflowApi.refresh(workflow.getId());
+                workflowApi.refresh(workflow.getId(), true);
                 workflowApi.publish(workflow.getId(), publishRequest);
             });
         List<Workflow> workflows = workflowApi.allPublishedWorkflows(null, null, null, null, null, false);
@@ -946,7 +946,7 @@ public class WorkflowIT extends BaseIT {
         assertEquals("There should be two workflows with name altname, there are " + count2, 2, count2);
 
         // Publish github workflow
-        workflowApi.refresh(githubWorkflow.getId());
+        workflowApi.refresh(githubWorkflow.getId(), true);
         workflowApi.publish(githubWorkflow.getId(), publishRequest);
 
         // Assert some things
@@ -958,7 +958,7 @@ public class WorkflowIT extends BaseIT {
         final long count4 = testingPostgres.runSelectStatement("select count(*) from workflowversion where valid = 't'", long.class);
         assertEquals("There should be 2 valid version tags, there are " + count4, 2, count4);
 
-        workflowApi.refresh(bitbucketWorkflow.getId());
+        workflowApi.refresh(bitbucketWorkflow.getId(), true);
         thrown.expect(ApiException.class);
         // Publish bitbucket workflow, will fail now since the workflow test case is actually invalid now
         workflowApi.publish(bitbucketWorkflow.getId(), publishRequest);
@@ -1006,7 +1006,7 @@ public class WorkflowIT extends BaseIT {
         Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openAPIClient);
         Workflow workflow = workflowsApi.manualRegister("github", DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "/Dockstore.wdl", "", "wdl", "/test.json");
 
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
         List<WorkflowVersion> workflowVersions = workflow.getWorkflowVersions();
         assertFalse(workflowVersions.isEmpty());
         boolean testedWDL = false;
@@ -1030,7 +1030,7 @@ public class WorkflowIT extends BaseIT {
         verifySourcefileChecksumsSaved(snapshotVersion);
 
         // Make sure refresh does not error.
-        workflowsApi.refresh(workflow2.getId());
+        workflowsApi.refresh(workflow2.getId(), true);
 
         // Test TRS conversion
         io.dockstore.openapi.client.model.FileWrapper fileWrapper = ga4Ghv20Api.toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/github.com/dockstore-testing/hello_world", "1.0.1");
@@ -1212,7 +1212,7 @@ public class WorkflowIT extends BaseIT {
         assertEquals("No workflows are in full mode", 0, count);
 
         // Refresh the workflow
-        workflowApi.refresh(githubWorkflow.getId());
+        workflowApi.refresh(githubWorkflow.getId(), true);
 
         // Confirm that correct number of sourcefiles are found
         githubWorkflow = workflowApi.getWorkflow(githubWorkflow.getId(), null);
@@ -1248,7 +1248,7 @@ public class WorkflowIT extends BaseIT {
                 "/examples/chksum_seqval_wf_interleaved_fq.json");
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_MORE_IMPORT_STRUCTURE, null, false);
 
-        workflowApi.refresh(workflowByPathGithub.getId());
+        workflowApi.refresh(workflowByPathGithub.getId(), true);
         workflowApi.publish(workflowByPathGithub.getId(), SwaggerUtility.createPublishRequest(true));
 
         // check on URLs for workflows via ga4gh calls
@@ -1276,7 +1276,7 @@ public class WorkflowIT extends BaseIT {
                         "");
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath("github.com/dockstore-testing/viral-pipelines", null, false);
 
-        workflowApi.refresh(workflowByPathGithub.getId());
+        workflowApi.refresh(workflowByPathGithub.getId(), true);
         workflowApi.publish(workflowByPathGithub.getId(), SwaggerUtility.createPublishRequest(true));
 
         // check on URLs for workflows via ga4gh calls
@@ -1421,7 +1421,7 @@ public class WorkflowIT extends BaseIT {
         // This checks if a workflow whose default name was manually registered as an empty string would become null
         assertNull(workflowByPathGithub.getWorkflowName());
 
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId());
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
 
         // This checks if a workflow whose default name is null would remain as null after refresh
         assertNull(workflow.getWorkflowName());
@@ -1449,7 +1449,7 @@ public class WorkflowIT extends BaseIT {
         // This checks if a workflow whose default name was manually registered as an empty string would become null
         assertNull(workflowByPathGithub.getWorkflowName());
 
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId());
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
 
         // Test that the secondary file's input file formats are recognized (secondary file is varscan_cnv.cwl)
         List<FileFormat> fileFormats = workflow.getInputFileFormats();
@@ -1484,7 +1484,7 @@ public class WorkflowIT extends BaseIT {
         List<WorkflowVersion> workflowVersions = workflow.getWorkflowVersions();
         workflowVersions.stream().filter(v -> v.getName().equals("rootTest")).findFirst().get().setWorkflowPath("/cnv.cwl");
         workflowApi.updateWorkflowVersion(workflow.getId(), workflowVersions);
-        workflowApi.refresh(workflowByPathGithub.getId());
+        workflowApi.refresh(workflowByPathGithub.getId(), true);
         final List<SourceFile> newMasterImports = workflowApi
             .secondaryDescriptors(workflow.getId(), "master", DescriptorLanguage.CWL.toString());
         assertEquals("should find 3 imports, found " + newMasterImports.size(), 3, newMasterImports.size());
@@ -1525,7 +1525,7 @@ public class WorkflowIT extends BaseIT {
         WorkflowsApi workflowApi = new WorkflowsApi(getWebClient(USER_2_USERNAME, testingPostgres));
         workflowApi.manualRegister("github", "DockstoreTestUser2/dockstore_workflow_cnv", "/workflow/cnv.cwl", "", "cwl", "/test.json");
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
-        workflowApi.refresh(workflowByPathGithub.getId());
+        workflowApi.refresh(workflowByPathGithub.getId(), true);
 
         // should not be able to get content normally
         Ga4GhApi anonymousGa4Ghv2Api = new Ga4GhApi(CommonTestUtilities.getWebClient(false, null, testingPostgres));
@@ -1596,12 +1596,12 @@ public class WorkflowIT extends BaseIT {
         workflowApi.manualRegister("github", "DockstoreTestUser2/dockstore_workflow_cnv", "/workflow/cnv.cwl", "", "cwl", "/test.json");
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId());
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
         workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
 
         Workflow md5workflow = workflowApi.manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker",
             "/checker-workflow-wrapping-workflow.cwl", "test", "cwl", null);
-        workflowApi.refresh(md5workflow.getId());
+        workflowApi.refresh(md5workflow.getId(), true);
         workflowApi.publish(md5workflow.getId(), SwaggerUtility.createPublishRequest(true));
 
         // give the workflow a few aliases
@@ -1655,7 +1655,7 @@ public class WorkflowIT extends BaseIT {
         workflowApi.manualRegister("github", "DockstoreTestUser2/gdc-dnaseq-cwl", "/workflows/dnaseq/transform.cwl", "", "cwl",
             "/workflows/dnaseq/transform.cwl.json");
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_GDC_DNASEQ_CWL_WORKFLOW, null, false);
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId());
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
 
         Assert.assertEquals("should have 2 version", 2, workflow.getWorkflowVersions().size());
         Optional<WorkflowVersion> workflowVersion = workflow.getWorkflowVersions().stream()
@@ -1708,7 +1708,7 @@ public class WorkflowIT extends BaseIT {
                 "/workflows/dnaseq/transform.cwl.json");
         final Workflow workflowByPathGithub = userWorkflowsApi
             .getWorkflowByPath(DOCKSTORE_TEST_USER2_GDC_DNASEQ_CWL_WORKFLOW + "/" + workflowName, null, false);
-        final Workflow workflow = userWorkflowsApi.refresh(workflowByPathGithub.getId());
+        final Workflow workflow = userWorkflowsApi.refresh(workflowByPathGithub.getId(), true);
 
         // Publish workflow, which will also add a topic
         userWorkflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
@@ -1742,7 +1742,7 @@ public class WorkflowIT extends BaseIT {
             "/cwl/v1.1/cat-job.json");
         final Workflow workflowByPathGithub = userWorkflowsApi
             .getWorkflowByPath("github.com/dockstore-testing/Workflows-For-CI/metadata", null, false);
-        final Workflow workflow = userWorkflowsApi.refresh(workflowByPathGithub.getId());
+        final Workflow workflow = userWorkflowsApi.refresh(workflowByPathGithub.getId(), true);
         workflow.getWorkflowVersions().forEach(workflowVersion -> {
             Assert.assertEquals("Print the contents of a file to stdout using 'cat' running in a docker container.", workflow.getDescription());
             Assert.assertEquals("Peter Amstutz", workflow.getAuthor());
@@ -1770,7 +1770,7 @@ public class WorkflowIT extends BaseIT {
                 "/cwl/v1.1/wc-job.json");
         final Workflow workflowByPathGithub2 = userWorkflowsApi
             .getWorkflowByPath("github.com/dockstore-testing/Workflows-For-CI/count-lines1-wf", null, false);
-        final Workflow workflow2 = userWorkflowsApi.refresh(workflowByPathGithub2.getId());
+        final Workflow workflow2 = userWorkflowsApi.refresh(workflowByPathGithub2.getId(), true);
         Assert.assertTrue(workflow.getWorkflowVersions().stream().anyMatch(versions -> "master".equals(versions.getName())));
         Optional<WorkflowVersion> optionalWorkflowVersion2 = workflow2.getWorkflowVersions().stream()
             .filter(version -> "master".equalsIgnoreCase(version.getName())).findFirst();
@@ -1785,7 +1785,7 @@ public class WorkflowIT extends BaseIT {
         // Register and refresh workflow
         Workflow workflow = ownerWorkflowApi.manualRegister(SourceControl.GITHUB.getFriendlyName(), "dockstore-testing/gatk-sv-clinical", "/GATKSVPipelineClinical.wdl",
                 "test", "wdl", "/test.json");
-        return ownerWorkflowApi.refresh(workflow.getId());
+        return ownerWorkflowApi.refresh(workflow.getId(), true);
     }
     
     @Test
@@ -1796,7 +1796,7 @@ public class WorkflowIT extends BaseIT {
                 "/workflow/cnv.cwl", "", "cwl", "/test.json");
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId());
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
         workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
 
         Assert.assertTrue(workflow.getWorkflowVersions().stream().anyMatch(versions -> "master".equals(versions.getName())));
@@ -1846,7 +1846,7 @@ public class WorkflowIT extends BaseIT {
                 "/workflow/cnv.cwl", "", "cwl", "/test.json");
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId());
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
         workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
 
         Assert.assertTrue(workflow.getWorkflowVersions().stream().anyMatch(versions -> "master".equals(versions.getName())));
@@ -1952,7 +1952,7 @@ public class WorkflowIT extends BaseIT {
         // Sourcefiles for workflowversions
         Workflow workflow = workflowsApi
                 .manualRegister(SourceControl.GITHUB.getFriendlyName(), DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "/Dockstore.cwl", "", "cwl", "/test.json");
-        workflow = workflowsApi.refresh(workflow.getId());
+        workflow = workflowsApi.refresh(workflow.getId(), true);
 
         WorkflowVersion workflowVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion1 -> workflowVersion1.getName().equals("testCWL")).findFirst().get();
 
@@ -1977,7 +1977,7 @@ public class WorkflowIT extends BaseIT {
         Workflow workflow2 = workflowsApi
                 .manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker", "/md5sum/md5sum-workflow.cwl",
                         "test", "cwl", null);
-        workflow2 = workflowsApi.refresh(workflow2.getId());
+        workflow2 = workflowsApi.refresh(workflow2.getId(), true);
         WorkflowVersion workflow2Version = workflow2.getWorkflowVersions().get(0);
         boolean throwsError = false;
         try {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -349,14 +349,14 @@ public class WorkflowIT extends BaseIT {
         WorkflowVersion branchVersion = workflow.getWorkflowVersions().stream().filter(wv -> wv.getName().equals("master")).findFirst().get();
         WorkflowVersion tagVersion = workflow.getWorkflowVersions().stream().filter(wv -> wv.getName().equals("test")).findFirst().get();
 
-        // test getting tool table json on a branch and that it clears after refresh worrkflow
+        // test getting tool table json on a branch and that it clears after refresh workflow
         String branchToolJsonFromApi = workflowApi.getTableToolContent(workflow.getId(), branchVersion.getId());
         String branchToolJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
         assertNotNull(branchToolJson);
         assertFalse(branchToolJson.isEmpty());
         assertEquals(branchToolJsonFromApi, branchToolJson);
 
-        workflow = workflowApi.refresh(workflow.getId(), false);
+        workflow = workflowApi.refresh(workflow.getId(), true);
         branchToolJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
         assertNull(branchToolJson);
 
@@ -368,7 +368,7 @@ public class WorkflowIT extends BaseIT {
         assertEquals(tagToolJsonFromApi, tagToolJson);
 
         workflowApi.getTableToolContent(workflow.getId(), branchVersion.getId());
-        workflow = workflowApi.refreshVersion(workflow.getId(), tagVersion.getName(), false);
+        workflow = workflowApi.refreshVersion(workflow.getId(), tagVersion.getName(), true);
         tagToolJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", tagVersion.getId()), String.class);
         assertNull(tagToolJson);
         branchToolJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
@@ -381,7 +381,7 @@ public class WorkflowIT extends BaseIT {
         assertFalse(branchDagJson.isEmpty());
         assertEquals(branchDagJsonFromApi, branchDagJson);
 
-        workflow = workflowApi.refresh(workflow.getId(), false);
+        workflow = workflowApi.refresh(workflow.getId(), true);
         branchDagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
         assertNull(branchDagJson);
 
@@ -393,7 +393,7 @@ public class WorkflowIT extends BaseIT {
         assertEquals(tagDagJsonFromApi, tagDagJson);
 
         workflowApi.getWorkflowDag(workflow.getId(), branchVersion.getId());
-        workflowApi.refreshVersion(workflow.getId(), tagVersion.getName(), false);
+        workflowApi.refreshVersion(workflow.getId(), tagVersion.getName(), true);
         tagDagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", tagVersion.getId()), String.class);
         assertNull(tagDagJson);
         branchDagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
@@ -402,7 +402,7 @@ public class WorkflowIT extends BaseIT {
         // Test json is cleared after an organization refresh
         UsersApi usersApi = new UsersApi(webClient);
         long userId = 1;
-        workflow = workflowApi.refresh(workflow.getId(), false);
+        workflow = workflowApi.refresh(workflow.getId(), true);
 
         final List<Workflow> workflows = usersApi.userWorkflows(userId);
         branchDagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", branchVersion.getId()), String.class);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SearchResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SearchResourceIT.java
@@ -109,7 +109,7 @@ public class SearchResourceIT extends BaseIT {
         final Workflow workflowByPathGithub = workflowApi
             .getWorkflowByPath(WorkflowIT.DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId());
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
         entriesApi.addAliases(workflow.getId(), "potatoAlias");
         workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(false));
         workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
@@ -154,7 +154,7 @@ public class SearchResourceIT extends BaseIT {
         final Workflow workflowByPathGithub = workflowApi
             .getWorkflowByPath(WorkflowIT.DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId());
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
 
         workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SearchResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SearchResourceIT.java
@@ -109,7 +109,7 @@ public class SearchResourceIT extends BaseIT {
         final Workflow workflowByPathGithub = workflowApi
             .getWorkflowByPath(WorkflowIT.DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
         entriesApi.addAliases(workflow.getId(), "potatoAlias");
         workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(false));
         workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
@@ -154,7 +154,7 @@ public class SearchResourceIT extends BaseIT {
         final Workflow workflowByPathGithub = workflowApi
             .getWorkflowByPath(WorkflowIT.DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), true);
+        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
 
         workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -225,7 +225,7 @@ public class ServiceIT extends BaseIT {
 
         // Should not be able to refresh service
         try {
-            client.refresh(services.get(0).getId(), true);
+            client.refresh(services.get(0).getId(), false);
             fail("Should not be able refresh a service");
         } catch (ApiException ex) {
             assertEquals("Should fail since you cannot refresh services.", HttpStatus.SC_BAD_REQUEST, ex.getCode());
@@ -368,7 +368,7 @@ public class ServiceIT extends BaseIT {
         assertEquals("Should only have one service", 1, services.size());
         io.swagger.client.model.Workflow service = services.get(0);
         try {
-            client.refresh(service.getId(), true);
+            client.refresh(service.getId(), false);
             fail("Should fail on refresh and not reach this point");
         } catch (ApiException ex) {
             assertEquals("Should not be able to refresh a dockstore.yml service.", HttpStatus.SC_BAD_REQUEST, ex.getCode());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -225,7 +225,7 @@ public class ServiceIT extends BaseIT {
 
         // Should not be able to refresh service
         try {
-            client.refresh(services.get(0).getId());
+            client.refresh(services.get(0).getId(), true);
             fail("Should not be able refresh a service");
         } catch (ApiException ex) {
             assertEquals("Should fail since you cannot refresh services.", HttpStatus.SC_BAD_REQUEST, ex.getCode());
@@ -368,7 +368,7 @@ public class ServiceIT extends BaseIT {
         assertEquals("Should only have one service", 1, services.size());
         io.swagger.client.model.Workflow service = services.get(0);
         try {
-            client.refresh(service.getId());
+            client.refresh(service.getId(), true);
             fail("Should fail on refresh and not reach this point");
         } catch (ApiException ex) {
             assertEquals("Should not be able to refresh a dockstore.yml service.", HttpStatus.SC_BAD_REQUEST, ex.getCode());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -244,7 +244,7 @@ public class UserResourceIT extends BaseIT {
         final Workflow workflowByPath = workflowsApi
             .getWorkflowByPath(WorkflowIT.DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, null, false);
         // refresh targeted
-        workflowsApi.refresh(workflowByPath.getId());
+        workflowsApi.refresh(workflowByPath.getId(), true);
 
         // Verify that admin can access unpublished workflow, because admin is going to verify later
         // that the workflow is gone
@@ -351,7 +351,7 @@ public class UserResourceIT extends BaseIT {
 
         // Try making a repo undeletable
         ghWorkflow = workflowsApi.addWorkflow(SourceControl.GITHUB.name(), "dockstoretesting", "basic-workflow");
-        workflowsApi.refresh(ghWorkflow.getId());
+        workflowsApi.refresh(ghWorkflow.getId(), true);
         repositories = userApi.getUserOrganizationRepositories(SourceControl.GITHUB.name(), "dockstoretesting");
         assertTrue(repositories.size() > 0);
         assertTrue(
@@ -418,7 +418,7 @@ public class UserResourceIT extends BaseIT {
 
         // Update an entry
         Workflow workflow = workflowsApi.getWorkflowByPath("gitlab.com/dockstore.test.user2/dockstore-workflow-md5sum-unified", null, false);
-        Workflow refreshedWorkflow = workflowsApi.refresh(workflow.getId());
+        Workflow refreshedWorkflow = workflowsApi.refresh(workflow.getId(), true);
 
         // Develop branch doesn't have a descriptor with the default Dockstore.cwl, it should pull from README instead
         Assert.assertTrue(refreshedWorkflow.getDescription().contains("To demonstrate the checker workflow proposal"));

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -244,7 +244,7 @@ public class UserResourceIT extends BaseIT {
         final Workflow workflowByPath = workflowsApi
             .getWorkflowByPath(WorkflowIT.DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, null, false);
         // refresh targeted
-        workflowsApi.refresh(workflowByPath.getId(), true);
+        workflowsApi.refresh(workflowByPath.getId(), false);
 
         // Verify that admin can access unpublished workflow, because admin is going to verify later
         // that the workflow is gone
@@ -351,7 +351,7 @@ public class UserResourceIT extends BaseIT {
 
         // Try making a repo undeletable
         ghWorkflow = workflowsApi.addWorkflow(SourceControl.GITHUB.name(), "dockstoretesting", "basic-workflow");
-        workflowsApi.refresh(ghWorkflow.getId(), true);
+        workflowsApi.refresh(ghWorkflow.getId(), false);
         repositories = userApi.getUserOrganizationRepositories(SourceControl.GITHUB.name(), "dockstoretesting");
         assertTrue(repositories.size() > 0);
         assertTrue(
@@ -418,7 +418,7 @@ public class UserResourceIT extends BaseIT {
 
         // Update an entry
         Workflow workflow = workflowsApi.getWorkflowByPath("gitlab.com/dockstore.test.user2/dockstore-workflow-md5sum-unified", null, false);
-        Workflow refreshedWorkflow = workflowsApi.refresh(workflow.getId(), true);
+        Workflow refreshedWorkflow = workflowsApi.refresh(workflow.getId(), false);
 
         // Develop branch doesn't have a descriptor with the default Dockstore.cwl, it should pull from README instead
         Assert.assertTrue(refreshedWorkflow.getDescription().contains("To demonstrate the checker workflow proposal"));

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -129,11 +129,11 @@ public class WebhookIT extends BaseIT {
         }
 
         // Should be able to refresh a legacy version
-        workflow = workflowApi.refreshVersion(workflow.getId(), "0.2", true);
+        workflow = workflowApi.refreshVersion(workflow.getId(), "0.2", false);
 
         // Should not be able to refresh a GitHub App version
         try {
-            workflowApi.refreshVersion(workflow.getId(), "0.1", true);
+            workflowApi.refreshVersion(workflow.getId(), "0.1", false);
             fail("Should not be able to refresh");
         } catch (ApiException ex) {
             assertEquals(HttpStatus.SC_BAD_REQUEST, ex.getCode());
@@ -141,7 +141,7 @@ public class WebhookIT extends BaseIT {
 
         // Refresh a version that doesn't already exist
         try {
-            workflowApi.refreshVersion(workflow.getId(), "dne", true);
+            workflowApi.refreshVersion(workflow.getId(), "dne", false);
             fail("Should not be able to refresh");
         } catch (ApiException ex) {
             assertEquals(HttpStatus.SC_BAD_REQUEST, ex.getCode());
@@ -155,7 +155,7 @@ public class WebhookIT extends BaseIT {
         testingPostgres.runUpdateStatement("UPDATE workflowversion SET commitid = NULL where name = '0.2'");
 
         // Refresh before frozen should populate the commit id
-        workflow = workflowApi.refreshVersion(workflow.getId(), "0.2", true);
+        workflow = workflowApi.refreshVersion(workflow.getId(), "0.2", false);
         WorkflowVersion workflowVersion = workflow.getWorkflowVersions().stream().filter(wv -> Objects.equals(wv.getName(), "0.2")).findFirst().get();
         assertNotNull(workflowVersion.getCommitID());
 
@@ -170,7 +170,7 @@ public class WebhookIT extends BaseIT {
         assertTrue(workflowVersion.isFrozen());
 
         // Ensure refresh does not touch frozen legacy version
-        workflow = workflowApi.refreshVersion(workflow.getId(), "0.2", true);
+        workflow = workflowApi.refreshVersion(workflow.getId(), "0.2", false);
         assertNotNull(workflow);
         workflowVersion = workflow.getWorkflowVersions().stream().filter(wv -> Objects.equals(wv.getName(), "0.2")).findFirst().get();
         assertNull(workflowVersion.getCommitID());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -109,7 +109,7 @@ public class WebhookIT extends BaseIT {
                 DescriptorLanguage.CWL.getLowerShortName(), "/test.json");
         
         // Refresh should work
-        workflow = workflowApi.refresh(workflow.getId());
+        workflow = workflowApi.refresh(workflow.getId(), true);
         assertEquals("Workflow should be FULL mode", Workflow.ModeEnum.FULL, workflow.getMode());
         assertTrue("All versions should be legacy", workflow.getWorkflowVersions().stream().allMatch(WorkflowVersion::isLegacyVersion));
 
@@ -122,18 +122,18 @@ public class WebhookIT extends BaseIT {
 
         // Refresh should now no longer work
         try {
-            workflowApi.refresh(workflow.getId());
+            workflowApi.refresh(workflow.getId(), true);
             fail("Should fail on refresh and not reach this point");
         } catch (ApiException ex) {
             assertEquals("Should not be able to refresh a dockstore.yml workflow.", HttpStatus.SC_BAD_REQUEST, ex.getCode());
         }
 
         // Should be able to refresh a legacy version
-        workflow = workflowApi.refreshVersion(workflow.getId(), "0.2");
+        workflow = workflowApi.refreshVersion(workflow.getId(), "0.2", true);
 
         // Should not be able to refresh a GitHub App version
         try {
-            workflowApi.refreshVersion(workflow.getId(), "0.1");
+            workflowApi.refreshVersion(workflow.getId(), "0.1", true);
             fail("Should not be able to refresh");
         } catch (ApiException ex) {
             assertEquals(HttpStatus.SC_BAD_REQUEST, ex.getCode());
@@ -141,7 +141,7 @@ public class WebhookIT extends BaseIT {
 
         // Refresh a version that doesn't already exist
         try {
-            workflowApi.refreshVersion(workflow.getId(), "dne");
+            workflowApi.refreshVersion(workflow.getId(), "dne", true);
             fail("Should not be able to refresh");
         } catch (ApiException ex) {
             assertEquals(HttpStatus.SC_BAD_REQUEST, ex.getCode());
@@ -155,7 +155,7 @@ public class WebhookIT extends BaseIT {
         testingPostgres.runUpdateStatement("UPDATE workflowversion SET commitid = NULL where name = '0.2'");
 
         // Refresh before frozen should populate the commit id
-        workflow = workflowApi.refreshVersion(workflow.getId(), "0.2");
+        workflow = workflowApi.refreshVersion(workflow.getId(), "0.2", true);
         WorkflowVersion workflowVersion = workflow.getWorkflowVersions().stream().filter(wv -> Objects.equals(wv.getName(), "0.2")).findFirst().get();
         assertNotNull(workflowVersion.getCommitID());
 
@@ -170,7 +170,7 @@ public class WebhookIT extends BaseIT {
         assertTrue(workflowVersion.isFrozen());
 
         // Ensure refresh does not touch frozen legacy version
-        workflow = workflowApi.refreshVersion(workflow.getId(), "0.2");
+        workflow = workflowApi.refreshVersion(workflow.getId(), "0.2", true);
         assertNotNull(workflow);
         workflowVersion = workflow.getWorkflowVersions().stream().filter(wv -> Objects.equals(wv.getName(), "0.2")).findFirst().get();
         assertNull(workflowVersion.getCommitID());
@@ -320,7 +320,7 @@ public class WebhookIT extends BaseIT {
 
         // Refresh
         try {
-            client.refresh(workflow.getId());
+            client.refresh(workflow.getId(), true);
             fail("Should fail on refresh and not reach this point");
         } catch (ApiException ex) {
             assertEquals("Should not be able to refresh a dockstore.yml workflow.", HttpStatus.SC_BAD_REQUEST, ex.getCode());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -109,7 +109,7 @@ public class WebhookIT extends BaseIT {
                 DescriptorLanguage.CWL.getLowerShortName(), "/test.json");
         
         // Refresh should work
-        workflow = workflowApi.refresh(workflow.getId(), true);
+        workflow = workflowApi.refresh(workflow.getId(), false);
         assertEquals("Workflow should be FULL mode", Workflow.ModeEnum.FULL, workflow.getMode());
         assertTrue("All versions should be legacy", workflow.getWorkflowVersions().stream().allMatch(WorkflowVersion::isLegacyVersion));
 
@@ -122,7 +122,7 @@ public class WebhookIT extends BaseIT {
 
         // Refresh should now no longer work
         try {
-            workflowApi.refresh(workflow.getId(), true);
+            workflowApi.refresh(workflow.getId(), false);
             fail("Should fail on refresh and not reach this point");
         } catch (ApiException ex) {
             assertEquals("Should not be able to refresh a dockstore.yml workflow.", HttpStatus.SC_BAD_REQUEST, ex.getCode());
@@ -320,7 +320,7 @@ public class WebhookIT extends BaseIT {
 
         // Refresh
         try {
-            client.refresh(workflow.getId(), true);
+            client.refresh(workflow.getId(), false);
             fail("Should fail on refresh and not reach this point");
         } catch (ApiException ex) {
             assertEquals("Should not be able to refresh a dockstore.yml workflow.", HttpStatus.SC_BAD_REQUEST, ex.getCode());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/languages/GalaxyPluginIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/languages/GalaxyPluginIT.java
@@ -161,8 +161,8 @@ public class GalaxyPluginIT {
         Workflow galaxyWorkflow = workflowApi
                 .manualRegister(SourceControl.GITHUB.name(), "dockstore-testing/galaxy-workflow-dockstore-example-1", "/Dockstore.gxwf.yml",
                         "", DescriptorLanguage.GXFORMAT2.getShortName(), "");
-        workflowApi.refresh(wdlWorkflow.getId());
-        workflowApi.refresh(galaxyWorkflow.getId());
+        workflowApi.refresh(wdlWorkflow.getId(), true);
+        workflowApi.refresh(galaxyWorkflow.getId(), true);
         workflowApi.publish(wdlWorkflow.getId(), SwaggerUtility.createPublishRequest(true));
         workflowApi.publish(galaxyWorkflow.getId(), SwaggerUtility.createPublishRequest(true));
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/languages/GalaxyPluginIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/languages/GalaxyPluginIT.java
@@ -161,8 +161,8 @@ public class GalaxyPluginIT {
         Workflow galaxyWorkflow = workflowApi
                 .manualRegister(SourceControl.GITHUB.name(), "dockstore-testing/galaxy-workflow-dockstore-example-1", "/Dockstore.gxwf.yml",
                         "", DescriptorLanguage.GXFORMAT2.getShortName(), "");
-        workflowApi.refresh(wdlWorkflow.getId(), true);
-        workflowApi.refresh(galaxyWorkflow.getId(), true);
+        workflowApi.refresh(wdlWorkflow.getId(), false);
+        workflowApi.refresh(galaxyWorkflow.getId(), false);
         workflowApi.publish(wdlWorkflow.getId(), SwaggerUtility.createPublishRequest(true));
         workflowApi.publish(galaxyWorkflow.getId(), SwaggerUtility.createPublishRequest(true));
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/Constants.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/Constants.java
@@ -25,6 +25,7 @@ public final class Constants {
     public static final String OPTIONAL_AUTH_MESSAGE = "Does not require authentication for published workflows,"
             + " authentication can be provided for restricted workflows";
     public static final String DOCKSTORE_YML_PATH = "/.dockstore.yml";
+    public static final String SKIP_COMMIT_ID = "skip";
 
     private Constants() {
         // not called

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -79,7 +79,7 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
 
     @Column(nullable = false, columnDefinition = "boolean default true")
     @ApiModelProperty(value = "Whether or not the version has been refreshed since its last edit on Dockstore.", position = 105)
-    private boolean synced = true;
+    private boolean synced = false;
 
     /**
      * In theory, this should be in a ServiceVersion.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -77,6 +77,10 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
     @ApiModelProperty(value = "Whether or not the version was added using the legacy refresh process.", position = 104)
     private boolean isLegacyVersion = true;
 
+    @Column(nullable = false, columnDefinition = "boolean default true")
+    @ApiModelProperty(value = "Whether or not the version has been refreshed since its last edit on Dockstore.", position = 105)
+    private boolean synced = true;
+
     /**
      * In theory, this should be in a ServiceVersion.
      * In practice, our use of generics caused this to mess up bigtype, so we'll prototype with this for now.
@@ -124,6 +128,7 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
         super.setReference(workflowVersion.getReference());
         workflowPath = workflowVersion.getWorkflowPath();
         lastModified = workflowVersion.getLastModified();
+        synced = workflowVersion.isSynced();
     }
 
     public void clone(WorkflowVersion tag) {
@@ -223,6 +228,14 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
 
     public void setToolTableJson(final String toolTableJson) {
         this.toolTableJson = toolTableJson;
+    }
+
+    public boolean isSynced() {
+        return synced;
+    }
+
+    public void setSynced(boolean synced) {
+        this.synced = synced;
     }
 
     @ApiModel(value = "WorkflowVersionPathInfo", description = "Object that "

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -77,7 +77,7 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
     @ApiModelProperty(value = "Whether or not the version was added using the legacy refresh process.", position = 104)
     private boolean isLegacyVersion = true;
 
-    @Column(nullable = false, columnDefinition = "boolean default true")
+    @Column(nullable = false, columnDefinition = "boolean default false")
     @ApiModelProperty(value = "Whether or not the version has been refreshed since its last edit on Dockstore.", position = 105)
     private boolean synced = false;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -308,11 +308,15 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
                         version.setName(ref.getName());
                         version.setReference(ref.getName());
                         OffsetDateTime date = ref.getTarget().getDate();
-                        version.setLastModified(Date.from(date.toInstant()));
+                        Date lastModifiedDate = Date.from(date.toInstant());
+                        version.setLastModified(lastModifiedDate);
                         String commitId = getCommitID(repositoryId, version);
 
                         if (toRefreshVersion(ref.getName(), commitId, existingDefaults, hardRefresh)) {
+                            LOG.info(gitUsername + ": Looking at reference: " + ref.getName());
                             version = initializeWorkflowVersion(branchName, existingWorkflow, existingDefaults);
+
+                            version.setLastModified(lastModifiedDate);
                             String calculatedPath = version.getWorkflowPath();
                             // Now grab source files
                             DescriptorLanguage.FileType identifiedType = workflow.getFileType();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
@@ -163,6 +163,7 @@ public class GitLabSourceCodeRepo extends SourceCodeRepoInterface {
     private void handleVersionOfWorkflow(String repositoryId, Workflow workflow, Optional<Workflow> existingWorkflow,
         Map<String, WorkflowVersion> existingDefaults, String id, String branchName, Version.ReferenceType type, Date committedDate, String commitId, boolean hardRefresh) {
         if (toRefreshVersion(branchName, commitId, existingDefaults, hardRefresh)) {
+            LOG.info(gitUsername + ": Looking at reference: " + branchName);
             // Initialize workflow version
             WorkflowVersion version = initializeWorkflowVersion(branchName, existingWorkflow, existingDefaults);
             String calculatedPath = version.getWorkflowPath();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
@@ -47,6 +47,8 @@ import org.gitlab.api.models.GitlabTag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
+
 /**
  * @author aduncan on 05/10/16.
  * @author dyuen
@@ -130,7 +132,7 @@ public class GitLabSourceCodeRepo extends SourceCodeRepoInterface {
 
     @Override
     public Workflow setupWorkflowVersions(String repositoryId, Workflow workflow, Optional<Workflow> existingWorkflow,
-            Map<String, WorkflowVersion> existingDefaults, Optional<String> versionName) {
+            Map<String, WorkflowVersion> existingDefaults, Optional<String> versionName, boolean hardRefresh) {
 
         try {
             GitlabProject project = gitlabAPI.getProject(repositoryId.split("/")[0], repositoryId.split("/")[1]);
@@ -140,7 +142,7 @@ public class GitLabSourceCodeRepo extends SourceCodeRepoInterface {
                 if (versionName.isEmpty() || Objects.equals(versionName.get(), tag.getName())) {
                     Date committedDate = tag.getCommit().getCommittedDate();
                     String commitId = tag.getCommit().getId();
-                    handleVersionOfWorkflow(repositoryId, workflow, existingWorkflow, existingDefaults, repositoryId, tag.getName(), Version.ReferenceType.TAG, committedDate, commitId);
+                    handleVersionOfWorkflow(repositoryId, workflow, existingWorkflow, existingDefaults, repositoryId, tag.getName(), Version.ReferenceType.TAG, committedDate, commitId, hardRefresh);
                 }
             });
             branches.forEach(branch -> {
@@ -148,7 +150,7 @@ public class GitLabSourceCodeRepo extends SourceCodeRepoInterface {
                     Date committedDate = branch.getCommit().getCommittedDate();
                     String commitId = branch.getCommit().getId();
                     handleVersionOfWorkflow(repositoryId, workflow, existingWorkflow, existingDefaults, repositoryId, branch.getName(),
-                            Version.ReferenceType.BRANCH, committedDate, commitId);
+                            Version.ReferenceType.BRANCH, committedDate, commitId, hardRefresh);
                 }
             });
         } catch (IOException e) {
@@ -159,26 +161,39 @@ public class GitLabSourceCodeRepo extends SourceCodeRepoInterface {
 
     @SuppressWarnings("checkstyle:parameternumber")
     private void handleVersionOfWorkflow(String repositoryId, Workflow workflow, Optional<Workflow> existingWorkflow,
-        Map<String, WorkflowVersion> existingDefaults, String id, String branchName, Version.ReferenceType type, Date committedDate, String commitId) {
-        // Initialize workflow version
-        WorkflowVersion version = initializeWorkflowVersion(branchName, existingWorkflow, existingDefaults);
-        String calculatedPath = version.getWorkflowPath();
+        Map<String, WorkflowVersion> existingDefaults, String id, String branchName, Version.ReferenceType type, Date committedDate, String commitId, boolean hardRefresh) {
+        if (toRefreshVersion(branchName, commitId, existingDefaults, hardRefresh)) {
+            // Initialize workflow version
+            WorkflowVersion version = initializeWorkflowVersion(branchName, existingWorkflow, existingDefaults);
+            String calculatedPath = version.getWorkflowPath();
 
-        // Now grab source files
-        DescriptorLanguage.FileType identifiedType = workflow.getFileType();
-        // TODO: No exceptions are caught here in the event of a failed call
-        SourceFile sourceFile = getSourceFile(calculatedPath, id, branchName, identifiedType);
+            // Now grab source files
+            DescriptorLanguage.FileType identifiedType = workflow.getFileType();
+            // TODO: No exceptions are caught here in the event of a failed call
+            SourceFile sourceFile = getSourceFile(calculatedPath, id, branchName, identifiedType);
 
-        version.setReferenceType(type);
-        version.setLastModified(committedDate);
-        version.setCommitID(commitId);
-        // Use default test parameter file if either new version or existing version that hasn't been edited
-        createTestParameterFiles(workflow, id, branchName, version, identifiedType);
-        version = combineVersionAndSourcefile(repositoryId, sourceFile, workflow, identifiedType, version, existingDefaults);
+            version.setReferenceType(type);
+            version.setLastModified(committedDate);
+            version.setCommitID(commitId);
+            // Use default test parameter file if either new version or existing version that hasn't been edited
+            createTestParameterFiles(workflow, id, branchName, version, identifiedType);
+            version = combineVersionAndSourcefile(repositoryId, sourceFile, workflow, identifiedType, version, existingDefaults);
 
-        version = versionValidation(version, workflow, calculatedPath);
-
-        workflow.addWorkflowVersion(version);
+            version = versionValidation(version, workflow, calculatedPath);
+            if (version != null) {
+                workflow.addWorkflowVersion(version);
+            }
+        } else {
+            // Version didn't change, but we don't want to delete
+            // Add a stub version with commit ID set to an ignore value
+            LOG.info(gitUsername + ": Skipping reference: " + branchName);
+            WorkflowVersion version = new WorkflowVersion();
+            version.setName(branchName);
+            version.setReference(branchName);
+            version.setLastModified(committedDate);
+            version.setCommitID(SKIP_COMMIT_ID);
+            workflow.addWorkflowVersion(version);
+        }
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -57,6 +57,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
+import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 
 /**
  * This defines the set of operations that is needed to interact with a particular
@@ -202,10 +203,31 @@ public abstract class SourceCodeRepoInterface {
      * @param existingWorkflow
      * @param existingDefaults
      * @param versionName
+     * @param hardRefresh
      * @return workflow with associated workflow versions
      */
     public abstract Workflow setupWorkflowVersions(String repositoryId, Workflow workflow, Optional<Workflow> existingWorkflow,
-            Map<String, WorkflowVersion> existingDefaults, Optional<String> versionName);
+            Map<String, WorkflowVersion> existingDefaults, Optional<String> versionName, boolean hardRefresh);
+
+    /**
+     * Determine whether to refresh a version or not
+     * Refresh version if any of the following is true
+     * * this is a hard refresh
+     * * version doesn't exist
+     * * commit id isn't set
+     * * commitId is different
+     * * synced == false
+     *
+     * @param versionName
+     * @param commitId
+     * @param existingDefaults
+     * @param hardRefresh
+     * @return
+     */
+    protected boolean toRefreshVersion(String versionName, String commitId, Map<String, WorkflowVersion> existingDefaults, boolean hardRefresh) {
+        WorkflowVersion existingVersion = existingDefaults.get(versionName);
+        return hardRefresh || existingVersion == null || existingVersion.getCommitID() == null || !Objects.equals(existingVersion.getCommitID(), commitId) || !existingVersion.isSynced();
+    }
 
     /**
      * Creates a basic workflow object with default values
@@ -224,9 +246,10 @@ public abstract class SourceCodeRepoInterface {
      * @param repositoryId Repository ID (ex. dockstore/dockstore-ui2)
      * @param existingWorkflow Optional existing workflow
      * @param versionName Optional version name to refresh
+     * @param hardRefresh
      * @return workflow
      */
-    public Workflow createWorkflowFromGitRepository(String repositoryId, Optional<Workflow> existingWorkflow, Optional<String> versionName) {
+    public Workflow createWorkflowFromGitRepository(String repositoryId, Optional<Workflow> existingWorkflow, Optional<String> versionName, boolean hardRefresh) {
         // Initialize workflow
         Workflow workflow = initializeWorkflow(repositoryId, new BioWorkflow());
 
@@ -266,7 +289,7 @@ public abstract class SourceCodeRepoInterface {
 
         // Create versions and associated source files
         //TODO: calls validation eventually, may simplify if we take into account metadata parsing below
-        workflow = setupWorkflowVersions(repositoryId, workflow, existingWorkflow, existingDefaults, versionName);
+        workflow = setupWorkflowVersions(repositoryId, workflow, existingWorkflow, existingDefaults, versionName, hardRefresh);
 
         if (versionName.isPresent() && workflow.getWorkflowVersions().size() == 0) {
             String msg = "Version " + versionName.get() + " was not found on Git repository";
@@ -332,7 +355,9 @@ public abstract class SourceCodeRepoInterface {
             Workflow workflow = (Workflow)entry;
             workflow.getWorkflowVersions().forEach(workflowVersion -> {
                 String filePath = workflowVersion.getWorkflowPath();
-                updateVersionMetadata(filePath, workflowVersion, type, repositoryId);
+                if (!Objects.equals(SKIP_COMMIT_ID, workflowVersion.getCommitID())) {
+                    updateVersionMetadata(filePath, workflowVersion, type, repositoryId);
+                }
             });
         }
     }
@@ -466,6 +491,7 @@ public abstract class SourceCodeRepoInterface {
         version.setName(branch);
         version.setReference(branch);
         version.setValid(false);
+        version.setSynced(true);
 
         // Determine workflow version from previous
         String calculatedPath;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
 
 import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
 import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
+import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 import static io.dockstore.webservice.core.WorkflowMode.DOCKSTORE_YML;
 import static io.dockstore.webservice.core.WorkflowMode.FULL;
 import static io.dockstore.webservice.core.WorkflowMode.STUB;
@@ -170,6 +171,12 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         for (WorkflowVersion version : newWorkflow.getWorkflowVersions()) {
             // skip frozen versions
             WorkflowVersion workflowVersionFromDB = existingVersionMap.get(version.getName());
+
+            // Skip these since they have not changed
+            if (Objects.equals(SKIP_COMMIT_ID, version.getCommitID())) {
+                continue;
+            }
+
             if (existingVersionMap.containsKey(version.getName())) {
                 if (workflowVersionFromDB.isFrozen()) {
                     continue;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -265,7 +265,7 @@ public class DockerRepoResource
 
         // Refresh checker workflow
         if (refreshedTool.getCheckerWorkflow() != null) {
-            workflowResource.refresh(user, refreshedTool.getCheckerWorkflow().getId());
+            workflowResource.refresh(user, refreshedTool.getCheckerWorkflow().getId(), true);
         }
         refreshedTool.getWorkflowVersions().forEach(Version::updateVerified);
         PublicStateManager.getInstance().handleIndexUpdate(refreshedTool, StateManagerMode.UPDATE);

--- a/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
@@ -176,9 +176,13 @@
 
     <changeSet author="aduncan" id="addSyncedColumnToWorkflowVersion">
         <addColumn tableName="workflowversion">
-            <column name="synced" type="BOOLEAN" defaultValueBoolean="true">
+            <column name="synced" type="BOOLEAN" defaultValueBoolean="false">
                 <constraints nullable="false"/>
             </column>
         </addColumn>
+
+        <sql dbms="postgresql">
+            UPDATE workflowversion SET synced = TRUE;
+        </sql>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
@@ -173,4 +173,14 @@
             UPDATE lambdaevent SET repository = split_part(repository,'/',2);
         </sql>
     </changeSet>
+
+    <changeSet author="aduncan" id="addSyncedColumnToWorkflowVersion">
+        <addColumn tableName="workflowversion">
+            <column name="synced" type="BOOLEAN"/>
+        </addColumn>
+        <sql dbms="postgresql">
+            UPDATE workflowversion SET synced = true;
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.9.0.xml
@@ -176,11 +176,9 @@
 
     <changeSet author="aduncan" id="addSyncedColumnToWorkflowVersion">
         <addColumn tableName="workflowversion">
-            <column name="synced" type="BOOLEAN"/>
+            <column name="synced" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
         </addColumn>
-        <sql dbms="postgresql">
-            UPDATE workflowversion SET synced = true;
-        </sql>
     </changeSet>
-
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -14,28 +14,34 @@ components:
       type: object
     BioWorkflow:
       allOf:
-        - $ref: '#/components/schemas/Workflow'
-        - properties:
-            is_checker:
-              type: boolean
-            parent_id:
-              format: int64
-              type: integer
-          type: object
+      - $ref: '#/components/schemas/Workflow'
+      - properties:
+          is_checker:
+            type: boolean
+          parent_id:
+            format: int64
+            type: integer
+        type: object
       type: object
     Checksum:
-      description: 'A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes. '
+      description: 'A production (immutable) tool version is required to have a hashcode.
+        Not required otherwise, but might be useful to detect changes. '
       example: '[{checksum=ea2a5db69bd20a42976838790bc29294df3af02b, type=sha1}]'
       properties:
         checksum:
           description: 'The hex-string encoded checksum for the data. '
           type: string
         type:
-          description: The digest method used to create the checksum. The value (e.g. `sha-256`) SHOULD be listed as `Hash Name String` in the https://github.com/ga4gh-discovery/ga4gh-checksum/blob/master/hash-alg.csv[GA4GH Checksum Hash Algorithm Registry]. Other values MAY be used, as long as implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4[RFC6920]. GA4GH may provide more explicit guidance for use of non-IANA-registered algorithms in the future.
+          description: The digest method used to create the checksum. The value (e.g.
+            `sha-256`) SHOULD be listed as `Hash Name String` in the https://github.com/ga4gh-discovery/ga4gh-checksum/blob/master/hash-alg.csv[GA4GH
+            Checksum Hash Algorithm Registry]. Other values MAY be used, as long as
+            implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4[RFC6920].
+            GA4GH may provide more explicit guidance for use of non-IANA-registered
+            algorithms in the future.
           type: string
       required:
-        - checksum
-        - type
+      - checksum
+      - type
       type: object
     Collection:
       description: Collection in an organization, collects entries
@@ -83,8 +89,8 @@ components:
           example: A collection of alignment algorithms
           type: string
       required:
-        - name
-        - topic
+      - name
+      - topic
       type: object
     CollectionEntry:
       properties:
@@ -367,9 +373,9 @@ components:
       properties:
         entryType:
           enum:
-            - TOOL
-            - WORKFLOW
-            - SERVICE
+          - TOOL
+          - WORKFLOW
+          - SERVICE
           type: string
         lastUpdateDate:
           format: date-time
@@ -387,7 +393,7 @@ components:
         message:
           type: string
       required:
-        - code
+      - code
       type: object
     Event:
       properties:
@@ -410,22 +416,22 @@ components:
           $ref: '#/components/schemas/Tool'
         type:
           enum:
-            - CREATE_ORG
-            - DELETE_ORG
-            - MODIFY_ORG
-            - APPROVE_ORG
-            - REJECT_ORG
-            - REREQUEST_ORG
-            - ADD_USER_TO_ORG
-            - REMOVE_USER_FROM_ORG
-            - MODIFY_USER_ROLE_ORG
-            - APPROVE_ORG_INVITE
-            - REJECT_ORG_INVITE
-            - CREATE_COLLECTION
-            - MODIFY_COLLECTION
-            - REMOVE_FROM_COLLECTION
-            - ADD_TO_COLLECTION
-            - ADD_VERSION_TO_ENTRY
+          - CREATE_ORG
+          - DELETE_ORG
+          - MODIFY_ORG
+          - APPROVE_ORG
+          - REJECT_ORG
+          - REREQUEST_ORG
+          - ADD_USER_TO_ORG
+          - REMOVE_USER_FROM_ORG
+          - MODIFY_USER_ROLE_ORG
+          - APPROVE_ORG_INVITE
+          - REJECT_ORG_INVITE
+          - CREATE_COLLECTION
+          - MODIFY_COLLECTION
+          - REMOVE_FROM_COLLECTION
+          - ADD_TO_COLLECTION
+          - ADD_VERSION_TO_ENTRY
           type: string
         user:
           $ref: '#/components/schemas/User'
@@ -445,10 +451,16 @@ components:
           type: string
       type: object
     FileWrapper:
-      description: 'A file provides content for one of - A tool descriptor is a metadata document that describes one or more tools. - A tool document that describes how to test with one or more sample test JSON. - A containerfile is a document that describes how to build a particular container image. Examples include Dockerfiles for creating Docker images and Singularity recipes for Singularity images '
+      description: 'A file provides content for one of - A tool descriptor is a metadata
+        document that describes one or more tools. - A tool document that describes
+        how to test with one or more sample test JSON. - A containerfile is a document
+        that describes how to build a particular container image. Examples include
+        Dockerfiles for creating Docker images and Singularity recipes for Singularity
+        images '
       properties:
         checksum:
-          description: 'A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes. '
+          description: 'A production (immutable) tool version is required to have
+            a hashcode. Not required otherwise, but might be useful to detect changes. '
           example: '[{checksum=ea2a5db69bd20a42976838790bc29294df3af02b, type=sha1}]'
           items:
             $ref: '#/components/schemas/Checksum'
@@ -457,7 +469,10 @@ components:
           description: The content of the file itself. One of url or content is required.
           type: string
         url:
-          description: Optional url to the underlying content, should include version information, and can include a git hash.  Note that this URL should resolve to the raw unwrapped content that would otherwise be available in content. One of url or content is required.
+          description: Optional url to the underlying content, should include version
+            information, and can include a git hash.  Note that this URL should resolve
+            to the raw unwrapped content that would otherwise be available in content.
+            One of url or content is required.
           type: string
       type: object
     Image:
@@ -472,11 +487,11 @@ components:
           type: string
         imageRegistry:
           enum:
-            - QUAY_IO
-            - DOCKER_HUB
-            - GITLAB
-            - AMAZON_ECR
-            - SEVEN_BRIDGES
+          - QUAY_IO
+          - DOCKER_HUB
+          - GITLAB
+          - AMAZON_ECR
+          - SEVEN_BRIDGES
           type: string
         os:
           type: string
@@ -489,22 +504,28 @@ components:
       description: Describes one container image.
       properties:
         checksum:
-          description: A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes.  This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
-          example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182, type=sha256}]'
+          description: A production (immutable) tool version is required to have a
+            hashcode. Not required otherwise, but might be useful to detect changes.  This
+            exposes the hashcode for specific image versions to verify that the container
+            version pulled is actually the version that was indexed by the registry.
+          example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182,
+            type=sha256}]'
           items:
             $ref: '#/components/schemas/Checksum'
           type: array
         image_name:
-          description: Used in conjunction with a registry_url if provided to locate images.
+          description: Used in conjunction with a registry_url if provided to locate
+            images.
           type: string
         image_type:
           enum:
-            - Docker
-            - Singularity
-            - Conda
+          - Docker
+          - Singularity
+          - Conda
           type: string
         registry_host:
-          description: A docker registry or a URL to a Singularity registry. Used along with image_name to locate a specific image.
+          description: A docker registry or a URL to a Singularity registry. Used
+            along with image_name to locate a specific image.
           type: string
         size:
           description: Size of the container in bytes.
@@ -544,9 +565,9 @@ components:
           type: boolean
         type:
           enum:
-            - PUSH
-            - DELETE
-            - INSTALL
+          - PUSH
+          - DELETE
+          - INSTALL
           type: string
       type: object
     Limits:
@@ -578,14 +599,14 @@ components:
           type: string
         priority:
           enum:
-            - LOW
-            - MEDIUM
-            - CRITICAL
+          - LOW
+          - MEDIUM
+          - CRITICAL
           type: string
         type:
           enum:
-            - SITEWIDE
-            - NEWSBODY
+          - SITEWIDE
+          - NEWSBODY
           type: string
       type: object
     Organization:
@@ -631,9 +652,9 @@ components:
           uniqueItems: true
         status:
           enum:
-            - PENDING
-            - REJECTED
-            - APPROVED
+          - PENDING
+          - REJECTED
+          - APPROVED
           type: string
         topic:
           type: string
@@ -669,8 +690,8 @@ components:
           $ref: '#/components/schemas/Organization'
         role:
           enum:
-            - MAINTAINER
-            - MEMBER
+          - MAINTAINER
+          - MEMBER
           type: string
         user:
           $ref: '#/components/schemas/User'
@@ -690,9 +711,9 @@ components:
           type: string
         role:
           enum:
-            - OWNER
-            - WRITER
-            - READER
+          - OWNER
+          - WRITER
+          - READER
           type: string
       type: object
     Profile:
@@ -738,10 +759,10 @@ components:
           type: boolean
         gitRegistry:
           enum:
-            - dockstore.org
-            - github.com
-            - bitbucket.org
-            - gitlab.com
+          - dockstore.org
+          - github.com
+          - bitbucket.org
+          - gitlab.com
           type: string
         organization:
           type: string
@@ -754,15 +775,15 @@ components:
       type: object
     Service:
       allOf:
-        - $ref: '#/components/schemas/Workflow'
+      - $ref: '#/components/schemas/Workflow'
       type: object
     SharedWorkflows:
       properties:
         role:
           enum:
-            - OWNER
-            - WRITER
-            - READER
+          - OWNER
+          - WRITER
+          - READER
           type: string
         workflows:
           items:
@@ -795,22 +816,22 @@ components:
           type: string
         type:
           enum:
-            - DOCKSTORE_CWL
-            - DOCKSTORE_WDL
-            - DOCKERFILE
-            - CWL_TEST_JSON
-            - WDL_TEST_JSON
-            - NEXTFLOW
-            - NEXTFLOW_CONFIG
-            - NEXTFLOW_TEST_PARAMS
-            - DOCKSTORE_YML
-            - DOCKSTORE_SERVICE_YML
-            - DOCKSTORE_SERVICE_TEST_JSON
-            - DOCKSTORE_SERVICE_OTHER
-            - DOCKSTORE_GXFORMAT2
-            - GXFORMAT2_TEST_FILE
-            - DOCKSTORE_SWL
-            - SWL_TEST_JSON
+          - DOCKSTORE_CWL
+          - DOCKSTORE_WDL
+          - DOCKERFILE
+          - CWL_TEST_JSON
+          - WDL_TEST_JSON
+          - NEXTFLOW
+          - NEXTFLOW_CONFIG
+          - NEXTFLOW_TEST_PARAMS
+          - DOCKSTORE_YML
+          - DOCKSTORE_SERVICE_YML
+          - DOCKSTORE_SERVICE_TEST_JSON
+          - DOCKSTORE_SERVICE_OTHER
+          - DOCKSTORE_GXFORMAT2
+          - GXFORMAT2_TEST_FILE
+          - DOCKSTORE_SWL
+          - SWL_TEST_JSON
           type: string
         verifiedBySource:
           additionalProperties:
@@ -839,8 +860,8 @@ components:
           type: string
         descriptionSource:
           enum:
-            - README
-            - DESCRIPTOR
+          - README
+          - DESCRIPTOR
           type: string
         dirtyBit:
           type: boolean
@@ -848,9 +869,9 @@ components:
           type: string
         doiStatus:
           enum:
-            - NOT_REQUESTED
-            - REQUESTED
-            - CREATED
+          - NOT_REQUESTED
+          - REQUESTED
+          - CREATED
           type: string
         doiURL:
           type: string
@@ -891,11 +912,11 @@ components:
           type: string
         referenceType:
           enum:
-            - COMMIT
-            - TAG
-            - BRANCH
-            - NOT_APPLICABLE
-            - UNSET
+          - COMMIT
+          - TAG
+          - BRANCH
+          - NOT_APPLICABLE
+          - UNSET
           type: string
         size:
           format: int64
@@ -946,14 +967,14 @@ components:
           type: string
         tokenSource:
           enum:
-            - quay.io
-            - github.com
-            - dockstore
-            - bitbucket.org
-            - gitlab.com
-            - zenodo.org
-            - google.com
-            - orcid.org
+          - quay.io
+          - github.com
+          - dockstore
+          - bitbucket.org
+          - gitlab.com
+          - zenodo.org
+          - google.com
+          - orcid.org
           type: string
         userId:
           format: int64
@@ -962,16 +983,27 @@ components:
           type: string
       type: object
     Tool:
-      description: A tool (or described tool) is defined as a tuple of a descriptor file (which potentially consists of multiple files), a set of container images, and a set of instructions for creating those images.
+      description: A tool (or described tool) is defined as a tuple of a descriptor
+        file (which potentially consists of multiple files), a set of container images,
+        and a set of instructions for creating those images.
       properties:
         aliases:
-          description: Support for this parameter is optional for tool registries that support aliases. A list of strings that can be used to identify this tool which could be  straight up URLs.  This can be used to expose alternative ids (such as GUIDs) for a tool for registries. Can be used to match tools across registries.
+          description: Support for this parameter is optional for tool registries
+            that support aliases. A list of strings that can be used to identify this
+            tool which could be  straight up URLs.  This can be used to expose alternative
+            ids (such as GUIDs) for a tool for registries. Can be used to match tools
+            across registries.
           items:
-            description: Support for this parameter is optional for tool registries that support aliases. A list of strings that can be used to identify this tool which could be  straight up URLs.  This can be used to expose alternative ids (such as GUIDs) for a tool for registries. Can be used to match tools across registries.
+            description: Support for this parameter is optional for tool registries
+              that support aliases. A list of strings that can be used to identify
+              this tool which could be  straight up URLs.  This can be used to expose
+              alternative ids (such as GUIDs) for a tool for registries. Can be used
+              to match tools across registries.
             type: string
           type: array
         checker_url:
-          description: Optional url to the checker tool that will exit successfully if this tool produced the expected result given test data.
+          description: Optional url to the checker tool that will exit successfully
+            if this tool produced the expected result given test data.
           type: string
         description:
           description: The description of the tool.
@@ -984,7 +1016,8 @@ components:
           example: "123456"
           type: string
         meta_version:
-          description: The version of this tool in the registry. Iterates when fields like the description, author, etc. are updated.
+          description: The version of this tool in the registry. Iterates when fields
+            like the description, author, etc. are updated.
           type: string
         name:
           description: The name of the tool.
@@ -1004,11 +1037,11 @@ components:
             $ref: '#/components/schemas/ToolVersion'
           type: array
       required:
-        - id
-        - organization
-        - toolclass
-        - url
-        - versions
+      - id
+      - organization
+      - toolclass
+      - url
+      - versions
       type: object
     ToolClass:
       properties:
@@ -1025,16 +1058,16 @@ components:
           type: string
         type:
           enum:
-            - CWL
-            - WDL
-            - NFL
-            - SERVICE
-            - GXFORMAT2
+          - CWL
+          - WDL
+          - NFL
+          - SERVICE
+          - GXFORMAT2
           type: string
         url:
           type: string
       required:
-        - type
+      - type
       type: object
     ToolDockerfile:
       properties:
@@ -1047,14 +1080,15 @@ components:
       properties:
         file_type:
           enum:
-            - TEST_FILE
-            - PRIMARY_DESCRIPTOR
-            - SECONDARY_DESCRIPTOR
-            - CONTAINERFILE
-            - OTHER
+          - TEST_FILE
+          - PRIMARY_DESCRIPTOR
+          - SECONDARY_DESCRIPTOR
+          - CONTAINERFILE
+          - OTHER
           type: string
         path:
-          description: Relative path of the file.  A descriptor's path can be used with the GA4GH .../{type}/descriptor/{relative_path} endpoint.
+          description: Relative path of the file.  A descriptor's path can be used
+            with the GA4GH .../{type}/descriptor/{relative_path} endpoint.
           type: string
       type: object
     ToolTesterLog:
@@ -1063,8 +1097,8 @@ components:
           type: string
         logType:
           enum:
-            - FULL
-            - SUMMARY
+          - FULL
+          - SUMMARY
           type: string
         runner:
           type: string
@@ -1116,51 +1150,65 @@ components:
           type: array
       type: object
     ToolVersion:
-      description: A tool version describes a particular iteration of a tool as described by a reference to a specific image and/or documents.
+      description: A tool version describes a particular iteration of a tool as described
+        by a reference to a specific image and/or documents.
       properties:
         author:
-          description: Contact information for the author of this version of the tool in the registry. (More complex authorship information is handled by the descriptor).
+          description: Contact information for the author of this version of the tool
+            in the registry. (More complex authorship information is handled by the
+            descriptor).
           items:
-            description: Contact information for the author of this version of the tool in the registry. (More complex authorship information is handled by the descriptor).
+            description: Contact information for the author of this version of the
+              tool in the registry. (More complex authorship information is handled
+              by the descriptor).
             type: string
           type: array
         containerfile:
-          description: Reports if this tool has a containerfile available. (For Docker-based tools, this would indicate the presence of a Dockerfile)
+          description: Reports if this tool has a containerfile available. (For Docker-based
+            tools, this would indicate the presence of a Dockerfile)
           type: boolean
         descriptor_type:
           description: The type (or types) of descriptors available.
           items:
             description: The type (or types) of descriptors available.
             enum:
-              - CWL
-              - WDL
-              - NFL
-              - SERVICE
-              - GALAXY
+            - CWL
+            - WDL
+            - NFL
+            - SERVICE
+            - GALAXY
             type: string
           type: array
         id:
-          description: An identifier of the version of this tool for this particular tool registry.
+          description: An identifier of the version of this tool for this particular
+            tool registry.
           example: v1
           type: string
         images:
-          description: All known docker images (and versions/hashes) used by this tool. If the tool has to evaluate any of the docker images strings at runtime, those ones cannot be reported here.
+          description: All known docker images (and versions/hashes) used by this
+            tool. If the tool has to evaluate any of the docker images strings at
+            runtime, those ones cannot be reported here.
           items:
             $ref: '#/components/schemas/ImageData'
           type: array
         included_apps:
-          description: An array of IDs for the applications that are stored inside this tool.
+          description: An array of IDs for the applications that are stored inside
+            this tool.
           example: '[https://bio.tools/tool/mytum.de/SNAP2/1, https://bio.tools/bioexcel_seqqc]'
           items:
-            description: An array of IDs for the applications that are stored inside this tool.
+            description: An array of IDs for the applications that are stored inside
+              this tool.
             example: '[https://bio.tools/tool/mytum.de/SNAP2/1, https://bio.tools/bioexcel_seqqc]'
             type: string
           type: array
         is_production:
-          description: This version of a tool is guaranteed to not change over time (for example, a  tool built from a tag in git as opposed to a branch). A production quality tool  is required to have a checksum
+          description: This version of a tool is guaranteed to not change over time
+            (for example, a  tool built from a tag in git as opposed to a branch).
+            A production quality tool  is required to have a checksum
           type: boolean
         meta_version:
-          description: The version of this tool version in the registry. Iterates when fields like the description, author, etc. are updated.
+          description: The version of this tool version in the registry. Iterates
+            when fields like the description, author, etc. are updated.
           type: string
         name:
           description: The name of the version.
@@ -1173,25 +1221,28 @@ components:
           example: http://agora.broadinstitute.org/tools/123456/versions/1
           type: string
         verified:
-          description: Reports whether this tool has been verified by a specific organization or individual.
+          description: Reports whether this tool has been verified by a specific organization
+            or individual.
           type: boolean
         verified_source:
-          description: Source of metadata that can support a verified tool, such as an email or URL.
+          description: Source of metadata that can support a verified tool, such as
+            an email or URL.
           items:
-            description: Source of metadata that can support a verified tool, such as an email or URL.
+            description: Source of metadata that can support a verified tool, such
+              as an email or URL.
             type: string
           type: array
       required:
-        - id
-        - url
+      - id
+      - url
       type: object
     ToolVersionV1:
       properties:
         descriptor-type:
           items:
             enum:
-              - CWL
-              - WDL
+            - CWL
+            - WDL
             type: string
           type: array
         dockerfile:
@@ -1228,8 +1279,8 @@ components:
           type: string
         privacyPolicyVersion:
           enum:
-            - NONE
-            - PRIVACY_POLICY_VERSION_2_5
+          - NONE
+          - PRIVACY_POLICY_VERSION_2_5
           type: string
         privacyPolicyVersionAcceptanceDate:
           format: date-time
@@ -1241,8 +1292,8 @@ components:
           type: string
         tosversion:
           enum:
-            - NONE
-            - TOS_VERSION_1
+          - NONE
+          - TOS_VERSION_1
           type: string
         tosversionAcceptanceDate:
           format: date-time
@@ -1264,22 +1315,22 @@ components:
           type: string
         type:
           enum:
-            - DOCKSTORE_CWL
-            - DOCKSTORE_WDL
-            - DOCKERFILE
-            - CWL_TEST_JSON
-            - WDL_TEST_JSON
-            - NEXTFLOW
-            - NEXTFLOW_CONFIG
-            - NEXTFLOW_TEST_PARAMS
-            - DOCKSTORE_YML
-            - DOCKSTORE_SERVICE_YML
-            - DOCKSTORE_SERVICE_TEST_JSON
-            - DOCKSTORE_SERVICE_OTHER
-            - DOCKSTORE_GXFORMAT2
-            - GXFORMAT2_TEST_FILE
-            - DOCKSTORE_SWL
-            - SWL_TEST_JSON
+          - DOCKSTORE_CWL
+          - DOCKSTORE_WDL
+          - DOCKERFILE
+          - CWL_TEST_JSON
+          - WDL_TEST_JSON
+          - NEXTFLOW
+          - NEXTFLOW_CONFIG
+          - NEXTFLOW_TEST_PARAMS
+          - DOCKSTORE_YML
+          - DOCKSTORE_SERVICE_YML
+          - DOCKSTORE_SERVICE_TEST_JSON
+          - DOCKSTORE_SERVICE_OTHER
+          - DOCKSTORE_GXFORMAT2
+          - GXFORMAT2_TEST_FILE
+          - DOCKSTORE_SWL
+          - SWL_TEST_JSON
           type: string
         valid:
           type: boolean
@@ -1306,16 +1357,16 @@ components:
           type: string
         descriptionSource:
           enum:
-            - README
-            - DESCRIPTOR
+          - README
+          - DESCRIPTOR
           type: string
         dirtyBit:
           type: boolean
         doiStatus:
           enum:
-            - NOT_REQUESTED
-            - REQUESTED
-            - CREATED
+          - NOT_REQUESTED
+          - REQUESTED
+          - CREATED
           type: string
         doiURL:
           type: string
@@ -1351,11 +1402,11 @@ components:
           type: string
         referenceType:
           enum:
-            - COMMIT
-            - TAG
-            - BRANCH
-            - NOT_APPLICABLE
-            - UNSET
+          - COMMIT
+          - TAG
+          - BRANCH
+          - NOT_APPLICABLE
+          - UNSET
           type: string
         sourceFiles:
           items:
@@ -1411,22 +1462,22 @@ components:
           type: string
         descriptorType:
           enum:
-            - CWL
-            - WDL
-            - gxformat2
-            - SWL
-            - NFL
-            - service
-            
-            
+          - CWL
+          - WDL
+          - gxformat2
+          - SWL
+          - NFL
+          - service
+          
+          
           type: string
         descriptorTypeSubclass:
           enum:
-            - docker-compose
-            - helm
-            - swarm
-            - kubernetes
-            - n/a
+          - docker-compose
+          - helm
+          - swarm
+          - kubernetes
+          - n/a
           type: string
         email:
           type: string
@@ -1468,10 +1519,10 @@ components:
           $ref: '#/components/schemas/Version'
         mode:
           enum:
-            - FULL
-            - STUB
-            - HOSTED
-            - DOCKSTORE_YML
+          - FULL
+          - STUB
+          - HOSTED
+          - DOCKSTORE_YML
           type: string
         organization:
           type: string
@@ -1488,10 +1539,10 @@ components:
           type: string
         sourceControl:
           enum:
-            - dockstore.org
-            - github.com
-            - bitbucket.org
-            - gitlab.com
+          - dockstore.org
+          - github.com
+          - bitbucket.org
+          - gitlab.com
           type: string
         source_control_provider:
           type: string
@@ -1520,7 +1571,7 @@ components:
         workflow_path:
           type: string
       required:
-        - type
+      - type
       type: object
     WorkflowVersion:
       properties:
@@ -1539,16 +1590,16 @@ components:
           type: string
         descriptionSource:
           enum:
-            - README
-            - DESCRIPTOR
+          - README
+          - DESCRIPTOR
           type: string
         dirtyBit:
           type: boolean
         doiStatus:
           enum:
-            - NOT_REQUESTED
-            - REQUESTED
-            - CREATED
+          - NOT_REQUESTED
+          - REQUESTED
+          - CREATED
           type: string
         doiURL:
           type: string
@@ -1589,11 +1640,11 @@ components:
           type: string
         referenceType:
           enum:
-            - COMMIT
-            - TAG
-            - BRANCH
-            - NOT_APPLICABLE
-            - UNSET
+          - COMMIT
+          - TAG
+          - BRANCH
+          - NOT_APPLICABLE
+          - UNSET
           type: string
         sourceFiles:
           items:
@@ -1602,11 +1653,13 @@ components:
           uniqueItems: true
         subClass:
           enum:
-            - DOCKER_COMPOSE
-            - SWARM
-            - KUBERNETES
-            - HELM
+          - DOCKER_COMPOSE
+          - SWARM
+          - KUBERNETES
+          - HELM
           type: string
+        synced:
+          type: boolean
         valid:
           type: boolean
         validations:
@@ -1645,7 +1698,10 @@ info:
     email: theglobalalliance@genomicsandhealth.org
     name: Dockstore@ga4gh
     url: https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506
-  description: This describes the dockstore API, a webservice that manages pairs of Docker images and associated metadata such as CWL documents and Dockerfiles used to build those images. Explore swagger.json for a Swagger 2.0 description of our API and explore openapi.yaml for OpenAPI 3.0 descriptions.
+  description: This describes the dockstore API, a webservice that manages pairs of
+    Docker images and associated metadata such as CWL documents and Dockerfiles used
+    to build those images. Explore swagger.json for a Swagger 2.0 description of our
+    API and explore openapi.yaml for OpenAPI 3.0 descriptions.
   license:
     name: Apache License Version 2.0
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
@@ -1659,11 +1715,11 @@ paths:
       description: Retrieves workflow version path information by alias.
       operationId: getWorkflowVersionPathInfoByAlias
       parameters:
-        - in: path
-          name: alias
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: alias
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -1672,77 +1728,78 @@ paths:
                 $ref: '#/components/schemas/WorkflowVersionPathInfo'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - aliases
+      - aliases
   /aliases/workflow-versions/{workflowVersionId}:
     post:
       description: Add aliases linked to a workflow version in Dockstore.
       operationId: addAliases_1
       parameters:
-        - in: path
-          name: workflowVersionId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: aliases
-          schema:
-            type: string
+      - in: path
+        name: workflowVersionId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: aliases
+        schema:
+          type: string
       responses:
         default:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WorkflowVersion'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - aliases
+      - aliases
   /api/ga4gh/v1/tools:
     get:
-      description: This endpoint returns all tools available or a filtered subset using metadata query parameters.
+      description: This endpoint returns all tools available or a filtered subset
+        using metadata query parameters.
       operationId: toolsGetV1
       parameters:
-        - in: query
-          name: id
-          schema:
-            type: string
-        - in: query
-          name: registry
-          schema:
-            type: string
-        - in: query
-          name: organization
-          schema:
-            type: string
-        - in: query
-          name: name
-          schema:
-            type: string
-        - in: query
-          name: toolname
-          schema:
-            type: string
-        - in: query
-          name: description
-          schema:
-            type: string
-        - in: query
-          name: author
-          schema:
-            type: string
-        - in: query
-          name: offset
-          schema:
-            type: string
-        - in: query
-          name: limit
-          schema:
-            format: int32
-            type: integer
+      - in: query
+        name: id
+        schema:
+          type: string
+      - in: query
+        name: registry
+        schema:
+          type: string
+      - in: query
+        name: organization
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: toolname
+        schema:
+          type: string
+      - in: query
+        name: description
+        schema:
+          type: string
+      - in: query
+        name: author
+        schema:
+          type: string
+      - in: query
+        name: offset
+        schema:
+          type: string
+      - in: query
+        name: limit
+        schema:
+          format: int32
+          type: integer
       responses:
         "200":
           content:
@@ -1754,17 +1811,18 @@ paths:
           description: An array of Tools that match the filter.
       summary: List all tools
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v1/tools/{id}:
     get:
-      description: This endpoint returns one specific tool (which has ToolVersions nested inside it)
+      description: This endpoint returns one specific tool (which has ToolVersions
+        nested inside it)
       operationId: toolsIdGetV1
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1774,17 +1832,17 @@ paths:
           description: A tool.
       summary: List one specific tool, acts as an anchor for self references
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions:
     get:
       description: Returns all versions of the specified tool
       operationId: toolsIdVersionGetV1
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1796,22 +1854,22 @@ paths:
           description: An array of tool versions
       summary: List versions of a tool
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions/{version_id}:
     get:
       description: This endpoint returns one specific tool version
       operationId: versionIdGetV1
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1821,22 +1879,22 @@ paths:
           description: A tool version.
       summary: List one specific tool version, acts as an anchor for self references
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions/{version_id}/dockerfile:
     get:
       description: Returns the dockerfile for the specified image.
       operationId: dockerfileGetV1
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1846,27 +1904,27 @@ paths:
           description: The tool payload.
       summary: Get the dockerfile for the specified image.
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/descriptor:
     get:
       description: Returns the CWL or WDL descriptor for the specified tool.
       operationId: descriptorGetV1
       parameters:
-        - in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1882,32 +1940,33 @@ paths:
           description: The tool can not be output in the specified type.
       summary: Get the tool descriptor (CWL/WDL) for the specified tool.
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}:
     get:
-      description: Returns additional CWL or WDL descriptors for the specified tool in the same or subdirectories
+      description: Returns additional CWL or WDL descriptors for the specified tool
+        in the same or subdirectories
       operationId: relativeDescriptorGetV1
       parameters:
-        - in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: relative_path
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: relative_path
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1921,28 +1980,29 @@ paths:
               schema:
                 $ref: '#/components/schemas/ToolDescriptor'
           description: The tool can not be output in the specified type.
-      summary: Get additional tool descriptor files (CWL/WDL) relative to the main file
+      summary: Get additional tool descriptor files (CWL/WDL) relative to the main
+        file
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v1/tools/{id}/versions/{version_id}/{type}/tests:
     get:
       operationId: testsGetV1
       parameters:
-        - in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1962,17 +2022,17 @@ paths:
           description: The tool can not be output in the specified type.
       summary: Get an array of test JSONs suitable for use with this descriptor type.
       tags:
-        - GA4GHV1
+      - GA4GHV1
   /api/ga4gh/v2/extended/containers/{organization}:
     get:
       description: This endpoint returns entries of an organization.
       operationId: entriesOrgGet
       parameters:
-        - in: path
-          name: organization
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: organization
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -1984,7 +2044,7 @@ paths:
           description: An array of Tools of the input organization.
       summary: List entries of an organization
       tags:
-        - extendedGA4GH
+      - extendedGA4GH
   /api/ga4gh/v2/extended/organizations:
     get:
       description: This endpoint returns list of all organizations.
@@ -2000,10 +2060,11 @@ paths:
           description: An array of organizations' names.
       summary: List all organizations
       tags:
-        - extendedGA4GH
+      - extendedGA4GH
   /api/ga4gh/v2/extended/tools/entry/_search:
     post:
-      description: This endpoint searches the index for all published tools and workflows. Used by utilities that expect to talk to an elastic search endpoint.
+      description: This endpoint searches the index for all published tools and workflows.
+        Used by utilities that expect to talk to an elastic search endpoint.
       operationId: toolsIndexSearch
       requestBody:
         content:
@@ -2019,7 +2080,7 @@ paths:
           description: An elastic search result.
       summary: Search the index of tools
       tags:
-        - extendedGA4GH
+      - extendedGA4GH
   /api/ga4gh/v2/extended/tools/index:
     post:
       description: This endpoint updates the index for all published tools and workflows.
@@ -2032,20 +2093,20 @@ paths:
                 type: integer
           description: An array of Tools of the input organization.
       security:
-        - bearer: []
+      - bearer: []
       summary: Update the index of tools
       tags:
-        - extendedGA4GH
+      - extendedGA4GH
   /api/ga4gh/v2/extended/tools/{organization}:
     get:
       description: This endpoint returns tools of an organization.
       operationId: toolsOrgGet
       parameters:
-        - in: path
-          name: organization
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: organization
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -2057,17 +2118,17 @@ paths:
           description: An array of Tools of the input organization.
       summary: List tools of an organization
       tags:
-        - extendedGA4GH
+      - extendedGA4GH
   /api/ga4gh/v2/extended/workflows/{organization}:
     get:
       description: This endpoint returns workflows of an organization.
       operationId: workflowsOrgGet
       parameters:
-        - in: path
-          name: organization
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: organization
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -2079,48 +2140,49 @@ paths:
           description: An array of Tools of the input organization.
       summary: List workflows of an organization
       tags:
-        - extendedGA4GH
+      - extendedGA4GH
   /api/ga4gh/v2/extended/{id}/versions/{version_id}/{type}/tests/{relative_path}:
     post:
-      description: Test JSON can be annotated with whether they ran correctly keyed by platform and associated with some metadata.
+      description: Test JSON can be annotated with whether they ran correctly keyed
+        by platform and associated with some metadata.
       operationId: verifyTestParameterFilePost
       parameters:
-        - in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: relative_path
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: platform
-          schema:
-            type: string
-        - in: query
-          name: platform_version
-          schema:
-            type: string
-        - in: query
-          name: verified
-          schema:
-            type: boolean
-        - in: query
-          name: metadata
-          schema:
-            type: string
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: relative_path
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: platform
+        schema:
+          type: string
+      - in: query
+        name: platform_version
+        schema:
+          type: string
+      - in: query
+        name: verified
+        schema:
+          type: boolean
+      - in: query
+        name: metadata
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -2141,19 +2203,20 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool test cannot be found to annotate.
       security:
-        - bearer: []
-      summary: Annotate test JSON with information on whether it ran successfully on particular platforms plus metadata
+      - bearer: []
+      summary: Annotate test JSON with information on whether it ran successfully
+        on particular platforms plus metadata
       tags:
-        - extendedGA4GH
+      - extendedGA4GH
   /auth/tokens/bitbucket.org:
     get:
       description: Add a new bitbucket.org token, used by quay.io redirect.
       operationId: addBitbucketToken
       parameters:
-        - in: query
-          name: code
-          schema:
-            type: string
+      - in: query
+        name: code
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2162,12 +2225,13 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /auth/tokens/github:
     post:
-      description: Allow satellizer to post a new GitHub token to dockstore, used by login, can create new users.
+      description: Allow satellizer to post a new GitHub token to dockstore, used
+        by login, can create new users.
       operationId: addToken
       requestBody:
         content:
@@ -2182,18 +2246,18 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /auth/tokens/github.com:
     get:
       description: Add a new github.com token, used by accounts page.
       operationId: addGithubToken
       parameters:
-        - in: query
-          name: code
-          schema:
-            type: string
+      - in: query
+        name: code
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2202,18 +2266,18 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /auth/tokens/gitlab.com:
     get:
       description: Add a new gitlab.com token.
       operationId: addGitlabToken
       parameters:
-        - in: query
-          name: code
-          schema:
-            type: string
+      - in: query
+        name: code
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2222,9 +2286,9 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /auth/tokens/google:
     post:
       description: Allow satellizer to post a new Google token to Dockstore.
@@ -2242,18 +2306,19 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /auth/tokens/orcid.org:
     post:
-      description: Using OAuth code from ORCID, request and store tokens from ORCID API
+      description: Using OAuth code from ORCID, request and store tokens from ORCID
+        API
       operationId: addOrcidToken
       parameters:
-        - in: query
-          name: code
-          schema:
-            type: string
+      - in: query
+        name: code
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2262,19 +2327,19 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Add a new orcid.org token
       tags:
-        - tokens
+      - tokens
   /auth/tokens/quay.io:
     get:
       description: Add a new quay IO token.
       operationId: addQuayToken
       parameters:
-        - in: query
-          name: access_token
-          schema:
-            type: string
+      - in: query
+        name: access_token
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2283,18 +2348,18 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /auth/tokens/zenodo.org:
     get:
       description: Add a new zenodo.org token, used by accounts page.
       operationId: addZenodoToken
       parameters:
-        - in: query
-          name: code
-          schema:
-            type: string
+      - in: query
+        name: code
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2303,39 +2368,39 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /auth/tokens/{tokenId}:
     delete:
       description: Delete a token.
       operationId: deleteToken
       parameters:
-        - in: path
-          name: tokenId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: tokenId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
     get:
       description: Get a specific token by id.
       operationId: listToken
       parameters:
-        - in: path
-          name: tokenId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: tokenId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -2344,9 +2409,9 @@ paths:
                 $ref: '#/components/schemas/Token'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - tokens
+      - tokens
   /containers/dockerRegistryList:
     get:
       description: Get the list of docker registries supported on Dockstore.
@@ -2361,32 +2426,32 @@ paths:
                 type: array
           description: default response
       tags:
-        - containers
+      - containers
   /containers/hostedEntry:
     post:
       description: Create a hosted tool.
       operationId: createHostedTool_1
       parameters:
-        - in: query
-          name: registry
-          schema:
-            type: string
-        - in: query
-          name: name
-          schema:
-            type: string
-        - in: query
-          name: descriptorType
-          schema:
-            type: string
-        - in: query
-          name: namespace
-          schema:
-            type: string
-        - in: query
-          name: entryName
-          schema:
-            type: string
+      - in: query
+        name: registry
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: descriptorType
+        schema:
+          type: string
+      - in: query
+        name: namespace
+        schema:
+          type: string
+      - in: query
+        name: entryName
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2395,24 +2460,24 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - hosted
+      - hosted
   /containers/hostedEntry/{entryId}:
     delete:
       description: Delete a revision of a hosted tool.
       operationId: deleteHostedToolVersion_1
       parameters:
-        - in: path
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: version
-          schema:
-            type: string
+      - in: path
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: version
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2421,19 +2486,19 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - hosted
+      - hosted
     patch:
       description: Non-idempotent operation for creating new revisions of hosted tools.
       operationId: editHostedTool
       parameters:
-        - in: path
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -2450,19 +2515,19 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - hosted
+      - hosted
   /containers/namespace/{namespace}/published:
     get:
       description: List all published tools belonging to the specified namespace.
       operationId: getPublishedContainersByNamespace
       parameters:
-        - in: path
-          name: namespace
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2473,21 +2538,21 @@ paths:
                 type: array
           description: default response
       tags:
-        - containers
+      - containers
   /containers/path/tool/{repository}:
     get:
       description: Get a tool by the specific tool path
       operationId: getContainerByToolPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: include
-          schema:
-            type: string
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: include
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2496,23 +2561,23 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/path/tool/{repository}/published:
     get:
       description: Get a published tool by the specific tool path.
       operationId: getPublishedContainerByToolPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: include
-          schema:
-            type: string
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: include
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2521,18 +2586,18 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       tags:
-        - containers
+      - containers
   /containers/path/{containerId}/tags:
     get:
       description: Get tags for a tool by id.
       operationId: getTagsByPath
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -2544,19 +2609,19 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containertags
+      - containertags
   /containers/path/{repository}:
     get:
       description: Get a list of tools by path.
       operationId: getContainerByPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2567,19 +2632,19 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/path/{repository}/published:
     get:
       description: Get a list of published tools by path.
       operationId: getPublishedContainerByPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2590,39 +2655,39 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/published:
     get:
       description: List all published tools.
       operationId: allPublishedContainers
       parameters:
-        - in: query
-          name: offset
-          schema:
-            type: string
-        - in: query
-          name: limit
-          schema:
-            default: 100
-            format: int32
-            type: integer
-        - in: query
-          name: filter
-          schema:
-            default: ""
-            type: string
-        - in: query
-          name: sortCol
-          schema:
-            default: stars
-            type: string
-        - in: query
-          name: sortOrder
-          schema:
-            default: desc
-            type: string
+      - in: query
+        name: offset
+        schema:
+          type: string
+      - in: query
+        name: limit
+        schema:
+          default: 100
+          format: int32
+          type: integer
+      - in: query
+        name: filter
+        schema:
+          default: ""
+          type: string
+      - in: query
+        name: sortCol
+        schema:
+          default: stars
+          type: string
+      - in: query
+        name: sortOrder
+        schema:
+          default: desc
+          type: string
       responses:
         default:
           content:
@@ -2633,7 +2698,7 @@ paths:
                 type: array
           description: default response
       tags:
-        - containers
+      - containers
   /containers/registerManual:
     post:
       description: Register a tool manually, along with tags.
@@ -2651,20 +2716,20 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/schema/{containerId}/published:
     get:
       description: Get a published tool's schema by ID.
       operationId: getPublishedContainerSchema
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -2675,17 +2740,17 @@ paths:
                 type: array
           description: default response
       tags:
-        - containers
+      - containers
   /containers/tags:
     get:
       description: List the tags for a tool.
       operationId: tags
       parameters:
-        - in: query
-          name: containerId
-          schema:
-            format: int64
-            type: integer
+      - in: query
+        name: containerId
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -2696,19 +2761,19 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{alias}/aliases:
     get:
       description: Retrieves a tool by alias.
       operationId: getToolByAlias
       parameters:
-        - in: path
-          name: alias
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: alias
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2717,43 +2782,43 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}:
     delete:
       description: Delete a tool.
       operationId: deleteContainer
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
     get:
       description: Retrieve a tool
       operationId: getContainer
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: include
-          schema:
-            type: string
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: include
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2762,19 +2827,19 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
     put:
       description: Update the tool with the given tool.
       operationId: updateContainer
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -2788,33 +2853,33 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/descriptor/{relative-path}:
     get:
       description: Get the corresponding descriptor file.
       operationId: secondaryDescriptorPath
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
-        - in: path
-          name: relative-path
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: language
-          schema:
-            type: string
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
+      - in: path
+        name: relative-path
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2823,24 +2888,24 @@ paths:
                 $ref: '#/components/schemas/SourceFile'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/dockerfile:
     get:
       description: Get the corresponding Dockerfile.
       operationId: dockerfile
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2849,24 +2914,24 @@ paths:
                 $ref: '#/components/schemas/SourceFile'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/labels:
     put:
       description: Update the labels linked to a tool.
       operationId: updateLabels
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: labels
-          schema:
-            type: string
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: labels
+        schema:
+          type: string
       requestBody:
         content:
           '*/*':
@@ -2880,28 +2945,28 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/primaryDescriptor:
     get:
       description: Get the primary descriptor file.
       operationId: primaryDescriptor
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
-        - in: query
-          name: language
-          schema:
-            type: string
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -2910,20 +2975,20 @@ paths:
                 $ref: '#/components/schemas/SourceFile'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/publish:
     post:
       description: Publish or unpublish a tool.
       operationId: publish
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -2937,20 +3002,20 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/refresh:
     get:
       description: Refresh one particular tool.
       operationId: refresh
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -2959,26 +3024,26 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/requestDOI/{tagId}:
     post:
       description: Request a DOI for this version of a tool.
       operationId: requestDOIForToolTag
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: tagId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: tagId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -2990,28 +3055,28 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containertags
+      - containertags
   /containers/{containerId}/secondaryDescriptors:
     get:
       description: Get a list of secondary descriptor files.
       operationId: secondaryDescriptors
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
-        - in: query
-          name: language
-          schema:
-            type: string
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -3022,20 +3087,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/star:
     put:
       description: Star a tool.
       operationId: starEntry
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -3047,20 +3112,20 @@ paths:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/starredUsers:
     get:
       description: Returns list of users who starred a tool.
       operationId: getStarredUsers
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -3072,18 +3137,18 @@ paths:
                 uniqueItems: true
           description: default response
       tags:
-        - containers
+      - containers
   /containers/{containerId}/tags:
     post:
       description: Add new tags linked to a tool.
       operationId: addTags
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -3102,19 +3167,19 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containertags
+      - containertags
     put:
       description: Update the tags linked to a tool.
       operationId: updateTags
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -3133,78 +3198,78 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containertags
+      - containertags
   /containers/{containerId}/tags/{tagId}:
     delete:
       description: Delete tag linked to a tool.
       operationId: deleteTags
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: tagId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: tagId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containertags
+      - containertags
   /containers/{containerId}/tags/{tagId}/sourcefiles:
     get:
       description: Retrieve sourcefiles for a container's version
       operationId: getTagsSourcefiles
       parameters:
-        - description: Container to retrieve the version from
-          in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Tag to retrieve the sourcefiles from
-          in: path
-          name: tagId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: List of file types to filter sourcefiles by
-          in: query
-          name: fileTypes
-          schema:
-            items:
-              enum:
-                - DOCKSTORE_CWL
-                - DOCKSTORE_WDL
-                - DOCKERFILE
-                - CWL_TEST_JSON
-                - WDL_TEST_JSON
-                - NEXTFLOW
-                - NEXTFLOW_CONFIG
-                - NEXTFLOW_TEST_PARAMS
-                - DOCKSTORE_YML
-                - DOCKSTORE_SERVICE_YML
-                - DOCKSTORE_SERVICE_TEST_JSON
-                - DOCKSTORE_SERVICE_OTHER
-                - DOCKSTORE_GXFORMAT2
-                - GXFORMAT2_TEST_FILE
-                - DOCKSTORE_SWL
-                - SWL_TEST_JSON
-              type: string
-            type: array
+      - description: Container to retrieve the version from
+        in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Tag to retrieve the sourcefiles from
+        in: path
+        name: tagId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: List of file types to filter sourcefiles by
+        in: query
+        name: fileTypes
+        schema:
+          items:
+            enum:
+            - DOCKSTORE_CWL
+            - DOCKSTORE_WDL
+            - DOCKERFILE
+            - CWL_TEST_JSON
+            - WDL_TEST_JSON
+            - NEXTFLOW
+            - NEXTFLOW_CONFIG
+            - NEXTFLOW_TEST_PARAMS
+            - DOCKSTORE_YML
+            - DOCKSTORE_SERVICE_YML
+            - DOCKSTORE_SERVICE_TEST_JSON
+            - DOCKSTORE_SERVICE_OTHER
+            - DOCKSTORE_GXFORMAT2
+            - GXFORMAT2_TEST_FILE
+            - DOCKSTORE_SWL
+            - SWL_TEST_JSON
+            type: string
+          type: array
       responses:
         default:
           content:
@@ -3216,34 +3281,34 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containertags
+      - containertags
   /containers/{containerId}/testParameterFiles:
     delete:
       description: Delete test parameter files to a tag.
       operationId: deleteTestParameterFiles
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: testParameterPaths
-          schema:
-            items:
-              type: string
-            type: array
-        - in: query
-          name: tagName
-          schema:
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: testParameterPaths
+        schema:
+          items:
             type: string
-        - in: query
-          name: descriptorType
-          schema:
-            type: string
+          type: array
+      - in: query
+        name: tagName
+        schema:
+          type: string
+      - in: query
+        name: descriptorType
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -3255,27 +3320,27 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
     get:
       description: Get the corresponding test parameter files.
       operationId: getTestParameterFiles
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
-        - in: query
-          name: descriptorType
-          schema:
-            type: string
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
+      - in: query
+        name: descriptorType
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -3286,33 +3351,33 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
     put:
       description: Add test parameter files to a tag.
       operationId: addTestParameterFiles
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: testParameterPaths
-          schema:
-            items:
-              type: string
-            type: array
-        - in: query
-          name: tagName
-          schema:
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: testParameterPaths
+        schema:
+          items:
             type: string
-        - in: query
-          name: descriptorType
-          schema:
-            type: string
+          type: array
+      - in: query
+        name: tagName
+        schema:
+          type: string
+      - in: query
+        name: descriptorType
+        schema:
+          type: string
       requestBody:
         content:
           '*/*':
@@ -3329,40 +3394,40 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/unstar:
     delete:
       description: Unstar a tool.
       operationId: unstarEntry
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/updateTagPaths:
     put:
       description: Change the tool paths.
       operationId: updateTagContainerPath
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -3376,20 +3441,20 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{containerId}/users:
     get:
       description: Get users of a tool.
       operationId: getUsers
       parameters:
-        - in: path
-          name: containerId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -3400,20 +3465,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{toolId}/defaultVersion:
     put:
       description: Update the default version of the given tool.
       operationId: updateDefaultVersion
       parameters:
-        - in: path
-          name: toolId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: toolId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -3427,35 +3492,35 @@ paths:
                 $ref: '#/components/schemas/Tool'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /containers/{toolId}/zip/{tagId}:
     get:
       description: Download a ZIP file of a tool and all associated files.
       operationId: getToolZip
       parameters:
-        - in: path
-          name: toolId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: tagId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: toolId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: tagId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/zip: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - containers
+      - containers
   /curation/notifications:
     get:
       description: Return all active notifications
@@ -3470,7 +3535,7 @@ paths:
                 type: array
           description: default response
       tags:
-        - curation
+      - curation
     post:
       description: Create a notification
       operationId: createNotification
@@ -3487,39 +3552,39 @@ paths:
                 $ref: '#/components/schemas/Notification'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - curation
+      - curation
   /curation/notifications/{id}:
     delete:
       description: Delete a notification
       operationId: deleteNotification
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: id
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - curation
+      - curation
     get:
       description: Return the notification with given id
       operationId: getNotification
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: id
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -3528,17 +3593,17 @@ paths:
                 $ref: '#/components/schemas/Notification'
           description: default response
       tags:
-        - curation
+      - curation
     put:
       description: Update a notification
       operationId: updateNotification
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: id
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -3552,24 +3617,24 @@ paths:
                 $ref: '#/components/schemas/Notification'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - curation
+      - curation
   /entries/{id}/aliases:
     post:
       description: Add aliases linked to a entry in Dockstore.
       operationId: addAliases_2
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: aliases
-          schema:
-            type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: aliases
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -3578,20 +3643,21 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - entries
+      - entries
   /entries/{id}/collections:
     get:
-      description: Get the collections and organizations that contain the published entry
+      description: Get the collections and organizations that contain the published
+        entry
       operationId: entryCollections
       parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: id
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -3602,19 +3668,19 @@ paths:
                 type: array
           description: default response
       tags:
-        - entries
+      - entries
   /entries/{id}/topic:
     post:
       description: Create a discourse topic for an entry.
       operationId: setDiscourseTopic
       parameters:
-        - description: The id of the entry to add a topic to.
-          in: path
-          name: id
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: The id of the entry to add a topic to.
+        in: path
+        name: id
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -3623,36 +3689,36 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - entries
+      - entries
   /events:
     get:
       description: Optional authentication.
       operationId: getEvents
       parameters:
-        - in: query
-          name: event_search_type
-          schema:
-            enum:
-              - STARRED_ENTRIES
-              - STARRED_ORGANIZATION
-              - ALL_STARRED
-            type: string
-        - in: query
-          name: limit
-          schema:
-            default: 10
-            format: int32
-            maximum: 100
-            minimum: 1
-            type: integer
-        - in: query
-          name: offset
-          schema:
-            default: 0
-            format: int32
-            type: integer
+      - in: query
+        name: event_search_type
+        schema:
+          enum:
+          - STARRED_ENTRIES
+          - STARRED_ORGANIZATION
+          - ALL_STARRED
+          type: string
+      - in: query
+        name: limit
+        schema:
+          default: 10
+          format: int32
+          maximum: 100
+          minimum: 1
+          type: integer
+      - in: query
+        name: offset
+        schema:
+          default: 0
+          format: int32
+          type: integer
       responses:
         default:
           content:
@@ -3663,10 +3729,10 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Get events based on filters.
       tags:
-        - events
+      - events
   /ga4gh/trs/v2/toolClasses:
     get:
       description: 'This endpoint returns all tool-classes available. '
@@ -3686,81 +3752,88 @@ paths:
                 type: array
           description: A list of potential tool classes.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: List all tool types
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools:
     get:
-      description: 'This endpoint returns all tools available or a filtered subset using metadata query parameters. '
+      description: 'This endpoint returns all tools available or a filtered subset
+        using metadata query parameters. '
       operationId: toolsGet
       parameters:
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: query
-          name: id
-          schema:
-            type: string
-        - description: Support for this parameter is optional for tool registries that support aliases. If provided will only return entries with the given alias.
-          in: query
-          name: alias
-          schema:
-            type: string
-        - description: Filter tools by the name of the subclass (#/definitions/ToolClass)
-          in: query
-          name: toolClass
-          schema:
-            type: string
-        - description: Filter tools by the name of the descriptor type (#/definitions/DescriptorType)
-          in: query
-          name: descriptorType
-          schema:
-            type: string
-        - description: The image registry that contains the image.
-          in: query
-          name: registry
-          schema:
-            type: string
-        - description: The organization in the registry that published the image.
-          in: query
-          name: organization
-          schema:
-            type: string
-        - description: The name of the image.
-          in: query
-          name: name
-          schema:
-            type: string
-        - description: The name of the tool.
-          in: query
-          name: toolname
-          schema:
-            type: string
-        - description: The description of the tool.
-          in: query
-          name: description
-          schema:
-            type: string
-        - description: The author of the tool (TODO a thought occurs, are we assuming that the author of the CWL and the image are the same?).
-          in: query
-          name: author
-          schema:
-            type: string
-        - description: Return only checker workflows.
-          in: query
-          name: checker
-          schema:
-            type: boolean
-        - description: Start index of paging. Pagination results can be based on numbers or other values chosen by the registry implementor (for example, SHA values). If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.
-          in: query
-          name: offset
-          schema:
-            type: string
-        - description: Amount of records to return in a given page.
-          in: query
-          name: limit
-          schema:
-            format: int32
-            type: integer
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: query
+        name: id
+        schema:
+          type: string
+      - description: Support for this parameter is optional for tool registries that
+          support aliases. If provided will only return entries with the given alias.
+        in: query
+        name: alias
+        schema:
+          type: string
+      - description: Filter tools by the name of the subclass (#/definitions/ToolClass)
+        in: query
+        name: toolClass
+        schema:
+          type: string
+      - description: Filter tools by the name of the descriptor type (#/definitions/DescriptorType)
+        in: query
+        name: descriptorType
+        schema:
+          type: string
+      - description: The image registry that contains the image.
+        in: query
+        name: registry
+        schema:
+          type: string
+      - description: The organization in the registry that published the image.
+        in: query
+        name: organization
+        schema:
+          type: string
+      - description: The name of the image.
+        in: query
+        name: name
+        schema:
+          type: string
+      - description: The name of the tool.
+        in: query
+        name: toolname
+        schema:
+          type: string
+      - description: The description of the tool.
+        in: query
+        name: description
+        schema:
+          type: string
+      - description: The author of the tool (TODO a thought occurs, are we assuming
+          that the author of the CWL and the image are the same?).
+        in: query
+        name: author
+        schema:
+          type: string
+      - description: Return only checker workflows.
+        in: query
+        name: checker
+        schema:
+          type: boolean
+      - description: Start index of paging. Pagination results can be based on numbers
+          or other values chosen by the registry implementor (for example, SHA values).
+          If this exceeds the current result set return an empty set.  If not specified
+          in the request, this will start at the beginning of the results.
+        in: query
+        name: offset
+        schema:
+          type: string
+      - description: Amount of records to return in a given page.
+        in: query
+        name: limit
+        schema:
+          format: int32
+          type: integer
       responses:
         "200":
           content:
@@ -3776,21 +3849,23 @@ paths:
                 type: array
           description: An array of Tools that match the filter.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: List all tools
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}:
     get:
-      description: This endpoint returns one specific tool (which has ToolVersions nested inside it).
+      description: This endpoint returns one specific tool (which has ToolVersions
+        nested inside it).
       operationId: toolsIdGet
       parameters:
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -3811,21 +3886,22 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool can not be found.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: List one specific tool, acts as an anchor for self references
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions:
     get:
       description: Returns all versions of the specified tool.
       operationId: toolsIdVersionsGet
       parameters:
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -3841,27 +3917,30 @@ paths:
                 type: array
           description: An array of tool versions.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: List versions of a tool
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}:
     get:
       description: This endpoint returns one specific tool version.
       operationId: toolsIdVersionsVersionIdGet
       parameters:
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - description: An identifier of the tool version, scoped to this registry, for example `v1`. We recommend that versions use semantic versioning https://semver.org/spec/v2.0.0.html  (For example, `1.0.0` instead of `develop`)
-          in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: An identifier of the tool version, scoped to this registry, for
+          example `v1`. We recommend that versions use semantic versioning https://semver.org/spec/v2.0.0.html  (For
+          example, `1.0.0` instead of `develop`)
+        in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -3882,27 +3961,32 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool can not be found.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: List one specific tool version, acts as an anchor for self references
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}/containerfile:
     get:
-      description: Returns the container specifications(s) for the specified image. For example, a CWL CommandlineTool can be associated with one specification for a container, a CWL Workflow can be associated with multiple specifications for containers.
+      description: Returns the container specifications(s) for the specified image.
+        For example, a CWL CommandlineTool can be associated with one specification
+        for a container, a CWL Workflow can be associated with multiple specifications
+        for containers.
       operationId: toolsIdVersionsVersionIdContainerfileGet
       parameters:
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - description: An identifier of the tool version for this particular tool registry, for example `v1`.
-          in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: An identifier of the tool version for this particular tool registry,
+          for example `v1`.
+        in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -3927,33 +4011,39 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: There are no container specifications for this tool.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: Get the container specification(s) for the specified image.
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}/{type}/descriptor:
     get:
-      description: Returns the descriptor for the specified tool (examples include CWL, WDL, or Nextflow documents).
+      description: Returns the descriptor for the specified tool (examples include
+        CWL, WDL, or Nextflow documents).
       operationId: toolsIdVersionsVersionIdTypeDescriptorGet
       parameters:
-        - description: The output type of the descriptor. Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped with metadata. Allowable values include "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL".
-          in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - description: An identifier of the tool version, scoped to this registry, for example `v1`.
-          in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - description: The output type of the descriptor. Plain types return the bare
+          descriptor while the "non-plain" types return a descriptor wrapped with
+          metadata. Allowable values include "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL",
+          "PLAIN_NFL".
+        in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: An identifier of the tool version, scoped to this registry, for
+          example `v1`.
+        in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -3974,39 +4064,55 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool descriptor can not be found.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: Get the tool descriptor for the specified tool
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}:
     get:
-      description: Descriptors can often include imports that refer to additional descriptors. This returns additional descriptors for the specified tool in the same or other directories that can be reached as a relative path. This endpoint can be useful for workflow engine implementations like cwltool to programmatically download all the descriptors for a tool and run it. This can optionally include other files described with FileWrappers such as test parameters and containerfiles.
+      description: Descriptors can often include imports that refer to additional
+        descriptors. This returns additional descriptors for the specified tool in
+        the same or other directories that can be reached as a relative path. This
+        endpoint can be useful for workflow engine implementations like cwltool to
+        programmatically download all the descriptors for a tool and run it. This
+        can optionally include other files described with FileWrappers such as test
+        parameters and containerfiles.
       operationId: toolsIdVersionsVersionIdTypeDescriptorRelativePathGet
       parameters:
-        - description: The output type of the descriptor. If not specified, it is up to the underlying implementation to determine which output type to return. Plain types return the bare descriptor while the "non-plain" types return a descriptor wrapped with metadata. Allowable values are "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL".
-          in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - description: An identifier of the tool version for this particular tool registry, for example `v1`.
-          in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
-        - description: A relative path to the additional file (same directory or subdirectories), for example 'foo.cwl' would return a 'foo.cwl' from the same directory as the main descriptor. 'nestedDirectory/foo.cwl' would return the file  from a nested subdirectory.  Unencoded paths such 'sampleDirectory/foo.cwl' should also be allowed.
-          in: path
-          name: relative_path
-          required: true
-          schema:
-            type: string
+      - description: The output type of the descriptor. If not specified, it is up
+          to the underlying implementation to determine which output type to return.
+          Plain types return the bare descriptor while the "non-plain" types return
+          a descriptor wrapped with metadata. Allowable values are "CWL", "WDL", "NFL",
+          "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL".
+        in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: An identifier of the tool version for this particular tool registry,
+          for example `v1`.
+        in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
+      - description: A relative path to the additional file (same directory or subdirectories),
+          for example 'foo.cwl' would return a 'foo.cwl' from the same directory as
+          the main descriptor. 'nestedDirectory/foo.cwl' would return the file  from
+          a nested subdirectory.  Unencoded paths such 'sampleDirectory/foo.cwl' should
+          also be allowed.
+        in: path
+        name: relative_path
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -4027,33 +4133,38 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool can not be output in the specified type.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: Get additional tool descriptor files relative to the main file
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}/{type}/files:
     get:
-      description: 'Get a list of objects that contain the relative path and file type. The descriptors are intended for use with the /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path : .+} endpoint.'
+      description: 'Get a list of objects that contain the relative path and file
+        type. The descriptors are intended for use with the /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path
+        : .+} endpoint.'
       operationId: toolsIdVersionsVersionIdTypeFilesGet
       parameters:
-        - description: The output type of the descriptor. Examples of allowable values are "CWL", "WDL", and "NFL".
-          in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - description: An identifier of the tool version for this particular tool registry, for example `v1`.
-          in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - description: The output type of the descriptor. Examples of allowable values
+          are "CWL", "WDL", and "NFL".
+        in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: An identifier of the tool version for this particular tool registry,
+          for example `v1`.
+        in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -4078,33 +4189,39 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool can not be output in the specified type.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: Get a list of objects that contain the relative path and file type
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /ga4gh/trs/v2/tools/{id}/versions/{version_id}/{type}/tests:
     get:
-      description: Get a list of test JSONs (these allow you to execute the tool successfully) suitable for use with this descriptor type.
+      description: Get a list of test JSONs (these allow you to execute the tool successfully)
+        suitable for use with this descriptor type.
       operationId: toolsIdVersionsVersionIdTypeTestsGet
       parameters:
-        - description: The type of the underlying descriptor. Allowable values include "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL". For example, "CWL" would return an list of ToolTests objects while "PLAIN_CWL" would return a bare JSON list with the content of the tests.
-          in: path
-          name: type
-          required: true
-          schema:
-            type: string
-        - description: A unique identifier of the tool, scoped to this registry, for example `123456`.
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - description: An identifier of the tool version for this particular tool registry, for example `v1`.
-          in: path
-          name: version_id
-          required: true
-          schema:
-            type: string
+      - description: The type of the underlying descriptor. Allowable values include
+          "CWL", "WDL", "NFL", "PLAIN_CWL", "PLAIN_WDL", "PLAIN_NFL". For example,
+          "CWL" would return an list of ToolTests objects while "PLAIN_CWL" would
+          return a bare JSON list with the content of the tests.
+        in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - description: A unique identifier of the tool, scoped to this registry, for
+          example `123456`.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: An identifier of the tool version for this particular tool registry,
+          for example `v1`.
+        in: path
+        name: version_id
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -4129,31 +4246,31 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The tool can not be output in the specified type.
       security:
-        - BEARER: []
+      - BEARER: []
       summary: Get a list of test JSONs
       tags:
-        - GA4GHV20
+      - GA4GHV20
   /lambdaEvents/{organization}:
     get:
       description: Get all of the Lambda Events for the given GitHub organization.
       operationId: getLambdaEventsByOrganization
       parameters:
-        - in: path
-          name: organization
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: offset
-          schema:
-            default: "0"
-            type: string
-        - in: query
-          name: limit
-          schema:
-            default: 100
-            format: int32
-            type: integer
+      - in: path
+        name: organization
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: offset
+        schema:
+          default: "0"
+          type: string
+      - in: query
+        name: limit
+        schema:
+          default: 100
+          format: int32
+          type: integer
       responses:
         default:
           content:
@@ -4164,9 +4281,9 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - lambdaEvents
+      - lambdaEvents
   /metadata/config.json:
     get:
       description: Configuration, NO authentication
@@ -4180,10 +4297,11 @@ paths:
           description: default response
       summary: Configuration for UI clients of the API
       tags:
-        - metadata
+      - metadata
   /metadata/descriptorLanguageList:
     get:
-      description: Get the list of descriptor languages supported on Dockstore, NO authentication
+      description: Get the list of descriptor languages supported on Dockstore, NO
+        authentication
       operationId: getDescriptorLanguages
       responses:
         default:
@@ -4196,7 +4314,7 @@ paths:
           description: List of descriptor languages
       summary: Get the list of descriptor languages supported on Dockstore
       tags:
-        - metadata
+      - metadata
   /metadata/dockerRegistryList:
     get:
       description: Get the list of docker registries supported on Dockstore, NO authentication
@@ -4212,7 +4330,7 @@ paths:
           description: List of Docker registries
       summary: Get the list of docker registries supported on Dockstore
       tags:
-        - metadata
+      - metadata
   /metadata/elasticSearch:
     get:
       description: Successful response if elastic search is up and running, NO authentication
@@ -4225,7 +4343,7 @@ paths:
           description: default response
       summary: Successful response if elastic search is up and running
       tags:
-        - metadata
+      - metadata
   /metadata/okHttpCachePerformance:
     get:
       description: Get measures of cache performance, NO authentication
@@ -4241,7 +4359,7 @@ paths:
           description: Cache performance information
       summary: Get measures of cache performance
       tags:
-        - metadata
+      - metadata
   /metadata/rss:
     get:
       description: List all published tools and workflows in creation order, NO authentication
@@ -4255,40 +4373,40 @@ paths:
           description: default response
       summary: List all published tools and workflows in creation order
       tags:
-        - metadata
+      - metadata
   /metadata/runner_dependencies:
     get:
       description: Returns the file containing runner dependencies, NO authentication
       operationId: getRunnerDependencies
       parameters:
-        - description: The Dockstore client version
-          in: query
-          name: client_version
-          schema:
-            type: string
-        - description: Python version, only relevant for the cwltool runner
-          in: query
-          name: python_version
-          schema:
-            default: "3"
-            type: string
-        - description: The tool runner
-          in: query
-          name: runner
-          schema:
-            default: cwltool
-            enum:
-              - cwltool
-            type: string
-        - description: Response type
-          in: query
-          name: output
-          schema:
-            default: text
-            enum:
-              - json
-              - text
-            type: string
+      - description: The Dockstore client version
+        in: query
+        name: client_version
+        schema:
+          type: string
+      - description: Python version, only relevant for the cwltool runner
+        in: query
+        name: python_version
+        schema:
+          default: "3"
+          type: string
+      - description: The tool runner
+        in: query
+        name: runner
+        schema:
+          default: cwltool
+          enum:
+          - cwltool
+          type: string
+      - description: Response type
+        in: query
+        name: output
+        schema:
+          default: text
+          enum:
+          - json
+          - text
+          type: string
       responses:
         default:
           content:
@@ -4298,10 +4416,12 @@ paths:
           description: The requirements.txt file
       summary: Returns the file containing runner dependencies
       tags:
-        - metadata
+      - metadata
   /metadata/sitemap:
     get:
-      description: List all available workflow, tool, organization, and collection paths. Available means published for tools/workflows, and approved for organizations and their respective collections. NO authentication
+      description: List all available workflow, tool, organization, and collection
+        paths. Available means published for tools/workflows, and approved for organizations
+        and their respective collections. NO authentication
       operationId: sitemap
       responses:
         default:
@@ -4315,7 +4435,7 @@ paths:
           description: default response
       summary: List all available workflow, tool, organization, and collection paths.
       tags:
-        - metadata
+      - metadata
   /metadata/sourceControlList:
     get:
       description: Get the list of source controls supported on Dockstore, NO authentication
@@ -4331,10 +4451,11 @@ paths:
           description: List of source control repositories
       summary: Get the list of source controls supported on Dockstore
       tags:
-        - metadata
+      - metadata
   /organizations:
     get:
-      description: List all organizations that have been approved by a curator or admin, sorted by number of stars.
+      description: List all organizations that have been approved by a curator or
+        admin, sorted by number of stars.
       operationId: getApprovedOrganizations
       responses:
         default:
@@ -4347,9 +4468,10 @@ paths:
           description: default response
       summary: List all available organizations.
       tags:
-        - organizations
+      - organizations
     post:
-      description: Create an organization. Organization requires approval by an admin before being made public.
+      description: Create an organization. Organization requires approval by an admin
+        before being made public.
       operationId: createOrganization
       requestBody:
         content:
@@ -4366,26 +4488,27 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Create an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/all:
     get:
-      description: List all organizations, regardless of organization status. Admin/curator only.
+      description: List all organizations, regardless of organization status. Admin/curator
+        only.
       operationId: getAllOrganizations
       parameters:
-        - description: Filter to apply to organizations.
-          in: query
-          name: type
-          required: true
-          schema:
-            enum:
-              - all
-              - pending
-              - rejected
-              - approved
-            type: string
+      - description: Filter to apply to organizations.
+        in: query
+        name: type
+        required: true
+        schema:
+          enum:
+          - all
+          - pending
+          - rejected
+          - approved
+          type: string
       responses:
         default:
           content:
@@ -4396,21 +4519,21 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: List all organizations.
       tags:
-        - organizations
+      - organizations
   /organizations/collections/{alias}/aliases:
     get:
       description: Retrieve a collection by alias.
       operationId: getCollectionByAlias
       parameters:
-        - description: Alias of the collection.
-          in: path
-          name: alias
-          required: true
-          schema:
-            type: string
+      - description: Alias of the collection.
+        in: path
+        name: alias
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -4420,25 +4543,26 @@ paths:
           description: default response
       summary: Retrieve a collection by alias.
       tags:
-        - organizations
+      - organizations
   /organizations/collections/{collectionId}/aliases:
     post:
-      description: Aliases are alphanumerical (case-insensitive and may contain internal hyphens), given in a comma-delimited list.
+      description: Aliases are alphanumerical (case-insensitive and may contain internal
+        hyphens), given in a comma-delimited list.
       operationId: addCollectionAliases_1
       parameters:
-        - description: Collection to modify.
-          in: path
-          name: collectionId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Comma-delimited list of aliases.
-          in: query
-          name: aliases
-          required: true
-          schema:
-            type: string
+      - description: Collection to modify.
+        in: path
+        name: collectionId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Comma-delimited list of aliases.
+        in: query
+        name: aliases
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -4447,21 +4571,21 @@ paths:
                 $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Add aliases linked to a collection in Dockstore.
       tags:
-        - organizations
+      - organizations
   /organizations/name/{name}:
     get:
       description: Retrieve an organization by name. Supports optional authentication.
       operationId: getOrganizationByName
       parameters:
-        - description: Organization name.
-          in: path
-          name: name
-          required: true
-          schema:
-            type: string
+      - description: Organization name.
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -4470,21 +4594,21 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve an organization by name.
       tags:
-        - organizations
+      - organizations
   /organizations/{alias}/aliases:
     get:
       description: Retrieve an organization by alias.
       operationId: getOrganizationByAlias
       parameters:
-        - description: Alias.
-          in: path
-          name: alias
-          required: true
-          schema:
-            type: string
+      - description: Alias.
+        in: path
+        name: alias
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -4494,19 +4618,19 @@ paths:
           description: default response
       summary: Retrieve an organization by alias.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}:
     get:
       description: Retrieve an organization by ID. Supports optional authentication.
       operationId: getOrganizationById
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -4515,21 +4639,22 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve an organization by ID.
       tags:
-        - organizations
+      - organizations
     put:
-      description: Update an organization. Currently only name, display name, description, topic, email, link, avatarUrl, and location can be updated.
+      description: Update an organization. Currently only name, display name, description,
+        topic, email, link, avatarUrl, and location can be updated.
       operationId: updateOrganization
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -4545,28 +4670,30 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Update an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/aliases:
     post:
-      description: Add aliases linked to a listing in Dockstore. Aliases are alphanumerical (case-insensitive and may contain internal hyphens), given in a comma-delimited list.
+      description: Add aliases linked to a listing in Dockstore. Aliases are alphanumerical
+        (case-insensitive and may contain internal hyphens), given in a comma-delimited
+        list.
       operationId: addOrganizationAliases_1
       parameters:
-        - description: Organization to modify.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Comma-delimited list of aliases.
-          in: query
-          name: aliases
-          required: true
-          schema:
-            type: string
+      - description: Organization to modify.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Comma-delimited list of aliases.
+        in: query
+        name: aliases
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -4575,22 +4702,22 @@ paths:
                 $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Add aliases linked to a listing in Dockstore.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/approve:
     post:
       description: Approve the organization with the given id. Admin/curator only.
       operationId: approveOrganization
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -4599,28 +4726,29 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Approve an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/collections:
     get:
-      description: Retrieve all collections for an organization. Supports optional authentication.
+      description: Retrieve all collections for an organization. Supports optional
+        authentication.
       operationId: getCollectionsFromOrganization
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Included fields.
-          in: query
-          name: include
-          required: true
-          schema:
-            type: string
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Included fields.
+        in: query
+        name: include
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -4631,21 +4759,21 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve all collections for an organization.
       tags:
-        - organizations
+      - organizations
     post:
       description: Create a collection in the given organization.
       operationId: createCollection
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -4661,29 +4789,29 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Create a collection in the given organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/collections/{collectionId}:
     get:
       description: Retrieve a collection by ID. Supports optional authentication.
       operationId: getCollectionById
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Collection ID.
-          in: path
-          name: collectionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Collection ID.
+        in: path
+        name: collectionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -4692,28 +4820,29 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve a collection by ID.
       tags:
-        - organizations
+      - organizations
     put:
-      description: Update a collection. Currently only name, display name, description, and topic can be updated.
+      description: Update a collection. Currently only name, display name, description,
+        and topic can be updated.
       operationId: updateCollection
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Collection ID.
-          in: path
-          name: collectionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Collection ID.
+        in: path
+        name: collectionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -4729,29 +4858,30 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Update a collection.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/collections/{collectionId}/description:
     get:
-      description: Retrieve a collection description by organization ID and collection ID. Supports optional authentication.
+      description: Retrieve a collection description by organization ID and collection
+        ID. Supports optional authentication.
       operationId: getCollectionDescription
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Collection ID.
-          in: path
-          name: collectionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Collection ID.
+        in: path
+        name: collectionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -4760,28 +4890,29 @@ paths:
                 type: string
           description: default response
       security:
-        - bearer: []
-      summary: Retrieve a collection description by organization ID and collection ID.
+      - bearer: []
+      summary: Retrieve a collection description by organization ID and collection
+        ID.
       tags:
-        - organizations
+      - organizations
     put:
       description: Update a collection's description. Description in markdown.
       operationId: updateCollectionDescription
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Collection ID.
-          in: path
-          name: collectionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Collection ID.
+        in: path
+        name: collectionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -4797,36 +4928,36 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Update a collection's description.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/collections/{collectionId}/entry:
     delete:
       description: Delete an entry to a collection.
       operationId: deleteEntryFromCollection
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Collection ID.
-          in: path
-          name: collectionId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Entry ID.
-          in: query
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Collection ID.
+        in: path
+        name: collectionId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Entry ID.
+        in: query
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -4835,35 +4966,35 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Delete an entry to a collection.
       tags:
-        - organizations
+      - organizations
     post:
       description: Add an entry to a collection.
       operationId: addEntryToCollection
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Collection ID.
-          in: path
-          name: collectionId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Entry ID.
-          in: query
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Collection ID.
+        in: path
+        name: collectionId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Entry ID.
+        in: query
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -4872,22 +5003,23 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Add an entry to a collection.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/description:
     get:
-      description: Retrieve an organization description by organization ID. Supports optional authentication.
+      description: Retrieve an organization description by organization ID. Supports
+        optional authentication.
       operationId: getOrganizationDescription
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -4896,21 +5028,22 @@ paths:
                 type: string
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve an organization description by organization ID.
       tags:
-        - organizations
+      - organizations
     put:
-      description: Update an organization's description. Expects description in markdown format.
+      description: Update an organization's description. Expects description in markdown
+        format.
       operationId: updateOrganizationDescription
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -4926,40 +5059,42 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Update an organization's description.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/events:
     get:
       description: Retrieve all events for an organization. Supports optional authentication.
       operationId: getOrganizationEvents
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Start index of paging.  If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.
-          in: query
-          name: offset
-          required: true
-          schema:
-            default: 0
-            format: int32
-            type: integer
-        - description: Amount of records to return in a given page, limited to 100
-          in: query
-          name: limit
-          required: true
-          schema:
-            default: 100
-            format: int32
-            maximum: 100
-            minimum: 1
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Start index of paging.  If this exceeds the current result set
+          return an empty set.  If not specified in the request, this will start at
+          the beginning of the results.
+        in: query
+        name: offset
+        required: true
+        schema:
+          default: 0
+          format: int32
+          type: integer
+      - description: Amount of records to return in a given page, limited to 100
+        in: query
+        name: limit
+        required: true
+        schema:
+          default: 100
+          format: int32
+          maximum: 100
+          minimum: 1
+          type: integer
       responses:
         default:
           content:
@@ -4970,50 +5105,51 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve all events for an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/invitation:
     post:
-      description: Accept or reject an organization invitation. True accepts the invitation, false rejects the invitation.
+      description: Accept or reject an organization invitation. True accepts the invitation,
+        false rejects the invitation.
       operationId: acceptOrRejectInvitation
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Accept or reject.
-          in: query
-          name: accept
-          required: true
-          schema:
-            type: boolean
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Accept or reject.
+        in: query
+        name: accept
+        required: true
+        schema:
+          type: boolean
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Accept or reject an organization invitation.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/members:
     get:
       description: Retrieve all members for an organization. Supports optional authentication.
       operationId: getOrganizationMembers
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5025,22 +5161,22 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve all members for an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/reject:
     post:
       description: Reject the organization with the given id. Admin/curator only.
       operationId: rejectOrganization
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5049,22 +5185,23 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Reject an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/request:
     post:
-      description: Re-request a review of the given organization. Requires the organization to be rejected.
+      description: Re-request a review of the given organization. Requires the organization
+        to be rejected.
       operationId: requestOrganizationReview
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5073,22 +5210,22 @@ paths:
                 $ref: '#/components/schemas/Organization'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Re-request an organization review.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/star:
     put:
       description: Star an organization.
       operationId: starOrganization
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -5102,22 +5239,22 @@ paths:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Star an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/starredUsers:
     get:
       description: Return list of users who starred the given approved organization.
       operationId: getStarredUsersForApprovedOrganization
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5130,85 +5267,85 @@ paths:
           description: default response
       summary: Return list of users who starred the given approved organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/unstar:
     delete:
       description: Unstar an organization.
       operationId: unstarOrganization
       parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Unstar an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/user:
     delete:
       description: Remove a user from an organization.
       operationId: deleteUserRole
       parameters:
-        - description: User ID of user to add to organization.
-          in: query
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: User ID of user to add to organization.
+        in: query
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Remove a user from an organization.
       tags:
-        - organizations
+      - organizations
     post:
       description: Update a user role in an organization.
       operationId: updateUserRole
       parameters:
-        - description: Role of user.
-          in: query
-          name: role
-          required: true
-          schema:
-            enum:
-              - MAINTAINER
-              - MEMBER
-            type: string
-        - description: User ID of user to add to organization.
-          in: query
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Role of user.
+        in: query
+        name: role
+        required: true
+        schema:
+          enum:
+          - MAINTAINER
+          - MEMBER
+          type: string
+      - description: User ID of user to add to organization.
+        in: query
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5217,43 +5354,44 @@ paths:
                 $ref: '#/components/schemas/OrganizationUser'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Update a user role in an organization.
       tags:
-        - organizations
+      - organizations
     put:
       description: Add a user role to an organization.
       operationId: addUserToOrg
       parameters:
-        - description: Role of user.
-          in: query
-          name: role
-          required: true
-          schema:
-            enum:
-              - MAINTAINER
-              - MEMBER
-            type: string
-        - description: User ID of user to add to organization.
-          in: query
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: Role of user.
+        in: query
+        name: role
+        required: true
+        schema:
+          enum:
+          - MAINTAINER
+          - MEMBER
+          type: string
+      - description: User ID of user to add to organization.
+        in: query
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
             schema:
               type: string
-        description: This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.
+        description: This is here to appease Swagger. It requires PUT methods to have
+          a body, even if it is empty. Please leave it empty.
       responses:
         default:
           content:
@@ -5262,35 +5400,35 @@ paths:
                 $ref: '#/components/schemas/OrganizationUser'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Add a user role to an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationId}/users/{username}:
     put:
       description: Add a user role to an organization.
       operationId: addUserToOrgByUsername
       parameters:
-        - description: User to add to org.
-          in: path
-          name: username
-          required: true
-          schema:
-            type: string
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: User to add to org.
+        in: path
+        name: username
+        required: true
+        schema:
+          type: string
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
             schema:
               enum:
-                - MAINTAINER
-                - MEMBER
+              - MAINTAINER
+              - MEMBER
               type: string
         description: Role of user.
         required: true
@@ -5302,27 +5440,27 @@ paths:
                 $ref: '#/components/schemas/OrganizationUser'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Add a user role to an organization.
       tags:
-        - organizations
+      - organizations
   /organizations/{organizationName}/collections/{collectionName}/name:
     get:
       description: Retrieve a collection by name. Supports optional authentication.
       operationId: getCollectionById_1
       parameters:
-        - description: Organization name.
-          in: path
-          name: organizationName
-          required: true
-          schema:
-            type: string
-        - description: Collection name.
-          in: path
-          name: collectionName
-          required: true
-          schema:
-            type: string
+      - description: Organization name.
+        in: path
+        name: organizationName
+        required: true
+        schema:
+          type: string
+      - description: Collection name.
+        in: path
+        name: collectionName
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5331,53 +5469,53 @@ paths:
                 $ref: '#/components/schemas/Collection'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Retrieve a collection by name.
       tags:
-        - organizations
+      - organizations
   /toolTester/logs:
     get:
       operationId: getToolTesterLog
       parameters:
-        - description: TRS Tool Id
-          example: '#workflow/github.com/dockstore/hello_world'
-          in: query
-          name: tool_id
-          required: true
-          schema:
-            type: string
-        - example: v1.0.0
-          in: query
-          name: tool_version_name
-          required: true
-          schema:
-            type: string
-        - example: hello_world.cwl.json
-          in: query
-          name: test_filename
-          required: true
-          schema:
-            type: string
-        - example: cwltool
-          in: query
-          name: runner
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: log_type
-          required: true
-          schema:
-            enum:
-              - FULL
-              - SUMMARY
-            type: string
-        - example: 1554477737092.log
-          in: query
-          name: filename
-          required: true
-          schema:
-            type: string
+      - description: TRS Tool Id
+        example: '#workflow/github.com/dockstore/hello_world'
+        in: query
+        name: tool_id
+        required: true
+        schema:
+          type: string
+      - example: v1.0.0
+        in: query
+        name: tool_version_name
+        required: true
+        schema:
+          type: string
+      - example: hello_world.cwl.json
+        in: query
+        name: test_filename
+        required: true
+        schema:
+          type: string
+      - example: cwltool
+        in: query
+        name: runner
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: log_type
+        required: true
+        schema:
+          enum:
+          - FULL
+          - SUMMARY
+          type: string
+      - example: 1554477737092.log
+        in: query
+        name: filename
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5387,24 +5525,24 @@ paths:
           description: default response
       summary: Get ToolTester log file
       tags:
-        - toolTester
+      - toolTester
   /toolTester/logs/search:
     get:
       operationId: search
       parameters:
-        - description: TRS Tool Id
-          example: '#workflow/github.com/dockstore/hello_world'
-          in: query
-          name: tool_id
-          required: true
-          schema:
-            type: string
-        - example: v1.0.0
-          in: query
-          name: tool_version_name
-          required: true
-          schema:
-            type: string
+      - description: TRS Tool Id
+        example: '#workflow/github.com/dockstore/hello_world'
+        in: query
+        name: tool_id
+        required: true
+        schema:
+          type: string
+      - example: v1.0.0
+        in: query
+        name: tool_version_name
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5416,17 +5554,17 @@ paths:
           description: default response
       summary: Search for ToolTester log files
       tags:
-        - toolTester
+      - toolTester
   /users/checkUser/{username}:
     get:
       description: Check if user with some username exists.
       operationId: checkUserExists
       parameters:
-        - in: path
-          name: username
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: username
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5435,9 +5573,9 @@ paths:
                 type: boolean
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/dockerRegistries:
     get:
       description: Get all of the Docker registries accessible to the logged-in user.
@@ -5452,20 +5590,21 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/dockerRegistries/{dockerRegistry}/organizations:
     get:
-      description: Get all of the organizations/namespaces of the Docker registry accessible to the logged-in user.
+      description: Get all of the organizations/namespaces of the Docker registry
+        accessible to the logged-in user.
       operationId: getDockerRegistriesOrganization
       parameters:
-        - description: Name of Docker registry
-          in: path
-          name: dockerRegistry
-          required: true
-          schema:
-            type: string
+      - description: Name of Docker registry
+        in: path
+        name: dockerRegistry
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5476,26 +5615,27 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/dockerRegistries/{dockerRegistry}/organizations/{organization}/repositories:
     get:
-      description: Get names of repositories associated with a specific namespace and Docker registry of the logged-in user.
+      description: Get names of repositories associated with a specific namespace
+        and Docker registry of the logged-in user.
       operationId: getDockerRegistryOrganizationRepositories
       parameters:
-        - description: Name of Docker registry
-          in: path
-          name: dockerRegistry
-          required: true
-          schema:
-            type: string
-        - description: Name of organization or namespace
-          in: path
-          name: organization
-          required: true
-          schema:
-            type: string
+      - description: Name of Docker registry
+        in: path
+        name: dockerRegistry
+        required: true
+        schema:
+          type: string
+      - description: Name of organization or namespace
+        in: path
+        name: organization
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5506,24 +5646,24 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/github/events:
     get:
       description: Get all of the GitHub Events for the logged in user.
       operationId: getUserGitHubEvents
       parameters:
-        - in: query
-          name: offset
-          schema:
-            type: string
-        - in: query
-          name: limit
-          schema:
-            default: 100
-            format: int32
-            type: integer
+      - in: query
+        name: offset
+        schema:
+          type: string
+      - in: query
+        name: limit
+        schema:
+          default: 100
+          format: int32
+          type: integer
       responses:
         default:
           content:
@@ -5534,9 +5674,9 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/github/sync:
     post:
       description: Syncs Dockstore account with GitHub App Installations.
@@ -5551,9 +5691,9 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/registries:
     get:
       description: Get all of the git registries accessible to the logged in user.
@@ -5565,33 +5705,34 @@ paths:
               schema:
                 items:
                   enum:
-                    - dockstore.org
-                    - github.com
-                    - bitbucket.org
-                    - gitlab.com
+                  - dockstore.org
+                  - github.com
+                  - bitbucket.org
+                  - gitlab.com
                   type: string
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/registries/{gitRegistry}/organizations:
     get:
-      description: Get all of the organizations for a given git registry accessible to the logged in user.
+      description: Get all of the organizations for a given git registry accessible
+        to the logged in user.
       operationId: getUserOrganizations
       parameters:
-        - description: Git registry
-          in: path
-          name: gitRegistry
-          required: true
-          schema:
-            enum:
-              - dockstore.org
-              - github.com
-              - bitbucket.org
-              - gitlab.com
-            type: string
+      - description: Git registry
+        in: path
+        name: gitRegistry
+        required: true
+        schema:
+          enum:
+          - dockstore.org
+          - github.com
+          - bitbucket.org
+          - gitlab.com
+          type: string
       responses:
         default:
           content:
@@ -5603,31 +5744,32 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/registries/{gitRegistry}/organizations/{organization}:
     get:
-      description: Get all of the repositories for an organization for a given git registry accessible to the logged in user.
+      description: Get all of the repositories for an organization for a given git
+        registry accessible to the logged in user.
       operationId: getUserOrganizationRepositories
       parameters:
-        - description: Git registry
-          in: path
-          name: gitRegistry
-          required: true
-          schema:
-            enum:
-              - dockstore.org
-              - github.com
-              - bitbucket.org
-              - gitlab.com
-            type: string
-        - description: Git organization
-          in: path
-          name: organization
-          required: true
-          schema:
-            type: string
+      - description: Git registry
+        in: path
+        name: gitRegistry
+        required: true
+        schema:
+          enum:
+          - dockstore.org
+          - github.com
+          - bitbucket.org
+          - gitlab.com
+          type: string
+      - description: Git organization
+        in: path
+        name: organization
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5638,9 +5780,9 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/starredOrganizations:
     get:
       description: Get the authenticated user's starred organizations.
@@ -5656,9 +5798,9 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/starredTools:
     get:
       description: Get the authenticated user's starred tools.
@@ -5674,9 +5816,9 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/starredWorkflows:
     get:
       description: Get the authenticated user's starred workflows.
@@ -5692,9 +5834,9 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/updateUserMetadata:
     get:
       description: Update metadata of all users.
@@ -5709,9 +5851,9 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/user:
     delete:
       description: Delete user if possible.
@@ -5724,9 +5866,9 @@ paths:
                 type: boolean
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
     get:
       description: Get the logged-in user.
       operationId: getUser
@@ -5738,18 +5880,18 @@ paths:
                 $ref: '#/components/schemas/User'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/user/changeUsername:
     post:
       description: Change username if possible.
       operationId: changeUsername
       parameters:
-        - in: query
-          name: username
-          schema:
-            type: string
+      - in: query
+        name: username
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5758,9 +5900,9 @@ paths:
                 $ref: '#/components/schemas/User'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/user/extended:
     get:
       description: Get additional information about the authenticated user.
@@ -5773,9 +5915,9 @@ paths:
                 $ref: '#/components/schemas/ExtendedUserData'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/user/memberships:
     get:
       description: Get the logged-in user's memberships.
@@ -5791,27 +5933,27 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/user/updateUserMetadata:
     get:
       description: Update metadata for logged in user.
       operationId: updateLoggedInUserMetadata
       parameters:
-        - in: query
-          name: source
-          schema:
-            enum:
-              - quay.io
-              - github.com
-              - dockstore
-              - bitbucket.org
-              - gitlab.com
-              - zenodo.org
-              - google.com
-              - orcid.org
-            type: string
+      - in: query
+        name: source
+        schema:
+          enum:
+          - quay.io
+          - github.com
+          - dockstore
+          - bitbucket.org
+          - gitlab.com
+          - zenodo.org
+          - google.com
+          - orcid.org
+          type: string
       responses:
         default:
           content:
@@ -5820,20 +5962,20 @@ paths:
                 $ref: '#/components/schemas/User'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/user/{userId}:
     delete:
       description: Terminate user if possible.
       operationId: terminateUsers
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5842,20 +5984,20 @@ paths:
                 type: boolean
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/user/{userId}/limits:
     get:
       description: Returns the specified user's limits. ADMIN or CURATOR only
       operationId: getUserLimits
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5864,19 +6006,19 @@ paths:
                 $ref: '#/components/schemas/Limits'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
     put:
       description: Update the specified user's limits. ADMIN or CURATOR only
       operationId: setUserLimits
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -5890,19 +6032,19 @@ paths:
                 $ref: '#/components/schemas/Limits'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/username/{username}:
     get:
       description: Get a user by username.
       operationId: listUser
       parameters:
-        - in: path
-          name: username
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: username
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5911,25 +6053,25 @@ paths:
                 $ref: '#/components/schemas/User'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/users/entries:
     get:
       description: Get all of the entries for a user, sorted by most recently updated.
       operationId: getUserEntries
       parameters:
-        - description: Maximum number of entries to return
-          in: query
-          name: count
-          schema:
-            format: int32
-            type: integer
-        - description: Filter paths with matching text
-          in: query
-          name: filter
-          schema:
-            type: string
+      - description: Maximum number of entries to return
+        in: query
+        name: count
+        schema:
+          format: int32
+          type: integer
+      - description: Filter paths with matching text
+        in: query
+        name: filter
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5940,25 +6082,26 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/users/organizations:
     get:
-      description: Get all of the Dockstore organizations for a user, sorted by most recently updated.
+      description: Get all of the Dockstore organizations for a user, sorted by most
+        recently updated.
       operationId: getUserDockstoreOrganizations
       parameters:
-        - description: Maximum number of organizations to return
-          in: query
-          name: count
-          schema:
-            format: int32
-            type: integer
-        - description: Filter paths with matching text
-          in: query
-          name: filter
-          schema:
-            type: string
+      - description: Maximum number of organizations to return
+        in: query
+        name: count
+        schema:
+          format: int32
+          type: integer
+      - description: Filter paths with matching text
+        in: query
+        name: filter
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -5969,20 +6112,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}:
     get:
       description: Get user by id.
       operationId: getSpecificUser
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -5991,20 +6134,20 @@ paths:
                 $ref: '#/components/schemas/User'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/containers:
     get:
       description: List all tools owned by the authenticated user.
       operationId: userContainers
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6015,20 +6158,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/containers/published:
     get:
       description: List all published tools from a user.
       operationId: userPublishedContainers
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6039,29 +6182,30 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/containers/{organization}/refresh:
     get:
-      description: Refresh all tools owned by the authenticated user with specified organization.
+      description: Refresh all tools owned by the authenticated user with specified
+        organization.
       operationId: refreshToolsByOrganization
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: organization
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: dockerRegistry
-          schema:
-            type: string
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: organization
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: dockerRegistry
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6072,20 +6216,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/services:
     get:
       description: List all services owned by the authenticated user.
       operationId: userServices
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6096,20 +6240,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/tokens:
     get:
       description: Get tokens with user id.
       operationId: getUserTokens
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6120,20 +6264,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/tokens/dockstore:
     get:
       description: Get Dockstore tokens with user id.
       operationId: getDockstoreUserTokens
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6144,20 +6288,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/tokens/github.com:
     get:
       description: Get Github tokens with user id.
       operationId: getGithubUserTokens
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6168,20 +6312,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/tokens/gitlab.com:
     get:
       description: Get Gitlab tokens with user id.
       operationId: getGitlabUserTokens
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6192,20 +6336,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/tokens/quay.io:
     get:
       description: Get Quay tokens with user id.
       operationId: getQuayUserTokens
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6216,21 +6360,21 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/workflows:
     get:
       description: List all workflows owned by the authenticated user.
       operationId: userWorkflows
       parameters:
-        - description: User ID
-          in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: User ID
+        in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6241,26 +6385,28 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
     patch:
-      description: Adds the logged-in user to any Dockstore workflows that they should have access to.
+      description: Adds the logged-in user to any Dockstore workflows that they should
+        have access to.
       operationId: addUserToDockstoreWorkflows
       parameters:
-        - description: User to update
-          in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: User to update
+        in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
             schema:
               type: string
-        description: This is here to appease Swagger. It requires PATCH methods to have a body, even if it is empty. Please leave it empty.
+        description: This is here to appease Swagger. It requires PATCH methods to
+          have a body, even if it is empty. Please leave it empty.
       responses:
         default:
           content:
@@ -6271,20 +6417,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /users/{userId}/workflows/published:
     get:
       description: List all published workflows from a user.
       operationId: userPublishedWorkflows
       parameters:
-        - in: path
-          name: userId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: userId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -6295,48 +6441,51 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - users
+      - users
   /workflows/github:
     delete:
-      description: Handles the deletion of a branch on GitHub. Will delete all workflow versions that match in all workflows that share the same repository.
+      description: Handles the deletion of a branch on GitHub. Will delete all workflow
+        versions that match in all workflows that share the same repository.
       operationId: handleGitHubBranchDeletion
       parameters:
-        - description: Repository path (ex. dockstore/dockstore-ui2)
-          in: query
-          name: repository
-          required: true
-          schema:
-            type: string
-        - description: Username of user on GitHub who triggered action
-          in: query
-          name: username
-          required: true
-          schema:
-            type: string
-        - description: Full git reference for a GitHub branch/tag. Ex. refs/heads/master or refs/tags/v1.0
-          in: query
-          name: gitReference
-          required: true
-          schema:
-            type: string
-        - description: GitHub installation ID
-          in: query
-          name: installationId
-          required: true
-          schema:
-            type: string
+      - description: Repository path (ex. dockstore/dockstore-ui2)
+        in: query
+        name: repository
+        required: true
+        schema:
+          type: string
+      - description: Username of user on GitHub who triggered action
+        in: query
+        name: username
+        required: true
+        schema:
+          type: string
+      - description: Full git reference for a GitHub branch/tag. Ex. refs/heads/master
+          or refs/tags/v1.0
+        in: query
+        name: gitReference
+        required: true
+        schema:
+          type: string
+      - description: GitHub installation ID
+        in: query
+        name: installationId
+        required: true
+        schema:
+          type: string
       responses:
         "418":
           description: This code tells AWS Lambda not to retry.
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/github/install:
     post:
-      description: Handle the installation of our GitHub app onto a repository or organization.
+      description: Handle the installation of our GitHub app onto a repository or
+        organization.
       operationId: handleGitHubInstallation
       requestBody:
         content:
@@ -6350,20 +6499,21 @@ paths:
                 username:
                   type: string
               required:
-                - installationId
-                - repositories
-                - username
+              - installationId
+              - repositories
+              - username
               type: object
       responses:
         "418":
           description: This code tells AWS Lambda not to retry.
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/github/release:
     post:
-      description: Handle a release of a repository on GitHub. Will create a workflow/service and version when necessary.
+      description: Handle a release of a repository on GitHub. Will create a workflow/service
+        and version when necessary.
       operationId: handleGitHubRelease
       requestBody:
         content:
@@ -6379,10 +6529,10 @@ paths:
                 username:
                   type: string
               required:
-                - gitReference
-                - installationId
-                - repository
-                - username
+              - gitReference
+              - installationId
+              - repository
+              - username
               type: object
       responses:
         default:
@@ -6394,60 +6544,34 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/hostedEntry:
     post:
       description: Create a hosted workflow.
       operationId: createHostedWorkflow_1
       parameters:
-        - in: query
-          name: registry
-          schema:
-            type: string
-        - in: query
-          name: name
-          schema:
-            type: string
-        - in: query
-          name: descriptorType
-          schema:
-            type: string
-        - in: query
-          name: namespace
-          schema:
-            type: string
-        - in: query
-          name: entryName
-          schema:
-            type: string
-      responses:
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Workflow'
-          description: default response
-      security:
-        - bearer: []
-      tags:
-        - hosted
-  /workflows/hostedEntry/{entryId}:
-    delete:
-      description: Delete a revision of a hosted workflow.
-      operationId: deleteHostedWorkflowVersion_1
-      parameters:
-        - in: path
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: version
-          schema:
-            type: string
+      - in: query
+        name: registry
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: descriptorType
+        schema:
+          type: string
+      - in: query
+        name: namespace
+        schema:
+          type: string
+      - in: query
+        name: entryName
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6456,19 +6580,45 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - hosted
+      - hosted
+  /workflows/hostedEntry/{entryId}:
+    delete:
+      description: Delete a revision of a hosted workflow.
+      operationId: deleteHostedWorkflowVersion_1
+      parameters:
+      - in: path
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: version
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entry'
+          description: default response
+      security:
+      - bearer: []
+      tags:
+      - hosted
     patch:
       description: Non-idempotent operation for creating new revisions of hosted workflows
       operationId: editHostedWorkflow
       parameters:
-        - in: path
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -6485,20 +6635,20 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - hosted
+      - hosted
     post:
       deprecated: true
       operationId: addZip
       parameters:
-        - description: hosted entry ID
-          in: path
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - description: hosted entry ID
+        in: path
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           multipart/form-data:
@@ -6516,39 +6666,39 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: successful operation
       security:
-        - bearer: []
+      - bearer: []
       summary: Creates a new revision of a hosted workflow from a zip
       tags:
-        - hosted
+      - hosted
   /workflows/manualRegister:
     post:
       description: Manually register a workflow.
       operationId: manualRegister
       parameters:
-        - in: query
-          name: workflowRegistry
-          schema:
-            type: string
-        - in: query
-          name: workflowPath
-          schema:
-            type: string
-        - in: query
-          name: defaultWorkflowPath
-          schema:
-            type: string
-        - in: query
-          name: workflowName
-          schema:
-            type: string
-        - in: query
-          name: descriptorType
-          schema:
-            type: string
-        - in: query
-          name: defaultTestParameterFilePath
-          schema:
-            type: string
+      - in: query
+        name: workflowRegistry
+        schema:
+          type: string
+      - in: query
+        name: workflowPath
+        schema:
+          type: string
+      - in: query
+        name: defaultWorkflowPath
+        schema:
+          type: string
+      - in: query
+        name: workflowName
+        schema:
+          type: string
+      - in: query
+        name: descriptorType
+        schema:
+          type: string
+      - in: query
+        name: defaultTestParameterFilePath
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6557,19 +6707,19 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/organization/{organization}/published:
     get:
       description: List all published workflows of an organization.
       operationId: getPublishedWorkflowsByOrganization
       parameters:
-        - in: path
-          name: organization
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: organization
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6580,17 +6730,17 @@ paths:
                 type: array
           description: default response
       tags:
-        - workflows
+      - workflows
   /workflows/path/entry/{repository}:
     get:
       description: Get an entry by path.
       operationId: getEntryByPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6599,19 +6749,19 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/path/entry/{repository}/published:
     get:
       description: Get a published entry by path.
       operationId: getPublishedEntryByPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6620,29 +6770,29 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       tags:
-        - workflows
+      - workflows
   /workflows/path/workflow/{repository}:
     get:
       description: Requires full path (including workflow name if applicable).
       operationId: getWorkflowByPath
       parameters:
-        - description: Repository path
-          in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - description: 'Comma-delimited list of fields to include: validations, aliases'
-          in: query
-          name: include
-          schema:
-            type: string
-        - description: Whether to get a service or workflow
-          in: query
-          name: services
-          schema:
-            default: false
-            type: boolean
+      - description: Repository path
+        in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - description: 'Comma-delimited list of fields to include: validations, aliases'
+        in: query
+        name: include
+        schema:
+          type: string
+      - description: Whether to get a service or workflow
+        in: query
+        name: services
+        schema:
+          default: false
+          type: boolean
       responses:
         default:
           content:
@@ -6651,25 +6801,25 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Get a workflow by path.
       tags:
-        - workflows
+      - workflows
   /workflows/path/workflow/{repository}/actions:
     get:
       description: Gets all actions a user can perform on a workflow.
       operationId: getWorkflowActions
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: services
-          schema:
-            default: false
-            type: boolean
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: services
+        schema:
+          default: false
+          type: boolean
       responses:
         default:
           content:
@@ -6677,44 +6827,44 @@ paths:
               schema:
                 items:
                   enum:
-                    - write
-                    - read
-                    - delete
-                    - share
+                  - write
+                  - read
+                  - delete
+                  - share
                   type: string
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/path/workflow/{repository}/permissions:
     delete:
       description: Remove the specified user role for a workflow.
       operationId: removeWorkflowRole
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: email
-          schema:
-            type: string
-        - in: query
-          name: role
-          schema:
-            enum:
-              - OWNER
-              - WRITER
-              - READER
-            type: string
-        - in: query
-          name: services
-          schema:
-            default: false
-            type: boolean
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: email
+        schema:
+          type: string
+      - in: query
+        name: role
+        schema:
+          enum:
+          - OWNER
+          - WRITER
+          - READER
+          type: string
+      - in: query
+        name: services
+        schema:
+          default: false
+          type: boolean
       responses:
         default:
           content:
@@ -6725,23 +6875,23 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
     get:
       description: Get all permissions for a workflow.
       operationId: getWorkflowPermissions
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: services
-          schema:
-            default: false
-            type: boolean
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: services
+        schema:
+          default: false
+          type: boolean
       responses:
         default:
           content:
@@ -6752,23 +6902,23 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
     patch:
       description: Set the specified permission for a user on a workflow.
       operationId: addWorkflowPermission
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: services
-          schema:
-            default: false
-            type: boolean
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: services
+        schema:
+          default: false
+          type: boolean
       requestBody:
         content:
           '*/*':
@@ -6784,28 +6934,28 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/path/workflow/{repository}/published:
     get:
       description: Get a published workflow by path
       operationId: getPublishedWorkflowByPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: include
-          schema:
-            type: string
-        - in: query
-          name: services
-          schema:
-            default: false
-            type: boolean
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: include
+        schema:
+          type: string
+      - in: query
+        name: services
+        schema:
+          default: false
+          type: boolean
       responses:
         default:
           content:
@@ -6814,17 +6964,17 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       tags:
-        - workflows
+      - workflows
   /workflows/path/{repository}:
     get:
       description: Get a list of workflows by path.
       operationId: getAllWorkflowByPath
       parameters:
-        - in: path
-          name: repository
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6835,44 +6985,44 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/published:
     get:
       description: List all published workflows.
       operationId: allPublishedWorkflows
       parameters:
-        - in: query
-          name: offset
-          schema:
-            type: string
-        - in: query
-          name: limit
-          schema:
-            default: 100
-            format: int32
-            type: integer
-        - in: query
-          name: filter
-          schema:
-            default: ""
-            type: string
-        - in: query
-          name: sortCol
-          schema:
-            default: stars
-            type: string
-        - in: query
-          name: sortOrder
-          schema:
-            default: desc
-            type: string
-        - in: query
-          name: services
-          schema:
-            default: false
-            type: boolean
+      - in: query
+        name: offset
+        schema:
+          type: string
+      - in: query
+        name: limit
+        schema:
+          default: 100
+          format: int32
+          type: integer
+      - in: query
+        name: filter
+        schema:
+          default: ""
+          type: string
+      - in: query
+        name: sortCol
+        schema:
+          default: stars
+          type: string
+      - in: query
+        name: sortOrder
+        schema:
+          default: desc
+          type: string
+      - in: query
+        name: services
+        schema:
+          default: false
+          type: boolean
       responses:
         default:
           content:
@@ -6883,22 +7033,22 @@ paths:
                 type: array
           description: default response
       tags:
-        - workflows
+      - workflows
   /workflows/published/{workflowId}:
     get:
       description: Get a published workflow.
       operationId: getPublishedWorkflow
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: include
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: include
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6907,71 +7057,72 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       tags:
-        - workflows
+      - workflows
   /workflows/registries/{gitRegistry}/organizations/{organization}/repositories/{repositoryName}:
     delete:
       description: Delete a stubbed workflow for a registry and repository path.
       operationId: deleteWorkflow
       parameters:
-        - description: Git registry
-          in: path
-          name: gitRegistry
-          required: true
-          schema:
-            enum:
-              - dockstore.org
-              - github.com
-              - bitbucket.org
-              - gitlab.com
-            type: string
-        - description: Git repository organization
-          in: path
-          name: organization
-          required: true
-          schema:
-            type: string
-        - description: Git repository name
-          in: path
-          name: repositoryName
-          required: true
-          schema:
-            type: string
+      - description: Git registry
+        in: path
+        name: gitRegistry
+        required: true
+        schema:
+          enum:
+          - dockstore.org
+          - github.com
+          - bitbucket.org
+          - gitlab.com
+          type: string
+      - description: Git repository organization
+        in: path
+        name: organization
+        required: true
+        schema:
+          type: string
+      - description: Git repository name
+        in: path
+        name: repositoryName
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
     post:
-      description: Adds a workflow for a registry and repository path with defaults set.
+      description: Adds a workflow for a registry and repository path with defaults
+        set.
       operationId: addWorkflow
       parameters:
-        - description: Git registry
-          in: path
-          name: gitRegistry
-          required: true
-          schema:
-            enum:
-              - dockstore.org
-              - github.com
-              - bitbucket.org
-              - gitlab.com
-            type: string
-        - description: Git repository organization
-          in: path
-          name: organization
-          required: true
-          schema:
-            type: string
-        - description: Git repository name
-          in: path
-          name: repositoryName
-          required: true
-          schema:
-            type: string
+      - description: Git registry
+        in: path
+        name: gitRegistry
+        required: true
+        schema:
+          enum:
+          - dockstore.org
+          - github.com
+          - bitbucket.org
+          - gitlab.com
+          type: string
+      - description: Git repository organization
+        in: path
+        name: organization
+        required: true
+        schema:
+          type: string
+      - description: Git repository name
+        in: path
+        name: repositoryName
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -6980,9 +7131,9 @@ paths:
                 $ref: '#/components/schemas/BioWorkflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/shared:
     get:
       description: Retrieve all workflows shared with user.
@@ -6997,19 +7148,19 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/versions:
     get:
       description: List the versions for a published workflow.
       operationId: tags_1
       parameters:
-        - in: query
-          name: workflowId
-          schema:
-            format: int64
-            type: integer
+      - in: query
+        name: workflowId
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -7020,19 +7171,19 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{alias}/aliases:
     get:
       description: Retrieves a workflow by alias.
       operationId: getWorkflowByAlias
       parameters:
-        - in: path
-          name: alias
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: alias
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7041,33 +7192,33 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{entryId}/registerCheckerWorkflow/{descriptorType}:
     post:
       description: Register a checker workflow and associates it with the given tool/workflow.
       operationId: registerCheckerWorkflow
       parameters:
-        - in: query
-          name: checkerWorkflowPath
-          schema:
-            type: string
-        - in: query
-          name: testParameterPath
-          schema:
-            type: string
-        - in: path
-          name: entryId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: descriptorType
-          required: true
-          schema:
-            type: string
+      - in: query
+        name: checkerWorkflowPath
+        schema:
+          type: string
+      - in: query
+        name: testParameterPath
+        schema:
+          type: string
+      - in: path
+        name: entryId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: descriptorType
+        required: true
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7076,24 +7227,24 @@ paths:
                 $ref: '#/components/schemas/Entry'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}:
     get:
       description: Retrieve a workflow
       operationId: getWorkflow
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: include
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: include
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7102,19 +7253,19 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
     put:
       description: Update the workflow with the given workflow.
       operationId: updateWorkflow
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -7128,26 +7279,26 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/dag/{workflowVersionId}:
     get:
       description: Get the DAG for a given workflow version.
       operationId: getWorkflowDag
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: workflowVersionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: workflowVersionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -7156,20 +7307,20 @@ paths:
                 type: string
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/defaultVersion:
     put:
       description: Update the default version of a workflow.
       operationId: updateDefaultVersion_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -7183,33 +7334,33 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/descriptor/{relative-path}:
     get:
       description: Get the corresponding descriptor file from source control.
       operationId: secondaryDescriptorPath_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
-        - in: path
-          name: relative-path
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: language
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
+      - in: path
+        name: relative-path
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7218,24 +7369,24 @@ paths:
                 $ref: '#/components/schemas/SourceFile'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/labels:
     put:
       description: Update the labels linked to a workflow.
       operationId: updateLabels_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: labels
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: labels
+        schema:
+          type: string
       requestBody:
         content:
           '*/*':
@@ -7249,28 +7400,28 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/primaryDescriptor:
     get:
       description: Get the primary descriptor file.
       operationId: primaryDescriptor_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
-        - in: query
-          name: language
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7279,20 +7430,20 @@ paths:
                 $ref: '#/components/schemas/SourceFile'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/publish:
     post:
       description: Publish or unpublish a workflow.
       operationId: publish_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -7306,20 +7457,25 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/refresh:
     get:
       description: Refresh one particular workflow.
       operationId: refresh_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: hardRefresh
+        schema:
+          default: true
+          type: boolean
       responses:
         default:
           content:
@@ -7328,25 +7484,30 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/refresh/{version}:
     get:
       description: Refresh one particular workflow version.
       operationId: refreshVersion
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: version
-          required: true
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: version
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: hardRefresh
+        schema:
+          default: true
+          type: boolean
       responses:
         default:
           content:
@@ -7355,26 +7516,26 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/requestDOI/{workflowVersionId}:
     put:
       description: Request a DOI for this version of a workflow.
       operationId: requestDOIForWorkflowVersion
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: workflowVersionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: workflowVersionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -7391,20 +7552,20 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/resetVersionPaths:
     put:
       description: Reset the workflow paths.
       operationId: updateWorkflowPath
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -7418,20 +7579,20 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/restub:
     get:
       description: Restub a workflow
       operationId: restub
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -7440,29 +7601,29 @@ paths:
                 $ref: '#/components/schemas/Workflow'
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       summary: Restub a workflow
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/secondaryDescriptors:
     get:
       description: Get the corresponding descriptor documents from source control.
       operationId: secondaryDescriptors_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: tag
-          schema:
-            type: string
-        - in: query
-          name: language
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: tag
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7473,20 +7634,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/star:
     put:
       description: Star a workflow.
       operationId: starEntry_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -7498,20 +7659,20 @@ paths:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/starredUsers:
     get:
       description: Returns list of users who starred the given workflow.
       operationId: getStarredUsers_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -7523,28 +7684,28 @@ paths:
                 uniqueItems: true
           description: default response
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/testParameterFiles:
     delete:
       description: Delete test parameter files for a given version.
       operationId: deleteTestParameterFiles_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: testParameterPaths
-          schema:
-            items:
-              type: string
-            type: array
-        - in: query
-          name: version
-          schema:
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: testParameterPaths
+        schema:
+          items:
             type: string
+          type: array
+      - in: query
+        name: version
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7556,23 +7717,23 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
     get:
       description: Get the corresponding test parameter files.
       operationId: getTestParameterFiles_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: version
-          schema:
-            type: string
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: version
+        schema:
+          type: string
       responses:
         default:
           content:
@@ -7583,29 +7744,29 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
     put:
       description: Add test parameter files for a given version.
       operationId: addTestParameterFiles_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: query
-          name: testParameterPaths
-          schema:
-            items:
-              type: string
-            type: array
-        - in: query
-          name: version
-          schema:
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: query
+        name: testParameterPaths
+        schema:
+          items:
             type: string
+          type: array
+      - in: query
+        name: version
+        schema:
+          type: string
       requestBody:
         content:
           '*/*':
@@ -7622,26 +7783,26 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/tools/{workflowVersionId}:
     get:
       description: Get the Tools for a given workflow version.
       operationId: getTableToolContent
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: workflowVersionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: workflowVersionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -7650,40 +7811,40 @@ paths:
                 type: string
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/unstar:
     delete:
       description: Unstar a workflow.
       operationId: unstarEntry_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/json: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/users:
     get:
       description: Get users of a workflow.
       operationId: getUsers_1
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
@@ -7694,20 +7855,20 @@ paths:
                 type: array
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/workflowVersions:
     put:
       description: Update the workflow versions linked to a workflow.
       operationId: updateWorkflowVersion
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
       requestBody:
         content:
           '*/*':
@@ -7726,52 +7887,52 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/workflowVersions/{workflowVersionId}/sourcefiles:
     get:
       description: Retrieve sourcefiles for an entry's version
       operationId: getWorkflowVersionsSourcefiles
       parameters:
-        - description: Workflow to retrieve the version from.
-          in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: Workflow version to retrieve the version from.
-          in: path
-          name: workflowVersionId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - description: List of file types to filter sourcefiles by
-          in: query
-          name: fileTypes
-          schema:
-            items:
-              enum:
-                - DOCKSTORE_CWL
-                - DOCKSTORE_WDL
-                - DOCKERFILE
-                - CWL_TEST_JSON
-                - WDL_TEST_JSON
-                - NEXTFLOW
-                - NEXTFLOW_CONFIG
-                - NEXTFLOW_TEST_PARAMS
-                - DOCKSTORE_YML
-                - DOCKSTORE_SERVICE_YML
-                - DOCKSTORE_SERVICE_TEST_JSON
-                - DOCKSTORE_SERVICE_OTHER
-                - DOCKSTORE_GXFORMAT2
-                - GXFORMAT2_TEST_FILE
-                - DOCKSTORE_SWL
-                - SWL_TEST_JSON
-              type: string
-            type: array
+      - description: Workflow to retrieve the version from.
+        in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: Workflow version to retrieve the version from.
+        in: path
+        name: workflowVersionId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - description: List of file types to filter sourcefiles by
+        in: query
+        name: fileTypes
+        schema:
+          items:
+            enum:
+            - DOCKSTORE_CWL
+            - DOCKSTORE_WDL
+            - DOCKERFILE
+            - CWL_TEST_JSON
+            - WDL_TEST_JSON
+            - NEXTFLOW
+            - NEXTFLOW_CONFIG
+            - NEXTFLOW_TEST_PARAMS
+            - DOCKSTORE_YML
+            - DOCKSTORE_SERVICE_YML
+            - DOCKSTORE_SERVICE_TEST_JSON
+            - DOCKSTORE_SERVICE_OTHER
+            - DOCKSTORE_GXFORMAT2
+            - GXFORMAT2_TEST_FILE
+            - DOCKSTORE_SWL
+            - SWL_TEST_JSON
+            type: string
+          type: array
       responses:
         default:
           content:
@@ -7783,85 +7944,94 @@ paths:
                 uniqueItems: true
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
   /workflows/{workflowId}/zip/{workflowVersionId}:
     get:
       description: Download a ZIP file of a workflow and all associated files.
       operationId: getWorkflowZip
       parameters:
-        - in: path
-          name: workflowId
-          required: true
-          schema:
-            format: int64
-            type: integer
-        - in: path
-          name: workflowVersionId
-          required: true
-          schema:
-            format: int64
-            type: integer
+      - in: path
+        name: workflowId
+        required: true
+        schema:
+          format: int64
+          type: integer
+      - in: path
+        name: workflowVersionId
+        required: true
+        schema:
+          format: int64
+          type: integer
       responses:
         default:
           content:
             application/zip: {}
           description: default response
       security:
-        - bearer: []
+      - bearer: []
       tags:
-        - workflows
+      - workflows
 servers:
-  - description: Current server when hosted on AWS
-    url: /api
-    variables: {}
-  - description: When working locally
-    url: /
-    variables: {}
-  - description: Production server
-    url: https://dockstore.org/api
-    variables: {}
-  - description: Staging server
-    url: https://staging.dockstore.org/api
-    variables: {}
-  - description: Nightly build server
-    url: https://dev.dockstore.net/api
-    variables: {}
+- description: Current server when hosted on AWS
+  url: /api
+  variables: {}
+- description: When working locally
+  url: /
+  variables: {}
+- description: Production server
+  url: https://dockstore.org/api
+  variables: {}
+- description: Staging server
+  url: https://staging.dockstore.org/api
+  variables: {}
+- description: Nightly build server
+  url: https://dev.dockstore.net/api
+  variables: {}
 tags:
-  - description: Create, update list aliases for accessing entries
-    name: aliases
-  - description: Operations on Dockstore organizations
-    name: organizations
-  - description: Needed for SmartAPI compatibility apparantly, might be cargo cult behaviour
-    name: NIHdatacommons
-  - description: List and register entries in the dockstore (pairs of images + metadata (CWL and Dockerfile))
-    name: containers
-  - description: List and modify tags for containers
-    name: containertags
-  - description: Interact with entries in Dockstore regardless of whether they are containers or workflows
-    name: entries
-  - description: Created and modify hosted entries in the dockstore
-    name: hosted
-  - description: Query lambda events triggered by GitHub Apps
-    name: lambdaEvents
-  - description: Information about Dockstore like RSS, sitemap, lists of dependencies, etc.
-    name: metadata
-  - description: List and modify notifications for users of Dockstore
-    name: curation
-  - description: List and register workflows in the dockstore (CWL, Nextflow, WDL)
-    name: workflows
-  - description: List, modify, refresh, and delete tokens for external services
-    name: tokens
-  - description: Interactions with the Dockstore-support's ToolTester application
-    name: toolTester
-  - description: List, modify, and manage end users of the dockstore
-    name: users
-  - description: Optional experimental extensions of the GA4GH API
-    name: extendedGA4GH
-  - description: A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [2.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0).
-    name: GA4GHV20
-  - description: A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [2.0.0-beta.2](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0-beta.2) . Integrators are welcome to use these endpoints but they are subject to change based on community input.
-    name: GA4GH
-  - description: A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [1.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/1.0.0) and is considered final (not subject to change)
-    name: GA4GHV1
+- description: Create, update list aliases for accessing entries
+  name: aliases
+- description: Operations on Dockstore organizations
+  name: organizations
+- description: Needed for SmartAPI compatibility apparantly, might be cargo cult behaviour
+  name: NIHdatacommons
+- description: List and register entries in the dockstore (pairs of images + metadata
+    (CWL and Dockerfile))
+  name: containers
+- description: List and modify tags for containers
+  name: containertags
+- description: Interact with entries in Dockstore regardless of whether they are containers
+    or workflows
+  name: entries
+- description: Created and modify hosted entries in the dockstore
+  name: hosted
+- description: Query lambda events triggered by GitHub Apps
+  name: lambdaEvents
+- description: Information about Dockstore like RSS, sitemap, lists of dependencies,
+    etc.
+  name: metadata
+- description: List and modify notifications for users of Dockstore
+  name: curation
+- description: List and register workflows in the dockstore (CWL, Nextflow, WDL)
+  name: workflows
+- description: List, modify, refresh, and delete tokens for external services
+  name: tokens
+- description: Interactions with the Dockstore-support's ToolTester application
+  name: toolTester
+- description: List, modify, and manage end users of the dockstore
+  name: users
+- description: Optional experimental extensions of the GA4GH API
+  name: extendedGA4GH
+- description: A curated subset of resources proposed as a common standard for tool
+    repositories. Implements TRS [2.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0).
+  name: GA4GHV20
+- description: A curated subset of resources proposed as a common standard for tool
+    repositories. Implements TRS [2.0.0-beta.2](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0-beta.2)
+    . Integrators are welcome to use these endpoints but they are subject to change
+    based on community input.
+  name: GA4GH
+- description: A curated subset of resources proposed as a common standard for tool
+    repositories. Implements TRS [1.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/1.0.0)
+    and is considered final (not subject to change)
+  name: GA4GHV1

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5844,6 +5844,12 @@ paths:
         required: true
         type: "integer"
         format: "int64"
+      - name: "hardRefresh"
+        in: "query"
+        description: "refresh all versions"
+        required: false
+        type: "boolean"
+        default: true
       responses:
         200:
           description: "successful operation"
@@ -5872,6 +5878,12 @@ paths:
         description: "version"
         required: true
         type: "string"
+      - name: "hardRefresh"
+        in: "query"
+        description: "refresh all versions"
+        required: false
+        type: "boolean"
+        default: true
       responses:
         200:
           description: "successful operation"
@@ -8661,6 +8673,11 @@ definitions:
         - "SWARM"
         - "KUBERNETES"
         - "HELM"
+      synced:
+        type: "boolean"
+        position: 105
+        description: "Whether or not the version has been refreshed since its last\
+          \ edit on Dockstore."
     description: "This describes one workflow version associated with a workflow."
   WorkflowVersionPathInfo:
     type: "object"

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
@@ -203,7 +203,7 @@ public class WDLHandlerTest {
 
         @Override
         public Workflow setupWorkflowVersions(String repositoryId, Workflow workflow, Optional<Workflow> existingWorkflow,
-                Map<String, WorkflowVersion> existingDefaults, Optional<String> versionName) {
+                Map<String, WorkflowVersion> existingDefaults, Optional<String> versionName, boolean hardRefresh) {
             return null;
         }
 


### PR DESCRIPTION
Adds smart refresh for refresh workflow and refresh version. Smart refresh will only update a version if required (change on dockstore or on git). If a version has not been edited, it will be skipped. This is based mostly on whether the commit ID for a version has changed since the last refresh.

There is the case where the commit id has not been changed, however, a refresh needs to be done since changes were made on Dockstore. Perhaps the default path for a workflow was changed. This is solved by the synced column for workflow versions.

The new column synced represents whether or not a change has been made to a workflow/version on Dockstore since the last refresh was done. Any API call which edits a workflow (ex. change default path) or edits a version (ex. change workflow path) will set this bit to false. When a version is added for the first time or updated, synced is set to true.

There is also a new optional hard refresh option for refresh and refresh version (Default true). Setting this to true is equivalent to the current refresh implementation. When it is false, it will be a smart refresh. This smart refresh is what the refresh in the UI will call.

For the migration, the default value of synced is false. This is because any new version added should be refreshed.

The migration also sets all existing workflow versions to have synced as true. This probably requires some discussion. It assumes that no one has used the API to update a workflow or workflow version, since doing so doesn't automatically call refresh. In the UI, any changes to a workflow or workflow version is followed by a refresh.

https://github.com/dockstore/dockstore/issues/3487