### PR TITLE
Partial Revert of #3972

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -80,7 +80,8 @@ import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.HttpConnector;
 import org.kohsuke.github.RateLimitHandler;
-import org.kohsuke.github.extras.okhttp3.OkHttpConnector;
+import org.kohsuke.github.extras.ImpatientHttpConnector;
+import org.kohsuke.github.extras.okhttp3.ObsoleteUrlFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,8 +101,9 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
     GitHubSourceCodeRepo(String gitUsername, String githubTokenContent) {
         this.gitUsername = gitUsername;
-        HttpConnector okHttp3Connector = new OkHttpConnector(
+        ObsoleteUrlFactory obsoleteUrlFactory = new ObsoleteUrlFactory(
                 new OkHttpClient.Builder().cache(DockstoreWebserviceApplication.getCache()).build());
+        HttpConnector okHttp3Connector = new ImpatientHttpConnector(obsoleteUrlFactory::open);
         try {
             this.github = new GitHubBuilder().withOAuthToken(githubTokenContent, gitUsername).withRateLimitHandler(RateLimitHandler.WAIT).withAbuseLimitHandler(AbuseLimitHandler.WAIT).withConnector(okHttp3Connector).build();
         } catch (IOException e) {


### PR DESCRIPTION
Main issue: https://ucsc-cgl.atlassian.net/browse/SEAB-2564

Potential fix for GitHub caching issue.
Reverted the "logical" changes from #3972, but still using `ObsoleteUrlFactory` from kohsuke/github.

Need help from someone to check if this fixes the caching issue.