### PR TITLE
use getters for Tag compareTo() (#3702)

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -50,7 +50,7 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
     @Column
     @JsonProperty("last_built")
     @ApiModelProperty(value = "For automated tools: The last time the container backing this tool version was built. For hosted: N/A", position = 101)
-    Date lastBuilt;
+    private Date lastBuilt;
 
     @Column
     @JsonProperty("image_id")
@@ -235,19 +235,19 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, reference);
+        return Objects.hash(id, this.getName(), this.getReference());
     }
 
     @Override
     public int compareTo(@NotNull Tag that) {
-        return ComparisonChain.start().compare(this.name, that.name, Ordering.natural().nullsFirst())
-            .compare(this.reference, reference, Ordering.natural().nullsFirst())
-            .compare(this.lastBuilt, that.lastBuilt, Ordering.natural().nullsFirst()).result();
+        return ComparisonChain.start().compare(this.getName(), that.getName(), Ordering.natural().nullsFirst())
+            .compare(this.getReference(), that.getReference(), Ordering.natural().nullsFirst())
+            .compare(this.getLastBuilt(), that.getLastBuilt(), Ordering.natural().nullsFirst()).result();
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("id", id).add("name", name).add("reference", reference).add("imageId", imageId)
+        return MoreObjects.toStringHelper(this).add("id", id).add("name", this.getName()).add("reference", this.getReference()).add("imageId", imageId)
             .add("dockerfilePath", dockerfilePath).toString();
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -93,11 +93,11 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     @Column
     @ApiModelProperty(value = "git commit/tag/branch", required = true, position = 1)
-    protected String reference;
+    private String reference;
 
     @Column
     @ApiModelProperty(value = "Implementation specific, can be a quay.io or docker hub tag name", required = true, position = 2)
-    protected String name;
+    private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parentid", nullable = false)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -170,7 +170,7 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, reference);
+        return Objects.hash(this.getName(), this.getReference());
     }
 
     @Override
@@ -181,7 +181,7 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("id", id).add("name", name).add("reference", reference).toString();
+        return MoreObjects.toStringHelper(this).add("id", id).add("name", this.getName()).add("reference", this.getReference()).toString();
     }
 
     public Service.SubClass getSubClass() {


### PR DESCRIPTION
Original issue: #3663
develop PR: #3702

* use getters for Tag compareTo()

* make name, reference, & lastBuilt private to be safe