### PR TITLE
Feature/more circle ci cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,12 +53,6 @@ workflows:
           <<: *common_filters
           requires:
             - build
-      - regression-integration-tests:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release.*$/
 jobs:
   regression-integration-tests:
     executor: integration_test_exec

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ jobs:
       script: mvn -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -P$TESTING_PROFILE,coverage -ntp
       env:
         - TESTING_PROFILE=require-cwltool-tests
+    - stage: coverage   
+      script: mvn --batch-mode clean install org.jacoco:jacoco-maven-plugin:report-integration org.jacoco:jacoco-maven-plugin:report-aggregate coveralls:report -P$TESTING_PROFILE,coverage     
+      env:      
+        - TESTING_PROFILE=regression-integration-tests  
+          if: branch = master OR branch =~ /^release.*$/      
         
 # not feeling the bang-for-the-buck for these, running only in release branch         
 #    - stage: coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       script: mvn --batch-mode clean install org.jacoco:jacoco-maven-plugin:report-integration org.jacoco:jacoco-maven-plugin:report-aggregate coveralls:report -P$TESTING_PROFILE,coverage     
       env:      
         - TESTING_PROFILE=regression-integration-tests  
-          if: branch = master OR branch =~ /^release.*$/      
+      if: branch = master OR branch =~ /^release.*$/
         
 # not feeling the bang-for-the-buck for these, running only in release branch         
 #    - stage: coverage


### PR DESCRIPTION
Regression tests do some cwltool launching. CircleCI is known to fail certain Docker within Docker functions (not all). Have to move it back to Travis

Actually has a chance of passing regression tests

Random note: Looks like CircleCI forgot to make regression tests depend on build, so that would likely fail regardless