### PR TITLE
Delete non-approved organizations

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -25,6 +25,7 @@ import io.swagger.client.model.Organization.StatusEnum;
 import io.swagger.client.model.PublishRequest;
 import io.swagger.client.model.StarRequest;
 import io.swagger.client.model.User;
+import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -84,6 +85,25 @@ public class OrganizationIT extends BaseIT {
     private Organization stubOrgObject() {
         String markdownDescription = "An h1 header ============ Paragraphs are separated by a blank line. 2nd paragraph. *Italic*, **bold**, and `monospace`. Itemized lists look like: * this one * that one * the other one Note that --- not considering the asterisk --- the actual text content starts at 4-columns in. > Block quotes are > written like so. > > They can span multiple paragraphs, > if you like. Use 3 dashes for an em-dash. Use 2 dashes for ranges (ex., \"it's all in chapters 12--14\"). Three dots ... will be converted to an ellipsis. Unicode is supported. ☺ ";
         Organization organization = new Organization();
+        organization.setName("testname");
+        organization.setDisplayName("test name");
+        organization.setLocation("testlocation");
+        organization.setLink("https://www.google.com");
+        organization.setEmail("test@email.com");
+        organization.setDescription(markdownDescription);
+        organization.setTopic("This is a short topic");
+        organization.setAvatarUrl("https://www.lifehardin.net/images/employees/default-logo.png");
+        return organization;
+    }
+
+    /**
+     * Creates an openAPI version of a stub Organization object
+     *
+     * @return openAPI Organization object
+     */
+    private io.dockstore.openapi.client.model.Organization openApiStubOrgObject() {
+        String markdownDescription = "An h1 header ============ Paragraphs are separated by a blank line. 2nd paragraph. *Italic*, **bold**, and `monospace`. Itemized lists look like: * this one * that one * the other one Note that --- not considering the asterisk --- the actual text content starts at 4-columns in. > Block quotes are > written like so. > > They can span multiple paragraphs, > if you like. Use 3 dashes for an em-dash. Use 2 dashes for ranges (ex., \"it's all in chapters 12--14\"). Three dots ... will be converted to an ellipsis. Unicode is supported. ☺ ";
+        io.dockstore.openapi.client.model.Organization organization = new io.dockstore.openapi.client.model.Organization();
         organization.setName("testname");
         organization.setDisplayName("test name");
         organization.setLocation("testlocation");
@@ -1561,5 +1581,65 @@ public class OrganizationIT extends BaseIT {
         users.remove(user);
         organization.setStarredUsers(users);
         assertEquals(0, organization.getStarredUsers().size());
+    }
+
+    @Test
+    public void testRemoveRejectedOrPendingOrganization() {
+        // Setup admin
+        final io.dockstore.openapi.client.ApiClient webClientAdminUser = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        io.dockstore.openapi.client.api.OrganizationsApi organizationsApi = new io.dockstore.openapi.client.api.OrganizationsApi(webClientAdminUser);
+
+        // Create an organization
+        io.dockstore.openapi.client.model.Organization organization = organizationsApi.createOrganization(openApiStubOrgObject());
+
+        // Organization should initially be pending
+        assertEquals(io.dockstore.openapi.client.model.Organization.StatusEnum.PENDING, organization.getStatus());
+
+        // Delete the organization
+        organizationsApi.deleteRejectedOrPendingOrganization(organization.getId());
+        try {
+            organizationsApi.getOrganizationByName(organization.getName());
+            fail("Organization should not be found since it was deleted");
+        } catch (io.dockstore.openapi.client.ApiException ex) {
+            assertEquals(HttpStatus.SC_NOT_FOUND, ex.getCode());
+        }
+
+        // Recreate the organization
+        organization = organizationsApi.createOrganization(openApiStubOrgObject());
+        assertEquals(io.dockstore.openapi.client.model.Organization.StatusEnum.PENDING, organization.getStatus());
+
+        // Reject the organization
+        organizationsApi.rejectOrganization(organization.getId());
+        organization = organizationsApi.getOrganizationById(organization.getId());
+        assertEquals(io.dockstore.openapi.client.model.Organization.StatusEnum.REJECTED, organization.getStatus());
+
+        // Delete the organization
+        organizationsApi.deleteRejectedOrPendingOrganization(organization.getId());
+        try {
+            organizationsApi.getOrganizationByName(organization.getName());
+            fail("Organization should not be found since it was deleted");
+        } catch (io.dockstore.openapi.client.ApiException ex) {
+            assertEquals(HttpStatus.SC_NOT_FOUND, ex.getCode());
+        }
+
+        // Recreate the organization
+        organization = organizationsApi.createOrganization(openApiStubOrgObject());
+        assertEquals(io.dockstore.openapi.client.model.Organization.StatusEnum.PENDING, organization.getStatus());
+
+        // Approve the organization
+        organizationsApi.approveOrganization(organization.getId());
+        organization = organizationsApi.getOrganizationById(organization.getId());
+        assertEquals(io.dockstore.openapi.client.model.Organization.StatusEnum.APPROVED, organization.getStatus());
+
+        //Try to delete the organization - this should fail
+        try {
+            organizationsApi.deleteRejectedOrPendingOrganization(organization.getId());
+            fail("User cannot delete their approved organization");
+        } catch (io.dockstore.openapi.client.ApiException ex) {
+            assertEquals(HttpStatus.SC_BAD_REQUEST, ex.getCode());
+        }
+
+        assertEquals(io.dockstore.openapi.client.model.Organization.StatusEnum.APPROVED, organization.getStatus());
+        assertEquals("testname", organization.getName());
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -36,6 +36,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByEntryIds", query = "SELECT e FROM Event e where (e.tool.id in :entryIDs) OR (e.workflow.id in :entryIDs) ORDER by id desc"),
         @NamedQuery(name = "io.dockstore.webservice.core.Event.deleteByEntryId", query = "DELETE Event e where e.tool.id = :entryId OR e.workflow.id = :entryId"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Event.deleteByOrganizationId", query = "DELETE Event e WHERE e.organization.id = :organizationId"),
         @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByUserId", query = "SELECT e FROM Event e where e.user.id = :userId"),
         @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByEntryId", query = "SELECT e FROM Event e where e.workflow.id = :entryId OR e.tool.id = :entryId"),
         @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllForOrganization", query = "SELECT eve FROM Event eve WHERE eve.organization.id = :organizationId ORDER BY id DESC"),

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Organization.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Organization.java
@@ -95,7 +95,7 @@ public class Organization implements Serializable, Aliasable {
 
     @Column
     @ApiModelProperty(value = "Set of users in the organization", required = true, position = 7)
-    @OneToMany(mappedBy = "organization", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "organization", fetch = FetchType.LAZY, orphanRemoval = true)
     private Set<OrganizationUser> users = new HashSet<>();
 
     @Column

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Organization.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Organization.java
@@ -95,7 +95,7 @@ public class Organization implements Serializable, Aliasable {
 
     @Column
     @ApiModelProperty(value = "Set of users in the organization", required = true, position = 7)
-    @OneToMany(mappedBy = "organization", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "organization", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     private Set<OrganizationUser> users = new HashSet<>();
 
     @Column

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
@@ -91,6 +91,14 @@ public class EventDAO extends AbstractDAO<Event> {
         currentSession().flush();
     }
 
+    public void deleteEventByOrganizationID(long organizationId) {
+        currentSession().flush();
+        Query<Event> query = this.currentSession().getNamedQuery("io.dockstore.webservice.core.Event.deleteByOrganizationId");
+        query.setParameter("organizationId", organizationId);
+        query.executeUpdate();
+        currentSession().flush();
+    }
+
     public void createAddTagToEntryEvent(User user, Entry entry, Version version) {
         if (version.getReferenceType() == Version.ReferenceType.TAG) {
             Event event = entry.getEventBuilder().withType(Event.EventType.ADD_VERSION_TO_ENTRY).withInitiatorUser(user).withVersion(version).build();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
@@ -96,9 +96,7 @@ public class EventDAO extends AbstractDAO<Event> {
         query.setParameter("organizationId", organizationId);
         query.executeUpdate();
         // Flush after executing the DELETE query. This would force Hibernate to synchronize the state of the
-        // current session with the database so the session can see that an organization has been deleted
-        // NOTE: Flushing does not commit the changes; manually accessing the DB will result with no changes to the
-        // "affected" rows until unit of work is over.
+        // current session with the database so the session can see that an event has been deleted
         currentSession().flush();
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
@@ -92,10 +92,13 @@ public class EventDAO extends AbstractDAO<Event> {
     }
 
     public void deleteEventByOrganizationID(long organizationId) {
-        currentSession().flush();
-        Query<Event> query = this.currentSession().getNamedQuery("io.dockstore.webservice.core.Event.deleteByOrganizationId");
+        Query query = namedQuery("io.dockstore.webservice.core.Event.deleteByOrganizationId");
         query.setParameter("organizationId", organizationId);
         query.executeUpdate();
+        // Flush after executing the DELETE query. This would force Hibernate to synchronize the state of the
+        // current session with the database so the session can see that an organization has been deleted
+        // NOTE: Flushing does not commit the changes; manually accessing the DB will result with no changes to the
+        // "affected" rows until unit of work is over.
         currentSession().flush();
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
@@ -414,7 +414,7 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
     @Path("/{organizationId}")
     @Timed
     @UnitOfWork
-    @ApiOperation(value = "Deletes an organization that is pending or rejected", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, hidden = true)
+    @ApiOperation(value = "hidden", hidden = true)
     @Operation(operationId = "deleteRejectedOrPendingOrganization", summary = "Delete pending or rejected organization", description = "Delete pending or rejected organization", security = @SecurityRequirement(name = "bearer"))
     public void deleteRejectedOrPendingOrganization(
             @Parameter(hidden = true, name = "user") @Auth User user,
@@ -430,14 +430,10 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
 
         // If the organization to be deleted is pending or has been rejected, then delete the organization
         if (organization.getStatus() == Organization.ApplicationState.PENDING || organization.getStatus() == Organization.ApplicationState.REJECTED) {
-            organization.getStarredUsers().clear();
-            organization.getAliases().clear();
-
             eventDAO.deleteEventByOrganizationID(organizationId);
-            organizationDAO.update(organization);
             organizationDAO.delete(organization);
         } else { // else if the organization is not pending nor rejected, then throw an error
-            throw new CustomWebApplicationException("You cannot delete an organization that is not currently pending or rejected", HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException("You can only delete organizations that are pending or has been rejected", HttpStatus.SC_BAD_REQUEST);
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
@@ -440,7 +440,7 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
             eventDAO.deleteEventByOrganizationID(organizationId);
             organizationDAO.delete(organization);
         } else { // else if the organization is not pending nor rejected, then throw an error
-            throw new CustomWebApplicationException("You can only delete organizations that are pending or has been rejected", HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException("You can only delete organizations that are pending or have been rejected", HttpStatus.SC_BAD_REQUEST);
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
@@ -42,6 +42,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.security.SecuritySchemes;
@@ -416,6 +418,11 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
     @UnitOfWork
     @ApiOperation(value = "hidden", hidden = true)
     @Operation(operationId = "deleteRejectedOrPendingOrganization", summary = "Delete pending or rejected organization", description = "Delete pending or rejected organization", security = @SecurityRequirement(name = "bearer"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "BAD REQUEST"),
+            @ApiResponse(responseCode = "403", description = "FORBIDDEN")
+    })
     public void deleteRejectedOrPendingOrganization(
             @Parameter(hidden = true, name = "user") @Auth User user,
             @Parameter(description = "Organization ID.", name = "organizationId", in = ParameterIn.PATH, required = true) @PathParam("organizationId") Long organizationId) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
@@ -419,7 +419,7 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
     @ApiOperation(value = "hidden", hidden = true)
     @Operation(operationId = "deleteRejectedOrPendingOrganization", summary = "Delete pending or rejected organization", description = "Delete pending or rejected organization", security = @SecurityRequirement(name = "bearer"))
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "OK"),
+            @ApiResponse(responseCode = "204", description = "NO CONTENT"),
             @ApiResponse(responseCode = "400", description = "BAD REQUEST"),
             @ApiResponse(responseCode = "403", description = "FORBIDDEN")
     })

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1759,7 +1759,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/WorkflowVersion'
           description: default response
       security:
         - bearer: []
@@ -2456,7 +2456,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tool'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []
@@ -2482,7 +2482,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tool'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []
@@ -4627,10 +4627,12 @@ paths:
             format: int64
             type: integer
       responses:
-        default:
-          content:
-            application/json: {}
-          description: default response
+        "204":
+          description: OK
+        "400":
+          description: BAD REQUEST
+        "403":
+          description: FORBIDDEN
       security:
         - bearer: []
       summary: Delete pending or rejected organization
@@ -6599,7 +6601,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1759,7 +1759,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/WorkflowVersion'
           description: default response
       security:
         - bearer: []
@@ -3694,7 +3694,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []
@@ -4563,7 +4563,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/Collection'
           description: default response
       security:
         - bearer: []
@@ -4615,6 +4615,27 @@ paths:
       tags:
         - organizations
   /organizations/{organizationId}:
+    delete:
+      description: Delete pending or rejected organization
+      operationId: deleteRejectedOrPendingOrganization
+      parameters:
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      security:
+        - bearer: []
+      summary: Delete pending or rejected organization
+      tags:
+        - organizations
     get:
       description: Retrieve an organization by ID. Supports optional authentication.
       operationId: getOrganizationById
@@ -4993,26 +5014,6 @@ paths:
       security:
         - bearer: []
       summary: Add an entry to a collection.
-      tags:
-        - organizations
-  /organizations/{organizationId}/deleteNonApprovedOrg:
-    delete:
-      description: Delete rejected organization
-      operationId: deleteRejectedOrPendingOrganization
-      parameters:
-        - description: Organization ID.
-          in: path
-          name: organizationId
-          required: true
-          schema:
-            format: int64
-            type: integer
-      responses:
-        default:
-          content:
-            application/json: {}
-          description: default response
-      summary: Delete rejected organization
       tags:
         - organizations
   /organizations/{organizationId}/description:
@@ -6572,7 +6573,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []
@@ -6598,7 +6599,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Workflow'
           description: default response
       security:
         - bearer: []

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -24,8 +24,8 @@ components:
           type: object
       type: object
     Checksum:
-      description: A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes.  This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
-      example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182, type=sha256}]'
+      description: 'A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes. '
+      example: '[{checksum=ea2a5db69bd20a42976838790bc29294df3af02b, type=sha1}]'
       properties:
         checksum:
           description: 'The hex-string encoded checksum for the data. '
@@ -1759,7 +1759,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WorkflowVersion'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -2456,7 +2456,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Tool'
           description: default response
       security:
         - bearer: []
@@ -2482,7 +2482,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Tool'
           description: default response
       security:
         - bearer: []
@@ -3694,7 +3694,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []
@@ -4628,7 +4628,7 @@ paths:
             type: integer
       responses:
         "204":
-          description: OK
+          description: NO CONTENT
         "400":
           description: BAD REQUEST
         "403":

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1759,7 +1759,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WorkflowVersion'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -3694,7 +3694,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -694,8 +694,8 @@ components:
             - SWL
             - NFL
             - service
-            - cwl
-            - wdl
+            
+            
           type: string
         hasHTTPImports:
           type: boolean
@@ -1479,8 +1479,8 @@ components:
             - SWL
             - NFL
             - service
-            - cwl
-            - wdl
+            
+            
           type: string
         descriptorTypeSubclass:
           enum:
@@ -3694,7 +3694,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -4472,7 +4472,7 @@ paths:
       operationId: createOrganization
       requestBody:
         content:
-          '*/*':
+          application/json:
             schema:
               $ref: '#/components/schemas/Organization'
         description: Organization to register.
@@ -4691,7 +4691,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organization'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -4993,6 +4993,26 @@ paths:
       security:
         - bearer: []
       summary: Add an entry to a collection.
+      tags:
+        - organizations
+  /organizations/{organizationId}/deleteNonApprovedOrg:
+    delete:
+      description: Delete rejected organization
+      operationId: deleteRejectedOrPendingOrganization
+      parameters:
+        - description: Organization ID.
+          in: path
+          name: organizationId
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      summary: Delete rejected organization
       tags:
         - organizations
   /organizations/{organizationId}/description:
@@ -6578,7 +6598,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -2913,6 +2913,8 @@ paths:
       summary: "Create an organization."
       description: "Organization requires approval by an admin before being made public."
       operationId: "createOrganization"
+      consumes:
+      - "application/json"
       produces:
       - "application/json"
       parameters:


### PR DESCRIPTION
dockstore/dockstore#3254

Implemented a new endpoint '/{organizationId}/deleteNonApprovedOrg' in
OrganizationResource to delete a non-approved organization

New endpoint would delete all rows from multiple tables using
organizationId before deleting the organization to avoid an FKEY error

Added a cascade parameter to 'users' in Organization.java in order
to address and delete the organizationid FKEY

Implemented a new method in EventDAO.java to delete a list of events
having a specific organizationId

Added a new NamedQuery to Event.java to execute the SQL statement of
deleting events based on a given organizationId

Added a @Consumes annotation for 'createOrganization' in order to
specify the content-type header as application/json so the test would
pass

Added a new test and stubObject for the new endpoint
