### PR TITLE
Feature/3785/publish orcid endpoint

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
@@ -13,6 +13,7 @@ import io.dockstore.openapi.client.api.WorkflowsApi;
 import io.dockstore.openapi.client.model.User;
 import io.dockstore.openapi.client.model.Workflow;
 import io.dockstore.openapi.client.model.WorkflowVersion;
+import io.dockstore.webservice.resources.EntryResource;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Before;
@@ -66,7 +67,7 @@ public class EntryResourceIT extends BaseIT {
             fail("Should not have been able to export an entry without DOI concept URL");
         } catch (ApiException e) {
             Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
-            Assert.assertEquals("Entry does not have a concept DOI associated with it", e.getMessage());
+            Assert.assertEquals(EntryResource.ENTRY_NO_DOI_ERROR_MESSAGE, e.getMessage());
         }
         testingPostgres.runUpdateStatement("update workflow set conceptDOI='dummy'");
         try {
@@ -74,14 +75,14 @@ public class EntryResourceIT extends BaseIT {
             fail("Should not have been able to export a version without DOI URL");
         } catch (ApiException e) {
             Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
-            Assert.assertEquals("Version does not have a DOI url associated with it", e.getMessage());
+            Assert.assertEquals(EntryResource.VERSION_NO_DOI_ERROR_MESSAGE, e.getMessage());
         }
         try {
             entriesApi.exportToORCID(workflowId, workflowVersionId + 1);
             fail("Should not have been able to export a version that doesn't belong to the entry");
         } catch (ApiException e) {
             Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
-            Assert.assertEquals("Version does not belong to entry", e.getMessage());
+            Assert.assertEquals(EntryResource.VERSION_NOT_BELONG_TO_ENTRY_ERROR_MESSAGE, e.getMessage());
         }
 
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
@@ -41,7 +41,7 @@ public class EntryResourceIT extends BaseIT {
     }
 
     /**
-     * Tests that refresh all works, also that refreshing without a quay.io token should not destroy tools
+     * Tests that exporting to ORCID does not work for entries or versions without DOI
      */
     @Test
     public void testOrcidExport() {
@@ -66,6 +66,7 @@ public class EntryResourceIT extends BaseIT {
             fail("Should not have been able to export an entry without DOI concept URL");
         } catch (ApiException e) {
             Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
+            Assert.assertEquals("Entry does not have a concept DOI associated with it", e.getMessage());
         }
         testingPostgres.runUpdateStatement("update workflow set conceptDOI='dummy'");
         try {
@@ -73,12 +74,14 @@ public class EntryResourceIT extends BaseIT {
             fail("Should not have been able to export a version without DOI URL");
         } catch (ApiException e) {
             Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
+            Assert.assertEquals("Version does not have a DOI url associated with it", e.getMessage());
         }
         try {
             entriesApi.exportToORCID(workflowId, workflowVersionId + 1);
             fail("Should not have been able to export a version that doesn't belong to the entry");
         } catch (ApiException e) {
             Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
+            Assert.assertEquals("Version does not belong to entry", e.getMessage());
         }
 
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
@@ -1,0 +1,85 @@
+package io.dockstore.client.cli;
+
+import java.util.List;
+
+import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.common.SourceControl;
+import io.dockstore.openapi.client.ApiClient;
+import io.dockstore.openapi.client.ApiException;
+import io.dockstore.openapi.client.api.EntriesApi;
+import io.dockstore.openapi.client.api.UsersApi;
+import io.dockstore.openapi.client.api.WorkflowsApi;
+import io.dockstore.openapi.client.model.User;
+import io.dockstore.openapi.client.model.Workflow;
+import io.dockstore.openapi.client.model.WorkflowVersion;
+import org.apache.http.HttpStatus;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+
+import static org.junit.Assert.fail;
+
+public class EntryResourceIT extends BaseIT {
+    @Rule
+    public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
+
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+
+    @Before
+    @Override
+    public void resetDBBetweenTests() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+    }
+
+    /**
+     * Tests that refresh all works, also that refreshing without a quay.io token should not destroy tools
+     */
+    @Test
+    public void testOrcidExport() {
+        ApiClient client = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        EntriesApi entriesApi = new EntriesApi(client);
+        UsersApi usersApi = new UsersApi(client);
+        User user = usersApi.getUser();
+        WorkflowsApi workflowsApi = new WorkflowsApi(client);
+        workflowsApi.manualRegister(SourceControl.GITHUB.name(), "DockstoreTestUser/dockstore-whalesay-wdl", "/dockstore.wdl", "",
+                DescriptorLanguage.WDL.getShortName(), "");
+
+        List<Workflow> workflows = usersApi.userWorkflows(user.getId());
+        Long workflowId = workflows.get(0).getId();
+        workflowsApi.refresh1(workflowId, false);
+        Assert.assertTrue(workflows.size() > 0);
+        Workflow workflow = workflowsApi.getWorkflow(workflowId, null);
+        List<WorkflowVersion> workflowVersions = workflow.getWorkflowVersions();
+        Long workflowVersionId = workflowVersions.get(0).getId();
+
+        try {
+            entriesApi.exportToORCID(workflowId, null);
+            fail("Should not have been able to export an entry without DOI concept URL");
+        } catch (ApiException e) {
+            Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
+        }
+        testingPostgres.runUpdateStatement("update workflow set conceptDOI='dummy'");
+        try {
+            entriesApi.exportToORCID(workflowId, workflowVersionId);
+            fail("Should not have been able to export a version without DOI URL");
+        } catch (ApiException e) {
+            Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
+        }
+        try {
+            entriesApi.exportToORCID(workflowId, workflowVersionId + 1);
+            fail("Should not have been able to export a version that doesn't belong to the entry");
+        } catch (ApiException e) {
+            Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
+        }
+
+    }
+}

--- a/dockstore-integration-testing/src/test/resources/partialDockstoreTest.yml
+++ b/dockstore-integration-testing/src/test/resources/partialDockstoreTest.yml
@@ -105,3 +105,7 @@ uiConfig:
   cwlVisualizerUri: https://view.commonwl.org
 
   gitHubAppInstallationUrl: https://github.com/apps/dockstore-testing-application
+
+  orcidAuthUrl: https://sandbox.orcid.org/oauth/authorize
+  orcidScope: /activities/update
+  orcidRedirectPath: /auth/orcid.org

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -320,7 +320,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
 
         final PermissionsInterface authorizer = PermissionsFactory.createAuthorizer(tokenDAO, configuration);
 
-        final EntryResource entryResource = new EntryResource(toolDAO, versionDAO, configuration);
+        final EntryResource entryResource = new EntryResource(tokenDAO, toolDAO, versionDAO, configuration);
         environment.jersey().register(entryResource);
 
         final WorkflowResource workflowResource = new WorkflowResource(httpClient, hibernate.getSessionFactory(), authorizer, entryResource, configuration);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
@@ -104,17 +104,7 @@ public final class ORCIDHelper {
         return postWorkString(ORCID_BASE_URL, id, workString, token);
     }
 
-
-    private static String transformWork(Work work) throws JAXBException {
-        JAXBContext context = JAXBContext.newInstance(Work.class);
-        StringWriter writer = new StringWriter();
-        Marshaller marshaller = context.createMarshaller();
-        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-        marshaller.marshal(work, writer);
-        return writer.getBuffer().toString();
-    }
-
-    private static HttpResponse postWorkString(String baseURL, String id, String workString, String token) throws IOException {
+    public static HttpResponse postWorkString(String baseURL, String id, String workString, String token) throws IOException {
         HttpPost postRequest = new HttpPost(baseURL + id + "/work");
         postRequest.addHeader("content-type", "application/vnd.orcid+xml");
         postRequest.addHeader("Authorization", "Bearer " + token);
@@ -126,5 +116,14 @@ public final class ORCIDHelper {
         } finally {
             httpClient.close();
         }
+    }
+
+    private static String transformWork(Work work) throws JAXBException {
+        JAXBContext context = JAXBContext.newInstance(Work.class);
+        StringWriter writer = new StringWriter();
+        Marshaller marshaller = context.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+        marshaller.marshal(work, writer);
+        return writer.getBuffer().toString();
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -98,6 +98,9 @@ import static io.dockstore.webservice.resources.ResourceConstants.OPENAPI_JWT_SE
 public class EntryResource implements AuthenticatedResourceInterface, AliasableResourceInterface<Entry> {
 
     private static final Logger LOG = LoggerFactory.getLogger(EntryResource.class);
+    public static final String VERSION_NOT_BELONG_TO_ENTRY_ERROR_MESSAGE = "Version does not belong to entry";
+    public static final String ENTRY_NO_DOI_ERROR_MESSAGE = "Entry does not have a concept DOI associated with it";
+    public static final String VERSION_NO_DOI_ERROR_MESSAGE = "Version does not have a DOI url associated with it";
 
     private final TokenDAO tokenDAO;
     private final ToolDAO toolDAO;
@@ -234,15 +237,15 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
         if (versionId != null) {
             Version version = versionDAO.findVersionInEntry(entry.getId(), versionId);
             if (version == null) {
-                throw new CustomWebApplicationException("Version does not belong to entry", HttpStatus.SC_BAD_REQUEST);
+                throw new CustomWebApplicationException(VERSION_NOT_BELONG_TO_ENTRY_ERROR_MESSAGE, HttpStatus.SC_BAD_REQUEST);
             }
             if (version.getDoiURL() == null) {
-                throw new CustomWebApplicationException("Version does not have a DOI url associated with it", HttpStatus.SC_BAD_REQUEST);
+                throw new CustomWebApplicationException(VERSION_NO_DOI_ERROR_MESSAGE, HttpStatus.SC_BAD_REQUEST);
             }
             optionalVersion = Optional.ofNullable(version);
         } else {
             if (entry.getConceptDoi() == null) {
-                throw new CustomWebApplicationException("Entry does not have a concept DOI associated with it", HttpStatus.SC_BAD_REQUEST);
+                throw new CustomWebApplicationException(ENTRY_NO_DOI_ERROR_MESSAGE, HttpStatus.SC_BAD_REQUEST);
             }
         }
         if (baseApiURL == null) {
@@ -250,7 +253,7 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
             throw new CustomWebApplicationException("Could not export to ORCID: Dockstore ORCID integration is not set up correctly.", HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
         if (orcidByUserId.isEmpty()) {
-            throw new CustomWebApplicationException("ORCID account is not linked to user account", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            throw new CustomWebApplicationException("ORCID account is not linked to user account", HttpStatus.SC_BAD_REQUEST);
         }
         try {
             String orcidWorkString = ORCIDHelper.getOrcidWorkString(entry, optionalVersion);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -17,6 +17,7 @@ package io.dockstore.webservice.resources;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +33,8 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import javax.xml.bind.JAXBException;
+import javax.xml.datatype.DatatypeConfigurationException;
 
 import com.codahale.metrics.annotation.Timed;
 import io.dockstore.common.DescriptorLanguage;
@@ -42,11 +45,14 @@ import io.dockstore.webservice.core.CollectionOrganization;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.SourceFile;
+import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.database.VersionVerifiedPlatform;
+import io.dockstore.webservice.helpers.ORCIDHelper;
 import io.dockstore.webservice.helpers.PublicStateManager;
+import io.dockstore.webservice.jdbi.TokenDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import io.dockstore.webservice.jdbi.VersionDAO;
 import io.dropwizard.auth.Auth;
@@ -71,6 +77,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.security.SecuritySchemes;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,6 +99,7 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
 
     private static final Logger LOG = LoggerFactory.getLogger(EntryResource.class);
 
+    private final TokenDAO tokenDAO;
     private final ToolDAO toolDAO;
     private final VersionDAO versionDAO;
     private final TopicsApi topicsApi;
@@ -101,14 +109,20 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
     private final String discourseApiUsername = "system";
     private final int maxDescriptionLength = 500;
     private final String hostName;
+    private URL orcidBaseUrl = null;
 
-    public EntryResource(ToolDAO toolDAO, VersionDAO versionDAO, DockstoreWebserviceConfiguration configuration) {
+    public EntryResource(TokenDAO tokenDAO, ToolDAO toolDAO, VersionDAO versionDAO, DockstoreWebserviceConfiguration configuration) {
         this.toolDAO = toolDAO;
         this.versionDAO = versionDAO;
-
+        this.tokenDAO = tokenDAO;
         discourseUrl = configuration.getDiscourseUrl();
         discourseKey = configuration.getDiscourseKey();
         discourseCategoryId = configuration.getDiscourseCategoryId();
+        try {
+            orcidBaseUrl = new URL(configuration.getUiConfig().getOrcidAuthUrl());
+        } catch (MalformedURLException e) {
+            LOG.error("The ORCID Auth URL in the dropwizard configuration file is malformed.");
+        }
 
         ApiClient apiClient = Configuration.getDefaultApiClient();
         apiClient.addDefaultHeader("Content-Type", "application/x-www-form-urlencoded");
@@ -194,6 +208,39 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
             }
             checkUser(user.get(), entry);
         }
+    }
+
+    @POST
+    @Path("/{entryId}/exportToOrcid")
+    @Timed
+    @UnitOfWork
+    @Operation(description = "Export entry to ORCID", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
+    @ApiResponse(responseCode = HttpStatus.SC_NO_CONTENT + "", description = "No Content")
+    @ApiResponse(responseCode = HttpStatus.SC_INTERNAL_SERVER_ERROR + "", description = "Internal Server Error")
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "Not Found")
+    @ApiOperation(value = "hidden", hidden = true)
+    public void exportToORCID(@Parameter(hidden = true, name = "user") @Auth User user, @Parameter(description = "The id of the entry to export.", name = "entryId", in = ParameterIn.PATH, required = true)
+        @PathParam("entryId") Long entryId) {
+        Entry<? extends Entry, ? extends Version> entry = toolDAO.getGenericEntryById(entryId);
+        checkEntry(entry);
+        checkEntryPermissions(Optional.of(user), entry);
+        List<Token> orcidByUserId = tokenDAO.findOrcidByUserId(user.getId());
+        if (orcidBaseUrl == null) {
+            throw new CustomWebApplicationException("Could not export to ORCID: Dockstore ORCID integration is not set up correctly.", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        }
+        try {
+            String orcidWorkString = ORCIDHelper.getOrcidWorkString(entry, Optional.empty());
+            // baseUrl should result in something like "https://api.sandbox.orcid.org/v3.0/" or "https://api.orcid.org/v3.0/";
+            String baseUrl = orcidBaseUrl.getProtocol() + "://" + "api." + orcidBaseUrl.getHost() + "/v3.0/";
+            HttpResponse response = ORCIDHelper.postWorkString(baseUrl, user.getOrcid(), orcidWorkString,
+                    orcidByUserId.get(0).getToken());
+            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_CREATED) {
+                throw new CustomWebApplicationException("Could not export to ORCID: " + response.getStatusLine().getReasonPhrase(), response.getStatusLine().getStatusCode());
+            }
+        } catch (JAXBException | DatatypeConfigurationException | IOException e) {
+            throw new CustomWebApplicationException("Could not export to ORCID: " + e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        }
+
     }
 
     @POST

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -97,10 +97,10 @@ import static io.dockstore.webservice.resources.ResourceConstants.OPENAPI_JWT_SE
 @Tag(name = "entries", description = ResourceConstants.ENTRIES)
 public class EntryResource implements AuthenticatedResourceInterface, AliasableResourceInterface<Entry> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(EntryResource.class);
     public static final String VERSION_NOT_BELONG_TO_ENTRY_ERROR_MESSAGE = "Version does not belong to entry";
     public static final String ENTRY_NO_DOI_ERROR_MESSAGE = "Entry does not have a concept DOI associated with it";
     public static final String VERSION_NO_DOI_ERROR_MESSAGE = "Version does not have a DOI url associated with it";
+    private static final Logger LOG = LoggerFactory.getLogger(EntryResource.class);
 
     private final TokenDAO tokenDAO;
     private final ToolDAO toolDAO;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -116,7 +116,9 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     private static final String QUAY_URL = "https://quay.io/api/v1/";
     private static final String BITBUCKET_URL = "https://bitbucket.org/";
     private static final String GITLAB_URL = "https://gitlab.com/";
-    private static final String ORCID_URL = "https://orcid.org/";
+    // TODO: Pull this from the config auth url
+    // private static final String ORCID_URL = "https://orcid.org/";
+    private static final String ORCID_URL = "https://sandbox.orcid.org/";
     private static final TOSVersion CURRENT_TOS_VERSION = TOSVersion.TOS_VERSION_1;
     private static final PrivacyPolicyVersion CURRENT_PRIVACY_POLICY_VERSION = PrivacyPolicyVersion.PRIVACY_POLICY_VERSION_2_5;
     private static final Logger LOG = LoggerFactory.getLogger(TokenResource.class);
@@ -141,6 +143,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     private final String googleClientSecret;
     private final String orcidClientID;
     private final String orcidClientSecret;
+    private final String orcidScope;
     private final HttpClient client;
     private final CachingAuthenticator<String, User> cachingAuthenticator;
 
@@ -167,6 +170,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
         this.googleClientID = configuration.getGoogleClientID();
         this.googleClientSecret = configuration.getGoogleClientSecret();
         this.orcidClientID = configuration.getOrcidClientID();
+        this.orcidScope = configuration.getUiConfig().getOrcidScope();
         this.orcidClientSecret = configuration.getOrcidClientSecret();
         this.client = client;
         this.cachingAuthenticator = cachingAuthenticator;
@@ -689,7 +693,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
                 ORCID_URL + "/authorize").build();
 
         try {
-            TokenResponse tokenResponse = flow.newTokenRequest(code).setScopes(Collections.singletonList("/authenticate"))
+            TokenResponse tokenResponse = flow.newTokenRequest(code).setScopes(Collections.singletonList(orcidScope))
                     .setRequestInitializer(request -> request.getHeaders().setAccept("application/json")).execute();
             accessToken = tokenResponse.getAccessToken();
             refreshToken = tokenResponse.getRefreshToken();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -179,7 +179,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
             // orcidUrl should be something like "https://sandbox.orcid.org/" or "https://orcid.org/"
             orcidUrl = orcidAuthUrl.getProtocol() + "://" + orcidAuthUrl.getHost() + "/";
         } catch (MalformedURLException e) {
-            LOG.error("The ORCID Auth URL in the dropwizard configuration file is malformed.");
+            LOG.error("The ORCID Auth URL in the dropwizard configuration file is malformed.", e);
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -17,6 +17,8 @@
 package io.dockstore.webservice.resources;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.Date;
@@ -116,9 +118,6 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     private static final String QUAY_URL = "https://quay.io/api/v1/";
     private static final String BITBUCKET_URL = "https://bitbucket.org/";
     private static final String GITLAB_URL = "https://gitlab.com/";
-    // TODO: Pull this from the config auth url
-    // private static final String ORCID_URL = "https://orcid.org/";
-    private static final String ORCID_URL = "https://sandbox.orcid.org/";
     private static final TOSVersion CURRENT_TOS_VERSION = TOSVersion.TOS_VERSION_1;
     private static final PrivacyPolicyVersion CURRENT_PRIVACY_POLICY_VERSION = PrivacyPolicyVersion.PRIVACY_POLICY_VERSION_2_5;
     private static final Logger LOG = LoggerFactory.getLogger(TokenResource.class);
@@ -149,6 +148,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
 
     private final String orcidSummary = "Add a new orcid.org token";
     private final String orcidDescription = "Using OAuth code from ORCID, request and store tokens from ORCID API";
+    private String orcidUrl = null;
 
     public TokenResource(TokenDAO tokenDAO, UserDAO enduserDAO, DeletedUsernameDAO deletedUsernameDAO, HttpClient client, CachingAuthenticator<String, User> cachingAuthenticator,
             DockstoreWebserviceConfiguration configuration) {
@@ -174,6 +174,13 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
         this.orcidClientSecret = configuration.getOrcidClientSecret();
         this.client = client;
         this.cachingAuthenticator = cachingAuthenticator;
+        try {
+            URL orcidAuthUrl = new URL(configuration.getUiConfig().getOrcidAuthUrl());
+            // orcidUrl should be something like "https://sandbox.orcid.org/" or "https://orcid.org/"
+            orcidUrl = orcidAuthUrl.getProtocol() + "://" + orcidAuthUrl.getHost() + "/";
+        } catch (MalformedURLException e) {
+            LOG.error("The ORCID Auth URL in the dropwizard configuration file is malformed.");
+        }
     }
 
     @GET
@@ -688,9 +695,9 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
         }
 
         final AuthorizationCodeFlow flow = new AuthorizationCodeFlow.Builder(BearerToken.authorizationHeaderAccessMethod(), HTTP_TRANSPORT,
-                JSON_FACTORY, new GenericUrl(ORCID_URL + "oauth/token"),
+                JSON_FACTORY, new GenericUrl(orcidUrl + "oauth/token"),
                 new ClientParametersAuthentication(orcidClientID, orcidClientSecret), orcidClientID,
-                ORCID_URL + "/authorize").build();
+                orcidUrl + "/authorize").build();
 
         try {
             TokenResponse tokenResponse = flow.newTokenRequest(code).setScopes(Collections.singletonList(orcidScope))

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3792,9 +3792,17 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Optional version ID of the entry version to export.
+          in: query
+          name: versionId
+          schema:
+            format: int64
+            type: integer
       responses:
         "204":
           description: No Content
+        "400":
+          description: Bad Request
         "404":
           description: Not Found
         "500":

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3780,6 +3780,29 @@ paths:
         - bearer: []
       tags:
         - curation
+  /entries/{entryId}/exportToOrcid:
+    post:
+      description: Export entry to ORCID
+      operationId: exportToORCID
+      parameters:
+        - description: The id of the entry to export.
+          in: path
+          name: entryId
+          required: true
+          schema:
+            format: int64
+            type: integer
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      security:
+        - bearer: []
+      tags:
+        - entries
   /entries/{entryId}/verifiedPlatforms:
     get:
       description: Get the verified platforms for each version of an entry.


### PR DESCRIPTION
For #3785 

Endpoint doesn't quite fit well with REST

Rather than creating another config variable for ORCID. Just re-using the orcid auth URL

It is observed that the DOI URL needs to be unique in order to successfully post to ORCID so the endpoint here requires entry or version DOI URL