### PR TITLE
Set publishing in .dockstore.yml

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/AbstractYamlService.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/AbstractYamlService.java
@@ -37,6 +37,10 @@ public abstract class AbstractYamlService {
      */
     private String description;
     /**
+     * Change the service's publish-state, if set
+     */
+    private Boolean publish;
+    /**
      * A list of files that Dockstore should index
      */
     private List<String> files;
@@ -79,6 +83,14 @@ public abstract class AbstractYamlService {
 
     public void setDescription(final String description) {
         this.description = description;
+    }
+
+    public Boolean getPublish() {
+        return publish;
+    }
+
+    public void setPublish(final Boolean publish) {
+        this.publish = publish;
     }
 
     public List<String> getFiles() {

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/AbstractYamlService.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/AbstractYamlService.java
@@ -37,7 +37,8 @@ public abstract class AbstractYamlService {
      */
     private String description;
     /**
-     * Change the service's publish-state, if set
+     * Change the service's publish-state, if set.
+     * null does nothing; True & False correspond with the current API behaviour of publishing & unpublishing.
      */
     private Boolean publish;
     /**

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
@@ -40,6 +40,8 @@ public class YamlWorkflow {
     @NotNull
     private String primaryDescriptorPath;
 
+    private Boolean publish;
+
     private Filters filters = new Filters();
 
     private List<String> testParameterFiles = new ArrayList<>();
@@ -70,6 +72,14 @@ public class YamlWorkflow {
 
     public void setPrimaryDescriptorPath(final String primaryDescriptorPath) {
         this.primaryDescriptorPath = primaryDescriptorPath;
+    }
+
+    public Boolean getPublish() {
+        return publish;
+    }
+
+    public void setPublish(final Boolean publish) {
+        this.publish = publish;
     }
 
     public Filters getFilters() {

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
@@ -40,6 +40,10 @@ public class YamlWorkflow {
     @NotNull
     private String primaryDescriptorPath;
 
+    /**
+     * Change the workflow's publish-state, if set.
+     * null does nothing; True & False correspond with the current API behaviour of publishing & unpublishing.
+     */
     private Boolean publish;
 
     private Filters filters = new Filters();

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -33,6 +33,7 @@ import org.junit.contrib.java.lang.system.SystemOutRule;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -89,7 +90,9 @@ public class DockstoreYamlTest {
         if (!workflowFoobar.isPresent()) {
             fail("Could not find workflow foobar");
         }
-        final YamlWorkflow workflow = workflowFoobar.get();
+
+        YamlWorkflow workflow = workflowFoobar.get();
+        assertTrue(workflow.getPublish());
         assertEquals("wdl", workflow.getSubclass());
         assertEquals("/Dockstore2.wdl", workflow.getPrimaryDescriptorPath());
         final List<String> testParameterFiles = workflow.getTestParameterFiles();
@@ -102,8 +105,15 @@ public class DockstoreYamlTest {
         final List<String> tags = filters.getTags();
         assertEquals(1, tags.size());
         assertEquals("gwas*", tags.get(0));
+
+        workflow = workflows.get(1);
+        assertFalse(workflow.getPublish());
+        workflow = workflows.get(2);
+        assertNull(workflow.getPublish());
+
         final Service12 service = dockstoreYaml.getService();
         assertNotNull(service);
+        assertTrue(service.getPublish());
     }
 
     @Test

--- a/dockstore-common/src/test/resources/fixtures/dockstore12.yml
+++ b/dockstore-common/src/test/resources/fixtures/dockstore12.yml
@@ -2,6 +2,7 @@ version: 1.2
 workflows:
   -  name: foobar
      subclass: wdl
+     publish: true
      primaryDescriptorPath: /Dockstore2.wdl
      testParameterFiles:
        - /dockstore.wdl.json
@@ -12,6 +13,7 @@ workflows:
          - gwas*
   -  name: foobar2
      subclass: cwl
+     publish: no
      primaryDescriptorPath: /Dockstore.cwl
      testParameterFiles:
        - /dockstore.cwl.json
@@ -28,6 +30,7 @@ service:
     The UCSC Xena browser is an exploration tool for public and private,
     multi-omic and clinical/phenotype data.
     It is recommended that you configure a reverse proxy to handle HTTPS
+  publish: True
   files:
     - docker-compose.yml
     - README.md

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -660,4 +660,22 @@ public class WebhookIT extends BaseIT {
         assertEquals(6, workflow.getWorkflowVersions().size());
         assertThrows(ApiException.class, () -> client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filterregexerror", "", false));
     }
+
+    /**
+     * This tests publishing functionality in .dockstore.yml
+     * @throws Exception
+     */
+    @Test
+    public void testDockstoreYmlPublish() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+        final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        WorkflowsApi client = new WorkflowsApi(webClient);
+
+        client.handleGitHubRelease(githubFiltersRepo, BasicIT.USER_2_USERNAME, "refs/heads/publish", installationId);
+        Workflow workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", "", false);
+        assertTrue(workflow.isIsPublished());
+        client.handleGitHubRelease(githubFiltersRepo, BasicIT.USER_2_USERNAME, "refs/heads/unpublish", installationId);
+        workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", "", false);
+        assertFalse(workflow.isIsPublished());
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -323,7 +323,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
 
         final WorkflowResource workflowResource = new WorkflowResource(httpClient, hibernate.getSessionFactory(), authorizer, entryResource, configuration);
         environment.jersey().register(workflowResource);
-        final ServiceResource serviceResource = new ServiceResource(httpClient, hibernate.getSessionFactory(), configuration);
+        final ServiceResource serviceResource = new ServiceResource(httpClient, hibernate.getSessionFactory(), entryResource, configuration);
         environment.jersey().register(serviceResource);
 
         // Note workflow resource must be passed to the docker repo resource, as the workflow resource refresh must be called for checker workflows

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LambdaEvent.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LambdaEvent.java
@@ -168,7 +168,8 @@ public class LambdaEvent {
     public enum LambdaEventType {
         PUSH,
         DELETE,
-        INSTALL
+        INSTALL,
+        PUBLISH
     }
 
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -431,7 +431,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                     try {
                         workflow = publishWorkflow(workflow, publish);
                     } catch (CustomWebApplicationException ex) {
-                        LOG.warn("Could not set publish state from YML.", ex.getMessage());
+                        LOG.warn("Could not set publish state from YML.", ex);
                     }
                 }
 
@@ -471,7 +471,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 try {
                     workflow = publishWorkflow(workflow, publish);
                 } catch (CustomWebApplicationException ex) {
-                    LOG.warn(ex.getMessage());
+                    LOG.warn("Could not set publish state from YML.", ex);
                 }
             }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -686,12 +686,16 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     }
 
     /**
-     * Publish or unpublish given workflow
+     * Publish or unpublish given workflow, if necessary.
      * @param workflow
      * @param publish
      * @return
      */
-    Workflow publishWorkflow(Workflow workflow, final boolean publish) {
+    protected Workflow publishWorkflow(Workflow workflow, final boolean publish) {
+        if (workflow.getIsPublished() == publish) {
+            return workflow;
+        }
+
         Workflow checker = workflow.getCheckerWorkflow();
 
         if (workflow.isIsChecker()) {
@@ -726,10 +730,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         }
 
         long id = workflowDAO.create(workflow);
-        workflow = workflowDAO.findById(id);
+        Workflow newWorkflow = workflowDAO.findById(id);
         if (publish) {
-            PublicStateManager.getInstance().handleIndexUpdate(workflow, StateManagerMode.PUBLISH);
-            if (workflow.getTopicId() == null) {
+            PublicStateManager.getInstance().handleIndexUpdate(newWorkflow, StateManagerMode.PUBLISH);
+            if (newWorkflow.getTopicId() == null) {
                 try {
                     entryResource.createAndSetDiscourseTopic(id);
                 } catch (CustomWebApplicationException ex) {
@@ -737,8 +741,8 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 }
             }
         } else {
-            PublicStateManager.getInstance().handleIndexUpdate(workflow, StateManagerMode.DELETE);
+            PublicStateManager.getInstance().handleIndexUpdate(newWorkflow, StateManagerMode.DELETE);
         }
-        return workflow;
+        return newWorkflow;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -729,20 +729,18 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             }
         }
 
-        long id = workflowDAO.create(workflow);
-        Workflow newWorkflow = workflowDAO.findById(id);
         if (publish) {
-            PublicStateManager.getInstance().handleIndexUpdate(newWorkflow, StateManagerMode.PUBLISH);
-            if (newWorkflow.getTopicId() == null) {
+            PublicStateManager.getInstance().handleIndexUpdate(workflow, StateManagerMode.PUBLISH);
+            if (workflow.getTopicId() == null) {
                 try {
-                    entryResource.createAndSetDiscourseTopic(id);
+                    entryResource.createAndSetDiscourseTopic(workflow.getId());
                 } catch (CustomWebApplicationException ex) {
                     LOG.error("Error adding discourse topic.", ex);
                 }
             }
         } else {
-            PublicStateManager.getInstance().handleIndexUpdate(newWorkflow, StateManagerMode.DELETE);
+            PublicStateManager.getInstance().handleIndexUpdate(workflow, StateManagerMode.DELETE);
         }
-        return newWorkflow;
+        return workflow;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -431,7 +431,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                     try {
                         workflow = publishWorkflow(workflow, publish);
                     } catch (CustomWebApplicationException ex) {
-                        LOG.warn(ex.getMessage());
+                        LOG.warn("Could not set publish state from YML.", ex.getMessage());
                     }
                 }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ServiceResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ServiceResource.java
@@ -16,7 +16,7 @@ import org.hibernate.SessionFactory;
 @Tag(name = "workflows", description = ResourceConstants.WORKFLOWS)
 public class ServiceResource extends AbstractWorkflowResource<Service> {
 
-    public ServiceResource(HttpClient client, SessionFactory sessionFactory, DockstoreWebserviceConfiguration configuration) {
-        super(client, sessionFactory, configuration, Service.class);
+    public ServiceResource(HttpClient client, SessionFactory sessionFactory, EntryResource entryResource, DockstoreWebserviceConfiguration configuration) {
+        super(client, sessionFactory, entryResource, configuration, Service.class);
     }
 }

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -7018,6 +7018,7 @@ definitions:
         - "PUSH"
         - "DELETE"
         - "INSTALL"
+        - "PUBLISH"
   LicenseInformation:
     type: "object"
     properties:


### PR DESCRIPTION
Main issue: #3876

Adds optional boolean `publish` field to .dockstore.yml workflows & services.

Added a `PUBLISH` LambdaEvent to indicate success/failure of YML publish/unpublish operations.

Moved core publishing code up from `WorkflowResource` to `AbstractWorkflowResource`.

New integration test uses https://github.com/DockstoreTestUser2/dockstoreyml-github-filters-test/commit/00c37a0d71baa171d13b86b1aab58b5fd68bf004 and https://github.com/DockstoreTestUser2/dockstoreyml-github-filters-test/commit/785c0a76a195348f82e4ef7d83ed42fd87fb8a28

**Behaviour**:
- Publishing is version-agnostic, using the latest push with a `publish` setting regardless of version.
- Setting `publish: True` or `publish: False` runs the same logic as `POST
​/workflows​/{workflowId}​/publish`.
- Not setting `publish` runs no publishing logic, effectively keeping the current setting.