### PR TITLE
prevent workflow tool list from updating workflowversion when frozen

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1531,7 +1531,13 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             LanguageHandlerInterface lInterface = LanguageHandlerFactory.getInterface(workflow.getFileType());
             final String toolTableJson = lInterface.getContent(workflowVersion.getWorkflowPath(), mainDescriptor.getContent(), secondaryDescContent,
                 LanguageHandlerInterface.Type.TOOLS, toolDAO);
-            workflowVersion.setToolTableJson(toolTableJson);
+
+            // Can't UPDATE workflowversion when frozen = true
+            if (workflowVersion.isFrozen()) {
+                LOG.warn("workflow version " + workflowVersionId + " is frozen without a mainDescriptor");
+            } else {
+                workflowVersion.setToolTableJson(toolTableJson);
+            }
             return toolTableJson;
         }
 


### PR DESCRIPTION
Main bug: #3819

The `workflowversion` table has a policy that blocks UPDATEs when `frozen = true`.
If the workflow tool list endpoint doesn't find a main descriptor file, it attempts to examine other files and attempt to update the table. For frozen entries (snapshotted/DOI) this results in a 500 error.

This PR blocks the UPDATE for frozen workflowversions and preserves the existing behaviour.