### PR TITLE
Cache dockstore-web-cache for CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,8 +141,7 @@ jobs:
     steps: # a collection of executable commands
       - checkout
       - restore_cache:
-          keys:
-            - dockstore-web-cache-unit-test
+          key: dockstore-web-cache-unit-test
       - run:
           name: Install yq
           command: |
@@ -198,9 +197,9 @@ jobs:
             - ~/.m2
           key: dockstore-java-{{ checksum "pom.xml" }}
       - save_cache:
-        key: dockstore-web-cache-unit-test
-        paths:
-          - /tmp/dockstore-web-cache
+          key: dockstore-web-cache-unit-test
+          paths:
+            - /tmp/dockstore-web-cache
       - run:
           name: Save test results
           command: |
@@ -274,8 +273,7 @@ commands:
             sudo apt update
             sudo apt install -y postgresql-client
       - restore_cache:
-          keys:
-            - dockstore-web-cache-{{ .Environment.TESTING_PROFILE }}
+          key: dockstore-web-cache-{{ .Environment.TESTING_PROFILE }}
   setup_integration_test:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,9 @@ jobs:
           POSTGRES_PASSWORD: postgres
     steps: # a collection of executable commands
       - checkout
+      - restore_cache:
+          keys:
+            - dockstore-web-cache-unit-test
       - run:
           name: Install yq
           command: |
@@ -194,6 +197,10 @@ jobs:
           paths:
             - ~/.m2
           key: dockstore-java-{{ checksum "pom.xml" }}
+      - save_cache:
+        key: dockstore-web-cache-unit-test
+        paths:
+          - /tmp/dockstore-web-cache
       - run:
           name: Save test results
           command: |
@@ -266,6 +273,9 @@ commands:
             sudo rm -rf /var/lib/apt/lists/*
             sudo apt update
             sudo apt install -y postgresql-client
+      - restore_cache:
+          keys:
+            - dockstore-web-cache-{{ .Environment.TESTING_PROFILE }}
   setup_integration_test:
     steps:
       - run:
@@ -308,6 +318,10 @@ commands:
           command: bash <(curl -s https://codecov.io/bash) -F ${TESTING_PROFILE//-} || echo "Codecov did not collect coverage reports"
   save_test_results:
     steps:
+      - save_cache:
+          key: dockstore-web-cache-{{ .Environment.TESTING_PROFILE }}
+          paths:
+            - /tmp/dockstore-web-cache
       - run:
           name: Save test results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,7 @@ commands:
             sudo apt update
             sudo apt install -y postgresql-client
       - restore_cache:
-          key: dockstore-web-cache-{{ .Environment.TESTING_PROFILE }}
+          key: dockstore-web-cache-{{ .Environment.CIRCLE_JOB }}
   setup_integration_test:
     steps:
       - run:
@@ -317,7 +317,7 @@ commands:
   save_test_results:
     steps:
       - save_cache:
-          key: dockstore-web-cache-{{ .Environment.TESTING_PROFILE }}
+          key: dockstore-web-cache-{{ .Environment.CIRCLE_JOB }}
           paths:
             - /tmp/dockstore-web-cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
     steps: # a collection of executable commands
       - checkout
       - restore_cache:
-          key: dockstore-web-cache-unit-test
+          key: dockstore-web-cache-unit-test-{{ .Environment.CACHE_VERSION }}
       - run:
           name: Install yq
           command: |
@@ -197,7 +197,7 @@ jobs:
             - ~/.m2
           key: dockstore-java-{{ checksum "pom.xml" }}
       - save_cache:
-          key: dockstore-web-cache-unit-test
+          key: dockstore-web-cache-unit-test-{{ .Environment.CACHE_VERSION }}
           paths:
             - /tmp/dockstore-web-cache
       - run:
@@ -273,7 +273,7 @@ commands:
             sudo apt update
             sudo apt install -y postgresql-client
       - restore_cache:
-          key: dockstore-web-cache-{{ .Environment.CIRCLE_JOB }}
+          key: dockstore-web-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_VERSION }}
   setup_integration_test:
     steps:
       - run:
@@ -317,7 +317,7 @@ commands:
   save_test_results:
     steps:
       - save_cache:
-          key: dockstore-web-cache-{{ .Environment.CIRCLE_JOB }}
+          key: dockstore-web-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_VERSION }}
           paths:
             - /tmp/dockstore-web-cache
       - run:


### PR DESCRIPTION
Main ticket: #3959

Using CircleCI's cache functionality to save http cache between builds.
i.e. the http cache generated by the unit test job should be carried over to future unit test jobs in future builds, the cache generated by workflow integration test jobs should be carried over future workflow integration test jobs, etc.

Caches on Circle automatically expire after 15 days. Cache keys only allow writing once, so if we ever need to clear the caches before they expire, simply rename the cache keys.