### PR TITLE
Feature/seab 2409/export workflow orcid

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 348 third-party dependencies.
+Lists of 353 third-party dependencies.
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.12:2.5.31 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.12:2.5.31 - https://akka.io/)
      (Apache License, Version 2.0) akka-slf4j (com.typesafe.akka:akka-slf4j_2.12:2.5.31 - https://akka.io/)
@@ -163,6 +163,7 @@ Lists of 348 third-party dependencies.
      (EPL 2.0) (GPL2 w/ CPE) HK2 Implementation Utilities (org.glassfish.hk2:hk2-utils:2.6.1 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-utils)
      (The Apache Software License, Version 2.0) Hoverfly Java (io.specto:hoverfly-java:0.12.0 - https://github.com/SpectoLabs/hoverfly-java)
      (Apache 2.0) io.grpc:grpc-context (io.grpc:grpc-context:1.22.1 - https://github.com/grpc/grpc-java)
+     (Eclipse Distribution License - v 1.0) istack common utility code runtime (com.sun.istack:istack-commons-runtime:3.0.11 - https://projects.eclipse.org/projects/ee4j/istack-commons/istack-commons-runtime)
      (The Apache Software License, Version 2.0) J2ObjC Annotations (com.google.j2objc:j2objc-annotations:1.3 - https://github.com/google/j2objc/)
      (The Apache Software License, Version 2.0) Jackson (org.codehaus.jackson:jackson-core-asl:1.9.13 - http://jackson.codehaus.org)
      (The Apache Software License, Version 2.0) Jackson 2 extensions to the Google APIs Client Library for Java (com.google.api-client:google-api-client-jackson2:1.30.10 - https://github.com/googleapis/google-api-java-client/google-api-client-jackson2)
@@ -187,6 +188,7 @@ Lists of 348 third-party dependencies.
      (The Apache Software License, Version 2.0) Jackson-module-parameter-names (com.fasterxml.jackson.module:jackson-module-parameter-names:2.11.3 - https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names)
      (Apache 2) Jadira Usertype Core (for Joda Time, Joda Money, Libphonenum and JDK Types with Hibernate) (org.jadira.usertype:usertype.core:7.0.0.CR1 - http://oss.jadira.co.uk/usertype.core/)
      (Apache 2) Jadira Usertype SPI Classes for Hibernate (org.jadira.usertype:usertype.spi:7.0.0.CR1 - http://oss.jadira.co.uk/usertype.spi/)
+     (EDL 1.0) Jakarta Activation (com.sun.activation:jakarta.activation:1.2.2 - https://github.com/eclipse-ee4j/jaf/jakarta.activation)
      (EDL 1.0) Jakarta Activation API jar (jakarta.activation:jakarta.activation-api:1.2.2 - https://github.com/eclipse-ee4j/jaf/jakarta.activation-api)
      (EPL 2.0) (GPL2 w/ CPE) Jakarta Annotations API (jakarta.annotation:jakarta.annotation-api:1.3.5 - https://projects.eclipse.org/projects/ee4j.ca)
      (Apache License 2.0) Jakarta Bean Validation API (jakarta.validation:jakarta.validation-api:2.0.2 - https://beanvalidation.org)
@@ -211,6 +213,7 @@ Lists of 348 third-party dependencies.
      (Eclipse Distribution License v. 1.0) (Eclipse Public License v1.0) javax.persistence-api (javax.persistence:javax.persistence-api:2.2 - https://github.com/javaee/jpa-spec)
      (CDDL + GPLv2 with classpath exception) javax.transaction API (javax.transaction:javax.transaction-api:1.3 - http://jta-spec.java.net)
      (CDDL 1.1) (GPL2 w/ CPE) javax.ws.rs-api (javax.ws.rs:javax.ws.rs-api:2.0.1 - http://jax-rs-spec.java.net)
+     (Eclipse Distribution License - v 1.0) JAXB Runtime (org.glassfish.jaxb:jaxb-runtime:2.3.3 - https://eclipse-ee4j.github.io/jaxb-ri/jaxb-runtime-parent/jaxb-runtime)
      (Apache License, version 2.0) JBoss Logging 3 (org.jboss.logging:jboss-logging:3.3.2.Final - http://www.jboss.org)
      (Apache License, Version 2.0) JCL 1.2 implemented over SLF4J (org.slf4j:jcl-over-slf4j:1.7.30 - http://www.slf4j.org)
      (Apache License, Version 2.0) jcommander (com.beust:jcommander:1.78 - https://jcommander.org)
@@ -304,6 +307,7 @@ Lists of 348 third-party dependencies.
      (Apache 2.0) OkHttp (com.squareup.okhttp3:okhttp:3.14.2 - https://github.com/square/okhttp/okhttp)
      (Apache 2.0) Okio (com.squareup.okio:okio:1.17.2 - https://github.com/square/okio/okio)
      (The Apache License, Version 2.0) OpenCensus (io.opencensus:opencensus-api:0.24.0 - https://github.com/census-instrumentation/opencensus-java)
+     (MIT License) ORCID - Model (org.orcid:orcid-model:3.0.4 - http://github.com/ORCID/orcid-model)
      (EPL 2.0) (GPL2 w/ CPE) OSGi resource locator (org.glassfish.hk2:osgi-resource-locator:1.0.3 - https://projects.eclipse.org/projects/ee4j/osgi-resource-locator)
      (MIT) parser (org.typelevel:jawn-parser_2.12:1.0.0 - http://github.com/typelevel/jawn)
      (The Apache Software License, Version 2.0) PF4J (org.pf4j:pf4j:3.2.0 - http://nexus.sonatype.org/oss-repository-hosting.html/pf4j-parent/pf4j)
@@ -343,6 +347,7 @@ Lists of 348 third-party dependencies.
      (Apache License 2.0) Throttling Appender (io.dropwizard.logback:logback-throttling-appender:1.1.0 - https://github.com/dropwizard/logback-throttling-appender/)
      (Apache License, Version 2.0) tomcat-jdbc (org.apache.tomcat:tomcat-jdbc:9.0.41 - https://tomcat.apache.org/)
      (Apache License, Version 2.0) tomcat-juli (org.apache.tomcat:tomcat-juli:9.0.41 - https://tomcat.apache.org/)
+     (Eclipse Distribution License - v 1.0) TXW2 Runtime (org.glassfish.jaxb:txw2:2.3.3 - https://eclipse-ee4j.github.io/jaxb-ri/jaxb-txw-parent/txw2)
      (WDL License https://github.com/openwdl/wdl/blob/master/LICENSE) wdl-biscayne (org.broadinstitute:wdl-biscayne_2.12:54 - no url defined)
      (WDL License https://github.com/openwdl/wdl/blob/master/LICENSE) wdl-draft2 (org.broadinstitute:wdl-draft2_2.12:54 - no url defined)
      (WDL License https://github.com/openwdl/wdl/blob/master/LICENSE) wdl-draft3 (org.broadinstitute:wdl-draft3_2.12:54 - no url defined)

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -704,6 +704,7 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <version>2.3.0-b170127.1453</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -691,13 +691,20 @@
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
-
-
+        <dependency>
+            <groupId>org.orcid</groupId>
+            <artifactId>orcid-model</artifactId>
+            <version>3.0.4</version>
+        </dependency>
         <dependency>
             <groupId>javax.persistence</groupId>
             <artifactId>javax.persistence-api</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.0-b170127.1453</version>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -695,16 +695,38 @@
             <groupId>org.orcid</groupId>
             <artifactId>orcid-model</artifactId>
             <version>3.0.4</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                    <artifactId>jackson-jaxrs-json-provider</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.swagger</groupId>
+                    <artifactId>swagger-jersey-jaxrs</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.0-b170127.1453</version>
+            <version>2.3.3</version>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
@@ -24,7 +24,6 @@ import org.orcid.jaxb.model.common.Relationship;
 import org.orcid.jaxb.model.common.WorkType;
 import org.orcid.jaxb.model.v3.release.common.CreatedDate;
 import org.orcid.jaxb.model.v3.release.common.LastModifiedDate;
-import org.orcid.jaxb.model.v3.release.common.Subtitle;
 import org.orcid.jaxb.model.v3.release.common.Title;
 import org.orcid.jaxb.model.v3.release.common.Url;
 import org.orcid.jaxb.model.v3.release.record.ExternalID;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
@@ -34,6 +34,7 @@ import org.orcid.jaxb.model.v3.release.record.WorkTitle;
 
 public final class ORCIDHelper {
     // TODO: Change to non-sandbox for Dockstore use while using sandbox for test
+    // Swagger-ui available here: https://api.orcid.org/v3.0/#!/Development_Member_API_v3.0/
     private static final String ORCID_SANDBOX_BASE_URL = "https://api.sandbox.orcid.org/v3.0/";
     private static final String ORCID_BASE_URL = "https://api.orcid.org/v3.0/";
 
@@ -56,7 +57,6 @@ public final class ORCIDHelper {
         Work work = new Work();
         WorkTitle workTitle = new WorkTitle();
         Title title = new Title();
-        Subtitle subtitle = new Subtitle("Dockstore Workflow");
         ExternalIDs externalIDs = new ExternalIDs();
         ExternalID externalID = new ExternalID();
         externalID.setType("doi");
@@ -76,7 +76,6 @@ public final class ORCIDHelper {
         journalTitle.setContent("Dockstore");
         work.setJournalTitle(journalTitle);
         workTitle.setTitle(title);
-        workTitle.setSubtitle(subtitle);
         work.setWorkTitle(workTitle);
         work.setShortDescription("A workflow exported from Dockstore");
         work.setWorkType(WorkType.SOFTWARE);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
@@ -120,8 +120,11 @@ public final class ORCIDHelper {
         postRequest.addHeader("Authorization", "Bearer " + token);
         StringEntity workEntity = new StringEntity(workString);
         postRequest.setEntity(workEntity);
-        CloseableHttpClient build = HttpClientBuilder.create().build();
-        HttpResponse response = build.execute(postRequest);
-        return response;
+        CloseableHttpClient httpClient = HttpClientBuilder.create().build();
+        try {
+            return httpClient.execute(postRequest);
+        } finally {
+            httpClient.close();
+        }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
@@ -1,0 +1,101 @@
+package io.dockstore.webservice.helpers;
+
+import io.dockstore.webservice.core.Entry;
+import io.dockstore.webservice.core.Version;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.orcid.jaxb.model.common.Relationship;
+import org.orcid.jaxb.model.common.WorkType;
+
+import org.orcid.jaxb.model.v3.release.common.*;
+import org.orcid.jaxb.model.v3.release.record.ExternalID;
+import org.orcid.jaxb.model.v3.release.record.ExternalIDs;
+import org.orcid.jaxb.model.v3.release.record.Work;
+import org.orcid.jaxb.model.v3.release.record.WorkTitle;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.Optional;
+
+public class ORCIDHelper {
+    /**
+     * Construct the XML for an ORCID work so that it can be posted using the ORCID API
+     * Current populated fields are Title, Subtitle, Last Modified, CreatedDate, DOI link, Short description
+     * An entry (and an optional version) in Dockstore can sent to ORCID
+     * @param e The entry to be sent to ORCID
+     * @param optionalVersion   Optional version of the entry to send to ORCID
+     * @return An ORCID Work to be sent to ORCID
+     * @throws JAXBException
+     * @throws DatatypeConfigurationException
+     */
+    public static String getOrcidWorkString(Entry e, Optional<Version> optionalVersion) throws JAXBException, DatatypeConfigurationException {
+        Work work = new Work();
+        WorkTitle workTitle = new WorkTitle();
+        Title title = new Title();
+        Subtitle subtitle = new Subtitle("Dockstore Workf");
+        ExternalIDs externalIDs = new ExternalIDs();
+        ExternalID externalID = new ExternalID();
+        externalID.setType("doi");
+        externalID.setValue("potato");
+        if (optionalVersion.isPresent()) {
+            Version v = optionalVersion.get();
+            Url url = new Url(v.getDoiURL());
+            externalID.setUrl(url);
+            title.setContent(e.getEntryPath() + ":" + v.getName());
+        } else {
+            Url url = new Url(e.getConceptDoi());
+            externalID.setUrl(url);
+            title.setContent(e.getEntryPath());
+        }
+        workTitle.setTitle(title);
+        workTitle.setSubtitle(subtitle);
+        work.setWorkTitle(workTitle);
+        work.setShortDescription("A workflow exported from Dockstore");
+        work.setWorkType(WorkType.SOFTWARE);
+        externalID.setRelationship(Relationship.SELF);
+        externalIDs.getExternalIdentifier().add(externalID);
+        work.setWorkExternalIdentifiers(externalIDs);
+        GregorianCalendar gregory = new GregorianCalendar();
+        gregory.setTime(new Date());
+        XMLGregorianCalendar calendar = DatatypeFactory.newInstance()
+                .newXMLGregorianCalendar(
+                        gregory);
+        CreatedDate createdDate = new CreatedDate(calendar);
+        work.setCreatedDate(createdDate);
+        LastModifiedDate lastModifiedDate = new LastModifiedDate();
+        lastModifiedDate.setValue(calendar);
+        work.setLastModifiedDate(lastModifiedDate);
+        return transformWork(work);
+    }
+
+    static String transformWork(Work work) throws JAXBException {
+        JAXBContext context = JAXBContext.newInstance(Work.class);
+        StringWriter writer = new StringWriter();
+        Marshaller marshaller = context.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+        marshaller.marshal(work, writer);
+        return writer.getBuffer().toString();
+    }
+
+    public static HttpResponse postWorkString(String id, String workString, String token) throws IOException {
+        HttpPost postRequest = new HttpPost("https://api.sandbox.orcid.org/v3.0/" + id + "/work");
+        postRequest.addHeader("content-type", "application/vnd.orcid+xml");
+        postRequest.addHeader("Authorization", "Bearer " + token);
+        StringEntity workEntity = new StringEntity(workString);
+        postRequest.setEntity(workEntity);
+        CloseableHttpClient build = HttpClientBuilder.create().build();
+        HttpResponse response = build.execute(postRequest);
+        return response;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
@@ -46,6 +46,7 @@ public final class ORCIDHelper {
      * External ID value must be unique, everything else can be the same (title, subtitle, etc)
      * An entry (and an optional version) in Dockstore can sent to ORCID
      * A DOI for the entry or version is required
+     * TODO: The implementation of short description needs work to ensure it's not too long
      * @param e The entry to be sent to ORCID
      * @param optionalVersion   Optional version of the entry to send to ORCID
      * @return An ORCID Work to be sent to ORCID
@@ -65,18 +66,19 @@ public final class ORCIDHelper {
             externalID.setUrl(url);
             externalID.setValue(v.getDoiURL());
             title.setContent(e.getEntryPath() + ":" + v.getName());
+            work.setShortDescription(v.getDescription());
         } else {
             Url url = new Url(e.getConceptDoi());
             externalID.setUrl(url);
             externalID.setValue(e.getConceptDoi());
             title.setContent(e.getEntryPath());
+            work.setShortDescription(e.getDescription());
         }
         Title journalTitle = new Title();
         journalTitle.setContent("Dockstore");
         work.setJournalTitle(journalTitle);
         workTitle.setTitle(title);
         work.setWorkTitle(workTitle);
-        work.setShortDescription("A workflow exported from Dockstore");
         work.setWorkType(WorkType.SOFTWARE);
         externalID.setRelationship(Relationship.SELF);
         externalIDs.getExternalIdentifier().add(externalID);

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ORCIDHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ORCIDHelperTest.java
@@ -1,5 +1,12 @@
 package io.dockstore.webservice.helpers;
 
+import java.io.IOException;
+import java.util.Date;
+import java.util.Optional;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.datatype.DatatypeConfigurationException;
+
 import io.dockstore.common.SourceControl;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Version;
@@ -9,12 +16,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Test;
-
-import javax.xml.bind.JAXBException;
-import javax.xml.datatype.DatatypeConfigurationException;
-import java.io.IOException;
-import java.util.Date;
-import java.util.Optional;
 
 public class ORCIDHelperTest {
 
@@ -34,7 +35,7 @@ public class ORCIDHelperTest {
         version.setDoiURL("https://doi.org/10.1038/s41586-020-1969-6");
         Optional<Version> optionalVersion = Optional.of(version);
         String orcidWorkString = ORCIDHelper.getOrcidWorkString(entry, optionalVersion);
-        HttpResponse response = ORCIDHelper.postWorkString(id, orcidWorkString, "fakeToken");
+        HttpResponse response = ORCIDHelper.postSandboxWorkString(id, orcidWorkString, "fakeToken");
         Assert.assertEquals("Should fail because of fake token", HttpStatus.SC_UNAUTHORIZED, response.getStatusLine().getStatusCode());
     }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ORCIDHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ORCIDHelperTest.java
@@ -1,0 +1,40 @@
+package io.dockstore.webservice.helpers;
+
+import io.dockstore.common.SourceControl;
+import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.Version;
+import io.dockstore.webservice.core.Workflow;
+import io.dockstore.webservice.core.WorkflowVersion;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.datatype.DatatypeConfigurationException;
+import java.io.IOException;
+import java.util.Date;
+import java.util.Optional;
+
+public class ORCIDHelperTest {
+
+    @Test
+    public void exportEntry() throws JAXBException, IOException, DatatypeConfigurationException {
+        Workflow entry = new BioWorkflow();
+        entry.setSourceControl(SourceControl.GITHUB);
+        entry.setOrganization("dockstore");
+        entry.setRepository("dockstore-ui2");
+        entry.setWorkflowName("test");
+        WorkflowVersion version = new WorkflowVersion();
+        version.setParent(entry);
+        version.setName("fakeVersionName");
+        // Gary's public ORCID iD
+        String id = "0000-0001-8365-0487";
+        version.setLastModified(new Date());
+        version.setDoiURL("https://doi.org/10.1038/s41586-020-1969-6");
+        Optional<Version> optionalVersion = Optional.of(version);
+        String orcidWorkString = ORCIDHelper.getOrcidWorkString(entry, optionalVersion);
+        HttpResponse response = ORCIDHelper.postWorkString(id, orcidWorkString, "fakeToken");
+        Assert.assertEquals("Should fail because of fake token", HttpStatus.SC_UNAUTHORIZED, response.getStatusLine().getStatusCode());
+    }
+}


### PR DESCRIPTION
For https://ucsc-cgl.atlassian.net/browse/SEAB-2409

Currently just a helper class that converts a Dockstore entry (and optional version) to an ORCID work and then sends it to the sandbox. The "test" is less of a test and more of a demo that sends the work to my sandbox ORCID profile.

Looks like: 

https://sandbox.orcid.org/0000-0001-8365-0487

There's an expand button in the top right of the work to show more info.

Notes:
- The DOI ID appears to be what differentiates different works. You can keep everything the same (title, etc), change DOI ID and that will successfully post a new work.  This also means that even if you change everything, it won't post unless the DOI ID is changed.
- Did not use the endpoint that updates because it's a pain and not sure it's useful if the DOI is required.
