### PR TITLE
handle non-DockerHub URL cases using determineImageRepository()

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -326,8 +326,6 @@ public interface LanguageHandlerInterface {
 
         String url;
 
-        Optional<Registry> registry = determineImageRegistry(dockerEntry);
-
         // Remove tag if exists
         Pattern p = Pattern.compile("([^:]+):?(\\S+)?");
         Matcher m = p.matcher(dockerEntry);
@@ -338,6 +336,9 @@ public interface LanguageHandlerInterface {
         if (dockerEntry.isEmpty()) {
             return null;
         }
+
+        // Regex for determining registry requires a tag; add a fake "0" tag
+        Optional<Registry> registry = determineImageRegistry(dockerEntry + ":0");
 
         // TODO: How to deal with multiple entries of a tool? For now just grab the first
         // TODO: How do we check that the URL is valid? If not then the entry is likely a local docker build

--- a/dockstore-webservice/src/main/resources/migrations.1.10.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.10.0.xml
@@ -77,4 +77,14 @@
     <changeSet author="nolwarre (generated)" id="notificationsCharLimit">
         <modifyDataType columnName="message" newDataType="varchar(1024)" tableName="notification"/>
     </changeSet>
+    <changeSet id="fixSevenBridgesImageLinks" author="gfjhogue">
+        <sql dbms="postgresql">
+            UPDATE workflowversion
+            SET tooltablejson = REPLACE(tooltablejson, 'hub.docker.com/_/images.sbgenomics.com', 'images.sbgenomics.com')
+            WHERE tooltablejson LIKE '%hub.docker.com/\_/images.sbgenomics.com%';
+            UPDATE workflowversion
+            SET dagjson = REPLACE(dagjson, 'hub.docker.com/_/images.sbgenomics.com', 'images.sbgenomics.com')
+            WHERE dagjson LIKE '%hub.docker.com/\_/images.sbgenomics.com%';
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -2,15 +2,21 @@ package io.dockstore.webservice.languages;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Set;
 
 import io.dockstore.common.Registry;
 import io.dockstore.webservice.core.FileFormat;
 import io.dockstore.webservice.core.ParsedInformation;
+import io.dockstore.webservice.core.Tool;
+import io.dockstore.webservice.jdbi.ToolDAO;
 import io.dropwizard.testing.ResourceHelpers;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
 
 /**
  * Tests public methods in the CWLHandler file
@@ -67,5 +73,26 @@ public class CWLHandlerTest {
         CWLHandler.setImportsBasedOnMapValue(parsedInformation5, "httppotato.cwl");
         Assert.assertFalse(parsedInformation5.isHasHTTPImports());
         Assert.assertTrue(parsedInformation5.isHasLocalImports());
+    }
+
+    @Test
+    public void testURLFromEntry() {
+        final LanguageHandlerInterface handler = Mockito.mock(LanguageHandlerInterface.class, Mockito.CALLS_REAL_METHODS);
+        final ToolDAO toolDAO = Mockito.mock(ToolDAO.class);
+
+        // Cases that don't rely on toolDAO
+        Assert.assertNull(handler.getURLFromEntry("", toolDAO));
+        Assert.assertEquals("https://images.sbgenomics.com/foo/bar", handler.getURLFromEntry("images.sbgenomics.com/foo/bar:1", toolDAO));
+        Assert.assertEquals("https://hub.docker.com/_/foo", handler.getURLFromEntry("foo:1", toolDAO));
+
+        // When toolDAO.findAllByPath() returns null/empty
+        when(toolDAO.findAllByPath(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(null);
+        Assert.assertEquals("https://quay.io/repository/foo/bar", handler.getURLFromEntry("quay.io/foo/bar:1", toolDAO));
+        Assert.assertEquals("https://hub.docker.com/r/foo/bar", handler.getURLFromEntry("foo/bar:1", toolDAO));
+
+        // When toolDAO.findAllByPath() returns non-empty List<Tool>
+        when(toolDAO.findAllByPath(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(List.of(Mockito.mock(Tool.class)));
+        Assert.assertEquals("https://www.dockstore.org/containers/quay.io/foo/bar", handler.getURLFromEntry("quay.io/foo/bar:1", toolDAO));
+        Assert.assertEquals("https://www.dockstore.org/containers/registry.hub.docker.com/foo/bar", handler.getURLFromEntry("foo/bar:1", toolDAO));
     }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -82,17 +82,23 @@ public class CWLHandlerTest {
 
         // Cases that don't rely on toolDAO
         Assert.assertNull(handler.getURLFromEntry("", toolDAO));
+        Assert.assertEquals("https://images.sbgenomics.com/foo/bar", handler.getURLFromEntry("images.sbgenomics.com/foo/bar", toolDAO));
         Assert.assertEquals("https://images.sbgenomics.com/foo/bar", handler.getURLFromEntry("images.sbgenomics.com/foo/bar:1", toolDAO));
+        Assert.assertEquals("https://hub.docker.com/_/foo", handler.getURLFromEntry("foo", toolDAO));
         Assert.assertEquals("https://hub.docker.com/_/foo", handler.getURLFromEntry("foo:1", toolDAO));
 
         // When toolDAO.findAllByPath() returns null/empty
         when(toolDAO.findAllByPath(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(null);
+        Assert.assertEquals("https://quay.io/repository/foo/bar", handler.getURLFromEntry("quay.io/foo/bar", toolDAO));
         Assert.assertEquals("https://quay.io/repository/foo/bar", handler.getURLFromEntry("quay.io/foo/bar:1", toolDAO));
+        Assert.assertEquals("https://hub.docker.com/r/foo/bar", handler.getURLFromEntry("foo/bar", toolDAO));
         Assert.assertEquals("https://hub.docker.com/r/foo/bar", handler.getURLFromEntry("foo/bar:1", toolDAO));
 
         // When toolDAO.findAllByPath() returns non-empty List<Tool>
         when(toolDAO.findAllByPath(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(List.of(Mockito.mock(Tool.class)));
+        Assert.assertEquals("https://www.dockstore.org/containers/quay.io/foo/bar", handler.getURLFromEntry("quay.io/foo/bar", toolDAO));
         Assert.assertEquals("https://www.dockstore.org/containers/quay.io/foo/bar", handler.getURLFromEntry("quay.io/foo/bar:1", toolDAO));
+        Assert.assertEquals("https://www.dockstore.org/containers/registry.hub.docker.com/foo/bar", handler.getURLFromEntry("foo/bar", toolDAO));
         Assert.assertEquals("https://www.dockstore.org/containers/registry.hub.docker.com/foo/bar", handler.getURLFromEntry("foo/bar:1", toolDAO));
     }
 }


### PR DESCRIPTION
Main issue: #3820

Current logic for making tool-links assumes all non-Quay entries were DockerHub entries:
https://github.com/dockstore/dockstore/blob/96424cf3dc0f7ca623efc17670613db659242b55/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java#L361

We already have code to recognize the registry of an entry string: https://github.com/dockstore/dockstore/blob/96424cf3dc0f7ca623efc17670613db659242b55/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java#L373

This PR prevents creation of incorrect DockerHub URLS for non-DockerHub entries.

I also assume that non-DockerHub/Quay `dockerEntry` strings are valid URLs (which is at least true for Seven Bridges). Any exceptions to this would require coding additional cases...