### PR TITLE
Remove warnings

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CloudInstanceResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CloudInstanceResource.java
@@ -46,7 +46,6 @@ public class CloudInstanceResource implements AuthenticatedResourceInterface {
     @GET
     @Timed
     @UnitOfWork(readOnly = true)
-    @Path("/")
     @Operation(operationId = "getCloudInstances", summary = "Get all known public cloud instances")
     @ApiResponse(responseCode = HttpStatus.SC_OK
             + "", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = CloudInstance.class))))
@@ -71,7 +70,6 @@ public class CloudInstanceResource implements AuthenticatedResourceInterface {
     @POST
     @Timed
     @UnitOfWork
-    @Path("/")
     @RolesAllowed({ "admin" })
     @Operation(operationId = "postCloudInstance", summary = "Add a new public cloud instance, admin only", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @Consumes(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Simple fix for the 

```
WARN  [2021-03-16 19:25:21,776] org.glassfish.jersey.internal.Errors: The following warnings have been detected: WARNING: The (sub)resource method postCloudInstance in io.dockstore.webservice.resources.CloudInstanceResource contains empty path annotation.
WARNING: The (sub)resource method getCloudInstances in io.dockstore.webservice.resources.CloudInstanceResource contains empty path annotation.
```

Strange that it's a warning, it's merely redundent to explicity specify "/" as path