### PR TITLE
Feature/3917/circle ci cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,8 @@ jobs:
           command: cp -r ~/.m2 .
       - persist_to_workspace:
           root: .
+          paths:
+            - .
   unit_test: # runs not using Workflows must have a `build` job as entry point
     docker: # run the steps with Docker
       - image: cimg/openjdk:11.0.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,13 +265,13 @@ commands:
           key: dockstore-java-{{ checksum "pom.xml" }}
       - run:
           name: manually copy back .m2
-          command: cp -r .m2 ~/.m2
+          command: cp -r .m2 ~/.m2    
       - run:
           name: Install yq
           command: |
             wget https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64
             chmod a+x yq_linux_amd64
-            sudo mv yq_linux_amd64 /usr/bin/yq          
+            sudo mv yq_linux_amd64 /usr/bin/yq            
   setup_integration_test:
     steps:
       - run:
@@ -292,13 +292,7 @@ commands:
           command: |
             sudo rm -rf /var/lib/apt/lists/*
             sudo apt update
-            sudo apt install -y postgresql-client
-      - run:
-          name: decrypt
-          command: |
-            sudo apt install openssl -y
-            openssl aes-256-cbc -d -in circle_ci_test_data.zip.enc -k $CIRCLE_CI_KEY -iv $CIRCLE_CI_IV >> test_data.zip
-            bash expand_confidential_bundle.sh test_data.zip abandonDatabaseConnectionsWithOrcid            
+            sudo apt install -y postgresql-client          
       - run:
           name: expand confidential data
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ executors:
           - network.host: 127.0.0.1
           - http.port: 9200
           - discovery.type: single-node
-    resource_class: large      
+    resource_class: large
 workflows:
   version: 2
   everything:
@@ -30,16 +30,16 @@ workflows:
           filters:
             branches:
               ignore:
-                - gh-pages           
-      - unit_test:         
+                - gh-pages
+      - unit_test:
           requires:
             - build
       - workflow-integration-tests:
           requires:
             - build
-      - tool-integration-tests:         
+      - tool-integration-tests:
           requires:
-            - build        
+            - build
       - integration-tests:
           requires:
             - build
@@ -54,30 +54,18 @@ jobs:
     executor: integration_test_exec
     environment:
       TESTING_PROFILE: regression-integration-tests
-    steps:  
+    steps:
       - setup_test
       - setup_integration_test
-      - run:
-          name: run integration test
-          command: mvn -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -P$TESTING_PROFILE,coverage -ntp
-      - run:
-          name: send coverage
-          command: bash <(curl -s https://codecov.io/bash) -F ${TESTING_PROFILE//-} || echo "Codecov did not collect coverage reports"      
   integration-tests:
     executor: integration_test_exec
     environment:
       TESTING_PROFILE: integration-tests
     steps:
       - setup_remote_docker:
-          version: 19.03.13            
+          version: 19.03.13
       - setup_test
       - setup_integration_test
-      - run:
-          name: run integration test
-          command: mvn -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -P$TESTING_PROFILE,coverage -ntp
-      - run:
-          name: send coverage
-          command: bash <(curl -s https://codecov.io/bash) -F ${TESTING_PROFILE//-} || echo "Codecov did not collect coverage reports"      
   tool-integration-tests:
     executor: integration_test_exec
     environment:
@@ -85,12 +73,6 @@ jobs:
     steps:
       - setup_test
       - setup_integration_test
-      - run:
-          name: run integration test
-          command: mvn -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -P$TESTING_PROFILE,coverage -ntp
-      - run:
-          name: send coverage
-          command: bash <(curl -s https://codecov.io/bash) -F ${TESTING_PROFILE//-} || echo "Codecov did not collect coverage reports"      
   workflow-integration-tests:
     executor: integration_test_exec
     environment:
@@ -98,12 +80,6 @@ jobs:
     steps:
       - setup_test
       - setup_integration_test
-      - run:
-          name: run integration test
-          command: mvn -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -P$TESTING_PROFILE,coverage -ntp
-      - run:
-          name: send coverage
-          command: bash <(curl -s https://codecov.io/bash) -F ${TESTING_PROFILE//-} || echo "Codecov did not collect coverage reports"      
   build:
     docker: # run the steps with Docker
       - image: cimg/openjdk:11.0.8
@@ -121,13 +97,7 @@ jobs:
             wget https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64
             chmod a+x yq_linux_amd64
             sudo mv yq_linux_amd64 /usr/bin/yq
-      - run:
-          name: Install git-secrets
-          command: |
-            wget --no-verbose -O git-secrets-1.3.0.tar.gz https://github.com/awslabs/git-secrets/archive/1.3.0.tar.gz
-            tar -zxf git-secrets-1.3.0.tar.gz
-            cd git-secrets-1.3.0
-            sudo make install
+      - install-git-secrets
       - run:
           name: decrypt
           command: |
@@ -161,17 +131,11 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_DB: postgres
           POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_PASSWORD: postgres   
+          POSTGRES_PASSWORD: postgres
     steps: # a collection of executable commands
-      - checkout    
+      - checkout
       - setup_test
-      - run:
-          name: Install git-secrets
-          command: |
-            wget --no-verbose -O git-secrets-1.3.0.tar.gz https://github.com/awslabs/git-secrets/archive/1.3.0.tar.gz
-            tar -zxf git-secrets-1.3.0.tar.gz
-            cd git-secrets-1.3.0
-            sudo make install
+      - install-git-secrets
       - setup_postgres
       - run:
           name: run the actual tests
@@ -246,8 +210,17 @@ jobs:
             echo "$QUAY_PASSWORD" | docker login -u=$QUAY_USERNAME --password-stdin quay.io
             docker push quay.io/dockstore/dockstore-webservice:$dockerVersion
 commands:
+  install-git-secrets:
+    steps:
+      - run:
+          name: Install git-secrets
+          command: |
+            wget --no-verbose -O git-secrets-1.3.0.tar.gz https://github.com/awslabs/git-secrets/archive/1.3.0.tar.gz
+            tar -zxf git-secrets-1.3.0.tar.gz
+            cd git-secrets-1.3.0
+            sudo make install
   setup_postgres:
-    steps:    
+    steps:
       - run:
           name: setup postgres
           command: |
@@ -256,25 +229,25 @@ commands:
   setup_test:
     steps:
       - attach_workspace:
-          at: .    
+          at: .
       - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
           key: dockstore-java-{{ checksum "pom.xml" }}
       - run:
           name: manually copy back .m2
-          command: cp -r .m2 ~/.m2    
+          command: cp -r .m2 ~/.m2
       - run:
           name: Install yq
           command: |
             wget https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64
             chmod a+x yq_linux_amd64
-            sudo mv yq_linux_amd64 /usr/bin/yq     
+            sudo mv yq_linux_amd64 /usr/bin/yq
       - run:
           name: Install postgresql client
           command: |
             sudo rm -rf /var/lib/apt/lists/*
             sudo apt update
-            sudo apt install -y postgresql-client                   
+            sudo apt install -y postgresql-client
   setup_integration_test:
     steps:
       - run:
@@ -289,20 +262,14 @@ commands:
             pip3 --version
       - run:
           name: install pip dependencies
-          command: scripts/install-tests.sh         
+          command: scripts/install-tests.sh
       - run:
           name: expand confidential data
           command: |
             bash expand_confidential_bundle.sh test_data.zip abandonDatabaseConnectionsWithOrcid 
             sudo mkdir /home/travis
             sudo mv dockstore-integration-testing/src/test/resources/dstesting_pcks8.pem /home/travis/dstesting_pcks8.pem
-      - run:
-          name: Install git-secrets
-          command: |
-            wget --no-verbose -O git-secrets-1.3.0.tar.gz https://github.com/awslabs/git-secrets/archive/1.3.0.tar.gz
-            tar -zxf git-secrets-1.3.0.tar.gz
-            cd git-secrets-1.3.0
-            sudo make install            
+      - install-git-secrets
       - run:
           name: install dockerize
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
@@ -311,9 +278,14 @@ commands:
       - run:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - setup_postgres  
+      - setup_postgres
       - run:
           name: Wait for ES
           command: |
-            wget --output-document /dev/null --waitretry=5 --tries=10 --retry-connrefused localhost:9200 || true      
-
+            wget --output-document /dev/null --waitretry=5 --tries=10 --retry-connrefused localhost:9200 || true
+      - run:
+          name: run integration test
+          command: mvn -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -P$TESTING_PROFILE,coverage -ntp
+      - run:
+          name: send coverage
+          command: bash <(curl -s https://codecov.io/bash) -F ${TESTING_PROFILE//-} || echo "Codecov did not collect coverage reports"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
       - image: cimg/openjdk:11.0.8
         environment:
           PGHOST: 127.0.0.1
-      - image: circleci/postgres:11.6
+      - image: circleci/postgres:11.8
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: postgres
@@ -19,7 +19,7 @@ executors:
           - network.host: 127.0.0.1
           - http.port: 9200
           - discovery.type: single-node
-    resource_class: xlarge      
+    resource_class: large      
 workflows:
   version: 2
   everything:
@@ -32,7 +32,6 @@ workflows:
       - unit_test:         
           requires:
             - build
-
       - workflow-integration-tests:
           requires:
             - build
@@ -141,6 +140,11 @@ jobs:
       #       wget --no-verbose https://repo.maven.apache.org/maven2/org/openapitools/openapi-generator-cli/4.3.0/openapi-generator-cli-4.3.0.jar -O openapi-generator-cli.jar
       #       java -jar openapi-generator-cli.jar validate -i dockstore-webservice/src/main/resources/swagger.yaml
       #       java -jar openapi-generator-cli.jar validate -i dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+      - run:
+          name: copy m2 manually
+          command: cp -r ~/.m2 .
+      - persist_to_workspace:
+          root: .
   unit_test: # runs not using Workflows must have a `build` job as entry point
     docker: # run the steps with Docker
       - image: cimg/openjdk:11.0.8
@@ -252,10 +256,14 @@ commands:
             psql -c 'create database webservice_test with owner = dockstore;' -U postgres
   setup_test:
     steps:
-      - checkout
+      - attach_workspace:
+          at: .    
       - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
           key: dockstore-java-{{ checksum "pom.xml" }}
+      - run:
+          name: manually copy back .m2
+          command: cp -r .m2 ~/.m2
       - run:
           name: Install yq
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,15 +31,15 @@ workflows:
             branches:
               ignore:
                 - gh-pages
-      # - unit_test:
-      #     requires:
-      #       - build
-      # - workflow-integration-tests:
-      #     requires:
-      #       - build
-      # - tool-integration-tests:
-      #     requires:
-      #       - build
+      - unit_test:
+          requires:
+            - build
+      - workflow-integration-tests:
+          requires:
+            - build
+      - tool-integration-tests:
+          requires:
+            - build
       - integration-tests:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,6 +269,8 @@ commands:
             bash expand_confidential_bundle.sh test_data.zip abandonDatabaseConnectionsWithOrcid 
             sudo mkdir /home/travis
             sudo mv dockstore-integration-testing/src/test/resources/dstesting_pcks8.pem /home/travis/dstesting_pcks8.pem
+            # Disable authentication cache. it causes flakey tests. Not updating the confidential bundle because I am lazy.
+            sed -i 's/expireAfterAccess=10m/expireAfterAccess=0s/g' dockstore-integration-testing/src/test/resources/dockstoreTest.yml
       - install-git-secrets
       - run:
           name: install dockerize

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  build-tools: circleci/build-tools@2.7.0
 executors:
   integration_test_exec:
     docker: # run the steps with Docker
@@ -109,6 +111,7 @@ jobs:
           JAVA_TOOL_OPTIONS: -Xmx512m # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Nothing to do with surefire plugin, it has its own JVM. The two of these must add up to a bit less than 4GB.
     steps: # a collection of executable commands
       - checkout # check out source code to working directory
+      - build-tools/merge-with-parent
       - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
           key: dockstore-java-{{ checksum "pom.xml" }}
@@ -169,12 +172,6 @@ jobs:
             tar -zxf git-secrets-1.3.0.tar.gz
             cd git-secrets-1.3.0
             sudo make install
-      - run:
-          name: Install postgresql client
-          command: |
-            sudo rm -rf /var/lib/apt/lists/*
-            sudo apt update
-            sudo apt install -y postgresql-client
       - setup_postgres
       - run:
           name: run the actual tests
@@ -271,7 +268,13 @@ commands:
           command: |
             wget https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64
             chmod a+x yq_linux_amd64
-            sudo mv yq_linux_amd64 /usr/bin/yq            
+            sudo mv yq_linux_amd64 /usr/bin/yq     
+      - run:
+          name: Install postgresql client
+          command: |
+            sudo rm -rf /var/lib/apt/lists/*
+            sudo apt update
+            sudo apt install -y postgresql-client                   
   setup_integration_test:
     steps:
       - run:
@@ -286,13 +289,7 @@ commands:
             pip3 --version
       - run:
           name: install pip dependencies
-          command: scripts/install-tests.sh
-      - run:
-          name: Install postgresql client
-          command: |
-            sudo rm -rf /var/lib/apt/lists/*
-            sudo apt update
-            sudo apt install -y postgresql-client          
+          command: scripts/install-tests.sh         
       - run:
           name: expand confidential data
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,7 @@ commands:
             sudo mv dockstore-integration-testing/src/test/resources/dstesting_pcks8.pem /home/travis/dstesting_pcks8.pem
             # Disable authentication cache. it causes flakey tests. Not updating the confidential bundle because I am lazy.
             sed -i 's/expireAfterAccess=10m/expireAfterAccess=0s/g' dockstore-integration-testing/src/test/resources/dockstoreTest.yml
+            sed -i 's/1s/10s/g' dockstore-integration-testing/src/test/resources/dockstoreTest.yml
       - install-git-secrets
       - run:
           name: install dockerize

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,15 +31,15 @@ workflows:
             branches:
               ignore:
                 - gh-pages
-      - unit_test:
-          requires:
-            - build
-      - workflow-integration-tests:
-          requires:
-            - build
-      - tool-integration-tests:
-          requires:
-            - build
+      # - unit_test:
+      #     requires:
+      #       - build
+      # - workflow-integration-tests:
+      #     requires:
+      #       - build
+      # - tool-integration-tests:
+      #     requires:
+      #       - build
       - integration-tests:
           requires:
             - build

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiIT.java
@@ -74,11 +74,15 @@ public class OpenApiIT {
     public void testSwagger20() {
         Response response = client.target(baseURL + "swagger.json").request().get();
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        // To prevent connection leak?
+        response.readEntity(String.class);
     }
 
     @Test
     public void testOpenApi30() {
         Response response = client.target(baseURL + "openapi.yaml").request().get();
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        // To prevent connection leak?
+        response.readEntity(String.class);
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -19,7 +19,6 @@ import io.swagger.client.api.UsersApi;
 import io.swagger.client.model.Collection;
 import io.swagger.client.model.CollectionOrganization;
 import io.swagger.client.model.Event;
-import io.swagger.client.model.Limits;
 import io.swagger.client.model.Organization;
 import io.swagger.client.model.Organization.StatusEnum;
 import io.swagger.client.model.PublishRequest;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -270,7 +270,6 @@ public class OrganizationIT extends BaseIT {
         final long count3 = testingPostgres.runSelectStatement("select count(*) from event where type = 'APPROVE_ORG'", long.class);
         assertEquals("There should be 1 event of type APPROVE_ORG, there are " + count3, 1, count3);
 
-
         try {
             organization.setName("NameSquatting");
             organization.setDisplayName("DisplayNameSquatting");
@@ -1551,9 +1550,6 @@ public class OrganizationIT extends BaseIT {
 
         // demote self to test setting invalid aliases
         testingPostgres.runUpdateStatement("update enduser set  isadmin='f'");
-        // need to invalidate cached creds
-        UsersApi usersApi = new UsersApi(webClientUser2);
-        usersApi.setUserLimits(usersApi.getUser().getId(), new Limits());
 
         boolean throwsError = false;
         try {
@@ -1718,7 +1714,6 @@ public class OrganizationIT extends BaseIT {
 
         organizationsApi.starOrganization(organization.getId(), UNSTAR_REQUEST);
         assertEquals(0, organizationsApi.getStarredUsersForApprovedOrganization(organization.getId()).size());
-
         // Should not be able to unstar twice
         try {
             organizationsApi.starOrganization(organization.getId(), UNSTAR_REQUEST);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -580,7 +580,7 @@ public class UserResourceIT extends BaseIT {
 
         // Should add a test above this to check that the API call should pass once the admin tokens are up to date
         // Testing that the updateLoggedInUserMetadata() should fail if GitHub tokens are expired or absent
-        testingPostgres.runUpdateStatement(String.format("DELETE FROM token WHERE userid = %d", admin.getId()));
+        testingPostgres.runUpdateStatement(String.format("DELETE FROM token WHERE userid = %d and tokensource = 'github.com'", admin.getId()));
         try {
             adminApi.updateLoggedInUserMetadata("github.com");
             fail("API call should fail and throw an error when no GitHub tokens are found or if tokens are out of date");


### PR DESCRIPTION
- m2 cache between jobs (not just between workflows)
- merge to parent
- remove some repetitive integration tests commands
- reduced resource to "large"
- swap to postgres11.8

Still missing:
- figure out where to write down CircleCI key and iv (CircleCI can't upload it like Travis can)
- Unit tests still uses postgres 9.x.x, it requires migration changes (splitting to different ticket)
- create issue to fix flakey tests
- remove coveralls from travis and pom
