### PR TITLE
Only run signature check before Docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
           command: |
             # Adding all "normal" certs into this local one that has the Hoverfly cert (instead of adding Hoverfly cert to the global one so it doesn't potentially affect other tests) 
             keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore LocalTrustStore -srcstorepass changeit -deststorepass changeit           
-            mvn -B clean install -Pnon-confidential-tests -Djavax.net.ssl.trustStore=../LocalTrustStore -Djavax.net.ssl.trustStorePassword=changeit -ntp
+            mvn -B clean install -Pnon-confidential-tests -Djavax.net.ssl.trustStore=../LocalTrustStore -Djavax.net.ssl.trustStorePassword=changeit  -DskipSignatureCheck=false -ntp
       - run:
           name: check that JPA classes are consistent with migrations
           command: |
@@ -162,5 +162,5 @@ jobs:
             # Convert slashes to underscores, e.g., feature/seab-1675/pushtoquay to feature_seab-1675_pushtoquay
             export dockerVersion=${tagOrBranch//\//_}
             docker build -t quay.io/dockstore/dockstore-webservice:$dockerVersion .
-            docker login -u=$QUAY_USERNAME -p=$QUAY_PASSWORD quay.io
+            echo "$QUAY_PASSWORD" | docker login -u=$QUAY_USERNAME --password-stdin quay.io
             docker push quay.io/dockstore/dockstore-webservice:$dockerVersion

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
 
         <skipTests>false</skipTests>
         <skipITs>true</skipITs>
+        <skipSignatureCheck>true</skipSignatureCheck>
     </properties>
 
     <organization>
@@ -460,6 +461,7 @@
                 </executions>
                 <configuration>
                     <quiet>true</quiet>
+                    <skip>${skipSignatureCheck}</skip>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-1878

By default, don't run the signature check. Enable it only when
building right before building Docker image that gets
pushed to Quay.

In looking at ticket, I noticed a warning saying we should use
--password-stdin to log into quay.io, so changed that as well.

CircleCI build on the branch went up from 11 minutes to 30 minutes :(  BUT, looking at config.yml, looks
like it will always be a lot slower the first time you change the pom.xml; hopefully the build on the PR
will be faster. Update, second build was 12 minutes, which seems on par with others.

Travis builds pending on when I create this PR.

Saw no obvious way to make the build itself go faster. :(