### PR TITLE
Disable push builds for almost everything

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ services:
 
 addons:
   postgresql: "11"
-
+branches:
+  only:
+    - "master"
+    - "develop"
 cache:
   directories:
   - /tmp/localstack_install_dir

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ services:
 addons:
   postgresql: "11"
 branches:
-  only:
-    - "master"
-    - "develop"
+  except:
+    - /^feature.*$/
 cache:
   directories:
   - /tmp/localstack_install_dir


### PR DESCRIPTION
- Push builds are gone from almost everything (notice you don't see it here)
- The reason why the easier "Build pushed branches" https://travis-ci.org/github/dockstore/dockstore/settings toggle is not used instead is because the Travis builds you see in https://github.com/dockstore/dockstore/commits/develop is likely going to disappear (not 100% confirmed). This PR should retain those builds (not 100% confirmed)

PS: We do care about the builds in https://github.com/dockstore/dockstore/commits/develop right?