### PR TITLE
fixDagAndTools

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
@@ -225,7 +225,7 @@ public class DAGWorkflowTestIT extends BaseIT {
     public void testDAGImportSyntax() throws ApiException {
         // Input: Dockstore.cwl
         // Repo: dockstore-whalesay-imports
-        // Branch: master
+        // Branch: update-to-valid-cwl
         // Test: "run: {import:.....}"
         // Return: DAG with two nodes and an edge connecting it (nodes:{{rev},{sorted}}, edges:{rev->sorted})
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DAGWorkflowTestIT.java
@@ -229,7 +229,7 @@ public class DAGWorkflowTestIT extends BaseIT {
         // Test: "run: {import:.....}"
         // Return: DAG with two nodes and an edge connecting it (nodes:{{rev},{sorted}}, edges:{rev->sorted})
 
-        final List<String> strings = getJSON("DockstoreTestUser2/dockstore-whalesay-imports", "/Dockstore.cwl", "cwl", "master");
+        final List<String> strings = getJSON("DockstoreTestUser2/dockstore-whalesay-imports", "/Dockstore.cwl", "cwl", "update-to-valid-cwl");
         int countNode = countNodeInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -191,7 +191,7 @@ public class ToolsWorkflowTestIT extends BaseIT {
         // Test: "run: {import:.....}"
         // Return: JSON string contains the two tools, both have docker requirement
 
-        final List<String> strings = getJSON("DockstoreTestUser2/dockstore-whalesay-imports", "/Dockstore.cwl", "cwl", "master");
+        final List<String> strings = getJSON("DockstoreTestUser2/dockstore-whalesay-imports", "/Dockstore.cwl", "cwl", "update-to-valid-cwl");
         int countNode = countToolInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -107,7 +107,7 @@ public class ToolsWorkflowTestIT extends BaseIT {
         int countNode = countToolInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);
-        Assert.assertEquals("JSON should have one tool with docker image, has " + countNode, 2, countNode);
+        Assert.assertEquals("JSON should have two tools with docker images, has " + countNode, 2, countNode);
         Assert.assertFalse("tool should not have untar since it has no docker image", strings.get(0).contains("untar"));
         Assert.assertTrue("tool should have compile as id", strings.get(0).contains("compile"));
         Assert.assertTrue("compile docker and link should not be blank" + strings.get(0), strings.get(0).contains(

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -96,22 +96,26 @@ public class ToolsWorkflowTestIT extends BaseIT {
 
     @Test
     public void testWorkflowToolCWL() throws IOException, ApiException {
+        // https://github.com/DockstoreTestUser2/test_workflow_cwl
         // Input: 1st-workflow.cwl
         // Repo: test_workflow_cwl
         // Branch: master
         // Test: normal cwl workflow DAG
-        // Return: JSON string with two tools, only one tool has a docker requirement
+        // Return: JSON string with two tools, in grep-and-count.cwl and arguments.cwl
 
         final List<String> strings = getJSON("DockstoreTestUser2/test_workflow_cwl", "/1st-workflow.cwl", "cwl", "master");
         int countNode = countToolInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);
-        Assert.assertEquals("JSON should have one tool with docker image, has " + countNode, 1, countNode);
+        Assert.assertEquals("JSON should have one tool with docker image, has " + countNode, 2, countNode);
         Assert.assertFalse("tool should not have untar since it has no docker image", strings.get(0).contains("untar"));
         Assert.assertTrue("tool should have compile as id", strings.get(0).contains("compile"));
         Assert.assertTrue("compile docker and link should not be blank" + strings.get(0), strings.get(0).contains(
             "\"id\":\"compile\"," + "\"file\":\"arguments.cwl\"," + "\"docker\":\"java:7\","
                 + "\"link\":\"https://hub.docker.com/_/java\""));
+        Assert.assertTrue("compile docker and link should not be blank" + strings.get(0), strings.get(0).contains(
+                "\"id\":\"wrkflow\"," + "\"file\":\"grep-and-count.cwl\"," + "\"docker\":\"java:7\","
+                        + "\"link\":\"https://hub.docker.com/_/java\""));
 
     }
 
@@ -188,7 +192,7 @@ public class ToolsWorkflowTestIT extends BaseIT {
         // Input: Dockstore.cwl
         // Repo: dockstore-whalesay-imports
         // Branch: master
-        // Test: "run: {import:.....}"
+        // Test: "run: {$import:.....}"
         // Return: JSON string contains the two tools, both have docker requirement
 
         final List<String> strings = getJSON("DockstoreTestUser2/dockstore-whalesay-imports", "/Dockstore.cwl", "cwl", "update-to-valid-cwl");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DAGHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DAGHelper.java
@@ -15,6 +15,7 @@
 
 package io.dockstore.webservice.helpers;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -38,11 +39,14 @@ public final class DAGHelper {
      * @param dag The unclean DAG with edges that may have undefined nodes
      * @return The clean DAG without edges that have undefined nodes
      */
-    public static String cleanDAG(String dag) {
-        ElementsDefinition elementsDefinition = GSON.fromJson(dag, ElementsDefinition.class);
-        Set<String> nodeIDs = elementsDefinition.nodes.stream().map(nodeDefinition -> nodeDefinition.data.id).collect(Collectors.toSet());
-        elementsDefinition.edges = elementsDefinition.edges.stream().filter(edgeDefinition -> nodeIDs.contains(edgeDefinition.data.source))
-            .collect(Collectors.toList());
-        return GSON.toJson(elementsDefinition);
+    public static Optional<String> cleanDAG(Optional<String> dag) {
+        if (dag.isPresent()) {
+            ElementsDefinition elementsDefinition = GSON.fromJson(dag.get(), ElementsDefinition.class);
+            Set<String> nodeIDs = elementsDefinition.nodes.stream().map(nodeDefinition -> nodeDefinition.data.id).collect(Collectors.toSet());
+            elementsDefinition.edges = elementsDefinition.edges.stream().filter(edgeDefinition -> nodeIDs.contains(edgeDefinition.data.source))
+                    .collect(Collectors.toList());
+            return Optional.of(GSON.toJson(elementsDefinition));
+        }
+        return Optional.empty();
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DAGHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DAGHelper.java
@@ -15,7 +15,6 @@
 
 package io.dockstore.webservice.helpers;
 
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -39,14 +38,12 @@ public final class DAGHelper {
      * @param dag The unclean DAG with edges that may have undefined nodes
      * @return The clean DAG without edges that have undefined nodes
      */
-    public static Optional<String> cleanDAG(Optional<String> dag) {
-        if (dag.isPresent()) {
-            ElementsDefinition elementsDefinition = GSON.fromJson(dag.get(), ElementsDefinition.class);
-            Set<String> nodeIDs = elementsDefinition.nodes.stream().map(nodeDefinition -> nodeDefinition.data.id).collect(Collectors.toSet());
-            elementsDefinition.edges = elementsDefinition.edges.stream().filter(edgeDefinition -> nodeIDs.contains(edgeDefinition.data.source))
-                    .collect(Collectors.toList());
-            return Optional.of(GSON.toJson(elementsDefinition));
-        }
-        return Optional.empty();
+    //
+    public static String cleanDAG(String dag) {
+        ElementsDefinition elementsDefinition = GSON.fromJson(dag, ElementsDefinition.class);
+        Set<String> nodeIDs = elementsDefinition.nodes.stream().map(nodeDefinition -> nodeDefinition.data.id).collect(Collectors.toSet());
+        elementsDefinition.edges = elementsDefinition.edges.stream().filter(edgeDefinition -> nodeIDs.contains(edgeDefinition.data.source))
+                .collect(Collectors.toList());
+        return GSON.toJson(elementsDefinition);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DAGHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DAGHelper.java
@@ -38,7 +38,6 @@ public final class DAGHelper {
      * @param dag The unclean DAG with edges that may have undefined nodes
      * @return The clean DAG without edges that have undefined nodes
      */
-    //
     public static String cleanDAG(String dag) {
         ElementsDefinition elementsDefinition = GSON.fromJson(dag, ElementsDefinition.class);
         Set<String> nodeIDs = elementsDefinition.nodes.stream().map(nodeDefinition -> nodeDefinition.data.id).collect(Collectors.toSet());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -358,12 +358,12 @@ public class CWLHandler implements LanguageHandlerInterface {
                         stepToType.put(workflowStepId, expressionToolType);
                     } else if (run instanceof Map) {
                         // must be import or include
-                        Object importVal = ((Map)run).get("import");
+                        Object importVal = ((Map)run).get("$import");
                         if (importVal != null) {
                             secondaryFile = importVal.toString();
                         }
 
-                        Object includeVal = ((Map)run).get("include");
+                        Object includeVal = ((Map)run).get("$include");
                         if (includeVal != null) {
                             secondaryFile = includeVal.toString();
                         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -358,18 +358,18 @@ public class CWLHandler implements LanguageHandlerInterface {
                         stepToType.put(workflowStepId, expressionToolType);
                     } else if (run instanceof Map) {
                         // must be import or include
-                        Object importVal = ((Map)run).get("$import");
+                        Object importVal = ((Map)run).containsKey("$import") ? ((Map)run).get("$import") : ((Map)run).get("import");
                         if (importVal != null) {
                             secondaryFile = importVal.toString();
                         }
 
-                        Object includeVal = ((Map)run).get("$include");
+                        Object includeVal = ((Map)run).containsKey("$include") ? ((Map)run).get("$include") : ((Map)run).get("include");
                         if (includeVal != null) {
                             secondaryFile = includeVal.toString();
                         }
 
                         if (secondaryFile == null) {
-                            LOG.error("Syntax incorrect. Could not $import or $include secondary file for run command: " + run);
+                            LOG.error("Syntax incorrect. Could not ($)import or ($)include secondary file for run command: " + run);
                             return Optional.empty();
                         }
                     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -367,6 +367,11 @@ public class CWLHandler implements LanguageHandlerInterface {
                         if (includeVal != null) {
                             secondaryFile = includeVal.toString();
                         }
+
+                        if (secondaryFile == null) {
+                            LOG.error("Syntax incorrect. Could not $import or $include secondary file for run command: " + run);
+                            return null;
+                        }
                     }
 
                     // Check secondary file for docker pull
@@ -388,7 +393,7 @@ public class CWLHandler implements LanguageHandlerInterface {
                     }
 
                     String dockerUrl = null;
-                    if (!stepToType.get(workflowStepId).equals(workflowType) && !Strings.isNullOrEmpty(stepDockerRequirement)) {
+                    if ((stepToType.get(workflowStepId).equals(workflowType) || stepToType.get(workflowStepId).equals(toolType)) && !Strings.isNullOrEmpty(stepDockerRequirement)) {//
                         dockerUrl = getURLFromEntry(stepDockerRequirement, dao);
                     }
 
@@ -561,7 +566,7 @@ public class CWLHandler implements LanguageHandlerInterface {
      * @param yaml
      * @return
      */
-    private String parseSecondaryFile(String stepDockerRequirement, String secondaryFileContents, Gson gson, Yaml yaml) {
+    private String parseSecondaryFile(String stepDockerRequirement, String secondaryFileContents, Gson gson, Yaml yaml) { //
         if (secondaryFileContents != null) {
             Map<String, Object> entryMapping = yaml.loadAs(secondaryFileContents, Map.class);
             JSONObject entryJson = new JSONObject(entryMapping);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -393,7 +393,7 @@ public class CWLHandler implements LanguageHandlerInterface {
                     }
 
                     String dockerUrl = null;
-                    if ((stepToType.get(workflowStepId).equals(workflowType) || stepToType.get(workflowStepId).equals(toolType)) && !Strings.isNullOrEmpty(stepDockerRequirement)) {//
+                    if ((stepToType.get(workflowStepId).equals(workflowType) || stepToType.get(workflowStepId).equals(toolType)) && !Strings.isNullOrEmpty(stepDockerRequirement)) {
                         dockerUrl = getURLFromEntry(stepDockerRequirement, dao);
                     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -141,7 +141,7 @@ public interface LanguageHandlerInterface {
      * @param dao                  used to retrieve information on tools
      * @return either a DAG or some form of a list of tools for a workflow
      */
-    String getContent(String mainDescriptorPath, String mainDescriptor, Set<SourceFile> secondarySourceFiles, Type type, ToolDAO dao);
+    Optional<String> getContent(String mainDescriptorPath, String mainDescriptor, Set<SourceFile> secondarySourceFiles, Type type, ToolDAO dao);
 
     /**
      * Checks that the test parameter files are valid JSON or YAML
@@ -167,7 +167,7 @@ public interface LanguageHandlerInterface {
         return new VersionTypeValidation(isValid, validationMessageObject);
     }
 
-    default String getCleanDAG(String mainDescriptorPath, String mainDescriptor, Set<SourceFile> secondarySourceFiles, Type type, ToolDAO dao) {
+    default Optional<String> getCleanDAG(String mainDescriptorPath, String mainDescriptor, Set<SourceFile> secondarySourceFiles, Type type, ToolDAO dao) {
         return DAGHelper.cleanDAG(getContent(mainDescriptorPath, mainDescriptor, secondarySourceFiles, type, dao));
     }
 
@@ -562,7 +562,7 @@ public interface LanguageHandlerInterface {
      * @param namespaceToPath ?
      * @return the actual JSON output of either a DAG or tool listing
      */
-    default String convertMapsToContent(final String mainDescName, final Type type, ToolDAO dao, final String callType,
+    default Optional<String> convertMapsToContent(final String mainDescName, final Type type, ToolDAO dao, final String callType,
         final String toolType, Map<String, ToolInfo> toolInfoMap, Map<String, String> namespaceToPath) {
 
         // Initialize data structures for DAG
@@ -626,12 +626,12 @@ public interface LanguageHandlerInterface {
 
         // Create JSON for DAG/table
         if (type == Type.DAG) {
-            return setupJSONDAG(nodePairs, toolInfoMap, callToType, nodeDockerInfo);
+            return Optional.of(setupJSONDAG(nodePairs, toolInfoMap, callToType, nodeDockerInfo));
         } else if (type == Type.TOOLS) {
-            return getJSONTableToolContent(nodeDockerInfo);
+            return Optional.of(getJSONTableToolContent(nodeDockerInfo));
         }
 
-        return null;
+        return Optional.empty();
     }
 
     enum Type {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -167,8 +167,13 @@ public interface LanguageHandlerInterface {
         return new VersionTypeValidation(isValid, validationMessageObject);
     }
 
-    default Optional<String> getCleanDAG(String mainDescriptorPath, String mainDescriptor, Set<SourceFile> secondarySourceFiles, Type type, ToolDAO dao) {
-        return DAGHelper.cleanDAG(getContent(mainDescriptorPath, mainDescriptor, secondarySourceFiles, type, dao));
+    default String getCleanDAG(String mainDescriptorPath, String mainDescriptor, Set<SourceFile> secondarySourceFiles, Type type, ToolDAO dao) {
+        Optional<String> content = getContent(mainDescriptorPath, mainDescriptor, secondarySourceFiles, type, dao);
+        if (content.isPresent()) {
+            return DAGHelper.cleanDAG(content.get());
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -167,13 +167,13 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
     }
 
     @Override
-    public String getContent(String mainDescriptorPath, String mainDescriptor, Set<SourceFile> secondarySourceFiles, Type type,
+    public Optional<String> getContent(String mainDescriptorPath, String mainDescriptor, Set<SourceFile> secondarySourceFiles, Type type,
         ToolDAO dao) {
 
         if (type == Type.DAG && minimalLanguageInterface instanceof CompleteLanguageInterface) {
             final Map<String, Object> maps = ((CompleteLanguageInterface)minimalLanguageInterface)
                 .loadCytoscapeElements(mainDescriptorPath, mainDescriptor, sourcefilesToIndexedFiles(secondarySourceFiles));
-            return gson.toJson(maps);
+            return Optional.of(gson.toJson(maps));
         } else if (type == Type.TOOLS &&  minimalLanguageInterface instanceof CompleteLanguageInterface) {
             // TODO: hook up tools here for Galaxy
             final List<CompleteLanguageInterface.RowData> rowData = ((CompleteLanguageInterface)minimalLanguageInterface)
@@ -186,8 +186,8 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
                 oldRow.put("link", row.link == null ? "" : row.link.toString());
                 return oldRow;
             }).collect(Collectors.toList());
-            return gson.toJson(collect);
+            return Optional.of(gson.toJson(collect));
         }
-        return "";
+        return Optional.empty();
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -324,7 +324,7 @@ public class NextflowHandler implements LanguageHandlerInterface {
     }
 
     @Override
-    public String getContent(String mainDescName, String mainDescriptor, Set<SourceFile> secondarySourceFiles, Type type, ToolDAO dao) {
+    public Optional<String> getContent(String mainDescName, String mainDescriptor, Set<SourceFile> secondarySourceFiles, Type type, ToolDAO dao) {
         String callType = "call"; // This may change later (ex. tool, workflow)
         String toolType = "tool";
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -397,7 +397,7 @@ public class WDLHandler implements LanguageHandlerInterface {
      * @return either a list of tools or a json map
      */
     @Override
-    public String getContent(String mainDescName, String mainDescriptor, Set<SourceFile> secondarySourceFiles,
+    public Optional<String> getContent(String mainDescName, String mainDescriptor, Set<SourceFile> secondarySourceFiles,
             LanguageHandlerInterface.Type type, ToolDAO dao) {
         // Initialize general variables
         String callType = "call"; // This may change later (ex. tool, workflow)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1440,11 +1440,11 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                     } else {
                         toolsJSONTable = Optional.of(existingTag.getToolTableJson());
                     }
+
                     if (toolsJSONTable.isPresent()) {
                         Set<Image> images = lInterface.getImagesFromRegistry(toolsJSONTable.get());
                         existingTag.getImages().addAll(images);
                     }
-
                     // Grab checksum for file descriptors if not already available.
                     for (SourceFile sourceFile : existingTag.getSourceFiles()) {
                         Optional<String> sha = FileFormatHelper.calcSHA1(sourceFile.getContent());
@@ -1462,10 +1462,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
                     // store dag
                     if (existingTag.getDagJson() == null) {
-                        Optional<String> dagJson = lInterface.getCleanDAG(w.getWorkflowPath(), getMainDescriptorFile(existingTag).getContent(), extractDescriptorAndSecondaryFiles(existingTag), LanguageHandlerInterface.Type.DAG, toolDAO);
-                        if (dagJson.isPresent()) {
-                            existingTag.setDagJson(dagJson.get());
-                        }
+                        String dagJson = lInterface.getCleanDAG(w.getWorkflowPath(), getMainDescriptorFile(existingTag).getContent(), extractDescriptorAndSecondaryFiles(existingTag), LanguageHandlerInterface.Type.DAG, toolDAO);
+                        existingTag.setDagJson(dagJson);
                     }
                 }
             }
@@ -1502,16 +1500,11 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             Set<SourceFile> secondaryDescContent = extractDescriptorAndSecondaryFiles(workflowVersion);
 
             LanguageHandlerInterface lInterface = LanguageHandlerFactory.getInterface(workflow.getFileType());
-            final Optional<String> dagJson = lInterface.getCleanDAG(workflowVersion.getWorkflowPath(), mainDescriptor.getContent(), secondaryDescContent,
+            final String dagJson = lInterface.getCleanDAG(workflowVersion.getWorkflowPath(), mainDescriptor.getContent(), secondaryDescContent,
                     LanguageHandlerInterface.Type.DAG, toolDAO);
-            if (dagJson.isPresent()) {
-                workflowVersion.setDagJson(dagJson.get());
-                return dagJson.get();
-            } else {
-                workflowVersion.setDagJson(null);
-                return null;
-            }
 
+            workflowVersion.setDagJson(dagJson);
+            return dagJson;
         }
         return null;
     }
@@ -1554,14 +1547,9 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             LanguageHandlerInterface lInterface = LanguageHandlerFactory.getInterface(workflow.getFileType());
             final Optional<String> toolTableJson = lInterface.getContent(workflowVersion.getWorkflowPath(), mainDescriptor.getContent(), secondaryDescContent,
                 LanguageHandlerInterface.Type.TOOLS, toolDAO);
-            if (toolTableJson.isPresent()) {
-                workflowVersion.setToolTableJson(toolTableJson.get());
-                return toolTableJson.get();
-            } else {
-                workflowVersion.setToolTableJson(null);
-                return null;
-            }
-
+            final String json = toolTableJson.orElseGet(null);
+            workflowVersion.setToolTableJson(json);
+            return json;
         }
 
         return null;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1507,8 +1507,11 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             if (dagJson.isPresent()) {
                 workflowVersion.setDagJson(dagJson.get());
                 return dagJson.get();
+            } else {
+                workflowVersion.setDagJson(null);
+                return null;
             }
-            return null;
+
         }
         return null;
     }
@@ -1554,8 +1557,11 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             if (toolTableJson.isPresent()) {
                 workflowVersion.setToolTableJson(toolTableJson.get());
                 return toolTableJson.get();
+            } else {
+                workflowVersion.setToolTableJson(null);
+                return null;
             }
-            return null;
+
         }
 
         return null;

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -6432,7 +6432,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1698,7 +1698,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/WorkflowVersion'
           description: default response
       security:
         - bearer: []

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -2395,7 +2395,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Tool'
           description: default response
       security:
         - bearer: []
@@ -2421,7 +2421,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Tool'
           description: default response
       security:
         - bearer: []
@@ -3578,7 +3578,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []
@@ -4447,7 +4447,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Collection'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1698,7 +1698,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WorkflowVersion'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -4447,7 +4447,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/Collection'
           description: default response
       security:
         - bearer: []
@@ -6432,7 +6432,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Workflow'
           description: default response
       security:
         - bearer: []
@@ -6458,7 +6458,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Workflow'
           description: default response
       security:
         - bearer: []

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -2395,7 +2395,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tool'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []
@@ -2421,7 +2421,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tool'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []
@@ -3578,7 +3578,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []
@@ -4447,7 +4447,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/Collection'
           description: default response
       security:
         - bearer: []
@@ -6458,7 +6458,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/DAGHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/DAGHelperTest.java
@@ -15,8 +15,6 @@
 
 package io.dockstore.webservice.helpers;
 
-import java.util.Optional;
-
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,9 +33,9 @@ public class DAGHelperTest {
     @Test
     public void cleanDAGTest() {
         String uncleanDAG = fixture("fixtures/uncleanDAG.json");
-        Optional<String> cleanDAG = DAGHelper.cleanDAG(Optional.of(uncleanDAG));
-        Assert.assertEquals(fixture("fixtures/cleanDAG.json").replace(" ", "").replace("\n", ""), cleanDAG.get().trim());
-        Optional<String> cleanerDAG = DAGHelper.cleanDAG(cleanDAG);
-        Assert.assertEquals(fixture("fixtures/cleanDAG.json").replace(" ", "").replace("\n", ""), cleanerDAG.get().trim());
+        String cleanDAG = DAGHelper.cleanDAG(uncleanDAG);
+        Assert.assertEquals(fixture("fixtures/cleanDAG.json").replace(" ", "").replace("\n", ""), cleanDAG.trim());
+        String cleanerDAG = DAGHelper.cleanDAG(cleanDAG);
+        Assert.assertEquals(fixture("fixtures/cleanDAG.json").replace(" ", "").replace("\n", ""), cleanerDAG.trim());
     }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/DAGHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/DAGHelperTest.java
@@ -15,6 +15,8 @@
 
 package io.dockstore.webservice.helpers;
 
+import java.util.Optional;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -33,9 +35,9 @@ public class DAGHelperTest {
     @Test
     public void cleanDAGTest() {
         String uncleanDAG = fixture("fixtures/uncleanDAG.json");
-        String cleanDAG = DAGHelper.cleanDAG(uncleanDAG);
-        Assert.assertEquals(fixture("fixtures/cleanDAG.json").replace(" ", "").replace("\n", ""), cleanDAG.trim());
-        String cleanerDAG = DAGHelper.cleanDAG(cleanDAG);
-        Assert.assertEquals(fixture("fixtures/cleanDAG.json").replace(" ", "").replace("\n", ""), cleanerDAG.trim());
+        Optional<String> cleanDAG = DAGHelper.cleanDAG(Optional.of(uncleanDAG));
+        Assert.assertEquals(fixture("fixtures/cleanDAG.json").replace(" ", "").replace("\n", ""), cleanDAG.get().trim());
+        Optional<String> cleanerDAG = DAGHelper.cleanDAG(cleanDAG);
+        Assert.assertEquals(fixture("fixtures/cleanDAG.json").replace(" ", "").replace("\n", ""), cleanerDAG.get().trim());
     }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
@@ -137,11 +137,16 @@ public class WDLHandlerTest {
         final ToolDAO toolDAO = Mockito.mock(ToolDAO.class);
         when(toolDAO.findAllByPath(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(null);
 
-        final String toolsStr = wdlHandler
+        final Optional<String> toolsStr = wdlHandler
                 .getContent(MAIN_WDL, content, new HashSet<SourceFile>(sourceFileMap.values()), LanguageHandlerInterface.Type.TOOLS, toolDAO);
-        final Gson gson = new Gson();
-        final Object[] tools = gson.fromJson(toolsStr, Object[].class);
-        Assert.assertEquals("There should be 227 tools", 227, tools.length);
+        if (toolsStr.isPresent()) {
+            final Gson gson = new Gson();
+            final Object[] tools = gson.fromJson(toolsStr.get(), Object[].class);
+            Assert.assertEquals("There should be 227 tools", 227, tools.length);
+        } else {
+            Assert.fail("Should be able to get tool json");
+        }
+
     }
 
     private String getGatkSvMainDescriptorContent() throws IOException {


### PR DESCRIPTION
#3349
I couldn't reproduce the original error described in the ticket above, but there was another problem anyway. In the cwl documentation, I only see `$include` and `$import` but we were checking for that without a `$`.
Now able to see a dag and tool table for  https://github.com/dockstore-testing/multi-step-cwl when testing locally, but it's still incorrect because of #3352 

#3797 
The workflow mentioned doesn't include a cwlVersion which caused the NPE. Changed getContent() to return an optional<String> instead. The version is marked as invalid in the versions table, but doesn't have a validation message in the files tab. When I register it locally now, it does have a validation message as well. I think the one on production just needs to be refreshed to get the validation message.

Merged https://github.com/DockstoreTestUser2/dockstore-whalesay-imports/pull/1 and updated some tests to use the new branch created.