### PR TITLE
Add "staging" so that duplicate entries don't form

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -100,6 +100,7 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
     private final int discourseCategoryId;
     private final String discourseApiUsername = "system";
     private final int maxDescriptionLength = 500;
+    private final String hostName;
 
     public EntryResource(ToolDAO toolDAO, VersionDAO versionDAO, DockstoreWebserviceConfiguration configuration) {
         this.toolDAO = toolDAO;
@@ -114,6 +115,7 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
         apiClient.addDefaultHeader("cache-control", "no-cache");
         apiClient.setBasePath(discourseUrl);
 
+        hostName = configuration.getExternalConfig().getHostname();
         topicsApi = new TopicsApi(apiClient);
     }
 
@@ -226,16 +228,21 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
         }
 
         // Create title and link to entry
+
         String entryLink = "https://dockstore.org/";
-        String title;
+        String title = "";
+        if (hostName.contains("staging")) {
+            entryLink = "https://staging.dockstore.org/";
+            title = "Staging ";
+        }
         if (entry instanceof BioWorkflow) {
-            title = ((BioWorkflow)(entry)).getWorkflowPath();
+            title += ((BioWorkflow)(entry)).getWorkflowPath();
             entryLink += "workflows/";
         } else if (entry instanceof Service) {
-            title = ((Service)(entry)).getWorkflowPath();
+            title += ((Service)(entry)).getWorkflowPath();
             entryLink += "services/";
         } else {
-            title = ((Tool)(entry)).getToolPath();
+            title += ((Tool)(entry)).getToolPath();
             entryLink += "tools/";
         }
 

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1361,6 +1361,7 @@ components:
           enum:
             - NONE
             - TOS_VERSION_1
+            - TOS_VERSION_2
           type: string
         tosversionAcceptanceDate:
           format: int64
@@ -1797,7 +1798,7 @@ info:
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
   termsOfService: TBD
   title: Dockstore API
-  version: 1.11.0-alpha.0-SNAPSHOT
+  version: 1.10.2-SNAPSHOT
 openapi: 3.0.1
 paths:
   /aliases/workflow-versions/{alias}:
@@ -1841,7 +1842,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WorkflowVersion'
+                $ref: '#/components/schemas/Aliasable'
           description: default response
       security:
         - bearer: []

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5,7 +5,7 @@ info:
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images. Explore swagger.json for a Swagger 2.0 description\
     \ of our API and explore openapi.yaml for OpenAPI 3.0 descriptions."
-  version: "1.11.0-alpha.0-SNAPSHOT"
+  version: "1.10.2-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:
@@ -7937,6 +7937,7 @@ definitions:
         enum:
         - "NONE"
         - "TOS_VERSION_1"
+        - "TOS_VERSION_2"
       userProfiles:
         type: "object"
         description: "Profile information of the user retrieved from 3rd party sites\


### PR DESCRIPTION
#3963, GH rate limit :'(
The exact entry is logged already, but just not in the same log as the one in the ticket. There will be a log like `io.dockstore.webservice.resources.EntryResource: Could not add a topic dockstore.org/NatalieEO/testing-version to category 11` adjacent to the one in the ticket