### PR TITLE
keep track of deleted users

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
@@ -27,7 +27,7 @@ public final class PipHelper {
             semVerString = "9001.9001.9001";
         }
         Version semVer = Version.valueOf(semVerString);
-        if (semVer.greaterThan(Version.valueOf("1.7.0"))) {
+        if (semVer.greaterThan(Version.valueOf("1.9.0"))) {
             return "1.10.0";
         }
         // Use the 1.7.0 even for snapshot

--- a/dockstore-common/src/test/java/io/dockstore/common/PipHelperTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/PipHelperTest.java
@@ -16,6 +16,8 @@ public class PipHelperTest {
         Assert.assertEquals("1.10.0", PipHelper.convertSemVerToAvailableVersion("1.10.0-snapshot"));
         Assert.assertEquals("1.10.0", PipHelper.convertSemVerToAvailableVersion("1.10.1"));
         Assert.assertEquals("1.10.0", PipHelper.convertSemVerToAvailableVersion("1.10.0"));
+        Assert.assertEquals("1.7.0", PipHelper.convertSemVerToAvailableVersion("1.9.0"));
+        Assert.assertEquals("1.7.0", PipHelper.convertSemVerToAvailableVersion("1.8.0"));
         Assert.assertEquals("1.7.0", PipHelper.convertSemVerToAvailableVersion("1.7.0-snapshot"));
         Assert.assertEquals("1.7.0", PipHelper.convertSemVerToAvailableVersion("1.7.0"));
         Assert.assertEquals("1.6.0", PipHelper.convertSemVerToAvailableVersion("1.6.0-snapshot"));

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -1419,24 +1419,44 @@ public class OrganizationIT extends BaseIT {
             fail("Was able to reject an approved collection");
         }
 
-        // version 8 and 9 belong to entryId 2
-        long versionId = 9L;
+        // versionId 8 and 9 belong to entryId 2
+        // versionId 1, 2, 3 belong to entryId 1
+        long versionId = 3L;
+        // The version name for the above version
+        String versionName = "latest";
 
         // Add tool and specific version to collection
         organizationsApi.addEntryToCollection(organization.getId(), collectionId, entryId, versionId);
         organizationsApi.addEntryToCollection(organization.getId(), collectionId, entryId, null);
 
-        // There should now be two entries for collection with ID 1 (one with version, one without), 3 entries in total
+        // There should now be 3 entries
+        // entry id 1, version id 3
+        // entry id 1, no version
+        // entry id 2, no version
         collectionById = organizationsApi.getCollectionById(organizationID, collectionId);
         assertEquals(3, collectionById.getEntries().size());
-        assertTrue("Collection has the version-specific entry", collectionById.getEntries().stream().anyMatch(entry -> "latest"
+        assertTrue("Collection has the version-specific entry", collectionById.getEntries().stream().anyMatch(entry -> versionName
                 .equals(entry.getVersionName()) && entry.getEntryPath().equals("quay.io/dockstore2/testrepo2")));
         assertTrue("Collection still has the non-version-specific entry", collectionById.getEntries().stream().anyMatch(entry -> entry.getVersionName() == null  && entry.getEntryPath().equals("quay.io/dockstore2/testrepo2")));
 
-        organizationsApi.deleteEntryFromCollection(organizationID, collectionId, entryId, versionId);
+        // When there's a matching entryId that has a version, but versionName parameter is something else, there should not be NPE
+        try {
+            organizationsApi.deleteEntryFromCollection(organizationID, collectionId, entryId, "doesNotExistVersionName");
+            Assert.fail("Can't delete a version that doesn't exist");
+        } catch (ApiException e) {
+            Assert.assertEquals("Version not found", e.getMessage());
+            Assert.assertEquals(HttpStatus.SC_NOT_FOUND, e.getCode());
+        }
+        organizationsApi.deleteEntryFromCollection(organizationID, collectionId, entryId, versionName);
         collectionById = organizationsApi.getCollectionById(organizationID, collectionId);
         assertEquals("Two entry remains in collection", 2, collectionById.getEntries().size());
         assertTrue("Collection has the non-version-specific entry even after deleting the version-specific one", collectionById.getEntries().stream().anyMatch(entry -> entry.getVersionName() == null && entry.getEntryPath().equals("quay.io/dockstore2/testrepo2")));
+
+        // When there's a matching entryId that has a version, but versionName parameter is null, there should not be NPE
+        organizationsApi.deleteEntryFromCollection(organizationID, collectionId, entryId, null);
+
+        collectionById = organizationsApi.getCollectionById(organizationID, collectionId);
+        assertEquals("Two entry remains in collection", 1, collectionById.getEntries().size());
 
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -42,6 +42,7 @@ import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Checksum;
 import io.dockstore.webservice.core.Collection;
 import io.dockstore.webservice.core.CollectionOrganization;
+import io.dockstore.webservice.core.DeletedUsername;
 import io.dockstore.webservice.core.EntryVersion;
 import io.dockstore.webservice.core.Event;
 import io.dockstore.webservice.core.FileFormat;
@@ -70,6 +71,7 @@ import io.dockstore.webservice.helpers.PersistenceExceptionMapper;
 import io.dockstore.webservice.helpers.PublicStateManager;
 import io.dockstore.webservice.helpers.TransactionExceptionMapper;
 import io.dockstore.webservice.helpers.statelisteners.TRSListener;
+import io.dockstore.webservice.jdbi.DeletedUsernameDAO;
 import io.dockstore.webservice.jdbi.EventDAO;
 import io.dockstore.webservice.jdbi.FileDAO;
 import io.dockstore.webservice.jdbi.TagDAO;
@@ -170,7 +172,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             Token.class, Tool.class, User.class, Tag.class, Label.class, SourceFile.class, Workflow.class, CollectionOrganization.class,
             WorkflowVersion.class, FileFormat.class, Organization.class, Notification.class, OrganizationUser.class, Event.class, Collection.class,
             Validation.class, BioWorkflow.class, Service.class, VersionMetadata.class, Image.class, Checksum.class, LambdaEvent.class,
-            ParsedInformation.class, EntryVersion.class) {
+            ParsedInformation.class, EntryVersion.class, DeletedUsername.class) {
         @Override
         public DataSourceFactory getDataSourceFactory(DockstoreWebserviceConfiguration configuration) {
             return configuration.getDataSourceFactory();
@@ -291,6 +293,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
 
         final UserDAO userDAO = new UserDAO(hibernate.getSessionFactory());
         final TokenDAO tokenDAO = new TokenDAO(hibernate.getSessionFactory());
+        final DeletedUsernameDAO deletedUsernameDAO = new DeletedUsernameDAO(hibernate.getSessionFactory());
         final ToolDAO toolDAO = new ToolDAO(hibernate.getSessionFactory());
         final FileDAO fileDAO = new FileDAO(hibernate.getSessionFactory());
         final WorkflowDAO workflowDAO = new WorkflowDAO(hibernate.getSessionFactory());
@@ -328,7 +331,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
 
         environment.jersey().register(dockerRepoResource);
         environment.jersey().register(new DockerRepoTagResource(toolDAO, tagDAO, eventDAO, versionDAO));
-        environment.jersey().register(new TokenResource(tokenDAO, userDAO, httpClient, cachingAuthenticator, configuration));
+        environment.jersey().register(new TokenResource(tokenDAO, userDAO, deletedUsernameDAO, httpClient, cachingAuthenticator, configuration));
 
         environment.jersey().register(new UserResource(httpClient, getHibernate().getSessionFactory(), workflowResource, serviceResource, dockerRepoResource, cachingAuthenticator, authorizer, configuration));
 
@@ -410,7 +413,6 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         // Initialize GitHub App Installation Access Token cache
         CacheConfigManager cacheConfigManager = CacheConfigManager.getInstance();
         cacheConfigManager.initCache();
-
     }
 
     private void describeAvailableLanguagePlugins(DefaultPluginManager languagePluginManager) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/DeletedUsername.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/DeletedUsername.java
@@ -1,0 +1,87 @@
+/*
+ *    Copyright 2021 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.dockstore.webservice.core;
+
+import java.sql.Timestamp;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * Stores deleted usernames
+ *
+ * @author natalieperez
+ */
+@ApiModel(value = "DeletedUsername", description = "End users for the dockstore")
+@Entity
+@Table(name = "deletedusername", uniqueConstraints = @UniqueConstraint(columnNames = { "username" }))
+@NamedQueries({ @NamedQuery (name = "io.dockstore.webservice.core.DeletedUsername.findByUsername", query = "SELECT u FROM DeletedUsername u WHERE u.username = :username")})
+public class DeletedUsername {
+
+    @Id
+    @Column
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @ApiModelProperty(value = "ID for deleted username", position = 0)
+    private long id;
+
+    @Column(nullable = false, unique = true)
+    @ApiModelProperty(value = "Username that has been deleted. Cannot be reused for 3 years")
+    private String username;
+
+    @Column(updatable = false)
+    @CreationTimestamp
+    private Timestamp dbCreateDate;
+
+    @Column
+    @JsonIgnore
+    @UpdateTimestamp
+    private Timestamp dbUpdateDate;
+
+    public DeletedUsername() {
+
+    }
+
+    public DeletedUsername(String username) {
+        this.username = username;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public Timestamp getDbCreateDate() {
+        return dbCreateDate;
+    }
+
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/EntryVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/EntryVersion.java
@@ -46,7 +46,17 @@ public class EntryVersion implements Serializable {
     }
 
     public boolean equals(Long entryId, Long versionId) {
-        return this.getEntry().getId() == entryId && (this.getVersion() != null ? this.getVersion().getId() == versionId : null == versionId);
+        return this.getEntry().getId() == entryId && compareVersionId(this.getVersion(), versionId);
+    }
+
+    private boolean compareVersionId(Version compareVersion, Long versionId) {
+        if (compareVersion == null && versionId == null) {
+            return true;
+        }
+        if (compareVersion == null || versionId == null) {
+            return false;
+        }
+        return compareVersion.getId() == versionId;
     }
 
     public Integer getId() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DeletedUserHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DeletedUserHelper.java
@@ -1,0 +1,34 @@
+package io.dockstore.webservice.helpers;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+import io.dockstore.webservice.core.DeletedUsername;
+import io.dockstore.webservice.jdbi.DeletedUsernameDAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class DeletedUserHelper {
+    // NIH suggests a 3 year limit before allowing username reuse.
+    private static final int NO_REUSE_TIME_LIMIT = 365 * 3;
+    private static final Logger LOG = LoggerFactory.getLogger(DeletedUserHelper.class);
+
+    private DeletedUserHelper() {
+
+    }
+
+    public static boolean deletedUserFound(String username, DeletedUsernameDAO deletedUsernameDAO) {
+        DeletedUsername deletedUsername = deletedUsernameDAO.findByUsername(username);
+        if (deletedUsername != null) {
+            LocalDateTime threeYearsAgoDateTime = LocalDateTime.now().minusDays(NO_REUSE_TIME_LIMIT);
+            Timestamp threeYearsAgoTimestamp = Timestamp.valueOf(threeYearsAgoDateTime);
+            if (deletedUsername.getDbCreateDate().before(threeYearsAgoTimestamp)) {
+                LOG.info("Username of deleted user is old enough to be used again. Deleting record of deleted user.");
+                deletedUsernameDAO.delete(deletedUsername);
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/DeletedUsernameDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/DeletedUsernameDAO.java
@@ -1,0 +1,30 @@
+package io.dockstore.webservice.jdbi;
+
+import io.dockstore.webservice.core.DeletedUsername;
+import io.dropwizard.hibernate.AbstractDAO;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+
+public class DeletedUsernameDAO extends AbstractDAO<DeletedUsername> {
+    public DeletedUsernameDAO(SessionFactory sessionFactory) {
+        super(sessionFactory);
+    }
+
+    public DeletedUsername findById(Long id) {
+        return get(id);
+    }
+
+    public long create(DeletedUsername deletedUsername) {
+        return persist(deletedUsername).getId();
+    }
+
+    public void delete(DeletedUsername deletedUsername) {
+        Session session = currentSession();
+        session.delete(deletedUsername);
+        session.flush();
+    }
+
+    public DeletedUsername findByUsername(String username) {
+        return uniqueResult(this.currentSession().getNamedQuery("io.dockstore.webservice.core.DeletedUsername.findByUsername").setParameter("username", username));
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -524,6 +524,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 existingWorkflowVersion.get().setDagJson(null);
                 existingWorkflowVersion.get().setToolTableJson(null);
                 existingWorkflowVersion.get().setReferenceType(remoteWorkflowVersion.getReferenceType());
+                existingWorkflowVersion.get().setValid(remoteWorkflowVersion.isValid());
 
                 updateDBVersionSourceFilesWithRemoteVersionSourceFiles(existingWorkflowVersion.get(), remoteWorkflowVersion);
             } else {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -59,10 +59,12 @@ import io.dockstore.webservice.core.TOSVersion;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.User;
+import io.dockstore.webservice.helpers.DeletedUserHelper;
 import io.dockstore.webservice.helpers.GitHubHelper;
 import io.dockstore.webservice.helpers.GitHubSourceCodeRepo;
 import io.dockstore.webservice.helpers.GoogleHelper;
 import io.dockstore.webservice.helpers.SourceCodeRepoFactory;
+import io.dockstore.webservice.jdbi.DeletedUsernameDAO;
 import io.dockstore.webservice.jdbi.TokenDAO;
 import io.dockstore.webservice.jdbi.UserDAO;
 import io.dropwizard.auth.Auth;
@@ -120,6 +122,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
 
     private final TokenDAO tokenDAO;
     private final UserDAO userDAO;
+    private final DeletedUsernameDAO deletedUsernameDAO;
 
     private final String githubClientID;
     private final String githubClientSecret;
@@ -143,10 +146,11 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     private final String orcidSummary = "Add a new orcid.org token";
     private final String orcidDescription = "Using OAuth code from ORCID, request and store tokens from ORCID API";
 
-    public TokenResource(TokenDAO tokenDAO, UserDAO enduserDAO, HttpClient client, CachingAuthenticator<String, User> cachingAuthenticator,
+    public TokenResource(TokenDAO tokenDAO, UserDAO enduserDAO, DeletedUsernameDAO deletedUsernameDAO, HttpClient client, CachingAuthenticator<String, User> cachingAuthenticator,
             DockstoreWebserviceConfiguration configuration) {
         this.tokenDAO = tokenDAO;
         userDAO = enduserDAO;
+        this.deletedUsernameDAO = deletedUsernameDAO;
         this.githubClientID = configuration.getGithubClientID();
         this.githubClientSecret = configuration.getGithubClientSecret();
         this.bitbucketClientID = configuration.getBitbucketClientID();
@@ -383,9 +387,16 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
 
         if (registerUser && authUser.isEmpty()) {
             if (user == null) {
+                String googleLogin = userinfo.getEmail();
+                String username = googleLogin;
+                int count = 1;
+
+                while (userDAO.findByUsername(username) != null || DeletedUserHelper.deletedUserFound(username, deletedUsernameDAO)) {
+                    username = username + count++;
+                }
+
                 user = new User();
-                // Pull user information from Google
-                user.setUsername(userinfo.getEmail());
+                user.setUsername(username);
                 userID = userDAO.create(user);
             } else {
                 throw new CustomWebApplicationException("User already exists, cannot register new user", HttpStatus.SC_FORBIDDEN);
@@ -515,7 +526,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
             // check that there was no previous user, but by default use the github login
             String username = githubLogin;
             int count = 1;
-            while (userDAO.findByUsername(username) != null) {
+            while (userDAO.findByUsername(username) != null || DeletedUserHelper.deletedUserFound(username, deletedUsernameDAO)) {
                 username = githubLogin + count++;
             }
 
@@ -570,8 +581,6 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
         }
         return dockstoreToken;
     }
-
-
 
     private Token createDockstoreToken(long userID, String githubLogin) {
         Token dockstoreToken;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -57,6 +57,7 @@ import io.dockstore.webservice.api.Limits;
 import io.dockstore.webservice.api.PrivilegeRequest;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Collection;
+import io.dockstore.webservice.core.DeletedUsername;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.EntryUpdateTime;
 import io.dockstore.webservice.core.ExtendedUserData;
@@ -73,12 +74,14 @@ import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowMode;
 import io.dockstore.webservice.core.database.EntryLite;
 import io.dockstore.webservice.core.database.MyWorkflows;
+import io.dockstore.webservice.helpers.DeletedUserHelper;
 import io.dockstore.webservice.helpers.EntryVersionHelper;
 import io.dockstore.webservice.helpers.GoogleHelper;
 import io.dockstore.webservice.helpers.PublicStateManager;
 import io.dockstore.webservice.helpers.SourceCodeRepoFactory;
 import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
 import io.dockstore.webservice.jdbi.BioWorkflowDAO;
+import io.dockstore.webservice.jdbi.DeletedUsernameDAO;
 import io.dockstore.webservice.jdbi.EntryDAO;
 import io.dockstore.webservice.jdbi.EventDAO;
 import io.dockstore.webservice.jdbi.LambdaEventDAO;
@@ -138,6 +141,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     private final ServiceDAO serviceDAO;
     private final EventDAO eventDAO;
     private final LambdaEventDAO lambdaEventDAO;
+    private final DeletedUsernameDAO deletedUsernameDAO;
     private PermissionsInterface authorizer;
     private final CachingAuthenticator cachingAuthenticator;
     private final HttpClient client;
@@ -158,6 +162,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
         this.bioWorkflowDAO = new BioWorkflowDAO(sessionFactory);
         this.serviceDAO = new ServiceDAO(sessionFactory);
         this.lambdaEventDAO = new LambdaEventDAO(sessionFactory);
+        this.deletedUsernameDAO = new DeletedUsernameDAO(sessionFactory);
         this.workflowResource = workflowResource;
         this.serviceResource = serviceResource;
         this.dockerRepoResource = dockerRepoResource;
@@ -252,6 +257,11 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
         if (!new ExtendedUserData(user, this.authorizer, userDAO).canChangeUsername()) {
             throw new CustomWebApplicationException("Cannot change username, user not ready", HttpStatus.SC_BAD_REQUEST);
         }
+
+        if (userDAO.findByUsername(username) != null || DeletedUserHelper.deletedUserFound(username, deletedUsernameDAO)) {
+            throw new CustomWebApplicationException("Cannot change user to " + username + " because it is already in use", HttpStatus.SC_BAD_REQUEST);
+        }
+
         user.setUsername(username);
         user.setSetupComplete(true);
         userDAO.clearCache();
@@ -297,7 +307,12 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
         deleteSelfFromEntries(user);
         invalidateTokensForUser(user);
         deleteSelfFromLambdaEvents(user);
-        return userDAO.delete(user);
+        boolean isDeleted =  userDAO.delete(user);
+        if (isDeleted) {
+            DeletedUsername deletedUsername = new DeletedUsername(user.getUsername());
+            deletedUsernameDAO.create(deletedUsername);
+        }
+        return isDeleted;
     }
 
     private void invalidateTokensForUser(User user) {
@@ -367,7 +382,10 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
                                    @ApiParam("User name to check") @PathParam("username") String username) {
         @SuppressWarnings("deprecation")
         User foundUser = userDAO.findByUsername(username);
-        return foundUser != null;
+        if (foundUser == null && !DeletedUserHelper.deletedUserFound(username, deletedUsernameDAO)) {
+            return false;
+        }
+        return true;
     }
 
     @GET

--- a/dockstore-webservice/src/main/resources/migrations.1.10.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.10.0.xml
@@ -119,4 +119,17 @@
         <modifyDataType columnName="forumurl" newDataType="varchar(256)" tableName="service"/>
         <modifyDataType columnName="forumurl" newDataType="varchar(256)" tableName="workflow"/>
     </changeSet>
+    <changeSet author="natalieperez (generated)" id="deletedUsernameTable">
+        <createTable tableName="deletedusername">
+            <column autoIncrement="true" name="id" type="BIGSERIAL">
+                <constraints primaryKey="true" primaryKeyName="deletedusername_pkey"/>
+            </column>
+            <column name="dbcreatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="dbupdatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="username" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addUniqueConstraint columnNames="username" constraintName="unique_deleted_username" tableName="deletedusername"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -5079,8 +5079,7 @@ paths:
           in: query
           name: versionId
           schema:
-            format: int64
-            type: integer
+            type: string
       responses:
         default:
           content:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -3417,12 +3417,11 @@ paths:
         required: true
         type: "integer"
         format: "int64"
-      - name: "versionId"
+      - name: "versionName"
         in: "query"
         description: "Version ID"
         required: false
-        type: "integer"
-        format: "int64"
+        type: "string"
       responses:
         200:
           description: "successful operation"


### PR DESCRIPTION
Hm realized I did this on the hotfix branch. Will move to develop if that's preferred.
https://ucsc-cgl.atlassian.net/browse/SEAB-2080

This PR:
- creates a table to track the usernames of deleted accounts. 
- Trying to sign up again with the same google or github user will append a number 
- Can't change a username to a deleted one
- When creating or changing the account, a check is done that the deleted username is 3 years old. If it is, then the deleted user entry is removed and the username can be used again.