### PR TITLE
use actual GitHub path as testparam path, don't use /test.json by default

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -536,6 +536,22 @@ public class WebhookIT extends BaseIT {
     }
 
     /**
+     * Test that a .dockstore.yml workflow has the expected path for its test parameter file.
+     */
+    @Test
+    public void testTestParameterPaths() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+        final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        WorkflowsApi client = new WorkflowsApi(webClient);
+
+        client.handleGitHubRelease(workflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/master", installationId);
+        Workflow workflow = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "", false);
+        WorkflowVersion version = workflow.getWorkflowVersions().get(0);
+        List<SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(version.getId());
+        assertTrue("Test file should have the expected path", sourceFiles.stream().filter(sourceFile -> sourceFile.getPath().equals("/dockstore.wdl.json")).findFirst().isPresent());
+    }
+
+    /**
      * This tests the GitHub release with .dockstore.yml located in /.github/.dockstore.yml
      */
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/languages/GalaxyPluginIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/languages/GalaxyPluginIT.java
@@ -89,10 +89,6 @@ public class GalaxyPluginIT {
 
     private static final String DROPWIZARD_CONFIGURATION_FILE_PATH = CommonTestUtilities.CONFIDENTIAL_CONFIG_PATH;
 
-    private final String galaxyWorkflowRepo = "DockstoreTestUser2/workflow-testing-repo";
-    private final String installationId = "1179416";
-    private FileDAO fileDAO;
-
     static {
         try {
             // stash a Galaxy plugin in the plugin directory
@@ -124,6 +120,10 @@ public class GalaxyPluginIT {
             System.out.println("Starting test: " + description.getMethodName());
         }
     };
+
+    private final String galaxyWorkflowRepo = "DockstoreTestUser2/workflow-testing-repo";
+    private final String installationId = "1179416";
+    private FileDAO fileDAO;
 
     @BeforeClass
     public static void dropAndRecreateDB() throws Exception {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -746,7 +746,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                         testFile.setContent(testFileContent);
 
                         // Only add test parameter file if it hasn't already been added
-                        boolean hasDuplicate = version.getSourceFiles().stream().anyMatch((SourceFile sf) -> sf.getPath().equals(workflow.getDefaultTestParameterFilePath()) && sf.getType() == testFile.getType());
+                        boolean hasDuplicate = version.getSourceFiles().stream().anyMatch((SourceFile sf) -> sf.getPath().equals(testFile.getPath()) && sf.getType() == testFile.getType());
                         if (!hasDuplicate) {
                             version.getSourceFiles().add(testFile);
                         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -736,6 +736,11 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             if (testParameterPaths != null) {
                 List<String> missingParamFiles = new ArrayList<>();
                 for (String testParameterPath : testParameterPaths) {
+                    // Only add test parameter file if it hasn't already been added
+                    boolean hasDuplicate = version.getSourceFiles().stream().anyMatch((SourceFile sf) -> sf.getPath().equals(testParameterPath) && sf.getType() == workflow.getDescriptorType().getTestParamType());
+                    if (hasDuplicate) {
+                        continue;
+                    }
                     String testFileContent = this.readFileFromRepo(testParameterPath, ref.getLeft(), repository);
                     if (testFileContent != null) {
                         SourceFile testFile = new SourceFile();
@@ -744,12 +749,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                         testFile.setPath(testParameterPath);
                         testFile.setAbsolutePath(testParameterPath);
                         testFile.setContent(testFileContent);
-
-                        // Only add test parameter file if it hasn't already been added
-                        boolean hasDuplicate = version.getSourceFiles().stream().anyMatch((SourceFile sf) -> sf.getPath().equals(testFile.getPath()) && sf.getType() == testFile.getType());
-                        if (!hasDuplicate) {
-                            version.getSourceFiles().add(testFile);
-                        }
+                        version.getSourceFiles().add(testFile);
                     } else {
                         missingParamFiles.add(testParameterPath);
                     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -736,19 +736,19 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             if (testParameterPaths != null) {
                 List<String> missingParamFiles = new ArrayList<>();
                 for (String testParameterPath : testParameterPaths) {
-                    String testJsonContent = this.readFileFromRepo(testParameterPath, ref.getLeft(), repository);
-                    if (testJsonContent != null) {
-                        SourceFile testJson = new SourceFile();
-                        // find type from file type, then find matching test param type
-                        testJson.setType(workflow.getDescriptorType().getTestParamType());
-                        testJson.setPath(workflow.getDefaultTestParameterFilePath());
-                        testJson.setAbsolutePath(workflow.getDefaultTestParameterFilePath());
-                        testJson.setContent(testJsonContent);
+                    String testFileContent = this.readFileFromRepo(testParameterPath, ref.getLeft(), repository);
+                    if (testFileContent != null) {
+                        SourceFile testFile = new SourceFile();
+                        // find type from file type
+                        testFile.setType(workflow.getDescriptorType().getTestParamType());
+                        testFile.setPath(testParameterPath);
+                        testFile.setAbsolutePath(testParameterPath);
+                        testFile.setContent(testFileContent);
 
                         // Only add test parameter file if it hasn't already been added
-                        boolean hasDuplicate = version.getSourceFiles().stream().anyMatch((SourceFile sf) -> sf.getPath().equals(workflow.getDefaultTestParameterFilePath()) && sf.getType() == testJson.getType());
+                        boolean hasDuplicate = version.getSourceFiles().stream().anyMatch((SourceFile sf) -> sf.getPath().equals(workflow.getDefaultTestParameterFilePath()) && sf.getType() == testFile.getType());
                         if (!hasDuplicate) {
-                            version.getSourceFiles().add(testJson);
+                            version.getSourceFiles().add(testFile);
                         }
                     } else {
                         missingParamFiles.add(testParameterPath);


### PR DESCRIPTION
Main issue: #3851

GitHub Apps workflows with Test Parameter Files specified in `.dockstore.yml` are assigned a path by `workflow.getDefaultTestParameterFilePath()`.
However this defaults to `/test.json` unless some other default for the workflow was set (seems like not in most cases) https://github.com/dockstore/dockstore/blob/d836384f3e6f993f4f30badebf62bda89d601d12/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java#L341
This is problematic for non-JSON (YML) test files appearing incorrectly on the UI, and likely causes file name collisions for multiple Test Parameter Files.

This PR changes the assignment of the Test Parameter File path to just be its path in git, this way the original name is preserved. This also aligns with how the Primary Descriptor path is set https://github.com/dockstore/dockstore/blob/d836384f3e6f993f4f30badebf62bda89d601d12/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java#L729

Finally, I also changed the variable names Test Parameter Files to not longer appear JSON-specific.