### PR TITLE
Improve auth realm description

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -301,7 +301,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
                 configuration.getAuthenticationCachePolicy());
         environment.jersey().register(new AuthDynamicFeature(
                 new OAuthCredentialAuthFilter.Builder<User>().setAuthenticator(cachingAuthenticator).setAuthorizer(new SimpleAuthorizer())
-                        .setPrefix("Bearer").setRealm("SUPER SECRET STUFF").buildAuthFilter()));
+                        .setPrefix("Bearer").setRealm("Dockstore User Authentication").buildAuthFilter()));
         environment.jersey().register(new AuthValueFactoryProvider.Binder<>(User.class));
         environment.jersey().register(RolesAllowedDynamicFeature.class);
 


### PR DESCRIPTION
This updates a realm description from "SUPER SECRET STUFF" to "Dockstore User Authentication" (related to [SEAB-1207](https://ucsc-cgl.atlassian.net/browse/SEAB-1207), but not a fix)