### PR TITLE
Fix/seab 1502/lazy versions

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -662,7 +662,7 @@ public class SwaggerClientIT extends BaseIT {
     public void testStarStarredWorkflow() throws ApiException {
         ApiClient client = getWebClient();
         WorkflowsApi workflowsApi = new WorkflowsApi(client);
-        Workflow workflow = workflowsApi.getPublishedWorkflowByPath("github.com/A/l", null, false);
+        Workflow workflow = workflowsApi.getPublishedWorkflowByPath("github.com/A/l", null, false, null);
         long workflowId = workflow.getId();
         assertEquals(11, workflowId);
         workflowsApi.starEntry(workflowId, STAR_REQUEST);
@@ -683,7 +683,7 @@ public class SwaggerClientIT extends BaseIT {
     public void testUnstarUnstarredWorkflow() throws ApiException {
         ApiClient client = getWebClient();
         WorkflowsApi workflowApi = new WorkflowsApi(client);
-        Workflow workflow = workflowApi.getPublishedWorkflowByPath("github.com/A/l", null, false);
+        Workflow workflow = workflowApi.getPublishedWorkflowByPath("github.com/A/l", null, false, null);
         long workflowId = workflow.getId();
         assertEquals(11, workflowId);
         thrown.expect(ApiException.class);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -84,7 +84,6 @@ import io.swagger.model.DescriptorType;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -84,6 +84,7 @@ import io.swagger.model.DescriptorType;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
@@ -566,6 +567,9 @@ public class WorkflowIT extends BaseIT {
         } finally {
             FileUtils.deleteQuietly(tempFile);
         }
+        DockstoreWebserviceApplication application = SUPPORT.getApplication();
+        SessionFactory sessionFactory = application.getHibernate().getSessionFactory();
+        sessionFactory.getCurrentSession().close();
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -889,7 +889,7 @@ public class WorkflowIT extends BaseIT {
         final Workflow publishedWorkflow = workflowApi.getPublishedWorkflow(workflowByPath.getId(), null);
         assertNotNull("did not get published workflow", publishedWorkflow);
         final Workflow publishedWorkflowByPath = workflowApi
-            .getPublishedWorkflowByPath(DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, null, false);
+            .getPublishedWorkflowByPath(DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, null, false, null);
         assertNotNull("did not get published workflow", publishedWorkflowByPath);
 
         // publish everything so pagination testing makes more sense (going to unfortunately use rate limit)
@@ -1893,7 +1893,7 @@ public class WorkflowIT extends BaseIT {
         Assert.assertNull("Getting workflow version via workflow path has null alias", workflowVersionByPath.getAliases());
 
         final Workflow publishedWorkflowByPath = workflowApi
-                .getPublishedWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
+                .getPublishedWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false, null);
         assertNotNull("did not get published workflow by path", publishedWorkflowByPath);
         Optional<WorkflowVersion> optionalWorkflowVersionByPublishedByPath = publishedWorkflowByPath.getWorkflowVersions().stream()
                 .filter(version -> "master".equalsIgnoreCase(version.getName())).findFirst();
@@ -1933,7 +1933,7 @@ public class WorkflowIT extends BaseIT {
 
 
         final Workflow publishedWorkflowByPathValidation = workflowApi
-                .getPublishedWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, "aliases", false);
+                .getPublishedWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, "aliases", false, null);
         assertNotNull("did not get published workflow by path", publishedWorkflowByPathValidation);
         Optional<WorkflowVersion> optionalWorkflowVersionByPublishedByPathValidation = publishedWorkflowByPathValidation.getWorkflowVersions().stream()
                 .filter(version -> "master".equalsIgnoreCase(version.getName())).findFirst();

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -288,8 +288,8 @@ public class ServiceIT extends BaseIT {
         testingPostgres.runUpdateStatement("update service set ispublished = 't'");
 
         // test retrieval
-        final io.swagger.client.model.Workflow returnedWorkflow = client.getPublishedWorkflowByPath(github + "/" + serviceRepo, "", false);
-        final io.swagger.client.model.Workflow returnedService = client.getPublishedWorkflowByPath(github + "/" + serviceRepo, "", true);
+        final io.swagger.client.model.Workflow returnedWorkflow = client.getPublishedWorkflowByPath(github + "/" + serviceRepo, "", false, null);
+        final io.swagger.client.model.Workflow returnedService = client.getPublishedWorkflowByPath(github + "/" + serviceRepo, "", true, null);
         assertNotSame(returnedWorkflow.getId(), returnedService.getId());
 
         // test GA4GH retrieval

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -455,12 +455,14 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
         this.email = version.getEmail();
     }
 
+    // This will force EAGER workflowVersions UNLESS the entry entity was detached prior to endpoint return
     @JsonProperty("input_file_formats")
     public Set<FileFormat> getInputFileFormats() {
         Stream<FileFormat> fileFormatStream = this.getWorkflowVersions().stream().flatMap(version -> version.getInputFileFormats().stream());
         return fileFormatStream.collect(Collectors.toSet());
     }
 
+    // This will force EAGER workflowVersions UNLESS the entry entity was detached prior to endpoint return
     @JsonProperty("output_file_formats")
     public Set<FileFormat> getOutputFileFormats() {
         Stream<FileFormat> fileFormatStream = this.getWorkflowVersions().stream().flatMap(version -> version.getOutputFileFormats().stream());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -73,7 +73,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 // Ensure that the version requested belongs to a workflow a user has access to.
 @NamedQueries({
-        @NamedQuery(name = "io.dockstore.webservice.core.Version.findVersionInEntry", query = "SELECT v FROM Version v WHERE :entryId = v.parent.id AND :versionId = v.id")
+        @NamedQuery(name = "io.dockstore.webservice.core.Version.findVersionInEntry", query = "SELECT v FROM Version v WHERE :entryId = v.parent.id AND :versionId = v.id"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Version.getCountByEntryId", query = "SELECT Count(v) FROM version v WHERE v.parent.id = :id")
 })
 
 @SuppressWarnings("checkstyle:magicnumber")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -74,7 +74,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 // Ensure that the version requested belongs to a workflow a user has access to.
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.Version.findVersionInEntry", query = "SELECT v FROM Version v WHERE :entryId = v.parent.id AND :versionId = v.id"),
-        @NamedQuery(name = "io.dockstore.webservice.core.Version.getCountByEntryId", query = "SELECT Count(v) FROM version v WHERE v.parent.id = :id")
+        @NamedQuery(name = "io.dockstore.webservice.core.Version.getCountByEntryId", query = "SELECT Count(v) FROM Version v WHERE v.parent.id = :id")
 })
 
 @SuppressWarnings("checkstyle:magicnumber")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -46,6 +46,7 @@ import io.dockstore.common.DescriptorLanguageSubclass;
 import io.dockstore.common.SourceControl;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.Hidden;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
@@ -230,6 +231,7 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
         return this.workflowVersions;
     }
 
+    @Hidden
     public void setWorkflowVersionsOverride(SortedSet<WorkflowVersion> newWorkflowVersions) {
         this.workflowVersions = newWorkflowVersions;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -46,7 +46,6 @@ import io.dockstore.common.DescriptorLanguageSubclass;
 import io.dockstore.common.SourceControl;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.Check;
@@ -126,12 +125,11 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
     @ApiModelProperty(value = "This is a descriptor type subclass for the workflow. Currently it is only used for services.", required = true, position = 22)
     private DescriptorLanguageSubclass descriptorTypeSubclass = DescriptorLanguageSubclass.NOT_APPLICABLE;
 
-    @OneToMany(fetch = FetchType.EAGER, orphanRemoval = true, targetEntity = Version.class, mappedBy = "parent")
+    @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, targetEntity = Version.class, mappedBy = "parent")
     @ApiModelProperty(value = "Implementation specific tracking of valid build workflowVersions for the docker container", position = 21)
     @OrderBy("id")
     @Cascade({ CascadeType.DETACH, CascadeType.SAVE_UPDATE })
-    @BatchSize(size = 25)
-    private final SortedSet<WorkflowVersion> workflowVersions;
+    private SortedSet<WorkflowVersion> workflowVersions;
 
     @JsonIgnore
     @OneToOne(targetEntity = WorkflowVersion.class, fetch = FetchType.LAZY)
@@ -227,7 +225,11 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
 
     @Override
     public Set<WorkflowVersion> getWorkflowVersions() {
-        return workflowVersions;
+        return this.workflowVersions;
+    }
+
+    public void setWorkflowVersionsOverride(SortedSet<WorkflowVersion> newWorkflowVersions) {
+        this.workflowVersions = newWorkflowVersions;
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -46,6 +46,7 @@ import io.dockstore.common.DescriptorLanguageSubclass;
 import io.dockstore.common.SourceControl;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.Check;
@@ -129,6 +130,7 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
     @ApiModelProperty(value = "Implementation specific tracking of valid build workflowVersions for the docker container", position = 21)
     @OrderBy("id")
     @Cascade({ CascadeType.DETACH, CascadeType.SAVE_UPDATE })
+    @BatchSize(size = 25)
     private SortedSet<WorkflowVersion> workflowVersions;
 
     @JsonIgnore

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -52,7 +52,7 @@ import org.apache.commons.io.FilenameUtils;
     "name" }))
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByAlias", query = "SELECT e from WorkflowVersion e JOIN e.aliases a WHERE KEY(a) IN :alias"),
-        @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByWorkflowIdAndVersionName", query = "FROM workflowversion v WHERE v.parent.id = :id And v.name = :name")
+        @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByWorkflowIdAndVersionName", query = "select v FROM WorkflowVersion v WHERE v.parent.id = :id And v.name = :name")
 })
 
 @SuppressWarnings("checkstyle:magicnumber")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -52,6 +52,8 @@ import org.apache.commons.io.FilenameUtils;
     "name" }))
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByAlias", query = "SELECT e from WorkflowVersion e JOIN e.aliases a WHERE KEY(a) IN :alias"),
+        @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByAlias", query = "SELECT e from WorkflowVersion e JOIN e.aliases a WHERE KEY(a) IN :alias"),
+        @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByWorkflowIdAndVersionName", query = "FROM workflowversion v WHERE v.parent.id = :id And v.name = :name")
 })
 
 @SuppressWarnings("checkstyle:magicnumber")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -52,7 +52,8 @@ import org.apache.commons.io.FilenameUtils;
     "name" }))
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByAlias", query = "SELECT e from WorkflowVersion e JOIN e.aliases a WHERE KEY(a) IN :alias"),
-        @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByWorkflowIdAndVersionName", query = "select v FROM WorkflowVersion v WHERE v.parent.id = :id And v.name = :name")
+        @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByWorkflowIdAndVersionName", query = "select v FROM WorkflowVersion v WHERE v.parent.id = :id And v.name = :name"),
+        @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByWorkflowId", query = "FROM workflowversion v WHERE v.parent.id = :id ORDER by dbUpdateDate DESC")
 })
 
 @SuppressWarnings("checkstyle:magicnumber")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -53,7 +53,7 @@ import org.apache.commons.io.FilenameUtils;
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByAlias", query = "SELECT e from WorkflowVersion e JOIN e.aliases a WHERE KEY(a) IN :alias"),
         @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByWorkflowIdAndVersionName", query = "select v FROM WorkflowVersion v WHERE v.parent.id = :id And v.name = :name"),
-        @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByWorkflowId", query = "FROM workflowversion v WHERE v.parent.id = :id ORDER by dbUpdateDate DESC")
+        @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByWorkflowId", query = "FROM WorkflowVersion v WHERE v.parent.id = :id ORDER by dbUpdateDate DESC")
 })
 
 @SuppressWarnings("checkstyle:magicnumber")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -52,7 +52,6 @@ import org.apache.commons.io.FilenameUtils;
     "name" }))
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByAlias", query = "SELECT e from WorkflowVersion e JOIN e.aliases a WHERE KEY(a) IN :alias"),
-        @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByAlias", query = "SELECT e from WorkflowVersion e JOIN e.aliases a WHERE KEY(a) IN :alias"),
         @NamedQuery(name = "io.dockstore.webservice.core.WorkflowVersion.getByWorkflowIdAndVersionName", query = "FROM workflowversion v WHERE v.parent.id = :id And v.name = :name")
 })
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -58,6 +58,7 @@ import io.dockstore.webservice.resources.AuthenticatedResourceInterface;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.http.HttpStatus;
+import org.hibernate.Hibernate;
 
 /**
  * This interface contains code for interacting with the files of versions for all types of entries (currently, tools and workflows)
@@ -103,6 +104,7 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
      * @return the filtered entry
      */
     default T filterContainersForHiddenTags(T entry) {
+        Hibernate.initialize(entry.getWorkflowVersions());
         return filterContainersForHiddenTags(Lists.newArrayList(entry)).get(0);
     }
 
@@ -112,6 +114,7 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
      */
     default List<T> filterContainersForHiddenTags(List<T> entries) {
         for (T entry : entries) {
+            Hibernate.initialize(entry.getWorkflowVersions());
             getDAO().evict(entry);
             // clear users which are also lazy loaded
             entry.setUsers(null);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
@@ -19,6 +19,7 @@ package io.dockstore.webservice.jdbi;
 import io.dockstore.webservice.core.Version;
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
 
 /**
  * @author xliu
@@ -43,5 +44,12 @@ public class VersionDAO<T extends Version> extends AbstractDAO<T> {
 
     public Version<T> findVersionInEntry(Long entryId, Long versionId) {
         return uniqueResult(namedQuery("io.dockstore.webservice.core.Version.findVersionInEntry").setParameter("entryId", entryId).setParameter("versionId", versionId));
+    }
+
+    // Currently not used for anything, will be used for paginated versions
+    public Long getVersionsCount(Long entryId) {
+        Query query = namedQuery("io.dockstore.webservice.core.Version.getCountByEntryId");
+        query.setParameter("id", entryId);
+        return (Long)query.getSingleResult();
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
@@ -47,9 +47,9 @@ public class VersionDAO<T extends Version> extends AbstractDAO<T> {
     }
 
     // Currently not used for anything, will be used for paginated versions
-    public Long getVersionsCount(Long entryId) {
+    public long getVersionsCount(long entryId) {
         Query query = namedQuery("io.dockstore.webservice.core.Version.getCountByEntryId");
         query.setParameter("id", entryId);
-        return (Long)query.getSingleResult();
+        return (long)query.getSingleResult();
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -33,7 +33,9 @@ import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.SourceControlConverter;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
+import io.dockstore.webservice.core.WorkflowVersion;
 import org.apache.http.HttpStatus;
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
 import org.slf4j.Logger;
@@ -228,6 +230,16 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
         q.where(cb.or(predicates.toArray(new Predicate[]{})));
 
         return list(q);
+    }
+
+    public List<WorkflowVersion> getWorkflowVersionsByWorkflowId(Long workflowId, int size) {
+        Session session = currentSession();
+        Query query = session.createQuery("from Version v WHERE v.parent.id = :id");
+        query.setParameter("id", workflowId);
+        query.setFirstResult(0);
+        query.setMaxResults(size);
+        List<WorkflowVersion> workflowVersionIds = query.getResultList();
+        return workflowVersionIds;
     }
 
     public List<Workflow> findByGitUrl(String giturl) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -232,14 +232,21 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
         return list(q);
     }
 
-    public List<WorkflowVersion> getWorkflowVersionsByWorkflowId(Long workflowId, int size) {
+    public List<WorkflowVersion> getWorkflowVersionsByWorkflowId(Long workflowId, int size, int firstResult) {
         Session session = currentSession();
-        Query query = session.createQuery("from Version v WHERE v.parent.id = :id");
+        Query query = session.createQuery("FROM Version v WHERE v.parent.id = :id ORDER by dbUpdateDate DESC");
         query.setParameter("id", workflowId);
-        query.setFirstResult(0);
+        query.setFirstResult(firstResult);
         query.setMaxResults(size);
         List<WorkflowVersion> workflowVersionIds = query.getResultList();
         return workflowVersionIds;
+    }
+
+    public Long getWorkflowVersionsCount(Long workflowId) {
+        Session session = currentSession();
+        Query query = session.createQuery("select count(v) from Version v WHERE v.parent.id = :id");
+        query.setParameter("id", workflowId);
+        return (Long)query.getSingleResult();
     }
 
     public List<Workflow> findByGitUrl(String giturl) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -242,12 +242,12 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
         return workflowVersionIds;
     }
 
-    public WorkflowVersion getWorkflowVersionByWorkflowIdAndVersionName(Long workflowId, String name) {
+    public List<WorkflowVersion> getWorkflowVersionByWorkflowIdAndVersionName(Long workflowId, String name) {
         Session session = currentSession();
         Query query = session.createQuery("FROM Version v WHERE v.parent.id = :id And v.name = :name");
         query.setParameter("id", workflowId);
         query.setParameter("name", name);
-        return (WorkflowVersion)query.getSingleResult();
+        return query.getResultList();
     }
 
     public Long getWorkflowVersionsCount(Long workflowId) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -242,6 +242,14 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
         return workflowVersionIds;
     }
 
+    public WorkflowVersion getWorkflowVersionByWorkflowIdAndVersionName(Long workflowId, String name) {
+        Session session = currentSession();
+        Query query = session.createQuery("FROM Version v WHERE v.parent.id = :id And v.name = :name");
+        query.setParameter("id", workflowId);
+        query.setParameter("name", name);
+        return (WorkflowVersion)query.getSingleResult();
+    }
+
     public Long getWorkflowVersionsCount(Long workflowId) {
         Session session = currentSession();
         Query query = session.createQuery("select count(v) from Version v WHERE v.parent.id = :id");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -33,9 +33,7 @@ import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.SourceControlConverter;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
-import io.dockstore.webservice.core.WorkflowVersion;
 import org.apache.http.HttpStatus;
-import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
 import org.slf4j.Logger;
@@ -230,31 +228,6 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
         q.where(cb.or(predicates.toArray(new Predicate[]{})));
 
         return list(q);
-    }
-
-    public List<WorkflowVersion> getWorkflowVersionsByWorkflowId(Long workflowId, int size, int firstResult) {
-        Session session = currentSession();
-        Query query = session.createQuery("FROM Version v WHERE v.parent.id = :id ORDER by dbUpdateDate DESC");
-        query.setParameter("id", workflowId);
-        query.setFirstResult(firstResult);
-        query.setMaxResults(size);
-        List<WorkflowVersion> workflowVersionIds = query.getResultList();
-        return workflowVersionIds;
-    }
-
-    public List<WorkflowVersion> getWorkflowVersionByWorkflowIdAndVersionName(Long workflowId, String name) {
-        Session session = currentSession();
-        Query query = session.createQuery("FROM Version v WHERE v.parent.id = :id And v.name = :name");
-        query.setParameter("id", workflowId);
-        query.setParameter("name", name);
-        return query.getResultList();
-    }
-
-    public Long getWorkflowVersionsCount(Long workflowId) {
-        Session session = currentSession();
-        Query query = session.createQuery("select count(v) from Version v WHERE v.parent.id = :id");
-        query.setParameter("id", workflowId);
-        return (Long)query.getSingleResult();
     }
 
     public List<Workflow> findByGitUrl(String giturl) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
@@ -44,10 +44,10 @@ public class WorkflowVersionDAO extends VersionDAO<WorkflowVersion> {
         return workflowVersionIds;
     }
 
-    public List<WorkflowVersion> getWorkflowVersionByWorkflowIdAndVersionName(Long workflowId, String name) {
-        Query query = namedQuery("io.dockstore.webservice.core.WorkflowVersion.getByWorkflowIdAndVersionName");
+    public WorkflowVersion getWorkflowVersionByWorkflowIdAndVersionName(Long workflowId, String name) {
+        Query<WorkflowVersion> query = namedQuery("io.dockstore.webservice.core.WorkflowVersion.getByWorkflowIdAndVersionName");
         query.setParameter("id", workflowId);
         query.setParameter("name", name);
-        return query.getResultList();
+        return uniqueResult(query);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
@@ -16,8 +16,12 @@
 
 package io.dockstore.webservice.jdbi;
 
+import java.util.List;
+
 import io.dockstore.webservice.core.WorkflowVersion;
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
 
 /**
  * @author dyuen
@@ -30,5 +34,22 @@ public class WorkflowVersionDAO extends VersionDAO<WorkflowVersion> {
 
     public WorkflowVersion findByAlias(String alias) {
         return uniqueResult(namedQuery("io.dockstore.webservice.core.WorkflowVersion.getByAlias").setParameter("alias", alias));
+    }
+
+    public List<WorkflowVersion> getWorkflowVersionsByWorkflowId(Long workflowId, int size, int firstResult) {
+        Session session = currentSession();
+        Query query = session.createQuery("FROM workflowversion v WHERE v.parent.id = :id ORDER by dbUpdateDate DESC");
+        query.setParameter("id", workflowId);
+        query.setFirstResult(firstResult);
+        query.setMaxResults(size);
+        List<WorkflowVersion> workflowVersionIds = query.getResultList();
+        return workflowVersionIds;
+    }
+
+    public List<WorkflowVersion> getWorkflowVersionByWorkflowIdAndVersionName(Long workflowId, String name) {
+        Query query = namedQuery("io.dockstore.webservice.core.WorkflowVersion.getByWorkflowIdAndVersionName");
+        query.setParameter("id", workflowId);
+        query.setParameter("name", name);
+        return query.getResultList();
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
@@ -19,7 +19,6 @@ package io.dockstore.webservice.jdbi;
 import java.util.List;
 
 import io.dockstore.webservice.core.WorkflowVersion;
-import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
@@ -35,7 +35,7 @@ public class WorkflowVersionDAO extends VersionDAO<WorkflowVersion> {
         return uniqueResult(namedQuery("io.dockstore.webservice.core.WorkflowVersion.getByAlias").setParameter("alias", alias));
     }
 
-    public List<WorkflowVersion> getWorkflowVersionsByWorkflowId(Long workflowId, int size, int firstResult) {
+    public List<WorkflowVersion> getWorkflowVersionsByWorkflowId(long workflowId, int size, int firstResult) {
         Query query = namedQuery("io.dockstore.webservice.core.WorkflowVersion.getByWorkflowId");
         query.setParameter("id", workflowId);
         query.setFirstResult(firstResult);
@@ -44,7 +44,7 @@ public class WorkflowVersionDAO extends VersionDAO<WorkflowVersion> {
         return workflowVersionIds;
     }
 
-    public WorkflowVersion getWorkflowVersionByWorkflowIdAndVersionName(Long workflowId, String name) {
+    public WorkflowVersion getWorkflowVersionByWorkflowIdAndVersionName(long workflowId, String name) {
         Query<WorkflowVersion> query = namedQuery("io.dockstore.webservice.core.WorkflowVersion.getByWorkflowIdAndVersionName");
         query.setParameter("id", workflowId);
         query.setParameter("name", name);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
@@ -37,8 +37,7 @@ public class WorkflowVersionDAO extends VersionDAO<WorkflowVersion> {
     }
 
     public List<WorkflowVersion> getWorkflowVersionsByWorkflowId(Long workflowId, int size, int firstResult) {
-        Session session = currentSession();
-        Query query = session.createQuery("FROM workflowversion v WHERE v.parent.id = :id ORDER by dbUpdateDate DESC");
+        Query query = namedQuery("io.dockstore.webservice.core.WorkflowVersion.getByWorkflowId");
         query.setParameter("id", workflowId);
         query.setFirstResult(firstResult);
         query.setMaxResults(size);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceConstants.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceConstants.java
@@ -37,6 +37,7 @@ public final class ResourceConstants {
     public static final String OPENAPI_JWT_SECURITY_DEFINITION_NAME = "bearer";
     public static final String APPEASE_SWAGGER_PATCH = "This is here to appease Swagger. It requires PATCH methods to have a body, even if it is empty. Please leave it empty.";
     public static final String PAGINATION_LIMIT = "100";
+    public static final int VERSION_PAGINATION_LIMIT = 200;
     public static final String PAGINATION_LIMIT_TEXT = "Amount of records to return in a given page, limited to " + PAGINATION_LIMIT;
     public static final String PAGINATION_OFFSET_TEXT = "Start index of paging. Pagination results can be based on numbers or other values chosen by the registry implementor (for example, SHA values). If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.";
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -564,6 +564,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     }
     private List<Workflow> getStrippedServices(User user) {
         final List<Workflow> services = getServices(user);
+        services.forEach(service -> Hibernate.initialize(service.getWorkflowVersions()));
         EntryVersionHelper.stripContent(services, this.userDAO);
         return services;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -938,14 +938,12 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @SuppressWarnings("checkstyle:MagicNumber")
     private void setWorkflowVersionSubset(Workflow workflow, String include, String versionName) {
         sessionFactory.getCurrentSession().detach(workflow);
-        Long workflowVersionsCount = this.workflowDAO.getWorkflowVersionsCount(workflow.getId());
-        LOG.info(String.valueOf(workflowVersionsCount));
 
         // Almost all observed workflows have under 200 version, this number should be lowered once the frontend actually supports pagination
-        List<WorkflowVersion> ids = this.workflowDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), 200, 0);
+        List<WorkflowVersion> ids = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), 200, 0);
         SortedSet<WorkflowVersion> workflowVersions = new TreeSet<>(ids);
-        if (versionName != null && !workflowVersions.stream().anyMatch(version -> version.getName().equals(versionName))) {
-            List<WorkflowVersion> workflowVersionByWorkflowIdAndVersionName = this.workflowDAO
+        if (versionName != null && workflowVersions.stream().noneMatch(version -> version.getName().equals(versionName))) {
+            List<WorkflowVersion> workflowVersionByWorkflowIdAndVersionName = this.workflowVersionDAO
                     .getWorkflowVersionByWorkflowIdAndVersionName(workflow.getId(), versionName);
             if (workflowVersionByWorkflowIdAndVersionName.size() == 1) {
                 WorkflowVersion workflowVersion = workflowVersionByWorkflowIdAndVersionName.get(0);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -501,7 +501,6 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         return existingWorkflow;
     }
 
-    @SuppressWarnings("checkstyle:MagicNumber")
     @GET
     @Timed
     @UnitOfWork(readOnly = true)
@@ -936,7 +935,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         setWorkflowVersionSubset(workflow, include);
         return workflow;
     }
-
+    @SuppressWarnings("checkstyle:MagicNumber")
     private void setWorkflowVersionSubset(Workflow workflow, String include) {
         sessionFactory.getCurrentSession().detach(workflow);
         Long workflowVersionsCount = this.workflowDAO.getWorkflowVersionsCount(workflow.getId());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -944,11 +944,10 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         List<WorkflowVersion> ids = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), VERSION_PAGINATION_LIMIT, 0);
         SortedSet<WorkflowVersion> workflowVersions = new TreeSet<>(ids);
         if (versionName != null && workflowVersions.stream().noneMatch(version -> version.getName().equals(versionName))) {
-            List<WorkflowVersion> workflowVersionByWorkflowIdAndVersionName = this.workflowVersionDAO
+            WorkflowVersion workflowVersionByWorkflowIdAndVersionName = this.workflowVersionDAO
                     .getWorkflowVersionByWorkflowIdAndVersionName(workflow.getId(), versionName);
-            if (workflowVersionByWorkflowIdAndVersionName.size() == 1) {
-                WorkflowVersion workflowVersion = workflowVersionByWorkflowIdAndVersionName.get(0);
-                workflowVersions.add(workflowVersion);
+            if (workflowVersionByWorkflowIdAndVersionName != null) {
+                workflowVersions.add(workflowVersionByWorkflowIdAndVersionName);
             }
         }
         workflow.setWorkflowVersionsOverride(workflowVersions);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -945,8 +945,12 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         List<WorkflowVersion> ids = this.workflowDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), 200, 0);
         SortedSet<WorkflowVersion> workflowVersions = new TreeSet<>(ids);
         if (versionName != null && !workflowVersions.stream().anyMatch(version -> version.getName().equals(versionName))) {
-            WorkflowVersion workflowVersion = this.workflowDAO.getWorkflowVersionByWorkflowIdAndVersionName(workflow.getId(), versionName);
-            workflowVersions.add(workflowVersion);
+            List<WorkflowVersion> workflowVersionByWorkflowIdAndVersionName = this.workflowDAO
+                    .getWorkflowVersionByWorkflowIdAndVersionName(workflow.getId(), versionName);
+            if (workflowVersionByWorkflowIdAndVersionName.size() == 1) {
+                WorkflowVersion workflowVersion = workflowVersionByWorkflowIdAndVersionName.get(0);
+                workflowVersions.add(workflowVersion);
+            }
         }
         workflow.setWorkflowVersionsOverride(workflowVersions);
         initializeAdditionalFields(include, workflow);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -516,7 +516,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         // This somehow forces users to get loaded
         Hibernate.initialize(workflow.getUsers());
         Hibernate.initialize(workflow.getAliases());
-        setWorkflowVersionSubset(workflow, include, null);
+        initializeAdditionalFields(include, workflow);
         return workflow;
     }
 
@@ -932,7 +932,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         checkEntry(workflow);
         checkCanRead(user, workflow);
         Hibernate.initialize(workflow.getAliases());
-        setWorkflowVersionSubset(workflow, include, null);
+        initializeAdditionalFields(include, workflow);
         return workflow;
     }
     @SuppressWarnings("checkstyle:MagicNumber")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -940,6 +940,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         sessionFactory.getCurrentSession().detach(workflow);
         Long workflowVersionsCount = this.workflowDAO.getWorkflowVersionsCount(workflow.getId());
         LOG.info(String.valueOf(workflowVersionsCount));
+        // Almost all observed workflows have under 150 version, this number should be lowered once the frontend actually supports pagination
         List<WorkflowVersion> ids = this.workflowDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), 150, 0);
         workflow.setWorkflowVersionsOverride(new TreeSet<>(ids));
         initializeAdditionalFields(include, workflow);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -138,6 +138,7 @@ import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
 import static io.dockstore.webservice.Constants.OPTIONAL_AUTH_MESSAGE;
 import static io.dockstore.webservice.core.WorkflowMode.DOCKSTORE_YML;
 import static io.dockstore.webservice.resources.ResourceConstants.OPENAPI_JWT_SECURITY_DEFINITION_NAME;
+import static io.dockstore.webservice.resources.ResourceConstants.VERSION_PAGINATION_LIMIT;
 
 /**
  * TODO: remember to document new security concerns for hosted vs other workflows
@@ -940,7 +941,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         sessionFactory.getCurrentSession().detach(workflow);
 
         // Almost all observed workflows have under 200 version, this number should be lowered once the frontend actually supports pagination
-        List<WorkflowVersion> ids = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), 200, 0);
+        List<WorkflowVersion> ids = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), VERSION_PAGINATION_LIMIT, 0);
         SortedSet<WorkflowVersion> workflowVersions = new TreeSet<>(ids);
         if (versionName != null && workflowVersions.stream().noneMatch(version -> version.getName().equals(versionName))) {
             List<WorkflowVersion> workflowVersionByWorkflowIdAndVersionName = this.workflowVersionDAO

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -24,8 +24,8 @@ components:
           type: object
       type: object
     Checksum:
-      description: 'A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes. '
-      example: '[{checksum=ea2a5db69bd20a42976838790bc29294df3af02b, type=sha1}]'
+      description: A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes.  This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
+      example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182, type=sha256}]'
       properties:
         checksum:
           description: 'The hex-string encoded checksum for the data. '
@@ -1517,6 +1517,12 @@ components:
             $ref: '#/components/schemas/WorkflowVersion'
           type: array
           uniqueItems: true
+        workflowVersionsOverride:
+          items:
+            $ref: '#/components/schemas/WorkflowVersion'
+          type: array
+          uniqueItems: true
+          writeOnly: true
         workflow_path:
           type: string
       required:
@@ -1651,7 +1657,7 @@ info:
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
   termsOfService: TBD
   title: Dockstore API
-  version: 1.9.1-SNAPSHOT
+  version: 1.9.1
 openapi: 3.0.1
 paths:
   /aliases/workflow-versions/{alias}:
@@ -1695,7 +1701,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WorkflowVersion'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -6453,7 +6459,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Workflow'
           description: default response
       security:
         - bearer: []
@@ -6806,6 +6812,10 @@ paths:
           schema:
             default: false
             type: boolean
+        - in: query
+          name: versionName
+          schema:
+            type: string
       responses:
         default:
           content:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -24,8 +24,8 @@ components:
           type: object
       type: object
     Checksum:
-      description: A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes.  This exposes the hashcode for specific image versions to verify that the container version pulled is actually the version that was indexed by the registry.
-      example: '[{checksum=77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182, type=sha256}]'
+      description: 'A production (immutable) tool version is required to have a hashcode. Not required otherwise, but might be useful to detect changes. '
+      example: '[{checksum=ea2a5db69bd20a42976838790bc29294df3af02b, type=sha1}]'
       properties:
         checksum:
           description: 'The hex-string encoded checksum for the data. '
@@ -1417,8 +1417,8 @@ components:
             - SWL
             - NFL
             - service
-            
-            
+            - cwl
+            - wdl
           type: string
         descriptorTypeSubclass:
           enum:
@@ -1517,12 +1517,6 @@ components:
             $ref: '#/components/schemas/WorkflowVersion'
           type: array
           uniqueItems: true
-        workflowVersionsOverride:
-          items:
-            $ref: '#/components/schemas/WorkflowVersion'
-          type: array
-          uniqueItems: true
-          writeOnly: true
         workflow_path:
           type: string
       required:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5,7 +5,7 @@ info:
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images. Explore swagger.json for a Swagger 2.0 description\
     \ of our API and explore openapi.yaml for OpenAPI 3.0 descriptions."
-  version: "1.9.1-SNAPSHOT"
+  version: "1.9.1"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:
@@ -5317,6 +5317,11 @@ paths:
         required: false
         type: "boolean"
         default: false
+      - name: "versionName"
+        in: "query"
+        description: "Version name"
+        required: false
+        type: "string"
       responses:
         200:
           description: "successful operation"


### PR DESCRIPTION
For https://ucsc-cgl.atlassian.net/browse/SEAB-1502

This doesn't actually lazy load versions for a vast majority of cases. input/output file format will force it to EAGER load.

This actually isn't real pagination either (though it's setup to be somewhat easy to add in the future). It'll just grab the first 200 newest versions + the version whose versionName is specified in the query parameter

