### PR TITLE
Make tool_path a string + keyword

### DIFF
--- a/dockstore-webservice/src/main/resources/queries/mapping_tool.json
+++ b/dockstore-webservice/src/main/resources/queries/mapping_tool.json
@@ -193,9 +193,6 @@
       "tool_maintainer_email": {
         "type": "text"
       },
-      "tool_path": {
-        "type": "text"
-      },
       "toolname": {
         "type": "text"
       },


### PR DESCRIPTION
Part 1 of 2 for #3985 

Need to make tool_path a string (which also then auto-generates keyword) in order for search to work with wildcard + slashes.

Note that full_workflow_path is already a string (instead of text).