### PR TITLE
Custom message if can't recognize key in .dockstore.yml

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
@@ -30,7 +30,7 @@ import org.yaml.snakeyaml.introspector.PropertyUtils;
 public final class DockstoreYamlHelper {
 
     public static final String ERROR_READING_DOCKSTORE_YML = "Error reading .dockstore.yml: ";
-    public static final Pattern pattern = Pattern.compile("Unable to find property '(.+)'");
+    public static final Pattern WRONG_KEY_PATTERN = Pattern.compile("Unable to find property '(.+)'");
 
     enum Version {
         ONE_ZERO("1.0") {
@@ -180,7 +180,7 @@ public final class DockstoreYamlHelper {
         } catch (Exception e) {
             final String exceptionMsg = e.getMessage();
             String errorMsg = ERROR_READING_DOCKSTORE_YML;
-            final Matcher matcher = pattern.matcher(exceptionMsg);
+            final Matcher matcher = WRONG_KEY_PATTERN.matcher(exceptionMsg);
 
             if (matcher.find()) {
                 errorMsg += " Unrecognized property \"" + matcher.group(1) + "\"";

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
@@ -177,7 +177,15 @@ public final class DockstoreYamlHelper {
             final Yaml yaml = new Yaml(constructor);
             return yaml.load(content);
         } catch (Exception e) {
-            final String msg = ERROR_READING_DOCKSTORE_YML + e.getMessage();
+            String msg = ERROR_READING_DOCKSTORE_YML;
+            String errorMsg = e.getMessage();
+            if (errorMsg.startsWith("Cannot create property=")) {
+                int startIndex = errorMsg.indexOf("=") + 1;
+                int endIndex = errorMsg.indexOf(" for JavaBean");
+                msg += " Unrecognized property \"" + errorMsg.substring(startIndex, endIndex) + "\".";
+            } else {
+                msg += e.getMessage();
+            }
             LOG.error(msg, e);
             throw new DockstoreYamlException(msg);
         }

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
@@ -179,10 +179,16 @@ public final class DockstoreYamlHelper {
         } catch (Exception e) {
             String msg = ERROR_READING_DOCKSTORE_YML;
             String errorMsg = e.getMessage();
-            if (errorMsg.startsWith("Cannot create property=")) {
-                int startIndex = errorMsg.indexOf("=") + 1;
-                int endIndex = errorMsg.indexOf(" for JavaBean");
-                msg += " Unrecognized property \"" + errorMsg.substring(startIndex, endIndex) + "\".";
+            final String cannotCreateProperty = "Unable to find property ";
+            if (errorMsg.contains(cannotCreateProperty)) {
+                String truncatedError = errorMsg.substring(errorMsg.indexOf(cannotCreateProperty) + cannotCreateProperty.length());
+                Pattern pattern = Pattern.compile("'(.+)'");
+                Matcher matcher = pattern.matcher(truncatedError);
+                if (matcher.find()) {
+                    msg += " Unrecognized property \"" + matcher.group(1) + "\"";
+                } else {
+                    msg += e.getMessage();
+                }
             } else {
                 msg += e.getMessage();
             }

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import io.dropwizard.testing.FixtureHelpers;
 import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.SystemErrRule;
@@ -181,6 +182,40 @@ public class DockstoreYamlTest {
             DockstoreYamlHelper.readAsDockstoreYaml12(content);
         } catch (DockstoreYamlHelper.DockstoreYamlException e) {
             assertEquals(Service12.MISSING_SUBCLASS, e.getMessage());
+        }
+    }
+
+    @Test
+    public void testWrongKeys() {
+        final String content = DOCKSTORE_GALAXY_YAML;
+        try {
+            DockstoreYamlHelper.readAsDockstoreYaml12(content);
+        } catch (DockstoreYamlHelper.DockstoreYamlException ex) {
+            Assert.fail("Should be able to parse correctly");
+        }
+
+        final String workflowsKey = DOCKSTORE_GALAXY_YAML.replaceFirst("workflows", "workflow");
+        try {
+            DockstoreYamlHelper.readAsDockstoreYaml12(workflowsKey);
+            Assert.fail("Shouldn't be able to parse correctly");
+        } catch (DockstoreYamlHelper.DockstoreYamlException ex) {
+            assertTrue(ex.getMessage().contains("Unrecognized property \"workflow\""));
+        }
+
+        final String nameKey = DOCKSTORE_GALAXY_YAML.replaceFirst("name", "Name");
+        try {
+            DockstoreYamlHelper.readAsDockstoreYaml12(nameKey);
+            Assert.fail("Shouldn't be able to parse correctly");
+        } catch (DockstoreYamlHelper.DockstoreYamlException ex) {
+            assertTrue(ex.getMessage().contains("Unrecognized property \"Name\""));
+        }
+
+        final String multipleKeys = DOCKSTORE_GALAXY_YAML.replaceFirst("name", "Name").replaceFirst("workflows", "workflow");
+        try {
+            DockstoreYamlHelper.readAsDockstoreYaml12(multipleKeys);
+            Assert.fail("Shouldn't be able to parse correctly");
+        } catch (DockstoreYamlHelper.DockstoreYamlException ex) {
+            assertTrue("Should only return first error", ex.getMessage().contains("Unrecognized property \"workflow\""));
         }
     }
 


### PR DESCRIPTION
#3564 
give custom message instead if can't recognize a property in .dockstore.yml
<img width="732" alt="Screen Shot 2020-09-08 at 4 56 48 PM" src="https://user-images.githubusercontent.com/16004905/92638944-f7365680-f28f-11ea-881b-b86c53a2f769.png">
