### PR TITLE
namespace cache for testing on circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
     steps: # a collection of executable commands
       - checkout
       - restore_cache:
-          key: dockstore-web-cache-unit-test-{{ .Environment.CACHE_VERSION }}
+          key: dockstore-web-cache-unit-test-{{ .Environment.CACHE_SEGMENTED_VERSION }}
       - run:
           name: Install yq
           command: |
@@ -213,7 +213,7 @@ jobs:
             - ~/.m2
           key: dockstore-java-{{ checksum "pom.xml" }}
       - save_cache:
-          key: dockstore-web-cache-unit-test-{{ .Environment.CACHE_VERSION }}
+          key: dockstore-web-cache-unit-test-{{ .Environment.CACHE_SEGMENTED_VERSION }}
           paths:
             - /tmp/dockstore-web-cache
       - run:
@@ -315,7 +315,7 @@ commands:
             sudo apt update
             sudo apt install -y postgresql-client
       - restore_cache:
-          key: dockstore-web-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_VERSION }}
+          key: dockstore-web-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_SEGMENTED_VERSION }}
   setup_integration_test:
     steps:
       - run:
@@ -359,7 +359,7 @@ commands:
   save_test_results:
     steps:
       - save_cache:
-          key: dockstore-web-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_VERSION }}
+          key: dockstore-web-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_SEGMENTED_VERSION }}
           paths:
             - /tmp/dockstore-web-cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
     steps: # a collection of executable commands
       - checkout
       - restore_cache:
-          key: dockstore-web-cache-unit-test-{{ .Environment.CACHE_SEGMENTED_VERSION }}
+          key: dockstore-web-cache-unit-test-{{ .Environment.CACHE_SEGMENTED_VERSION }}-segmented
       - run:
           name: Install yq
           command: |
@@ -213,7 +213,7 @@ jobs:
             - ~/.m2
           key: dockstore-java-{{ checksum "pom.xml" }}
       - save_cache:
-          key: dockstore-web-cache-unit-test-{{ .Environment.CACHE_SEGMENTED_VERSION }}
+          key: dockstore-web-cache-unit-test-{{ .Environment.CACHE_SEGMENTED_VERSION }}-segmented
           paths:
             - /tmp/dockstore-web-cache
       - run:
@@ -315,7 +315,7 @@ commands:
             sudo apt update
             sudo apt install -y postgresql-client
       - restore_cache:
-          key: dockstore-web-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_SEGMENTED_VERSION }}
+          key: dockstore-web-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_SEGMENTED_VERSION }}-segmented
   setup_integration_test:
     steps:
       - run:
@@ -359,7 +359,7 @@ commands:
   save_test_results:
     steps:
       - save_cache:
-          key: dockstore-web-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_SEGMENTED_VERSION }}
+          key: dockstore-web-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_SEGMENTED_VERSION }}-segmented
           paths:
             - /tmp/dockstore-web-cache
       - run:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![license](https://img.shields.io/hexpm/l/plug.svg?maxAge=2592000)](LICENSE)
 [![CircleCI](https://circleci.com/gh/dockstore/dockstore/tree/develop.svg?style=svg)](https://circleci.com/gh/dockstore/dockstore/tree/develop)
 [![Documentation Status](https://readthedocs.org/projects/dockstore/badge/?version=develop)](https://dockstore.readthedocs.io/en/develop/?badge=develop)
-[![Docker Repository on Quay](https://quay.io/repository/dockstore/dockstore-webservice/status "Docker Repository on Quay")](https://quay.io/repository/dockstore/dockstore-webservice)
 
 
 # Dockstore

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -189,8 +189,12 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         new DockstoreWebserviceApplication().run(args);
     }
 
-    public static Cache getCache() {
-        return cache;
+    public static Cache getCache(String cacheNamespace) {
+        if (cacheNamespace == null) {
+            return cache;
+        } else {
+            return generateCache(cacheNamespace);
+        }
     }
 
     @Override
@@ -220,18 +224,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         bootstrap.addBundle(new MultiPartBundle());
 
         if (cache == null) {
-            int cacheSize = CACHE_IN_MB * BYTES_IN_KILOBYTE * KILOBYTES_IN_MEGABYTE; // 100 MiB
-            final File cacheDir;
-            try {
-                // let's try using the same cache each time
-                // not sure how corruptible/non-curruptable the cache is
-                // https://github.com/square/okhttp/blob/parent-3.10.0/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.java#L82 looks promising
-                cacheDir = Files.createDirectories(Paths.get(DOCKSTORE_WEB_CACHE)).toFile();
-            } catch (IOException e) {
-                LOG.error("Could no create or re-use web cache", e);
-                throw new RuntimeException(e);
-            }
-            cache = new Cache(cacheDir, cacheSize);
+            cache = generateCache(null);
         }
         try {
             cache.initialize();
@@ -257,6 +250,21 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
                 throw new RuntimeException(factoryException);
             }
         }
+    }
+
+    private static Cache generateCache(String suffix) {
+        int cacheSize = CACHE_IN_MB * BYTES_IN_KILOBYTE * KILOBYTES_IN_MEGABYTE; // 100 MiB
+        final File cacheDir;
+        try {
+            // let's try using the same cache each time
+            // not sure how corruptible/non-curruptable the cache is
+            // namespace cache when testing on circle ci
+            cacheDir = Files.createDirectories(Paths.get(DOCKSTORE_WEB_CACHE + (suffix == null ? "" : "/" + suffix))).toFile();
+        } catch (IOException e) {
+            LOG.error("Could no create or re-use web cache", e);
+            throw new RuntimeException(e);
+        }
+        return new Cache(cacheDir, cacheSize);
     }
 
     private static void configureMapper(ObjectMapper objectMapper) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -194,7 +194,7 @@ public abstract class AbstractImageRegistry {
             List<Tag> toolTags = getTags(tool);
             final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory
                 .createSourceCodeRepo(tool.getGitUrl(), client, bitbucketToken == null ? null : bitbucketToken.getContent(),
-                    gitlabToken == null ? null : gitlabToken.getContent(), githubToken == null ? null : githubToken.getContent());
+                    gitlabToken == null ? null : gitlabToken.getContent(), githubToken);
             updateTags(toolTags, tool, sourceCodeRepo, tagDAO, fileDAO, toolDAO, fileFormatDAO, eventDAO, user);
         }
 
@@ -241,7 +241,7 @@ public abstract class AbstractImageRegistry {
             List<Tag> toolTags = getTags(tool);
             final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory
                 .createSourceCodeRepo(tool.getGitUrl(), client, bitbucketToken == null ? null : bitbucketToken.getContent(),
-                    gitlabToken == null ? null : gitlabToken.getContent(), githubToken.getContent());
+                    gitlabToken == null ? null : gitlabToken.getContent(), githubToken);
             updateTags(toolTags, tool, sourceCodeRepo, tagDAO, fileDAO, toolDAO, fileFormatDAO, eventDAO, user);
         }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -102,14 +102,20 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     private static final Logger LOG = LoggerFactory.getLogger(GitHubSourceCodeRepo.class);
     private final GitHub github;
 
-    public GitHubSourceCodeRepo(String gitUsername, String githubTokenContent) {
+    /**
+     *
+     * @param githubTokenUsername the username for githubTokenContent
+     * @param gitUsername deprecate this, this is more accurately, the github organization for a specific repository when this class was used for one repo at a time, weird
+     * @param githubTokenContent authorization token
+     */
+    public GitHubSourceCodeRepo(@Deprecated String gitUsername, String githubTokenContent, String githubTokenUsername) {
         this.gitUsername = gitUsername;
         // this code is duplicate from DockstoreWebserviceApplication, except this is a lot faster for unknown reasons ...
         OkHttpClient.Builder builder = new OkHttpClient().newBuilder();
-        builder.eventListener(new CacheHitListener(GitHubSourceCodeRepo.class.getSimpleName(), gitUsername));
+        builder.eventListener(new CacheHitListener(GitHubSourceCodeRepo.class.getSimpleName(), githubTokenUsername));
         if (System.getenv("CIRCLE_SHA1") != null) {
             // namespace cache by user when testing
-            builder.cache(DockstoreWebserviceApplication.getCache(gitUsername));
+            builder.cache(DockstoreWebserviceApplication.getCache(githubTokenUsername));
         } else {
             // use general cache
             builder.cache(DockstoreWebserviceApplication.getCache(null));
@@ -119,7 +125,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
         HttpConnector okHttp3Connector = new ImpatientHttpConnector(obsoleteUrlFactory::open);
         try {
-            this.github = new GitHubBuilder().withOAuthToken(githubTokenContent, gitUsername).withRateLimitHandler(new WaitReporter(gitUsername))
+            this.github = new GitHubBuilder().withOAuthToken(githubTokenContent, githubTokenUsername).withRateLimitHandler(new WaitReporter(githubTokenUsername))
                     .withAbuseLimitHandler(AbuseLimitHandler.WAIT).withConnector(okHttp3Connector).build();
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -105,9 +105,14 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     public GitHubSourceCodeRepo(String gitUsername, String githubTokenContent) {
         this.gitUsername = gitUsername;
         // this code is duplicate from DockstoreWebserviceApplication, except this is a lot faster for unknown reasons ...
-        OkHttpClient.Builder builder = new OkHttpClient().newBuilder().cache(DockstoreWebserviceApplication.getCache());
+        OkHttpClient.Builder builder = new OkHttpClient().newBuilder();
+        builder.eventListener(new CacheHitListener(GitHubSourceCodeRepo.class.getSimpleName(), gitUsername));
         if (System.getenv("CIRCLE_SHA1") != null) {
-            builder.eventListener(new CacheHitListener(GitHubSourceCodeRepo.class.getSimpleName(), gitUsername));
+            // namespace cache by user when testing
+            builder.cache(DockstoreWebserviceApplication.getCache(gitUsername));
+        } else {
+            // use general cache
+            builder.cache(DockstoreWebserviceApplication.getCache(null));
         }
         OkHttpClient build = builder.build();
         ObsoleteUrlFactory obsoleteUrlFactory = new ObsoleteUrlFactory(build);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
@@ -44,13 +44,13 @@ public final class SourceCodeRepoFactory {
 
     public static SourceCodeRepoInterface createGitHubAppRepo(String token) {
         // The gitUsername doesn't seem to matter
-        return new GitHubSourceCodeRepo("dockstore", token);
+        return new GitHubSourceCodeRepo("dockstore", token, "JWT");
     }
 
     public static SourceCodeRepoInterface createSourceCodeRepo(Token token) {
         SourceCodeRepoInterface repo;
         if (Objects.equals(token.getTokenSource(), TokenType.GITHUB_COM)) {
-            repo = new GitHubSourceCodeRepo(token.getUsername(), token.getContent());
+            repo = new GitHubSourceCodeRepo(token.getUsername(), token.getContent(), token.getUsername());
         } else if (Objects.equals(token.getTokenSource(), TokenType.BITBUCKET_ORG)) {
             repo = new BitBucketSourceCodeRepo(token.getUsername(), token.getContent());
         } else if (Objects.equals(token.getTokenSource(), TokenType.GITLAB_COM)) {
@@ -65,7 +65,7 @@ public final class SourceCodeRepoFactory {
     }
 
     public static SourceCodeRepoInterface createSourceCodeRepo(String gitUrl, HttpClient client, String bitbucketTokenContent,
-            String gitlabTokenContent, String githubTokenContent) {
+            String gitlabTokenContent, Token githubToken) {
 
         Map<String, String> repoUrlMap = parseGitUrl(gitUrl);
 
@@ -78,7 +78,7 @@ public final class SourceCodeRepoFactory {
 
         SourceCodeRepoInterface repo;
         if (SourceControl.GITHUB.toString().equals(source)) {
-            repo = new GitHubSourceCodeRepo(gitUsername, githubTokenContent);
+            repo = new GitHubSourceCodeRepo(gitUsername, githubToken.getContent(), githubToken.getUsername());
         } else if (SourceControl.BITBUCKET.toString().equals(source)) {
             if (bitbucketTokenContent != null) {
                 repo = new BitBucketSourceCodeRepo(gitUsername, bitbucketTokenContent);
@@ -106,11 +106,11 @@ public final class SourceCodeRepoFactory {
      * @param gitUrl    Git URL to identify which SourceCodeRepo to return
      * @param bitbucketTokenContent The user's Bitbucket token if it exists, null otherwise
      * @param gitlabTokenContent    The user's GitLab token if it exists, null otherwise
-     * @param githubTokenContent    The user's GitHub token if it exists, null otherwise
+     * @param githubToken    The user's GitHub token if it exists, null otherwise
      * @return  a SourceCode repo if a token exists, null otherwise
      */
     public static SourceCodeRepoInterface createSourceCodeRepo(String gitUrl, String bitbucketTokenContent,
-            String gitlabTokenContent, String githubTokenContent) {
+            String gitlabTokenContent, Token githubToken) {
         Map<String, String> repoUrlMap = parseGitUrl(gitUrl);
         if (repoUrlMap == null) {
             return null;
@@ -118,7 +118,7 @@ public final class SourceCodeRepoFactory {
         String source = repoUrlMap.get("Source");
         String gitUsername = repoUrlMap.get("Username");
         if (SourceControl.GITHUB.toString().equals(source)) {
-            return githubTokenContent != null ? new GitHubSourceCodeRepo(gitUsername, githubTokenContent) : null;
+            return githubToken != null ? new GitHubSourceCodeRepo(gitUsername, githubToken.getContent(), githubToken.getUsername()) : null;
         } else if (SourceControl.BITBUCKET.toString().equals(source)) {
             return bitbucketTokenContent != null ? new BitBucketSourceCodeRepo(gitUsername, bitbucketTokenContent) : null;
         } else if (SourceControl.GITLAB.toString().equals(source)) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -68,6 +68,7 @@ import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 public abstract class SourceCodeRepoInterface {
     public static final Logger LOG = LoggerFactory.getLogger(SourceCodeRepoInterface.class);
     public static final int BYTES_IN_KB = 1024;
+    @Deprecated
     String gitUsername;
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -134,11 +134,11 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         List<Token> tokens = getAndRefreshTokens(user, tokenDAO, client, bitbucketClientID, bitbucketClientSecret);
 
         final String bitbucketTokenContent = getToken(tokens, TokenType.BITBUCKET_ORG);
-        final String gitHubTokenContent = getToken(tokens, TokenType.GITHUB_COM);
+        Token gitHubToken = Token.extractToken(tokens, TokenType.GITHUB_COM);
         final String gitlabTokenContent = getToken(tokens, TokenType.GITLAB_COM);
 
         final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory
-            .createSourceCodeRepo(gitUrl, client, bitbucketTokenContent, gitlabTokenContent, gitHubTokenContent);
+            .createSourceCodeRepo(gitUrl, client, bitbucketTokenContent, gitlabTokenContent, gitHubToken);
         if (sourceCodeRepo == null) {
             throw new CustomWebApplicationException("Git tokens invalid, please re-link your git accounts.", HttpStatus.SC_BAD_REQUEST);
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -270,7 +270,7 @@ public class DockerRepoResource
 
         final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory
             .createSourceCodeRepo(tool.getGitUrl(), client, bitbucketToken == null ? null : bitbucketToken.getContent(),
-                gitlabToken == null ? null : gitlabToken.getContent(), githubToken == null ? null : githubToken.getContent());
+                gitlabToken == null ? null : gitlabToken.getContent(), githubToken);
 
         // Get all registries
         ImageRegistryFactory factory = new ImageRegistryFactory(quayToken);
@@ -589,7 +589,7 @@ public class DockerRepoResource
         Token bitbucketToken = Token.extractToken(tokens, TokenType.BITBUCKET_ORG);
         final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory
                 .createSourceCodeRepo(tool.getGitUrl(), bitbucketToken == null ? null : bitbucketToken.getContent(),
-                        gitlabToken == null ? null : gitlabToken.getContent(), githubToken == null ? null : githubToken.getContent());
+                        gitlabToken == null ? null : gitlabToken.getContent(), githubToken);
         if (sourceCodeRepo != null) {
             sourceCodeRepo.checkSourceCodeValidity();
             String gitRepositoryFromGitUrl = AbstractImageRegistry.getGitRepositoryFromGitUrl(tool.getGitUrl());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -358,7 +358,7 @@ public class MetadataResource {
     @ApiResponse(description = "Cache performance information", content = @Content(mediaType = "application/json"))
     @ApiOperation(value = "Get measures of cache performance.", notes = "NO authentication", response = Map.class)
     public Map<String, String> getCachePerformance() {
-        Cache cache = DockstoreWebserviceApplication.getCache();
+        Cache cache = DockstoreWebserviceApplication.getCache(null);
         Map<String, String> results = new HashMap<>();
         results.put("requestCount", String.valueOf(cache.requestCount()));
         results.put("networkCount", String.valueOf(cache.networkCount()));


### PR DESCRIPTION
Found out from https://github.com/square/okhttp/issues/6214 that the okhttp cache seems to just use the URL as a cache key rather all the vary headers as we would have expected. 

In other words, since we have two test users. If we always have tests that go through tests for user A then tests for user B targeted at one repo, the second set of tests will always miss and evict the cache left over from A. Then a new cache is saved based on B which never works for A

As a solution, got side-tracked by application interceptors (https://square.github.io/okhttp/interceptors/). That would work for the suggestion to add a superfluous query parameter. Otherwise, a superior choice would be to add a fragment as suggested https://square.github.io/okhttp/interceptors/ but non-logging interceptors seem broken in the kohsuke library (might be implied by https://github.com/hub4j/github-api/issues/151)

So adding the ability to rotate caches by github user on CI (but got sidetracked by a very misleading variable name).

Followup issues:
* do we need a segmented cache in production too? But this approach breaks the LRU nature of the cache
* alternatively why can't we use interceptors properly in kohsuke to have a properly unified multi-user cache?

------------------

A sense of where we currently are with cache misses (which use rate limit)
set 1 is where we started, set 2 is after setting licenses on a bunch of our testing repos, set 6 should be with the new segmented cache

```
$ cat set1/* | grep "api.github" | wc -l
2249
$ cat set2/* | grep "api.github" | wc -l
2089
$ cat set6/* | grep "api.github" | wc -l
457
```