### PR TITLE
filter workflows using criteria builder on TRS endpoint

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
@@ -26,6 +26,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.TestUtility;
+import io.dockstore.common.TestingPostgres;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dropwizard.client.JerseyClientBuilder;
@@ -60,6 +61,7 @@ public abstract class GA4GHIT {
         DockstoreWebserviceApplication.class, CommonTestUtilities.PUBLIC_CONFIG_PATH,
         ConfigOverride.config("database.properties.hibernate.hbm2ddl.auto", "validate"));
     protected static javax.ws.rs.client.Client client;
+    protected static TestingPostgres testingPostgres;
     @Rule
     public final TestRule watcher = new TestWatcher() {
         protected void starting(Description description) {
@@ -83,6 +85,7 @@ public abstract class GA4GHIT {
         CommonTestUtilities.dropAndCreateWithTestData(SUPPORT, true);
         SUPPORT.before();
         client = new JerseyClientBuilder(SUPPORT.getEnvironment()).build("test client").property(ClientProperties.READ_TIMEOUT, WAIT_TIME);
+        testingPostgres = new TestingPostgres(SUPPORT);
     }
 
     @AfterClass

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2FinalIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2FinalIT.java
@@ -77,6 +77,17 @@ public class GA4GHV2FinalIT extends GA4GHIT {
         toolsIdWorkflow();
     }
 
+    @Test
+    public void testOnlyPublishedWorkflowsAreReturned() throws Exception {
+        long count = testingPostgres.runSelectStatement("select count(*) from workflow where ispublished = 't'", long.class);
+        count = count + testingPostgres.runSelectStatement("select count(*) from tool where ispublished = 't'", long.class);
+        Response response = checkedResponse(baseURL + "tools");
+        List<Tool> responseObject = response.readEntity(new GenericType<>() {
+        });
+
+        Assert.assertEquals(count, responseObject.size());
+    }
+
     /**
      * TODO: Test organization
      */

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceControlConverter.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceControlConverter.java
@@ -40,7 +40,7 @@ public class SourceControlConverter implements AttributeConverter<SourceControl,
     @Override
     public SourceControl convertToEntityAttribute(String dbData) {
         if (dbData == null || dbData.isEmpty()) {
-            LOG.error("Cannot convert null or empty source control");
+            LOG.info("Cannot convert null or empty source control");
             return null;
         }
         Optional<SourceControl> first = Lists.newArrayList(SourceControl.values()).stream().filter(val -> val.toString().equals(dbData))

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceControlConverter.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceControlConverter.java
@@ -48,7 +48,7 @@ public class SourceControlConverter implements AttributeConverter<SourceControl,
         if (first.isPresent()) {
             return first.get();
         } else {
-            LOG.error("could not convert token type: " + dbData);
+            LOG.error("could not convert source control: " + dbData);
             return null;
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceControlConverter.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceControlConverter.java
@@ -39,6 +39,10 @@ public class SourceControlConverter implements AttributeConverter<SourceControl,
 
     @Override
     public SourceControl convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isEmpty()) {
+            LOG.error("Cannot convert null or empty source control");
+            return null;
+        }
         Optional<SourceControl> first = Lists.newArrayList(SourceControl.values()).stream().filter(val -> val.toString().equals(dbData))
             .findFirst();
         if (first.isPresent()) {

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -309,8 +309,8 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
 
             // TODO: Have DescriptorLanguage indicate whether the language supports tools. Make this less hack-ish
             // Only WDL and CWL tools are supported on Dockstore.
-            if (descriptorLanguageFound && (toolClass == null || COMMAND_LINE_TOOL.equalsIgnoreCase(toolClass)) &&
-                    (DescriptorLanguage.WDL.equals(descriptorLanguage) || DescriptorLanguage.CWL.equals(descriptorLanguage) || descriptorType == null)) {
+            if (descriptorLanguageFound && (toolClass == null || COMMAND_LINE_TOOL.equalsIgnoreCase(toolClass))
+                    && (DescriptorLanguage.WDL.equals(descriptorLanguage) || DescriptorLanguage.CWL.equals(descriptorLanguage) || descriptorType == null)) {
                 all.addAll(toolDAO.findAllPublished());
             }
             if (descriptorLanguageFound && (toolClass == null || WORKFLOW.equalsIgnoreCase(toolClass))) {

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -278,47 +278,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
             return trsResponses.get().build();
         }
 
-        final List<Entry<?, ?>> all = new ArrayList<>();
-
-
-        // short circuit id and alias filters, these are a bit weird because they have a max of one result
-        if (id != null) {
-            ParsedRegistryID parsedID = new ParsedRegistryID(id);
-            Entry<?, ?> entry = getEntry(parsedID, user);
-            all.add(entry);
-        } else if (alias != null) {
-            all.add(toolDAO.getGenericEntryByAlias(alias));
-        } else {
-            // If there is no matching descriptor language, then do not add any tools or workflows.
-            DescriptorLanguage descriptorLanguage = null;
-            boolean descriptorLanguageFound = true;
-
-            // Tricky case for GALAXY because it doesn't match the rules of the other languages
-            if ("galaxy".equalsIgnoreCase(descriptorType)) {
-                descriptorType = DescriptorLanguage.GXFORMAT2.getShortName();
-            }
-
-            if (descriptorType != null) {
-                try {
-                    descriptorLanguage = DescriptorLanguage.convertShortStringToEnum(descriptorType);
-                } catch (UnsupportedOperationException ex) {
-                    LOG.info(ex.getMessage());
-                    descriptorLanguageFound = false;
-                }
-            }
-
-            // TODO: Have DescriptorLanguage indicate whether the language supports tools. Make this less hack-ish
-            // Only WDL and CWL tools are supported on Dockstore.
-            if (descriptorLanguageFound && (toolClass == null || COMMAND_LINE_TOOL.equalsIgnoreCase(toolClass))
-                    && (DescriptorLanguage.WDL.equals(descriptorLanguage) || DescriptorLanguage.CWL.equals(descriptorLanguage) || descriptorType == null)) {
-                all.addAll(toolDAO.findAllPublished());
-            }
-            if (descriptorLanguageFound && (toolClass == null || WORKFLOW.equalsIgnoreCase(toolClass))) {
-                // filter published workflows using criteria builder
-                all.addAll(workflowDAO.filterTrsToolsGet(descriptorLanguage, registry, organization, name, toolname, description, author, checker));
-            }
-            all.sort(Comparator.comparing(Entry::getGitUrl));
-        }
+        final List<Entry<?, ?>> all = getEntries(id, alias, toolClass, descriptorType, registry, organization, name, toolname, description, author, checker, user);
 
         List<io.openapi.model.Tool> results = new ArrayList<>();
 
@@ -410,6 +370,52 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         }
         trsListener.loadTRSResponse(hashcode, responseBuilder);
         return responseBuilder.build();
+    }
+
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
+    private List<Entry<?, ?>> getEntries(String id, String alias, String toolClass, String descriptorType, String registry, String organization, String name, String toolname,
+            String description, String author, Boolean checker, Optional<User> user) {
+
+        final List<Entry<?, ?>> all = new ArrayList<>();
+
+        if (id != null) {
+            ParsedRegistryID parsedID = new ParsedRegistryID(id);
+            Entry<?, ?> entry = getEntry(parsedID, user);
+            all.add(entry);
+        } else if (alias != null) {
+            all.add(toolDAO.getGenericEntryByAlias(alias));
+        } else {
+            DescriptorLanguage descriptorLanguage = null;
+            if (descriptorType != null) {
+                try {
+                    // Tricky case for GALAXY because it doesn't match the rules of the other languages
+                    if ("galaxy".equalsIgnoreCase(descriptorType)) {
+                        descriptorType = DescriptorLanguage.GXFORMAT2.getShortName();
+                    }
+
+                    descriptorLanguage = DescriptorLanguage.convertShortStringToEnum(descriptorType);
+                } catch (UnsupportedOperationException ex) {
+                    // If unable to match descriptor language, do not return any entries.
+                    LOG.info(ex.getMessage());
+                    return all;
+                }
+            }
+
+            // TODO: Have DescriptorLanguage indicate whether the language supports tools. Make this less hack-ish
+            // Add tools if user didn't provide a tool class or the tool class provided matches to tools, AND
+            // user didn't provide a descriptor type or the one they provided matches to CWL or WDL
+            if (toolClass == null || COMMAND_LINE_TOOL.equalsIgnoreCase(toolClass)) {
+                if (descriptorType == null  || descriptorLanguage == DescriptorLanguage.WDL || descriptorLanguage == DescriptorLanguage.CWL) {
+                    all.addAll(toolDAO.findAllPublished());
+                }
+
+            }
+            if (toolClass == null || WORKFLOW.equalsIgnoreCase(toolClass)) {
+                // filter published workflows using criteria builder
+                all.addAll(workflowDAO.filterTrsToolsGet(descriptorLanguage, registry, organization, name, toolname, description, author, checker));
+            }
+        }
+        return all;
     }
 
     private void handleParameter(String parameter, String queryName, List<String> filters) {

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1841,7 +1841,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Aliasable'
+                $ref: '#/components/schemas/WorkflowVersion'
           description: default response
       security:
         - bearer: []


### PR DESCRIPTION
#3838 
This only filters workflows for now. I'll work on the tools part while waiting for feedback, but since I'm off tomorrow I just wanted to make sure at least this got in before the release.


Behavior is slightly different from before. The source control filter used to check if the column contained the term, but now it needs to be equal.