### PR TITLE
More codacy fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ before_cache:
 
 after_success:
 - bash <(curl -s https://codecov.io/bash) -F ${TESTING_PROFILE//-} || echo "Codecov did not collect coverage reports"
-- java -jar codacy-coverage-reporter-assembly.jar report -l Java -r build/reports/jacoco/test/jacocoTestReport.xml
+- java -jar codacy-coverage-reporter-assembly.jar report -l Java -r reports/target/site/jacoco-aggregate/jacoco.xml 
   
 notifications:
   webhooks: https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ before_cache:
 
 after_success:
 - bash <(curl -s https://codecov.io/bash) -F ${TESTING_PROFILE//-} || echo "Codecov did not collect coverage reports"
-- java -jar codacy-coverage-reporter-assembly.jar report -l Java -r reports/target/site/jacoco-aggregate/jacoco.xml 
+- java -jar codacy-coverage-reporter-assembly.jar report -l Java -r reports/target/site/jacoco-aggregate/jacoco.xml
   
 notifications:
   webhooks: https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,14 +86,14 @@ before_install:
 - scripts/decrypt.sh
 # turn this back on with updates to swagger (particularly swagger-maven-plugin), current implementation is too non-deterministic
 #- scripts/check-swagger.sh
-- wget --no-verbose -O git-secrets-1.3.0.tar.gz https://github.com/awslabs/git-secrets/archive/1.3.0.tar.gz
+- wget -user DockstoreTestUser --password $DOCKSTORE_TEST_ACCESS_TOKEN --no-verbose -O git-secrets-1.3.0.tar.gz https://github.com/awslabs/git-secrets/archive/1.3.0.tar.gz
 - tar -zxf git-secrets-1.3.0.tar.gz
 - cd git-secrets-1.3.0
 - sudo make install
 - cd ../
 # codacy hookup https://docs.codacy.com/coverage-reporter/alternative-ways-of-running-coverage-reporter/
 - sudo apt-get install jq
-- curl -LSs "$(curl -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({name, browser_download_url} | select(.name | endswith(".jar"))) | .[0].browser_download_url')" -o codacy-coverage-reporter-assembly.jar
+- curl -u DockstoreTestUser:$DOCKSTORE_TEST_ACCESS_TOKEN -LSs "$(curl -u DockstoreTestUser:$DOCKSTORE_TEST_ACCESS_TOKEN  -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({name, browser_download_url} | select(.name | endswith(".jar"))) | .[0].browser_download_url')" -o codacy-coverage-reporter-assembly.jar
 - pyenv global 3.6.10
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ before_install:
 - scripts/decrypt.sh
 # turn this back on with updates to swagger (particularly swagger-maven-plugin), current implementation is too non-deterministic
 #- scripts/check-swagger.sh
-- wget -user DockstoreTestUser --password $DOCKSTORE_TEST_ACCESS_TOKEN --no-verbose -O git-secrets-1.3.0.tar.gz https://github.com/awslabs/git-secrets/archive/1.3.0.tar.gz
+- wget --user DockstoreTestUser --password $DOCKSTORE_TEST_ACCESS_TOKEN --no-verbose -O git-secrets-1.3.0.tar.gz https://github.com/awslabs/git-secrets/archive/1.3.0.tar.gz
 - tar -zxf git-secrets-1.3.0.tar.gz
 - cd git-secrets-1.3.0
 - sudo make install


### PR DESCRIPTION
Seems broken for a while before  https://github.com/dockstore/dockstore/pull/3828
Based on https://travis-ci.org/github/dockstore/dockstore/jobs/688925351

Hitting rate limits a lot, using an encrypted access token for dockstore user for wget and curl