### PR TITLE
Cache GitHub app tokens for a little less time

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/CacheConfigManager.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/CacheConfigManager.java
@@ -95,10 +95,13 @@ public class CacheConfigManager {
      */
     public void initCache() {
         final int maxSize = 100;
+        // GitHub token has a 1 hour expiration; leave a generous gap
+        // so we don't fetch a token that may expire as we use it
+        final int timeOutInMinutes = 58;
         if (installationAccessTokenCache == null) {
             installationAccessTokenCache = CacheBuilder.newBuilder()
                     .maximumSize(maxSize)
-                    .expireAfterWrite(1, TimeUnit.HOURS)
+                    .expireAfterWrite(timeOutInMinutes, TimeUnit.MINUTES)
                     .recordStats()
                     .build(new CacheLoader<>() {
                         @Override


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-1691

We are occasionally seeing bad credentials errors for
the GitHub token in the logs. This is a bit of a speculative fix,
but I have seen similar problems in other environments of using a token
that has expired.

The speculation is: Token is good for one hour, we cache it for one
hour. We fetch the token from the cache .5 seconds before it expires.
Making the GitHub API calls takes more than .5 seconds; token is
expired and call fails.

2 minutes buffer may seem overkill, but maybe the network is sluggish,
the web service is bogged down, and a huge repo needs to be cloned.

