### PR TITLE
github library update (lots of bug fixes)

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -150,7 +150,7 @@ Lists of 367 third-party dependencies.
      (The Apache Software License, Version 2.0) FindBugs-jsr305 (com.google.code.findbugs:jsr305:3.0.2 - http://findbugs.sourceforge.net/)
      (The Apache Software License, Version 2.0) GeAnTyRef (io.leangen.geantyref:geantyref:1.3.7 - https://github.com/leangen/geantyref)
      (Apache 2.0) genericExtras (io.circe:circe-generic-extras_2.12:0.13.0 - https://github.com/circe/circe-generic-extras)
-     (The MIT license) GitHub API for Java (org.kohsuke:github-api:1.116 - https://github-api.kohsuke.org/)
+     (The MIT license) GitHub API for Java (org.kohsuke:github-api:1.123 - https://github-api.kohsuke.org/)
      (The Apache Software License, Version 2.0) Gitlab Java API Wrapper (org.gitlab:java-gitlab-api:4.0.0 - http://nexus.sonatype.org/oss-repository-hosting.html/java-gitlab-api)
      (The Apache Software License, Version 2.0) Google APIs Client Library for Java (com.google.api-client:google-api-client:1.31.2 - https://github.com/googleapis/google-api-java-client/google-api-client)
      (BSD New license) Google Auth Library for Java - Credentials (com.google.auth:google-auth-library-credentials:0.22.1 - https://github.com/googleapis/google-auth-library-java/google-auth-library-credentials)

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -1103,7 +1103,7 @@ POM as their parent.
             <dependency>
                 <groupId>org.kohsuke</groupId>
                 <artifactId>github-api</artifactId>
-                <version>1.116</version>
+                <version>1.123</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Noticed that the library issue tracker and changelog is quite active
Too many changes from 1.116 to 1.123 to count including some automatic handling of JWT tokens
Might be useful anyway