### PR TITLE
Feature/seab 1855/GitHub helper test

### DIFF
--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GitHubHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GitHubHelperTest.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.LicenseInformation;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kohsuke.github.AbuseLimitHandler;
 import org.kohsuke.github.GitHub;

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GitHubHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GitHubHelperTest.java
@@ -13,7 +13,6 @@ import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.RateLimitHandler;
 
 // Ignoring for now, see https://ucsc-cgl.atlassian.net/browse/SEAB-1855
-@Ignore
 public class GitHubHelperTest {
 
     private static final String CODE = "abcdefghijklmnop";

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GitHubHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GitHubHelperTest.java
@@ -1,15 +1,8 @@
 package io.dockstore.webservice.helpers;
 
-import java.io.IOException;
-
 import io.dockstore.webservice.CustomWebApplicationException;
-import io.dockstore.webservice.core.LicenseInformation;
 import org.junit.Assert;
 import org.junit.Test;
-import org.kohsuke.github.AbuseLimitHandler;
-import org.kohsuke.github.GitHub;
-import org.kohsuke.github.GitHubBuilder;
-import org.kohsuke.github.RateLimitHandler;
 
 // Ignoring for now, see https://ucsc-cgl.atlassian.net/browse/SEAB-1855
 public class GitHubHelperTest {
@@ -28,24 +21,5 @@ public class GitHubHelperTest {
             Assert.assertEquals("HTTP 400 Bad Request", e.getMessage());
         }
 
-    }
-
-
-    // TODO: Replace repos with something less likely to change
-    @Test
-    public void testGitHubLicense() throws IOException {
-        GitHub gitHub = new GitHubBuilder().withRateLimitHandler(RateLimitHandler.WAIT).withAbuseLimitHandler(
-                AbuseLimitHandler.WAIT).build();
-        LicenseInformation licenseInformation = GitHubHelper.getLicenseInformation(gitHub, "dockstore-testing/md5sum-checker");
-        Assert.assertEquals("Apache License 2.0", licenseInformation.getLicenseName());
-
-        licenseInformation = GitHubHelper.getLicenseInformation(gitHub, "dockstore-testing/galaxy-workflows");
-        Assert.assertEquals("MIT License", licenseInformation.getLicenseName());
-
-        licenseInformation = GitHubHelper.getLicenseInformation(gitHub, "dockstoretestuser2/cwl-gene-prioritization");
-        Assert.assertEquals("Other", licenseInformation.getLicenseName());
-
-        licenseInformation = GitHubHelper.getLicenseInformation(gitHub, "dockstore-testing/silly-example");
-        Assert.assertNull(licenseInformation.getLicenseName());
     }
 }


### PR DESCRIPTION
For https://ucsc-cgl.atlassian.net/browse/SEAB-1824 and https://ucsc-cgl.atlassian.net/browse/SEAB-1855


- Make the test an integration test (since it integrates with GitHub)
- use the DockstoreTestUser2 GitHub access token
- change withRateLimitHandler wait to fail because it's most likely going to wait 10 mins and timeout anyways

I ran the other GitHubHelperTest test in a loop 1000 times and it works fine. 