### PR TITLE
start es, kibana, postgres from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 #this file sets up elasticsearch, kibana, and postgres containers for running dockstore locally
-#dockstore works without elasticsearch but the search page requires elasticsearch to be running
+#dockstore can run  without elasticsearch but the search page requires elasticsearch to be running
 #kibana can be used alongside elasticsearch as a visual interface for the indices and send queries directly
 #this only brings up the postgres container, not the actual database
 version: '2.2'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+#this file sets up elasticsearch, kibana, and postgres containers for running dockstore locally
+#dockstore works without elasticsearch but the search page requires elasticsearch to be running
+#kibana can be used alongside elasticsearch as a visual interface for the indices and send queries directly
+#this only brings up the postgres container, not the actual database
 version: '2.2'
 services:
   es01:
@@ -16,6 +20,8 @@ services:
       - xpack.graph.enabled=false
       - xpack.watcher.enabled=false
       - xpack.ml.enabled=false
+      - script.allowed_types= none
+      - script.allowed_contexts= none
     ulimits:
       memlock:
         soft: -1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     # networks:
       # - elastic
   postgres_db:
-    image: postgres:11.6
+    image: postgres:11.8
     container_name: postgres1
     ports:
       - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,3 +59,4 @@ volumes:
 networks:
   elastic:
     driver: bridge
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+version: '2.2'
+services:
+  es01:
+    #uncomment after elasticsearch upgrade
+    #image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.3
+    container_name: es01
+    environment:
+      - node.name=es01
+      - cluster.name=es-docker-cluster
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
+      - xpack.graph.enabled=false
+      - xpack.watcher.enabled=false
+      - xpack.ml.enabled=false
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - data01:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - elastic 
+  # uncomment to run a kibana instance 
+  # kib01:
+    # image: docker.elastic.co/kibana/kibana:6.8.3
+    # container_name: kib01
+    # ports:
+      # - 5601:5601
+    # environment:
+      # ELASTICSEARCH_URL: http://es01:9200
+      # ELASTICSEARCH_HOSTS: http://es01:9200
+    # networks:
+      # - elastic
+  postgres_db:
+    image: postgres:11.6
+    container_name: postgres1
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+volumes:
+  data01:
+    driver: local
+  db_data:
+
+networks:
+  elastic:
+    driver: bridge


### PR DESCRIPTION
- for [SEAB-1948](https://ucsc-cgl.atlassian.net/browse/SEAB-1948)
- running `docker-compose up -d` brings up elasticsearch and postgres containers. kibana instance can be uncommented if needed
