### PR TITLE
4030/deleting pending orgs bug

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -1229,6 +1229,24 @@ public class OrganizationIT extends BaseIT {
         }
     }
 
+    @Test
+    public void TestDeletingPendingOrgWithCollection() {
+        final ApiClient webClientUser2 = getWebClient(USER_2_USERNAME, testingPostgres);
+        final io.dockstore.openapi.client.ApiClient webClientOpenApiUser = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        OrganizationsApi organizationsApi = new OrganizationsApi(webClientUser2);
+        io.dockstore.openapi.client.api.OrganizationsApi organizationsOpenApi = new io.dockstore.openapi.client.api.OrganizationsApi(webClientOpenApiUser);
+
+        Organization organization = createOrg(organizationsApi);
+        Collection stubCollection = stubCollectionObject();
+        Collection collection = organizationsApi.createCollection(organization.getId(), stubCollection);
+        long collectionId = collection.getId();
+        testingPostgres.runUpdateStatement("UPDATE tool set ispublished = true WHERE id = 2");
+
+        organizationsApi.addEntryToCollection(organization.getId(), collectionId, 2L, 8L);
+        organizationsOpenApi.deleteRejectedOrPendingOrganization(organization.getId());
+
+    }
+
     /**
      * This tests that you can add a collection to an Organization and tests conditions for when it is visible
      */

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -1230,7 +1230,7 @@ public class OrganizationIT extends BaseIT {
     }
 
     @Test
-    public void TestDeletingPendingOrgWithCollection() {
+    public void testDeletingPendingOrgWithCollection() {
         final ApiClient webClientUser2 = getWebClient(USER_2_USERNAME, testingPostgres);
         final io.dockstore.openapi.client.ApiClient webClientOpenApiUser = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         OrganizationsApi organizationsApi = new OrganizationsApi(webClientUser2);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -1243,8 +1243,18 @@ public class OrganizationIT extends BaseIT {
         testingPostgres.runUpdateStatement("UPDATE tool set ispublished = true WHERE id = 2");
 
         organizationsApi.addEntryToCollection(organization.getId(), collectionId, 2L, 8L);
+        long collectionCount = testingPostgres.runSelectStatement("select count(*) from collection", long.class);
+        assertEquals(1, collectionCount);
+
         organizationsOpenApi.deleteRejectedOrPendingOrganization(organization.getId());
 
+        // Test collection is gone
+        collectionCount = testingPostgres.runSelectStatement("select count(*) from collection", long.class);
+        assertEquals(0, collectionCount);
+
+        // Test tool is still there
+        long tool = testingPostgres.runSelectStatement("select count(*) from tool where id = 2", long.class);
+        assertEquals(1, tool);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -25,6 +25,8 @@ import javax.persistence.JoinColumns;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapKeyColumn;
+import javax.persistence.NamedNativeQueries;
+import javax.persistence.NamedNativeQuery;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
@@ -54,7 +56,15 @@ import org.hibernate.annotations.UpdateTimestamp;
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.Collection.getByAlias", query = "SELECT e from Collection e JOIN e.aliases a WHERE KEY(a) IN :alias"),
         @NamedQuery(name = "io.dockstore.webservice.core.Collection.findAllByOrg", query = "SELECT col FROM Collection col WHERE organizationid = :organizationId"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Collection.deleteByOrgId", query = "DELETE Collection c WHERE c.organization.id = :organizationId"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Collection.findAllByOrgId", query = "SELECT c from Collection c WHERE c.organization.id = :organizationId"),
         @NamedQuery(name = "io.dockstore.webservice.core.Collection.findByNameAndOrg", query = "SELECT col FROM Collection col WHERE lower(col.name) = lower(:name) AND organizationid = :organizationId"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Collection.findEntryVersionsByCollectionId", query = "SELECT entries FROM Collection c JOIN c.entries entries WHERE entries.id = :entryVersionId"),
+})
+
+@NamedNativeQueries({
+        @NamedNativeQuery(name = "io.dockstore.webservice.core.Collection.deletedEntryVersionsByCollectionId", query =
+                "DELETE FROM collection_entry_version WHERE collection_id = :collectionId")
 })
 @SuppressWarnings("checkstyle:magicnumber")
 public class Collection implements Serializable, Aliasable {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -63,8 +63,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 })
 
 @NamedNativeQueries({
-        // This is native query since I couldn't figure out how to do a delete with a join in HQL
-        @NamedNativeQuery(name = "io.dockstore.webservice.core.Collection.deletedEntryVersionsByCollectionId", query =
+        // This is a native query since I couldn't figure out how to do a delete with a join in HQL
+        @NamedNativeQuery(name = "io.dockstore.webservice.core.Collection.deleteEntryVersionsByCollectionId", query =
                 "DELETE FROM collection_entry_version WHERE collection_id = :collectionId")
 })
 @SuppressWarnings("checkstyle:magicnumber")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -63,6 +63,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 })
 
 @NamedNativeQueries({
+        // This is native query since I couldn't figure out how to do a delete with a join in HQL
         @NamedNativeQuery(name = "io.dockstore.webservice.core.Collection.deletedEntryVersionsByCollectionId", query =
                 "DELETE FROM collection_entry_version WHERE collection_id = :collectionId")
 })

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/CollectionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/CollectionDAO.java
@@ -44,6 +44,22 @@ public class CollectionDAO extends AbstractDAO<Collection> {
         return uniqueResult(query);
     }
 
+    public void deleteCollectionByOrgId(long organizationId) {
+        currentSession().flush();
+        Query query = namedQuery("io.dockstore.webservice.core.Collection.deleteByOrgId")
+                .setParameter("organizationId", organizationId);
+        query.executeUpdate();
+        currentSession().flush();
+    }
+
+    public void deleteEntryVersionByCollectionId(long collectionId) {
+        currentSession().flush();
+        Query query = namedQuery("io.dockstore.webservice.core.Collection.deletedEntryVersionsByCollectionId").setParameter("collectionId", collectionId);
+        query.executeUpdate();
+        currentSession().flush();
+
+    }
+
     public Collection getByAlias(String alias) {
         return uniqueResult(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Collection.getByAlias").setParameter("alias", alias));
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/CollectionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/CollectionDAO.java
@@ -44,20 +44,15 @@ public class CollectionDAO extends AbstractDAO<Collection> {
         return uniqueResult(query);
     }
 
-    public void deleteCollectionByOrgId(long organizationId) {
-        currentSession().flush();
+    public void deleteCollectionsByOrgId(long organizationId) {
         Query query = namedQuery("io.dockstore.webservice.core.Collection.deleteByOrgId")
                 .setParameter("organizationId", organizationId);
         query.executeUpdate();
-        currentSession().flush();
     }
 
     public void deleteEntryVersionByCollectionId(long collectionId) {
-        currentSession().flush();
-        Query query = namedQuery("io.dockstore.webservice.core.Collection.deletedEntryVersionsByCollectionId").setParameter("collectionId", collectionId);
+        Query query = namedQuery("io.dockstore.webservice.core.Collection.deleteEntryVersionsByCollectionId").setParameter("collectionId", collectionId);
         query.executeUpdate();
-        currentSession().flush();
-
     }
 
     public Collection getByAlias(String alias) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
@@ -447,7 +447,7 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
             eventDAO.deleteEventByOrganizationID(organizationId);
             List<Collection> collections = collectionDAO.findAllByOrg(organizationId);
             collections.stream().forEach(collection -> collectionDAO.deleteEntryVersionByCollectionId(collection.getId()));
-            collectionDAO.deleteCollectionByOrgId(organizationId);
+            collectionDAO.deleteCollectionsByOrgId(organizationId);
             organizationDAO.delete(organization);
         } else { // else if the organization is not pending nor rejected, then throw an error
             throw new CustomWebApplicationException("You can only delete organizations that are pending or have been rejected", HttpStatus.SC_BAD_REQUEST);


### PR DESCRIPTION
#4030 
I couldn't reproduce getting a 403, but got 500s instead. The 500s were because we didn't handle the case of deleting an org if it already has collections with entries inside.