### PR TITLE
fix githubWebhookDelete() for deleting default WorkflowVersion

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -314,6 +314,27 @@ public class WebhookIT extends BaseIT {
     }
 
     /**
+     * This tests deleting a GitHub App workflow's default version
+     */
+    @Test
+    public void testDeleteDefaultWorkflowVersion() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+        final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        WorkflowsApi client = new WorkflowsApi(webClient);
+
+        client.handleGitHubRelease(githubFiltersRepo, BasicIT.USER_2_USERNAME, "refs/tags/1.0", installationId);
+        Workflow workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", "", false);
+        assertEquals("should have 1 version", 1, workflow.getWorkflowVersions().size());
+        assertNull("should have no default version until set", workflow.getDefaultVersion());
+        workflow = client.updateWorkflowDefaultVersion(workflow.getId(), workflow.getWorkflowVersions().get(0).getName());
+        assertNotNull("should have a default version after setting", workflow.getDefaultVersion());
+        client.handleGitHubBranchDeletion(githubFiltersRepo, BasicIT.USER_2_USERNAME, "refs/tags/1.0", installationId);
+        workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", "", false);
+        assertEquals("should have 0 versions after deletion", 0, workflow.getWorkflowVersions().size());
+        assertNull("should have no default version after previous default is deleted", workflow.getDefaultVersion());
+    }
+
+    /**
      * This tests calling refresh on a workflow with a Dockstore.yml
      */
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -322,16 +322,30 @@ public class WebhookIT extends BaseIT {
         final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
         WorkflowsApi client = new WorkflowsApi(webClient);
 
+        // Add 1.0 tag and set as default version
         client.handleGitHubRelease(githubFiltersRepo, BasicIT.USER_2_USERNAME, "refs/tags/1.0", installationId);
         Workflow workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", "", false);
         assertEquals("should have 1 version", 1, workflow.getWorkflowVersions().size());
         assertNull("should have no default version until set", workflow.getDefaultVersion());
         workflow = client.updateWorkflowDefaultVersion(workflow.getId(), workflow.getWorkflowVersions().get(0).getName());
         assertNotNull("should have a default version after setting", workflow.getDefaultVersion());
+
+        // Add 2.0 tag
+        client.handleGitHubRelease(githubFiltersRepo, BasicIT.USER_2_USERNAME, "refs/tags/2.0", installationId);
+        workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", "", false);
+        assertEquals("should have 2 versions", 2, workflow.getWorkflowVersions().size());
+
+        // Delete 1.0 tag, should reassign 2.0 as the default version
         client.handleGitHubBranchDeletion(githubFiltersRepo, BasicIT.USER_2_USERNAME, "refs/tags/1.0", installationId);
         workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", "", false);
+        assertEquals("should have 1 version after deletion", 1, workflow.getWorkflowVersions().size());
+        assertNotNull("should have reassigned the default version during deletion", workflow.getDefaultVersion());
+
+        // Delete 2.0 tag, unset default version
+        client.handleGitHubBranchDeletion(githubFiltersRepo, BasicIT.USER_2_USERNAME, "refs/tags/2.0", installationId);
+        workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", "", false);
         assertEquals("should have 0 versions after deletion", 0, workflow.getWorkflowVersions().size());
-        assertNull("should have no default version after previous default is deleted", workflow.getDefaultVersion());
+        assertNull("should have no default version after final version is deleted", workflow.getDefaultVersion());
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -282,6 +282,13 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         List<Workflow> workflows = workflowDAO.findAllByPath("github.com/" + repository, false).stream().filter(workflow -> Objects.equals(workflow.getMode(), DOCKSTORE_YML)).collect(
                 Collectors.toList());
 
+        // When the git reference is the default version, unset the default version
+        workflows.forEach(workflow -> {
+            if (workflow.getActualDefaultVersion() != null && workflow.getActualDefaultVersion().getName().equals(gitReferenceName.get())) {
+                workflow.setActualDefaultVersion(null);
+            }
+        });
+
         // Delete all non-frozen versions that have the same git reference name
         workflows.forEach(workflow -> workflow.getWorkflowVersions().removeIf(workflowVersion -> Objects.equals(workflowVersion.getName(), gitReferenceName.get()) && !workflowVersion.isFrozen()));
         LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, username, LambdaEvent.LambdaEventType.DELETE);


### PR DESCRIPTION
Main issue: #3796

We currently don't handle deleting versions via GitHub Apps that are the **default** version for a workflow on Dockstore (results in an SQL foreign key violation).

This PR checks if the version being deleted is a default version for a workflow, and if so, unsets the workflow's default version.