### PR TITLE
Okhttp update, working display of cache misses, small rate limit improvement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,3 +367,5 @@ commands:
           when: always
       - store_test_results:
           path: ~/test-results
+      - store_artifacts:
+          path: /tmp/dockstore-web-cache.misses.log

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 370 third-party dependencies.
+Lists of 371 third-party dependencies.
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.12:2.5.31 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.12:2.5.31 - https://akka.io/)
      (Apache License, Version 2.0) akka-slf4j (com.typesafe.akka:akka-slf4j_2.12:2.5.31 - https://akka.io/)
@@ -224,6 +224,7 @@ Lists of 370 third-party dependencies.
      (CDDL + GPLv2 with classpath exception) javax.transaction API (javax.transaction:javax.transaction-api:1.3 - http://jta-spec.java.net)
      (CDDL 1.1) (GPL2 w/ CPE) javax.ws.rs-api (javax.ws.rs:javax.ws.rs-api:2.0.1 - http://jax-rs-spec.java.net)
      (Eclipse Distribution License - v 1.0) JAXB Runtime (org.glassfish.jaxb:jaxb-runtime:2.3.3 - https://eclipse-ee4j.github.io/jaxb-ri/jaxb-runtime-parent/jaxb-runtime)
+     (CDDL 1.1) (GPL2 w/ CPE) jaxb-api (javax.xml.bind:jaxb-api:2.3.0 - https://github.com/javaee/jaxb-spec/jaxb-api)
      (Apache License, version 2.0) JBoss Logging 3 (org.jboss.logging:jboss-logging:3.3.2.Final - http://www.jboss.org)
      (Apache License, Version 2.0) JCL 1.2 implemented over SLF4J (org.slf4j:jcl-over-slf4j:1.7.30 - http://www.slf4j.org)
      (Apache License, Version 2.0) jcommander (com.beust:jcommander:1.78 - https://jcommander.org)

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 367 third-party dependencies.
+Lists of 370 third-party dependencies.
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.12:2.5.31 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.12:2.5.31 - https://akka.io/)
      (Apache License, Version 2.0) akka-slf4j (com.typesafe.akka:akka-slf4j_2.12:2.5.31 - https://akka.io/)
@@ -171,6 +171,7 @@ Lists of 367 third-party dependencies.
      (EPL 2.0) (GPL2 w/ CPE) HK2 Implementation Utilities (org.glassfish.hk2:hk2-utils:2.6.1 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-utils)
      (The Apache Software License, Version 2.0) Hoverfly Java (io.specto:hoverfly-java:0.12.0 - https://github.com/SpectoLabs/hoverfly-java)
      (The Apache Software License, Version 2.0) HPPC Collections (com.carrotsearch:hppc:0.8.1 - http://labs.carrotsearch.com/hppc.html/hppc)
+     (The Apache Software License, Version 2.0) IntelliJ IDEA Annotations (org.jetbrains:annotations:13.0 - http://www.jetbrains.org)
      (Apache 2.0) io.grpc:grpc-context (io.grpc:grpc-context:1.22.1 - https://github.com/grpc/grpc-java)
      (Eclipse Distribution License - v 1.0) istack common utility code runtime (com.sun.istack:istack-commons-runtime:3.0.11 - https://projects.eclipse.org/projects/ee4j/istack-commons/istack-commons-runtime)
      (The Apache Software License, Version 2.0) J2ObjC Annotations (com.google.j2objc:j2objc-annotations:1.3 - https://github.com/google/j2objc/)
@@ -315,10 +316,12 @@ Lists of 367 third-party dependencies.
      (Apache License, Version 2.0) Netty/Transport/Native/Epoll (io.netty:netty-transport-native-epoll:4.1.36.Final - http://netty.io/netty-transport-native-epoll/)
      (Apache License, Version 2.0) Netty/Transport/Native/Unix/Common (io.netty:netty-transport-native-unix-common:4.1.36.Final - http://netty.io/netty-transport-native-unix-common/)
      (Apache 2) Objenesis (org.objenesis:objenesis:3.0.1 - http://objenesis.org)
-     (Apache 2.0) OkHttp (com.squareup.okhttp3:okhttp:3.14.2 - https://github.com/square/okhttp/okhttp)
-     (Apache 2.0) Okio (com.squareup.okio:okio:1.17.2 - https://github.com/square/okio/okio)
+     (The Apache Software License, Version 2.0) okhttp (com.squareup.okhttp3:okhttp:4.7.0 - https://square.github.io/okhttp/)
+     (The Apache Software License, Version 2.0) Okio (com.squareup.okio:okio:2.6.0 - https://github.com/square/okio/)
      (The Apache License, Version 2.0) OpenCensus (io.opencensus:opencensus-api:0.24.0 - https://github.com/census-instrumentation/opencensus-java)
      (MIT License) ORCID - Model (org.orcid:orcid-model:3.0.4 - http://github.com/ORCID/orcid-model)
+     (The Apache License, Version 2.0) org.jetbrains.kotlin:kotlin-stdlib (org.jetbrains.kotlin:kotlin-stdlib:1.3.71 - https://kotlinlang.org/)
+     (The Apache License, Version 2.0) org.jetbrains.kotlin:kotlin-stdlib-common (org.jetbrains.kotlin:kotlin-stdlib-common:1.3.71 - https://kotlinlang.org/)
      (EPL 2.0) (GPL2 w/ CPE) OSGi resource locator (org.glassfish.hk2:osgi-resource-locator:1.0.3 - https://projects.eclipse.org/projects/ee4j/osgi-resource-locator)
      (MIT) parser (org.typelevel:jawn-parser_2.12:1.0.0 - http://github.com/typelevel/jawn)
      (The Apache Software License, Version 2.0) PF4J (org.pf4j:pf4j:3.2.0 - http://nexus.sonatype.org/oss-repository-hosting.html/pf4j-parent/pf4j)

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 371 third-party dependencies.
+Lists of 370 third-party dependencies.
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.12:2.5.31 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.12:2.5.31 - https://akka.io/)
      (Apache License, Version 2.0) akka-slf4j (com.typesafe.akka:akka-slf4j_2.12:2.5.31 - https://akka.io/)
@@ -224,7 +224,6 @@ Lists of 371 third-party dependencies.
      (CDDL + GPLv2 with classpath exception) javax.transaction API (javax.transaction:javax.transaction-api:1.3 - http://jta-spec.java.net)
      (CDDL 1.1) (GPL2 w/ CPE) javax.ws.rs-api (javax.ws.rs:javax.ws.rs-api:2.0.1 - http://jax-rs-spec.java.net)
      (Eclipse Distribution License - v 1.0) JAXB Runtime (org.glassfish.jaxb:jaxb-runtime:2.3.3 - https://eclipse-ee4j.github.io/jaxb-ri/jaxb-runtime-parent/jaxb-runtime)
-     (CDDL 1.1) (GPL2 w/ CPE) jaxb-api (javax.xml.bind:jaxb-api:2.3.0 - https://github.com/javaee/jaxb-spec/jaxb-api)
      (Apache License, version 2.0) JBoss Logging 3 (org.jboss.logging:jboss-logging:3.3.2.Final - http://www.jboss.org)
      (Apache License, Version 2.0) JCL 1.2 implemented over SLF4J (org.slf4j:jcl-over-slf4j:1.7.30 - http://www.slf4j.org)
      (Apache License, Version 2.0) jcommander (com.beust:jcommander:1.78 - https://jcommander.org)

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -60,7 +60,7 @@ POM as their parent.
         <postgresql.version>42.2.5</postgresql.version>
         <mockito.version>2.28.2</mockito.version>
         <cwlavro.version>2.0.4.4</cwlavro.version>
-        <okhttp.version>3.14.2</okhttp.version>
+        <okhttp.version>4.7.0</okhttp.version>
         <slf4j.version>1.7.30</slf4j.version>
         <swagger-ui.version>3.25.0</swagger-ui.version>
         <httpcomponents.version>4.5.13</httpcomponents.version>
@@ -787,13 +787,19 @@ POM as their parent.
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp</artifactId>
                 <version>${okhttp.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.squareup.okhttp3</groupId>
+                        <artifactId>okhttp-urlconnection</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp-urlconnection</artifactId>
-                <version>${okhttp.version}</version>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio</artifactId>
+                <version>2.6.0</version>
             </dependency>
-
+            
             <!-- https://mvnrepository.com/artifact/com.google.http-client/google-http-client-jackson -->
             <dependency>
                 <groupId>com.google.http-client</groupId>
@@ -950,6 +956,26 @@ POM as their parent.
                 <version>2.8.8</version>
             </dependency>
 
+            <!-- https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp-bom -->
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp-bom</artifactId>
+                <version>${okhttp.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>1.3.71</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-common</artifactId>
+                <version>1.3.71</version>
+            </dependency>
+
+
 
             <!-- webservice dependencies -->
             <dependency>
@@ -970,6 +996,11 @@ POM as their parent.
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-logging</artifactId>
+                <version>${dropwizard.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-lifecycle</artifactId>
                 <version>${dropwizard.version}</version>
             </dependency>
             <dependency>

--- a/dockstore-common/src/main/java/io/dockstore/common/Constants.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/Constants.java
@@ -27,12 +27,6 @@ public final class Constants {
     public static final String WEBSERVICE_TOKEN_USER_1 = "webservice.tokenUser1"; // Dummy dockstore token for user 1
     public static final String WEBSERVICE_TOKEN_USER_2 = "webservice.tokenUser2"; // Dummy dockstore token for user 2
 
-    public static final String POSTGRES_HOST = "database.postgresHost";
-    public static final String POSTGRES_USERNAME = "database.postgresUser";
-    public static final String POSTGRES_PASSWORD = "database.postgresPass";
-    public static final String POSTGRES_DBNAME = "database.postgresDBName";
-    public static final String POSTGRES_MAX_CONNECTIONS = "database.maxConnections";
-
     private Constants() {
         // hide the default constructor for a constant class
     }

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -92,12 +92,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.liquibase</groupId>
-            <artifactId>liquibase-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-client</artifactId>
             <version>1.11.0-alpha.1-SNAPSHOT</version>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -70,25 +70,17 @@
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
             <version>1.11.0-alpha.1-SNAPSHOT</version>
-            <exclusions>
-                <!-- https://mvnrepository.com/artifact/org.liquibase/liquibase-core -->
-                <exclusion>
-                    <groupId>org.liquibase</groupId>
-                    <artifactId>liquibase-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
             <version>1.11.0-alpha.1-SNAPSHOT</version>
-            <exclusions>
-                <!-- https://mvnrepository.com/artifact/org.liquibase/liquibase-core -->
-                <exclusion>
-                    <groupId>org.liquibase</groupId>
-                    <artifactId>liquibase-core</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -70,11 +70,25 @@
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
             <version>1.11.0-alpha.1-SNAPSHOT</version>
+            <!-- looks like these are excluded because they bring in duplicate liquibase.build.properties -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.liquibase</groupId>
+                    <artifactId>liquibase-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
             <version>1.11.0-alpha.1-SNAPSHOT</version>
+            <!-- looks like these are excluded because they bring in duplicate liquibase.build.properties -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.liquibase</groupId>
+                    <artifactId>liquibase-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BaseIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BaseIT.java
@@ -113,7 +113,7 @@ public class BaseIT {
         GHRateLimit ghRateLimitQuietly2 = user2.getGhRateLimitQuietly();
 
         user1.reportOnGitHubRelease(user1Limit, ghRateLimitQuietly1, "n/a", USER_1_USERNAME, "n/a", true);
-        user1.reportOnGitHubRelease(user2Limit, ghRateLimitQuietly2, "n/a", USER_2_USERNAME, "n/a", true);
+        user2.reportOnGitHubRelease(user2Limit, ghRateLimitQuietly2, "n/a", USER_2_USERNAME, "n/a", true);
 
         SUPPORT.getEnvironment().healthChecks().shutdown();
         SUPPORT.after();

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BaseIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BaseIT.java
@@ -75,21 +75,6 @@ public class BaseIT {
         CommonTestUtilities.dropAndRecreateNoTestData(SUPPORT);
         SUPPORT.before();
         testingPostgres = new TestingPostgres(SUPPORT);
-
-        // this is not great, doing this per test suite sucks. But at this point, there is no easy way to get the test tokens for both test users without loading both databases and dumping them too?
-        // also see code below
-        //        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
-        //        String githubToken1 = testingPostgres
-        //                .runSelectStatement("select content from token where username='" + USER_1_USERNAME + "' and tokensource='github.com'",
-        //                        String.class);
-        //        String githubToken2 = testingPostgres
-        //                .runSelectStatement("select content from token where username='" + USER_2_USERNAME + "' and tokensource='github.com'",
-        //                        String.class);
-        //        user1 = new GitHubSourceCodeRepo(USER_1_USERNAME, githubToken1);
-        //        user2 = new GitHubSourceCodeRepo(USER_2_USERNAME, githubToken2);
-        //
-        //        user1Limit = user1.getGhRateLimitQuietly();
-        //        user2Limit = user2.getGhRateLimitQuietly();
     }
 
     public static void assertNoMetricsLeaks(DropwizardTestSupport<DockstoreWebserviceConfiguration> support) throws InterruptedException {
@@ -108,12 +93,6 @@ public class BaseIT {
 
     @AfterClass
     public static void afterClass() {
-        //        GHRateLimit ghRateLimitQuietly1 = user1.getGhRateLimitQuietly();
-        //        GHRateLimit ghRateLimitQuietly2 = user2.getGhRateLimitQuietly();
-        //
-        //        user1.reportOnGitHubRelease(user1Limit, ghRateLimitQuietly1, "n/a", USER_1_USERNAME, "n/a", true);
-        //        user2.reportOnGitHubRelease(user2Limit, ghRateLimitQuietly2, "n/a", USER_2_USERNAME, "n/a", true);
-
         SUPPORT.getEnvironment().healthChecks().shutdown();
         SUPPORT.after();
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BaseIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BaseIT.java
@@ -27,7 +27,6 @@ import io.dockstore.common.TestingPostgres;
 import io.dockstore.common.Utilities;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
-import io.dockstore.webservice.helpers.GitHubSourceCodeRepo;
 import io.dropwizard.testing.DropwizardTestSupport;
 import io.swagger.client.ApiClient;
 import io.swagger.client.auth.ApiKeyAuth;
@@ -43,7 +42,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
-import org.kohsuke.github.GHRateLimit;
 
 /**
  * Base integration test class
@@ -64,13 +62,6 @@ public class BaseIT {
     // This is not an admin
     static final String OTHER_USERNAME = "OtherUser";
 
-
-    // record starting rate limit per set of tests
-    private static GHRateLimit user1Limit;
-    private static GHRateLimit user2Limit;
-    private static GitHubSourceCodeRepo user1;
-    private static GitHubSourceCodeRepo user2;
-
     @Rule
     public final TestRule watcher = new TestWatcher() {
         protected void starting(Description description) {
@@ -84,13 +75,21 @@ public class BaseIT {
         CommonTestUtilities.dropAndRecreateNoTestData(SUPPORT);
         SUPPORT.before();
         testingPostgres = new TestingPostgres(SUPPORT);
-        INIConfiguration parseConfig = Utilities.parseConfig(FileUtils.getFile("src", "test", "resources", "config").getAbsolutePath());
 
-        user1 = new GitHubSourceCodeRepo(USER_1_USERNAME, parseConfig.getString(Constants.WEBSERVICE_TOKEN_USER_1));
-        user2 = new GitHubSourceCodeRepo(USER_2_USERNAME, parseConfig.getString(Constants.WEBSERVICE_TOKEN_USER_2));
-
-        user1Limit = user1.getGhRateLimitQuietly();
-        user2Limit = user2.getGhRateLimitQuietly();
+        // this is not great, doing this per test suite sucks. But at this point, there is no easy way to get the test tokens for both test users without loading both databases and dumping them too?
+        // also see code below
+        //        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+        //        String githubToken1 = testingPostgres
+        //                .runSelectStatement("select content from token where username='" + USER_1_USERNAME + "' and tokensource='github.com'",
+        //                        String.class);
+        //        String githubToken2 = testingPostgres
+        //                .runSelectStatement("select content from token where username='" + USER_2_USERNAME + "' and tokensource='github.com'",
+        //                        String.class);
+        //        user1 = new GitHubSourceCodeRepo(USER_1_USERNAME, githubToken1);
+        //        user2 = new GitHubSourceCodeRepo(USER_2_USERNAME, githubToken2);
+        //
+        //        user1Limit = user1.getGhRateLimitQuietly();
+        //        user2Limit = user2.getGhRateLimitQuietly();
     }
 
     public static void assertNoMetricsLeaks(DropwizardTestSupport<DockstoreWebserviceConfiguration> support) throws InterruptedException {
@@ -109,11 +108,11 @@ public class BaseIT {
 
     @AfterClass
     public static void afterClass() {
-        GHRateLimit ghRateLimitQuietly1 = user1.getGhRateLimitQuietly();
-        GHRateLimit ghRateLimitQuietly2 = user2.getGhRateLimitQuietly();
-
-        user1.reportOnGitHubRelease(user1Limit, ghRateLimitQuietly1, "n/a", USER_1_USERNAME, "n/a", true);
-        user2.reportOnGitHubRelease(user2Limit, ghRateLimitQuietly2, "n/a", USER_2_USERNAME, "n/a", true);
+        //        GHRateLimit ghRateLimitQuietly1 = user1.getGhRateLimitQuietly();
+        //        GHRateLimit ghRateLimitQuietly2 = user2.getGhRateLimitQuietly();
+        //
+        //        user1.reportOnGitHubRelease(user1Limit, ghRateLimitQuietly1, "n/a", USER_1_USERNAME, "n/a", true);
+        //        user2.reportOnGitHubRelease(user2Limit, ghRateLimitQuietly2, "n/a", USER_2_USERNAME, "n/a", true);
 
         SUPPORT.getEnvironment().healthChecks().shutdown();
         SUPPORT.after();

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>dropwizard-logging</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-lifecycle</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-quay-client</artifactId>
             <version>1.11.0-alpha.1-SNAPSHOT</version>
@@ -544,6 +548,11 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>13.0</version>
         </dependency>
 
         <dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -47,10 +47,6 @@
             <artifactId>dropwizard-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-lifecycle</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-quay-client</artifactId>
             <version>1.11.0-alpha.1-SNAPSHOT</version>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -546,12 +546,6 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-            <version>13.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-core</artifactId>
             <exclusions>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/CacheHitListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/CacheHitListener.java
@@ -1,0 +1,51 @@
+package io.dockstore.webservice;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import javax.validation.constraints.NotNull;
+
+import okhttp3.Call;
+import okhttp3.EventListener;
+import okhttp3.Response;
+import okhttp3.internal.connection.RealCall;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CacheHitListener extends EventListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CacheHitListener.class);
+
+    private final String listenerTag;
+
+    public CacheHitListener(String listenerTag) {
+        this.listenerTag = listenerTag;
+    }
+
+    @Override
+    public void cacheConditionalHit(@NotNull Call call, @NotNull Response cachedResponse) {
+        /* do nothing, might be useful for debugging rate limit */
+    }
+
+    @Override
+    public void cacheHit(@NotNull Call call, @NotNull Response response) {
+        /* do nothing, might be useful for debugging rate limit */
+    }
+
+    @Override
+    public void cacheMiss(@NotNull Call call) {
+        if (System.getenv("CIRCLE_SHA1") != null) {
+            String endpointCalled = ((RealCall)call).getOriginalRequest().url().toString();
+
+            if (!endpointCalled.contains("rate_limit")) {
+                LOG.info(listenerTag + " cacheMiss for : " + endpointCalled);
+                try {
+                    FileUtils.writeStringToFile(DockstoreWebserviceApplication.CACHE_MISS_LOG_FILE, endpointCalled + "\n", StandardCharsets.UTF_8, true);
+                } catch (IOException e) {
+                    LOG.error("could not write cache miss to log", e);
+                }
+            }
+        }
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/CacheHitListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/CacheHitListener.java
@@ -35,16 +35,14 @@ public class CacheHitListener extends EventListener {
 
     @Override
     public void cacheMiss(@NotNull Call call) {
-        if (System.getenv("CIRCLE_SHA1") != null) {
-            String endpointCalled = ((RealCall)call).getOriginalRequest().url().toString();
-
-            if (!endpointCalled.contains("rate_limit")) {
-                LOG.info(listenerTag + " cacheMiss for : " + endpointCalled);
-                try {
-                    FileUtils.writeStringToFile(DockstoreWebserviceApplication.CACHE_MISS_LOG_FILE, endpointCalled + "\n", StandardCharsets.UTF_8, true);
-                } catch (IOException e) {
-                    LOG.error("could not write cache miss to log", e);
-                }
+        String endpointCalled = ((RealCall)call).getOriginalRequest().url().toString();
+        if (!endpointCalled.contains("rate_limit")) {
+            LOG.info(listenerTag + " cacheMiss for : " + endpointCalled);
+            try {
+                FileUtils.writeStringToFile(DockstoreWebserviceApplication.CACHE_MISS_LOG_FILE, endpointCalled + "\n",
+                        StandardCharsets.UTF_8, true);
+            } catch (IOException e) {
+                LOG.error("could not write cache miss to log", e);
             }
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -26,6 +26,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import javax.validation.constraints.NotNull;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -148,7 +150,6 @@ import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.glassfish.jersey.CommonProperties;
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
-import org.jetbrains.annotations.NotNull;
 import org.kohsuke.github.extras.okhttp3.ObsoleteUrlFactory;
 import org.pf4j.DefaultPluginManager;
 import org.pf4j.PluginWrapper;
@@ -237,7 +238,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         try {
             cache.initialize();
         } catch (IOException e) {
-            LOG.error("Could no create web cache, initialization exception", e);
+            LOG.error("Could not create web cache, initialization exception", e);
             throw new RuntimeException(e);
         }
         // match HttpURLConnection which does not have a timeout by default

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -504,10 +504,12 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
 
         @Override
         public void stop() throws Exception {
-            LOG.info("attempting to properly shutdown cache");
-            cache.flush();
-            cache.close();
-            LOG.info("completed writing cache");
+            if (!cache.isClosed()) {
+                LOG.info("attempting to properly shutdown cache");
+                cache.flush();
+                cache.close();
+                LOG.info("completed writing cache");
+            }
         }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -498,9 +498,10 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
 
         @Override
         public void stop() throws Exception {
-            LOG.info("properly writing cache, or at least trying to");
+            LOG.info("attempting to properly shutdown cache");
             cache.flush();
             cache.close();
+            LOG.info("completed writing cache");
         }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -235,6 +235,12 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             }
             cache = new Cache(cacheDir, cacheSize);
         }
+        try {
+            cache.initialize();
+        } catch (IOException e) {
+            LOG.error("Could no create web cache, initialization exception", e);
+            throw new RuntimeException(e);
+        }
         // match HttpURLConnection which does not have a timeout by default
         okHttpClient = new OkHttpClient().newBuilder().eventListener(new EventListener() {
             @Override
@@ -262,7 +268,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             if (factoryException.getMessage().contains("factory already defined")) {
                 LOG.debug("OkHttpClient already registered, skipping");
             } else {
-                LOG.error("Could no create web cache, factory exception", factoryException);
+                LOG.error("Could not create web cache, factory exception", factoryException);
                 throw new RuntimeException(factoryException);
             }
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -240,7 +240,12 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             throw new RuntimeException(e);
         }
         // match HttpURLConnection which does not have a timeout by default
-        okHttpClient = new OkHttpClient().newBuilder().eventListener(new CacheHitListener(DockstoreWebserviceApplication.class.getSimpleName())).cache(cache).connectTimeout(0, TimeUnit.SECONDS).readTimeout(0, TimeUnit.SECONDS).writeTimeout(0, TimeUnit.SECONDS).build();
+        OkHttpClient.Builder builder = new OkHttpClient().newBuilder();
+        if (System.getenv("CIRCLE_SHA1") != null) {
+            builder.eventListener(new CacheHitListener(DockstoreWebserviceApplication.class.getSimpleName()));
+        }
+        okHttpClient = builder.cache(cache).connectTimeout(0, TimeUnit.SECONDS).readTimeout(0, TimeUnit.SECONDS)
+                .writeTimeout(0, TimeUnit.SECONDS).build();
         try {
             // this can only be called once per JVM, a factory exception is thrown in our tests
             URL.setURLStreamHandlerFactory(new ObsoleteUrlFactory(okHttpClient));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -120,7 +120,6 @@ import io.dropwizard.forms.MultiPartBundle;
 import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
-import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.migrations.MigrationsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -420,10 +419,6 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         // Initialize GitHub App Installation Access Token cache
         CacheConfigManager cacheConfigManager = CacheConfigManager.getInstance();
         cacheConfigManager.initCache();
-
-        // properly shutdown http cache
-        ManagedCache myManagedObject = new ManagedCache(cache);
-        environment.lifecycle().manage(myManagedObject);
     }
 
     private void registerAPIsAndMisc(Environment environment) {
@@ -487,29 +482,5 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
 
     public HibernateBundle<DockstoreWebserviceConfiguration> getHibernate() {
         return hibernate;
-    }
-
-    private static class ManagedCache implements Managed {
-
-        private final Cache cache;
-
-        ManagedCache(Cache cache) {
-            this.cache = cache;
-        }
-
-        @Override
-        public void start() throws Exception {
-            cache.initialize();
-        }
-
-        @Override
-        public void stop() throws Exception {
-            if (!cache.isClosed()) {
-                LOG.info("attempting to properly shutdown cache");
-                cache.flush();
-                cache.close();
-                LOG.info("completed writing cache");
-            }
-        }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/CacheConfigManager.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/CacheConfigManager.java
@@ -10,8 +10,8 @@ import com.google.common.cache.LoadingCache;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import io.dockstore.webservice.DockstoreWebserviceApplication;
 import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
@@ -22,14 +22,14 @@ public class CacheConfigManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(CacheConfigManager.class);
 
-    private static CacheConfigManager cacheConfigManager = new CacheConfigManager();
+    private static final CacheConfigManager CACHE_CONFIG_MANAGER = new CacheConfigManager();
 
     private static LoadingCache<String, String> installationAccessTokenCache;
 
     private static volatile String jsonWebToken;
 
     public static CacheConfigManager getInstance() {
-        return cacheConfigManager;
+        return CACHE_CONFIG_MANAGER;
     }
 
     /**
@@ -54,8 +54,6 @@ public class CacheConfigManager {
      * @return Installation Access Token
      */
     private String getInstallationAccessTokenFromInstallationId(String installationId) throws Exception {
-        OkHttpClient client = new OkHttpClient();
-
         Request request = new Request.Builder()
                 .url("https://api.github.com/app/installations/" + installationId + "/access_tokens")
                 .post(RequestBody.create(MediaType.parse(""), "")) // Empty body to appease library
@@ -65,7 +63,7 @@ public class CacheConfigManager {
 
         String errorMsg = "Unable to retrieve installation access token.";
         try {
-            Response response = client.newCall(request).execute();
+            Response response = DockstoreWebserviceApplication.okHttpClient.newCall(request).execute();
             JsonElement body = new JsonParser().parse(response.body().string());
             if (body.isJsonObject()) {
                 JsonObject responseBody = body.getAsJsonObject();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
@@ -18,7 +18,7 @@ package io.dockstore.webservice.helpers;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -26,13 +26,7 @@ import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
@@ -43,18 +37,12 @@ import com.google.api.client.auth.oauth2.ClientParametersAuthentication;
 import com.google.api.client.auth.oauth2.TokenResponse;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.util.PemReader;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import io.dockstore.webservice.CustomWebApplicationException;
-import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.core.LicenseInformation;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.jdbi.TokenDAO;
 import io.dockstore.webservice.jdbi.UserDAO;
-import okhttp3.Request;
-import okhttp3.Response;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpStatus;
 import org.kohsuke.github.GHLicense;
@@ -117,122 +105,6 @@ public final class GitHubHelper {
         }
     }
 
-    /**
-     * Builds, but does not execute, a request to invoke a GitHub Apps API, which requires a
-     * particular Accept header
-     * @param url
-     * @param jsonWebToken
-     * @return
-     */
-    private static Request buildGitHubAppRequest(String url, String jsonWebToken) {
-        return new Request.Builder()
-                .url(url)
-                .get()
-                .addHeader("Accept", "application/vnd.github.machine-man-preview+json")
-                .addHeader("Authorization", "Bearer " + jsonWebToken)
-                .build();
-    }
-
-    /**
-     * Executes a GitHub Apps API request, and returns the value of the "repository_selection" property
-     * in the response. If the request fails or returns a response that does not include
-     * a "repository_selection" property, returns null.
-     * @param request
-     * @return
-     */
-    public static String makeGitHubAppRequestAndGetRepositorySelection(Request request) {
-        try {
-            Response response = DockstoreWebserviceApplication.okHttpClient.newCall(request).execute();
-            JsonElement body = new JsonParser().parse(response.body().string());
-            if (body.isJsonObject()) {
-                JsonObject responseBody = body.getAsJsonObject();
-                if (response.isSuccessful()) {
-                    JsonElement repoSelection = responseBody.get("repository_selection");
-                    if (repoSelection != null && repoSelection.isJsonPrimitive()) {
-                        return repoSelection.getAsString();
-                    }
-                } else {
-                    JsonElement errorMessage = responseBody.get("message");
-                    if (errorMessage != null && errorMessage.isJsonPrimitive()) {
-                        // This should just mean the org or repo doesn't have GitHub installed, and isn't an error condition AFAIK
-                        LOG.warn("Unable to fetch " + request.url().toString() + ": " + errorMessage.getAsString());
-                    }
-                }
-            }
-        } catch (IOException ex) {
-            LOG.error("Unable to get GitHub App installation for  " + request.url().toString(), ex);
-        }
-        return null;
-    }
-
-    /**
-     * Deterines if the specified repo has the Dockstore GitHub app installed
-     * @param fullyQualifiedRepo
-     * @param jsonWebToken
-     * @return
-     */
-    private static boolean checkIfRepoHasGitHubAppInstall(String fullyQualifiedRepo, String jsonWebToken) {
-        final Request request = buildGitHubAppRequest("https://api.github.com/repos/" + fullyQualifiedRepo + "/installation", jsonWebToken);
-        final String repositorySelection = makeGitHubAppRequestAndGetRepositorySelection(request);
-        // Returning "selected" for my repo in my tests, but GitHub documentation example has "all".
-        return Objects.equals(repositorySelection, "selected") || Objects.equals(repositorySelection, "all");
-    }
-
-    /**
-     * Determine if the organization has GitHub app installed on all repositories
-     * @param organization name of organization
-     * @param jsonWebToken JWT for GitHub App
-     * @return organization name
-     */
-    private static String checkIfOrganizationHasGitHubAppInstall(String organization, String jsonWebToken) {
-        final Request request = buildGitHubAppRequest("https://api.github.com/orgs/" + organization + "/installation", jsonWebToken);
-        final String repositorySelection = makeGitHubAppRequestAndGetRepositorySelection(request);
-        // Returning "selected" for my repo in my tests, but GitHub documentation example has "all".
-        return Objects.equals(repositorySelection, "all") || Objects.equals(repositorySelection, "selected") ? organization : null;
-    }
-
-    /**
-     * Retrieves all organizations a user belongs to that have GitHub app installed on all repositories
-     * @return set of organizations
-     */
-    public static Set<String> getOrganizationsWithGitHubApp(Set<String> organizations) {
-        return organizations.stream()
-                .map((String organization) -> checkIfOrganizationHasGitHubAppInstall(organization, CacheConfigManager.getJsonWebToken()))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toSet());
-    }
-
-    public static Set<String> getReposWithGitHubApp(Set<String> repos) {
-        return repos.stream()
-                .filter(repo -> checkIfRepoHasGitHubAppInstall(repo, CacheConfigManager.getJsonWebToken()))
-                .collect(Collectors.toSet());
-    }
-
-    /**
-     * Returns the org from a fully qualified GitHub repo, e.g., returns dockstore from dockstore/dockstore-ui2
-     * @param repositoryName name best be in the right format
-     * @return
-     */
-    public static String orgFromRepo(String repositoryName) {
-        return repositoryName.split("/")[0];
-    }
-
-    /**
-     * Returns all repos in <code>allRepositories</code> that have the Dockstore GitHub app installed, and that
-     * don't belong to an org that already has the Dockstore GitHub app installed.
-     * @param allRepositories
-     * @param orgsWithAppInstalled
-     * @return
-     */
-    public static Set<String> individualReposWithGitHubApp(Collection<String> allRepositories, Collection<String> orgsWithAppInstalled) {
-        // Also get repos that have the App installed. This for repos that whose org does not have the app installed
-        final Set<String> reposInApplessOrgs = allRepositories.stream()
-                .filter(repositoryName -> !orgsWithAppInstalled.contains(orgFromRepo(repositoryName)))
-                .collect(Collectors.toSet());
-
-        // Repos that have the GitHub app installed, but their orgs doesn't have the GitHub app installed
-        return getReposWithGitHubApp(reposInApplessOrgs);
-    }
 
     /**
      * Refresh the JWT for GitHub apps
@@ -244,7 +116,7 @@ public final class GitHubHelper {
         System.out.println("working dir=" + Paths.get("").toAbsolutePath().toString());
         try {
             String pemFileContent = FileUtils
-                    .readFileToString(new File(gitHubPrivateKeyFile), Charset.forName("UTF-8"));
+                    .readFileToString(new File(gitHubPrivateKeyFile), StandardCharsets.UTF_8);
             final PemReader.Section privateKey = PemReader.readFirstSectionAndClose(new StringReader(pemFileContent), "PRIVATE KEY");
             if (privateKey != null) {
                 KeyFactory keyFactory = KeyFactory.getInstance("RSA");
@@ -271,47 +143,6 @@ public final class GitHubHelper {
                 LOG.error(ex.getMessage(), ex);
             }
         }
-    }
-
-    /**
-     * Setup tokens required for GitHub apps
-     * @param gitHubAppId
-     * @param gitHubPrivateKeyFile
-     * @param installationId App installation ID (per repository)
-     * @return Installation access token for the given repository
-     */
-    public static String gitHubAppSetup(String gitHubAppId, String gitHubPrivateKeyFile, String installationId) {
-        checkJWT(gitHubAppId, gitHubPrivateKeyFile);
-        String installationAccessToken = CacheConfigManager.getInstance().getInstallationAccessTokenFromCache(installationId);
-        if (installationAccessToken == null) {
-            String msg = "Could not get an installation access token for install with id " + installationId;
-            LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        }
-        return installationAccessToken;
-    }
-
-
-    public static Collection<String> reposToCreateEntitiesFor(Collection<String> repositories, Optional<String> organization,
-            Set<String> existingWorkflowPaths) {
-        // Get all unique organizations
-        final Set<String> myOrganizations = organization.map(o -> Collections.singleton(o))
-                .orElseGet(() -> repositories.stream()
-                        .map(repositoryName -> orgFromRepo(repositoryName))
-                        .collect(Collectors.toSet()));
-
-        // Get ORGs that have App installed
-        final Set<String> orgsWithAppInstalled = getOrganizationsWithGitHubApp(myOrganizations);
-
-        final Set<String> reposWithGitHubApp = individualReposWithGitHubApp(repositories, orgsWithAppInstalled);
-
-        // Create services that don't yet exist for repos that have app installed, either directly or through the org
-        return repositories.stream()
-                .filter(repositoryName -> !existingWorkflowPaths.contains("github.com/" + repositoryName))
-                .filter(repositoryName -> reposWithGitHubApp.contains(repositoryName)
-                        || orgsWithAppInstalled.contains(orgFromRepo(repositoryName)))
-                .collect(Collectors.toList());
-
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -106,7 +106,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
     GitHubSourceCodeRepo(String gitUsername, String githubTokenContent) {
         this.gitUsername = gitUsername;
-        // this code is duplicate from DockstoreWebserviceApplication, escept this is a lot faster ...
+        // this code is duplicate from DockstoreWebserviceApplication, except this is a lot faster ...
         ObsoleteUrlFactory obsoleteUrlFactory = new ObsoleteUrlFactory(new OkHttpClient.Builder().eventListener(new EventListener() {
             @Override
             public void cacheConditionalHit(@NotNull Call call, @NotNull Response cachedResponse) {
@@ -128,7 +128,8 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         }).cache(DockstoreWebserviceApplication.getCache()).build());
         HttpConnector okHttp3Connector = new ImpatientHttpConnector(obsoleteUrlFactory::open);
         try {
-            this.github = new GitHubBuilder().withOAuthToken(githubTokenContent, gitUsername).withRateLimitHandler(RateLimitHandler.WAIT).withAbuseLimitHandler(AbuseLimitHandler.WAIT).withConnector(okHttp3Connector).build();
+            this.github = new GitHubBuilder().withOAuthToken(githubTokenContent, gitUsername).withRateLimitHandler(RateLimitHandler.WAIT)
+                    .withAbuseLimitHandler(AbuseLimitHandler.WAIT).withConnector(okHttp3Connector).build();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -33,6 +33,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import javax.validation.constraints.NotNull;
+
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import io.dockstore.common.DescriptorLanguage;
@@ -69,7 +71,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.http.HttpStatus;
-import org.jetbrains.annotations.NotNull;
 import org.kohsuke.github.AbuseLimitHandler;
 import org.kohsuke.github.GHBranch;
 import org.kohsuke.github.GHCommit;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -104,7 +104,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     private static final Logger LOG = LoggerFactory.getLogger(GitHubSourceCodeRepo.class);
     private final GitHub github;
 
-    GitHubSourceCodeRepo(String gitUsername, String githubTokenContent) {
+    public GitHubSourceCodeRepo(String gitUsername, String githubTokenContent) {
         this.gitUsername = gitUsername;
         // this code is duplicate from DockstoreWebserviceApplication, except this is a lot faster ...
         ObsoleteUrlFactory obsoleteUrlFactory = new ObsoleteUrlFactory(new OkHttpClient.Builder().eventListener(new EventListener() {
@@ -836,7 +836,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
     private void reportOnRateLimit(String id, GHRateLimit startRateLimit, GHRateLimit endRateLimit) {
         if (startRateLimit != null && endRateLimit != null) {
-            int used = startRateLimit.remaining - endRateLimit.remaining;
+            int used = startRateLimit.getRemaining() - endRateLimit.getRemaining();
             if (used > 0) {
                 LOG.debug(id + ": used up " + used + " GitHub rate limited requests");
             } else {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -888,7 +888,11 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         }
 
         try {
-            tags = repo.getRefs("refs/tags/");
+            // this crazy looking structure is because getRefs can result in a cache miss (on repos without tags) whereas listTags seems to not have this problem
+            // yes this could probably be re-coded to use listTags directly
+            if (repo.listTags().iterator().hasNext()) {
+                tags = repo.getRefs("refs/tags/");
+            }
         } catch (GHFileNotFoundException ex) {
             LOG.debug("No tags found for  " + repo.getName());
             if (!getBranchesSucceeded) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -102,8 +102,14 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
     public GitHubSourceCodeRepo(String gitUsername, String githubTokenContent) {
         this.gitUsername = gitUsername;
-        // this code is duplicate from DockstoreWebserviceApplication, except this is a lot faster ...
-        ObsoleteUrlFactory obsoleteUrlFactory = new ObsoleteUrlFactory(new OkHttpClient.Builder().eventListener(new CacheHitListener(GitHubSourceCodeRepo.class.getSimpleName())).cache(DockstoreWebserviceApplication.getCache()).build());
+        // this code is duplicate from DockstoreWebserviceApplication, except this is a lot faster for unknown reasons ...
+        OkHttpClient.Builder builder = new OkHttpClient().newBuilder().cache(DockstoreWebserviceApplication.getCache());
+        if (System.getenv("CIRCLE_SHA1") != null) {
+            builder.eventListener(new CacheHitListener(GitHubSourceCodeRepo.class.getSimpleName()));
+        }
+        OkHttpClient build = builder.build();
+        ObsoleteUrlFactory obsoleteUrlFactory = new ObsoleteUrlFactory(build);
+
         HttpConnector okHttp3Connector = new ImpatientHttpConnector(obsoleteUrlFactory::open);
         try {
             this.github = new GitHubBuilder().withOAuthToken(githubTokenContent, gitUsername).withRateLimitHandler(RateLimitHandler.WAIT)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -163,36 +163,6 @@ public class DockerRepoResource
         this.toolDAO = new ToolDAO(sessionFactory);
     }
 
-    List<Tool> refreshToolsForUser(Long userId, String organization) {
-        refreshBitbucketToken(userId);
-
-        // Get user's quay and git tokens
-        List<Token> tokens = tokenDAO.findByUserId(userId);
-        Token quayToken = Token.extractToken(tokens, TokenType.QUAY_IO);
-        Token githubToken = Token.extractToken(tokens, TokenType.GITHUB_COM);
-        Token bitbucketToken = Token.extractToken(tokens, TokenType.BITBUCKET_ORG);
-        Token gitlabToken = Token.extractToken(tokens, TokenType.GITLAB_COM);
-
-        // with Docker Hub support it is now possible that there is no quayToken
-        checkTokens(quayToken, githubToken, bitbucketToken, gitlabToken);
-
-        // Get a list of all image registries
-        ImageRegistryFactory factory = new ImageRegistryFactory(quayToken);
-        final List<AbstractImageRegistry> allRegistries = factory.getAllRegistries();
-
-        // Get a list of all namespaces from all image registries
-        List<Tool> updatedTools = new ArrayList<>();
-        for (AbstractImageRegistry abstractImageRegistry : allRegistries) {
-            Registry registry = abstractImageRegistry.getRegistry();
-            LOG.info("Grabbing " + registry.getFriendlyName() + " repos");
-
-            updatedTools.addAll(abstractImageRegistry
-                .refreshTools(userId, userDAO, toolDAO, tagDAO, fileDAO, fileFormatDAO, client, githubToken, bitbucketToken,
-                    gitlabToken, organization, eventDAO, dashboardPrefix));
-        }
-        return updatedTools;
-    }
-
     List<Tool> refreshToolsForUser(Long userId, String organization, String repository) {
         refreshBitbucketToken(userId);
 


### PR DESCRIPTION
Saving some work on rate limit for later

- noticed github library tests with a much newer okhttp library (4.4.1), think we pinned a lower (3.14.2) version and it worked due to some of their backwards compatibility includes https://github.com/hub4j/github-api/blob/github-api-1.123/pom.xml#L40
- used 4.7.0 to gain access to easier to read cache miss messages https://github.com/square/okhttp/blob/edf477cb4e7b1d59c6e3e5ac00870619340ce990/CHANGELOG.md#version-470
- numbers didn't add up, so noticed we have a method low-balling rate limit using calls
- noticed that cache is not being properly saved on exit (can confirm by running a github release, shutting down, then re-running the same release twice. The first and second call will make actual calls while the third will run entirely from cache)

Edit:
- cache is being saved properly, but constantly changing JWT token (every ten minutes) or restarting the web service clears it instantly since the the JWT token cache is only in memory
- debugging by putting a breakpoint at https://github.com/dockstore/dockstore/pull/4096/files#diff-1d1e171d7034c5aa326eaa5c95926ed80c493c7d9663651407bddad8e752a435R126 is the most useful. See https://square.github.io/okhttp/caching/ for details
- had an attempt at recording rate limit used on a test suite level, but it didn't quite work out
- suspicious of https://github.com/dockstore/dockstore/pull/4096/files#diff-1d1e171d7034c5aa326eaa5c95926ed80c493c7d9663651407bddad8e752a435R895 which always results in a big pile of cache misses on a bunch of our testing repos that have no tags
- deleted a bunch of unreachable private methods while debugging

Additional warning: a bunch of our tests suppress output on test success, so you don't necessarily see the cache miss messages

Look at `/tmp/dockstore-web-cache.misses.log` for a list of cache misses when running on CircleCI