### PR TITLE
Comment out openapi_validation (until we fix it)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,36 +10,36 @@ workflows:
                 - gh-pages
 #      - openapi_validation
 jobs:
-#  openapi_validation:
-#    docker: # run the steps with Docker
-#      - image: circleci/openjdk:11.0.4-jdk-stretch
-#        environment:
-#          JAVA_TOOL_OPTIONS: -Xmx512m # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Nothing to do with surefire plugin, it has its own JVM. The two of these must add up to a bit less than 4GB.
-#    steps: # a collection of executable commands
-#      - checkout # check out source code to working directory
-#      - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
-#          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
-#          key: dockstore-java-{{ checksum "pom.xml" }}
-#      - run:
-#          name: install dockerize
-#          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-#          environment:
-#            DOCKERIZE_VERSION: v0.3.0
-#      - run:
-#          name: Install yq
-#          command: |
-#            wget https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64
-#            chmod a+x yq_linux_amd64
-#            sudo mv yq_linux_amd64 /usr/bin/yq
-#      - run:
-#          name: run the actual tests
-#          command: mvn -B clean install -DskipTests
-#      - run:
-#          name: validate openapi
-#          command: |
-#            wget --no-verbose https://repo.maven.apache.org/maven2/org/openapitools/openapi-generator-cli/4.3.0/openapi-generator-cli-4.3.0.jar -O openapi-generator-cli.jar
-#            java -jar openapi-generator-cli.jar validate -i dockstore-webservice/src/main/resources/swagger.yaml
-#            java -jar openapi-generator-cli.jar validate -i dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+  openapi_validation:
+    docker: # run the steps with Docker
+      - image: circleci/openjdk:11.0.4-jdk-stretch
+        environment:
+          JAVA_TOOL_OPTIONS: -Xmx512m # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Nothing to do with surefire plugin, it has its own JVM. The two of these must add up to a bit less than 4GB.
+    steps: # a collection of executable commands
+      - checkout # check out source code to working directory
+      - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
+          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+          key: dockstore-java-{{ checksum "pom.xml" }}
+      - run:
+          name: install dockerize
+          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          environment:
+            DOCKERIZE_VERSION: v0.3.0
+      - run:
+          name: Install yq
+          command: |
+            wget https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64
+            chmod a+x yq_linux_amd64
+            sudo mv yq_linux_amd64 /usr/bin/yq
+      - run:
+          name: run the actual tests
+          command: mvn -B clean install -DskipTests
+      - run:
+          name: validate openapi
+          command: |
+            wget --no-verbose https://repo.maven.apache.org/maven2/org/openapitools/openapi-generator-cli/4.3.0/openapi-generator-cli-4.3.0.jar -O openapi-generator-cli.jar
+            java -jar openapi-generator-cli.jar validate -i dockstore-webservice/src/main/resources/swagger.yaml
+            java -jar openapi-generator-cli.jar validate -i dockstore-webservice/src/main/resources/openapi3/openapi.yaml
   unit_test: # runs not using Workflows must have a `build` job as entry point
     docker: # run the steps with Docker
       - image: circleci/openjdk:11.0.4-jdk-stretch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ workflows:
             branches:
               ignore:
                 - gh-pages
-      - openapi_validation
+#      - openapi_validation
 jobs:
 #  openapi_validation:
 #    docker: # run the steps with Docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,36 +10,36 @@ workflows:
                 - gh-pages
       - openapi_validation
 jobs:
-  openapi_validation:
-    docker: # run the steps with Docker
-      - image: circleci/openjdk:11.0.4-jdk-stretch
-        environment:
-          JAVA_TOOL_OPTIONS: -Xmx512m # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Nothing to do with surefire plugin, it has its own JVM. The two of these must add up to a bit less than 4GB.
-    steps: # a collection of executable commands
-      - checkout # check out source code to working directory
-      - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
-          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
-          key: dockstore-java-{{ checksum "pom.xml" }}
-      - run:
-          name: install dockerize
-          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-          environment:
-            DOCKERIZE_VERSION: v0.3.0
-      - run:
-          name: Install yq
-          command: |
-            wget https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64
-            chmod a+x yq_linux_amd64
-            sudo mv yq_linux_amd64 /usr/bin/yq
-      - run:
-          name: run the actual tests
-          command: mvn -B clean install -DskipTests
-      - run:
-          name: validate openapi
-          command: |
-            wget --no-verbose https://repo.maven.apache.org/maven2/org/openapitools/openapi-generator-cli/4.3.0/openapi-generator-cli-4.3.0.jar -O openapi-generator-cli.jar
-            java -jar openapi-generator-cli.jar validate -i dockstore-webservice/src/main/resources/swagger.yaml
-            java -jar openapi-generator-cli.jar validate -i dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+#  openapi_validation:
+#    docker: # run the steps with Docker
+#      - image: circleci/openjdk:11.0.4-jdk-stretch
+#        environment:
+#          JAVA_TOOL_OPTIONS: -Xmx512m # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Nothing to do with surefire plugin, it has its own JVM. The two of these must add up to a bit less than 4GB.
+#    steps: # a collection of executable commands
+#      - checkout # check out source code to working directory
+#      - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
+#          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+#          key: dockstore-java-{{ checksum "pom.xml" }}
+#      - run:
+#          name: install dockerize
+#          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+#          environment:
+#            DOCKERIZE_VERSION: v0.3.0
+#      - run:
+#          name: Install yq
+#          command: |
+#            wget https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64
+#            chmod a+x yq_linux_amd64
+#            sudo mv yq_linux_amd64 /usr/bin/yq
+#      - run:
+#          name: run the actual tests
+#          command: mvn -B clean install -DskipTests
+#      - run:
+#          name: validate openapi
+#          command: |
+#            wget --no-verbose https://repo.maven.apache.org/maven2/org/openapitools/openapi-generator-cli/4.3.0/openapi-generator-cli-4.3.0.jar -O openapi-generator-cli.jar
+#            java -jar openapi-generator-cli.jar validate -i dockstore-webservice/src/main/resources/swagger.yaml
+#            java -jar openapi-generator-cli.jar validate -i dockstore-webservice/src/main/resources/openapi3/openapi.yaml
   unit_test: # runs not using Workflows must have a `build` job as entry point
     docker: # run the steps with Docker
       - image: circleci/openjdk:11.0.4-jdk-stretch


### PR DESCRIPTION
Main issue: https://ucsc-cgl.atlassian.net/browse/SEAB-1617

We settled on commenting out the automated `openapi_validation` circle-ci test until we fix the validation issues.

This way commits won't show as failed builds due to this test always failing.