### PR TITLE
Fix/3790/wrong GitHub app language

### DIFF
--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1418,8 +1418,8 @@ components:
             - SWL
             - NFL
             - service
-            
-            
+            - cwl
+            - wdl
           type: string
         descriptorTypeSubclass:
           enum:
@@ -2421,7 +2421,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tool'
+                $ref: '#/components/schemas/Entry'
           description: default response
       security:
         - bearer: []
@@ -7228,6 +7228,42 @@ paths:
           description: default response
       security:
         - bearer: []
+      tags:
+        - workflows
+  /workflows/{workflowId}/descriptorType:
+    post:
+      description: Use with caution. This deletes all the workflowVersions, only use if there's nothing worth keeping in the workflow.
+      operationId: updateDescriptorType
+      parameters:
+        - in: path
+          name: workflowId
+          required: true
+          schema:
+            format: int64
+            type: integer
+        - in: query
+          name: descriptorType
+          schema:
+            enum:
+              - CWL
+              - WDL
+              - gxformat2
+              - SWL
+              - NFL
+              - service
+              - cwl
+              - wdl
+            type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Workflow'
+          description: default response
+      security:
+        - bearer: []
+      summary: Changes the descriptor type of an unpublished, invalid workflow.
       tags:
         - workflows
   /workflows/{workflowId}/labels:


### PR DESCRIPTION
For #3790 

Changing descriptor language is kind of a big deal. I think my current plan is to add an endpoint that's not advertised that could be used to change the descriptor language on unpublished and invalid workflows.  I didn't trigger a refresh on existing versions because I don't think that works with GitHub Apps. I also removed all versions because if the descriptor language has changed, pretty much all versions are obsolete.

Didn't automatically change the descriptor language when a new version (that says it's a different descriptor language) is pushed because it can be fairly dangerous to manipulate workflow level information in a version level endpoint. For example, if you have 20 valid NFL versions, and then a bad push was made, suddenly the entire workflow is classified as WDL or something

TODO: Wrong base branch, need to cherry-pick later