### PR TITLE
Run regression tests on CircleCI machine instance type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,22 @@ workflows:
     jobs:
       - build:
           <<: *common_filters
+      - unit_test:
+          <<: *common_filters
+          requires:
+            - build
+      - workflow-integration-tests:
+          <<: *common_filters
+          requires:
+            - build
+      - tool-integration-tests:
+          <<: *common_filters
+          requires:
+            - build
+      - integration-tests:
+          <<: *common_filters
+          requires:
+            - build
       - regression-integration-tests:
           <<: *common_filters
           requires:
@@ -158,7 +174,7 @@ jobs:
       - run:
           name: run the non-confidential integration tests
           command: |
-            # Adding all "normal" certs into this local one that has the Hoverfly cert (instead of adding Hoverfly cert to the global one so it doesn't potentially affect other tests) 
+            # Adding all "normal" certs into this local one that has the Hoverfly cert (instead of adding Hoverfly cert to the global one so it doesn't potentially affect other tests)
             /usr/local/jdk-11.0.8/bin/keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore LocalTrustStore -srcstorepass changeit -deststorepass changeit
             # mvn -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Pnon-confidential-tests,coverage -Djavax.net.ssl.trustStore=../LocalTrustStore -Djavax.net.ssl.trustStorePassword=changeit  -DskipSignatureCheck=false -ntp
             mvn -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Pnon-confidential-tests,coverage -Djavax.net.ssl.trustStore=../LocalTrustStore -Djavax.net.ssl.trustStorePassword=changeit -ntp
@@ -260,7 +276,7 @@ commands:
     steps:
       - attach_workspace:
           at: .
-      - run:
+      - run: # Useful for verifying default versions on machine image
           name: Java/Maven/Python versions
           command: |
             java -version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ executors:
     resource_class: medium+
   machine_integration_test_exec:
     machine: # run the steps with Ubuntu VM
-      image: ubuntu-1604:202010-01
+      image: ubuntu-2004:202010-01
     environment:
       PGHOST: 127.0.0.1
     resource_class: medium
@@ -245,6 +245,18 @@ commands:
           command: |
             psql -c "create user dockstore with password 'dockstore' createdb;" -U postgres
             psql -c 'create database webservice_test with owner = dockstore;' -U postgres
+  old_python:
+    steps:
+      - run:
+          name: Install & use Python 3.6
+          command: |
+            sudo add-apt-repository ppa:deadsnakes/ppa
+            sudo apt-get update
+            sudo apt-get install python3.6 python3-virtualenv
+            virtualenv -p /usr/bin/python3.6 venv
+            source venv/bin/activate
+            which python3
+            which python
   setup_machine:
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,8 +256,6 @@ commands:
             sudo apt-get install python3.6 python3-virtualenv
             virtualenv -p /usr/bin/python3.6 venv
             echo 'source venv/bin/activate' >> ~/.bashrc
-            source venv/bin/activate
-            python3 -V
   setup_machine:
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,10 +321,7 @@ commands:
             DOCKERIZE_VERSION: v0.6.1
       - run:
           name: Wait for db
-          command: |
-            docker ps
-            docker logs -f postgres1 --tail 10
-            dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - setup_postgres
       - run:
           name: Wait for ES

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,8 +252,8 @@ commands:
       - run:
           name: Install Java 11 & Maven
           command: |
-            sudo apt install openjdk-11-jdk
-            sudo apt install maven=3.6.3
+            java -version
+            mvn -v
       - run:
           name: Initialize postgres
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,11 +25,7 @@ executors:
     machine: # run the steps with Ubuntu VM
       image: ubuntu-2004:202010-01
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_DB: postgres
-      PG_HOST: localhost
-      POSTGRES_HOST_AUTH_METHOD: trust
-      POSTGRES_PASSWORD: postgres
+      PGHOST: 127.0.0.1
     resource_class: medium
 
 common_filters: &common_filters
@@ -59,6 +55,8 @@ jobs:
     steps:
       - setup_machine
       - setup_test
+      - setup_integration_test
+      - save_test_results
   integration-tests:
     executor: integration_test_exec
     environment:
@@ -249,11 +247,11 @@ commands:
             psql -c 'create database webservice_test with owner = dockstore;' -U postgres
   setup_machine:
     steps:
+      - attach_workspace:
+          at: .
       - run:
-          name: Initialize postgres
-          command: |
-            psql --version
-            psql -c max_connections=200
+          name: Docker-Compose
+          command: docker-compose up -d
   setup_test:
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,16 @@ executors:
           - http.port: 9200
           - discovery.type: single-node
     resource_class: medium+
+  machine_integration_test_exec:
+    machine: # run the steps with Ubuntu VM
+      image: ubuntu-2004:202010-01
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      PG_HOST: localhost
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_PASSWORD: postgres
+    resource_class: medium
 
 common_filters: &common_filters
   filters:
@@ -30,38 +40,25 @@ common_filters: &common_filters
       ignore:
         - gh-pages
 
-    
+
 workflows:
   version: 2
   everything:
     jobs:
       - build:
           <<: *common_filters
-      - unit_test:
-          <<: *common_filters
-          requires:
-            - build
-      - workflow-integration-tests:
-          <<: *common_filters
-          requires:
-            - build
-      - tool-integration-tests:
-          <<: *common_filters
-          requires:
-            - build
-      - integration-tests:
+      - regression-integration-tests:
           <<: *common_filters
           requires:
             - build
 jobs:
   regression-integration-tests:
-    executor: integration_test_exec
+    executor: machine_integration_test_exec
     environment:
       TESTING_PROFILE: regression-integration-tests
     steps:
+      - setup_machine
       - setup_test
-      - setup_integration_test
-      - save_test_results
   integration-tests:
     executor: integration_test_exec
     environment:
@@ -250,6 +247,18 @@ commands:
           command: |
             psql -c "create user dockstore with password 'dockstore' createdb;" -U postgres
             psql -c 'create database webservice_test with owner = dockstore;' -U postgres
+  setup_machine:
+    steps:
+      - run:
+          name: Install Java 11 & Maven
+          command: |
+            sudo apt install openjdk-11-jdk
+            sudo apt install maven=3.6.3
+      - run:
+          name: Initialize postgres
+          command: |
+            postgres --version
+            postgres -c max_connections=200
   setup_test:
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,13 +269,6 @@ commands:
       - run:
           name: Docker-Compose
           command: docker-compose up -d
-      - run:
-          name: Configure iptables
-          command: |
-            sysctl net.ipv4.ip_forward=1
-            iptables -t nat -A PREROUTING -p tcp --dport 5432 -j DNAT --to-destination 0.0.0.0:5432
-            iptables -t nat -A PREROUTING -p tcp --dport 9200 -j DNAT --to-destination 0.0.0.0:9200
-            iptables -t nat -A POSTROUTING -j MASQUERADE
   setup_test:
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ executors:
     resource_class: medium+
   machine_integration_test_exec:
     machine: # run the steps with Ubuntu VM
-      image: ubuntu-2004:202010-01
+      image: ubuntu-1604:202010-01
     environment:
       PGHOST: 127.0.0.1
     resource_class: medium
@@ -249,6 +249,12 @@ commands:
     steps:
       - attach_workspace:
           at: .
+      - run:
+          name: Java/Maven/Python versions
+          command: |
+            java -version
+            mvn -v
+            python3 -V
       - run:
           name: Docker-Compose
           command: docker-compose up -d

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,15 +250,10 @@ commands:
   setup_machine:
     steps:
       - run:
-          name: Install Java 11 & Maven
-          command: |
-            java -version
-            mvn -v
-      - run:
           name: Initialize postgres
           command: |
-            postgres --version
-            postgres -c max_connections=200
+            psql --version
+            psql -c max_connections=200
   setup_test:
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,7 @@ commands:
           command: |
             psql -c "create user dockstore with password 'dockstore' createdb;" -U postgres
             psql -c 'create database webservice_test with owner = dockstore;' -U postgres
-  old_python:
+  old_python: # Need Python 3.6 for old Dockstore 1.7 requirements.txt
     steps:
       - run:
           name: Install & use Python 3.6
@@ -268,10 +268,14 @@ commands:
             python3 -V
       - run:
           name: Docker-Compose
+          command: docker-compose up -d
+      - run:
+          name: Configure iptables
           command: |
-            docker-compose up -d
-            docker ps
-            docker inspect postgres1
+            sysctl net.ipv4.ip_forward=1
+            iptables -t nat -A PREROUTING -p tcp --dport 5432 -j DNAT --to-destination 0.0.0.0:5432
+            iptables -t nat -A PREROUTING -p tcp --dport 9200 -j DNAT --to-destination 0.0.0.0:9200
+            iptables -t nat -A POSTROUTING -j MASQUERADE
   setup_test:
     steps:
       - attach_workspace:
@@ -324,7 +328,9 @@ commands:
             DOCKERIZE_VERSION: v0.6.1
       - run:
           name: Wait for db
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+          command: |
+            docker ps
+            dockerize -wait tcp://localhost:5432 -timeout 1m
       - setup_postgres
       - run:
           name: Wait for ES

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,9 +255,9 @@ commands:
             sudo apt-get update
             sudo apt-get install python3.6 python3-virtualenv
             virtualenv -p /usr/bin/python3.6 venv
+            echo 'source venv/bin/activate' >> ~/.bashrc
             source venv/bin/activate
-            which python3
-            which python
+            python3 -V
   setup_machine:
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ jobs:
     environment:
       TESTING_PROFILE: regression-integration-tests
     steps:
+      - old_python
       - setup_machine
       - setup_test
       - setup_integration_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ commands:
           command: |
             sudo add-apt-repository ppa:deadsnakes/ppa
             sudo apt-get update
-            sudo apt-get install python3.6 python3-virtualenv
+            sudo apt-get install python3.6 python3.6-dev python3-virtualenv
             virtualenv -p /usr/bin/python3.6 venv
             echo 'source venv/bin/activate' >> ~/.bashrc
   setup_machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,10 @@ commands:
             python3 -V
       - run:
           name: Docker-Compose
-          command: docker-compose up -d
+          command: |
+            docker-compose up -d
+            docker ps
+            docker inspect postgres1
   setup_test:
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,11 @@ workflows:
           requires:
             - build
       - regression-integration-tests:
-          <<: *common_filters
+          filters:
+            branches:
+              only:
+                - master
+                - /^release.*$/
           requires:
             - build
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,6 +323,7 @@ commands:
           name: Wait for db
           command: |
             docker ps
+            docker logs -f postgres1 --tail 10
             dockerize -wait tcp://localhost:5432 -timeout 1m
       - setup_postgres
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,8 @@ jobs:
       script: mvn -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -P$TESTING_PROFILE,coverage -ntp
       env:
         - TESTING_PROFILE=require-cwltool-tests
-    - stage: coverage   
-      script: mvn --batch-mode clean install org.jacoco:jacoco-maven-plugin:report-integration org.jacoco:jacoco-maven-plugin:report-aggregate -P$TESTING_PROFILE,coverage
-      env:      
-        - TESTING_PROFILE=regression-integration-tests  
-      if: branch = master OR branch =~ /^release.*$/
-        
-# not feeling the bang-for-the-buck for these, running only in release branch         
+
+# not feeling the bang-for-the-buck for these, running only in release branch
 #    - stage: coverage
 #      script: mvn --batch-mode clean install org.jacoco:jacoco-maven-plugin:report-integration org.jacoco:jacoco-maven-plugin:report-aggregate -P$TESTING_PROFILE,coverage -DskipClientITs=true
 #      if: branch = master OR branch =~ /^release.*$/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
   postgres_db:
     image: postgres:11.8
     container_name: postgres1
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
     ports:
       - "5432:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,8 @@ services:
     ports:
       - 9200:9200
     networks:
-      - elastic 
-  # uncomment to run a kibana instance 
+      - elastic
+  # uncomment to run a kibana instance
   # kib01:
     # image: docker.elastic.co/kibana/kibana:6.8.3
     # container_name: kib01
@@ -61,4 +61,3 @@ volumes:
 networks:
   elastic:
     driver: bridge
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     # networks:
       # - elastic
   postgres_db:
-    image: postgres:11.8
+    image: postgres:11.10
     container_name: postgres1
     ports:
       - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     # networks:
       # - elastic
   postgres_db:
-    image: postgres:11.10
+    image: postgres:11.6
     container_name: postgres1
     ports:
       - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     # networks:
       # - elastic
   postgres_db:
-    image: postgres:11.6
+    image: postgres:11.8
     container_name: postgres1
     ports:
       - "5432:5432"

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -12,7 +12,7 @@ if [ "${TESTING_PROFILE}" = "unit-tests" ] || [ "${TESTING_PROFILE}" == "automat
 fi
 
 if [ "${TESTING_PROFILE}" = "regression-integration-tests" ]; then
-    pip3 install --user -r dockstore-webservice/src/main/resources/requirements/1.7.0/requirements3.txt
+    pip3 install -r dockstore-webservice/src/main/resources/requirements/1.7.0/requirements3.txt
 else
     pip3 install --user -r dockstore-webservice/src/main/resources/requirements/1.10.0/requirements3.txt
 fi


### PR DESCRIPTION
Main issue: #3958

Our CircleCI tests up until now run on Circle's Docker instances. This leads to issues with CLI tests which end up running Docker (Docker-in-Docker situation).

This PR adds the `machine_integration_test_exec` executor (using an Ubuntu 20.04 image) and the `setup_machine` command (using docker-compose) to our Circle config.

Additionally, since Ubuntu defaults to Python 3.8 and our old Pip dependencies for regression tests need Python 3.6, the `old_python` command sets up a Python virtual environment with 3.6.

See that regression tests and everything else succeeds here: https://app.circleci.com/pipelines/github/dockstore/dockstore/5140/workflows/322e417b-eb0b-4eac-b725-461f4b585bba

**Further reading on Executor types:** https://circleci.com/docs/2.0/executor-types/

**Extra Discussion:**
In theory, we could use this to run any of our integration test jobs on machine instances using `machine_integration_test_exec` and running `setup_machine` before `setup_test`. The main cost of using machine instances instead of Docker is the overhead of manually spinning up Docker containers within the machine-job, rather than Circle CI doing its Docker-magic (but also this is a thing: https://circleci.com/docs/2.0/docker-layer-caching/).