### PR TITLE
Feature/seab 2622/cromwell test failures

### DIFF
--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -43,23 +43,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>io.dockstore</groupId>
-            <artifactId>dockstore-client</artifactId>
-            <version>${dockstore-client.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.dockstore</groupId>
-                    <artifactId>dockstore-common</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.dockstore</groupId>
-                    <artifactId>swagger-java-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.dockstore</groupId>
-                    <artifactId>openapi-java-client</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-client</artifactId>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.google.common.collect.Lists;
+import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.Registry;
@@ -189,7 +190,7 @@ public class CRUDClientIT extends BaseIT {
 
         // Publish tool
         ContainersApi containersApi = new ContainersApi(getWebClient(ADMIN_USERNAME, testingPostgres));
-        PublishRequest pub = SwaggerUtility.createPublishRequest(true);
+        PublishRequest pub = CommonTestUtilities.createPublishRequest(true);
         containersApi.publish(dockstoreTool.getId(), pub);
 
         // files should be visible afterwards
@@ -299,7 +300,7 @@ public class CRUDClientIT extends BaseIT {
         assertTrue(thrownException);
 
         // Publish workflow
-        PublishRequest pub = SwaggerUtility.createPublishRequest(true);
+        PublishRequest pub = CommonTestUtilities.createPublishRequest(true);
         workflowsApi.publish(dockstoreWorkflow.getId(), pub);
 
         // files should be visible afterwards

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
@@ -89,8 +89,8 @@ public class CheckerWorkflowIT extends BaseIT {
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
         ContainersApi containersApi = new ContainersApi(webClient);
 
-        final PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
-        final PublishRequest unpublishRequest = SwaggerUtility.createPublishRequest(false);
+        final PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
+        final PublishRequest unpublishRequest = CommonTestUtilities.createPublishRequest(false);
 
         // Manually register a tool
         DockstoreTool newTool = new DockstoreTool();
@@ -296,8 +296,8 @@ public class CheckerWorkflowIT extends BaseIT {
         final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
 
-        final PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
-        final PublishRequest unpublishRequest = SwaggerUtility.createPublishRequest(false);
+        final PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
+        final PublishRequest unpublishRequest = CommonTestUtilities.createPublishRequest(false);
 
         // Manually register a workflow
         Workflow githubWorkflow = workflowApi
@@ -389,8 +389,8 @@ public class CheckerWorkflowIT extends BaseIT {
         final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
 
-        final PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
-        final PublishRequest unpublishRequest = SwaggerUtility.createPublishRequest(false);
+        final PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
+        final PublishRequest unpublishRequest = CommonTestUtilities.createPublishRequest(false);
 
         // Manually register a workflow
         Workflow githubWorkflow = workflowApi

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ClientRegressionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ClientRegressionIT.java
@@ -86,7 +86,6 @@ public class ClientRegressionIT extends BaseIT {
     @Override
     public void resetDBBetweenTests() throws Exception {
         CommonTestUtilities.cleanStatePrivate1(SUPPORT);
-        Client.DEBUG.set(false);
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
@@ -17,34 +17,19 @@
 package io.dockstore.client.cli;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.io.Files;
-import com.google.gson.Gson;
-import io.dockstore.client.cli.nested.AbstractEntryClient;
-import io.dockstore.client.cli.nested.LanguageClientFactory;
-import io.dockstore.client.cli.nested.LanguageClientInterface;
-import io.dockstore.client.cli.nested.ToolClient;
-import io.dockstore.common.ConfidentialTest;
-import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.LanguageHandlerHelper;
-import io.dockstore.common.WDLFileProvisioning;
 import io.dockstore.common.WdlBridge;
 import io.dropwizard.testing.ResourceHelpers;
-import io.swagger.client.ApiException;
-import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
-import org.junit.experimental.categories.Category;
 import wdl.draft3.parser.WdlParser;
 
 /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
@@ -76,73 +76,6 @@ public class CromwellIT {
     }
 
     @Test
-    public void runWDLWorkflow() throws IOException, ApiException {
-        Client client = new Client();
-        client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
-        AbstractEntryClient main = new ToolClient(client, false);
-        LanguageClientInterface wdlClient = LanguageClientFactory.createLanguageCLient(main, DescriptorLanguage.WDL)
-            .orElseThrow(RuntimeException::new);
-        File workflowFile = new File(ResourceHelpers.resourceFilePath("wdl.wdl"));
-        File parameterFile = new File(ResourceHelpers.resourceFilePath("wdl.json"));
-        // run a workflow
-        final long run = wdlClient.launch(workflowFile.getAbsolutePath(), true, null, parameterFile.getAbsolutePath(), null, null);
-        Assert.assertEquals(0, run);
-    }
-
-    @Test
-    public void failRunWDLWorkflow() throws IOException, ApiException {
-        exit.expectSystemExitWithStatus(3);
-        Client client = new Client();
-        client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
-        AbstractEntryClient main = new ToolClient(client, false);
-        LanguageClientInterface wdlClient = LanguageClientFactory.createLanguageCLient(main, DescriptorLanguage.WDL)
-            .orElseThrow(RuntimeException::new);
-        File workflowFile = new File(ResourceHelpers.resourceFilePath("wdl.wdl"));
-        File parameterFile = new File(ResourceHelpers.resourceFilePath("wdl_wrong.json"));
-        // run a workflow
-        final long run = wdlClient.launch(workflowFile.getAbsolutePath(), true, null, parameterFile.getAbsolutePath(), null, null);
-        Assert.assertTrue(run != 0);
-    }
-
-    @Test
-    @Category(ConfidentialTest.class)
-    public void fileProvisioning() throws IOException, ApiException {
-        Client client = new Client();
-        client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
-        AbstractEntryClient main = new ToolClient(client, false);
-        LanguageClientInterface wdlClient = LanguageClientFactory.createLanguageCLient(main, DescriptorLanguage.WDL)
-            .orElseThrow(RuntimeException::new);
-        File workflowFile = new File(ResourceHelpers.resourceFilePath("wdlfileprov.wdl"));
-        File parameterFile = new File(ResourceHelpers.resourceFilePath("wdlfileprov.json"));
-        WdlBridge wdlBridge = new WdlBridge();
-        Map<String, String> wdlInputs = null;
-        try {
-            wdlInputs = wdlBridge.getInputFiles(workflowFile.getAbsolutePath(), "/wdlfileprov.wdl");
-        } catch (WdlParser.SyntaxError ex) {
-            Assert.fail("Should not have any issue parsing file");
-        }
-
-        WDLFileProvisioning wdlFileProvisioning = new WDLFileProvisioning(ResourceHelpers.resourceFilePath("config_file.txt"));
-        Gson gson = new Gson();
-        String jsonString;
-
-        final File tempDir = Files.createTempDir();
-
-        jsonString = FileUtils.readFileToString(parameterFile, StandardCharsets.UTF_8);
-        Map<String, Object> inputJson = gson.fromJson(jsonString, HashMap.class);
-
-        Map<String, Object> fileMap = wdlFileProvisioning.pullFiles(inputJson, wdlInputs);
-
-        String newJsonPath = wdlFileProvisioning.createUpdatedInputsJson(inputJson, fileMap);
-        // run a workflow
-        final long run = wdlClient.launch(workflowFile.getAbsolutePath(), true, null, newJsonPath, tempDir.getAbsolutePath(), null);
-        Assert.assertEquals(0, run);
-        // let's check that provisioning out occured
-        final Collection<File> files = FileUtils.listFiles(tempDir, null, true);
-        Assert.assertEquals(2, files.size());
-    }
-
-    @Test
     public void testWDLResolver() {
         // If resolver works, this should throw no errors
         File sourceFile = new File(ResourceHelpers.resourceFilePath("wdl-sanger-workflow.wdl"));
@@ -165,22 +98,6 @@ public class CromwellIT {
         }
     }
 
-    /**
-     * This tests compatibility with Cromwell 30.2 by running a workflow (https://github.com/dockstore/dockstore/issues/1211)
-     */
-    @Test
-    public void testRunWorkflow() throws IOException, ApiException {
-        Client client = new Client();
-        client.setConfigFile(ResourceHelpers.resourceFilePath("config"));
-        AbstractEntryClient main = new ToolClient(client, false);
-        LanguageClientInterface wdlClient = LanguageClientFactory.createLanguageCLient(main, DescriptorLanguage.WDL)
-            .orElseThrow(RuntimeException::new);
-        File workflowFile = new File(ResourceHelpers.resourceFilePath("hello_world.wdl"));
-        File parameterFile = new File(ResourceHelpers.resourceFilePath("hello_world.json"));
-        // run a workflow
-        final long run = wdlClient.launch(workflowFile.getAbsolutePath(), true, null, parameterFile.getAbsolutePath(), null, null);
-        Assert.assertEquals(0, run);
-    }
 
     /**
      * This tests compatibility with Cromwell 30.2 by converting to JSON (https://github.com/dockstore/dockstore/issues/1211)

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EventResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EventResourceIT.java
@@ -96,7 +96,7 @@ public class EventResourceIT extends BaseIT {
 
         // Publish
         if (toPublish) {
-            tool = containersApi.publish(tool.getId(), SwaggerUtility.createPublishRequest(true));
+            tool = containersApi.publish(tool.getId(), CommonTestUtilities.createPublishRequest(true));
             assertTrue(tool.isIsPublished());
         }
         return tool;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSIT.java
@@ -119,7 +119,7 @@ public class ExtendedTRSIT extends BaseIT {
 
             // refresh and publish the workflow
             final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
-            workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+            workflowApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
         }
 
         // create verification data as the verifyingUser
@@ -207,7 +207,7 @@ public class ExtendedTRSIT extends BaseIT {
         registeredTool = toolApi.refresh(registeredTool.getId());
 
         // Make publish request (true)
-        final PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        final PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         toolApi.publish(registeredTool.getId(), publishRequest);
 
         // check on URLs for workflows via ga4gh calls

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -401,7 +401,7 @@ public class GeneralIT extends BaseIT {
         List<Tag> tags = tool.getWorkflowVersions();
         verifySourcefileChecksumsSaved(tags);
 
-        PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         toolApi.publish(tool.getId(), publishRequest);
         // Dockerfile
         List<FileWrapper> fileWrappers = ga4Ghv20Api.toolsIdVersionsVersionIdContainerfileGet("quay.io/dockstoretestuser2/quayandgithub/alternate", "master");
@@ -470,7 +470,7 @@ public class GeneralIT extends BaseIT {
         }
 
         // verified platforms can be viewed by others once published
-        PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         workflowApi.publish(workflow.getId(), publishRequest);
         versionsVerified = user1EntriesApi.getVerifiedPlatforms(workflow.getId());
         Assert.assertEquals(1, versionsVerified.size());
@@ -544,7 +544,7 @@ public class GeneralIT extends BaseIT {
         }
 
         // file types can be viewed by others once published
-        PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         workflowApi.publish(workflow.getId(), publishRequest);
         fileTypes = user1entriesApi.getVersionsFileTypes(workflow.getId(), workflowVersion.getId());
         assertEquals(2, fileTypes.size());
@@ -1061,7 +1061,7 @@ public class GeneralIT extends BaseIT {
         Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openAPIClient);
         DockstoreTool tool = toolApi.getContainerByToolPath("quay.io/dockstoretestuser2/quayandgithub", null);
         tool = toolApi.refresh(tool.getId());
-        PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         toolApi.publish(tool.getId(), publishRequest);
         Tool ga4ghatool = ga4Ghv20Api.toolsIdGet("quay.io/dockstoretestuser2/quayandgithub");
 
@@ -1471,7 +1471,7 @@ public class GeneralIT extends BaseIT {
         }
 
         // Publish tool
-        PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         containersApi.publish(refresh.getId(), publishRequest);
 
         // Get published tool by alias as owner
@@ -1549,7 +1549,7 @@ public class GeneralIT extends BaseIT {
         }
 
         // Publish
-        PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         ownerContainersApi.publish(toolId, publishRequest);
 
         // Try downloading published

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -126,7 +126,7 @@ public class GeneralWorkflowIT extends BaseIT {
 
         // Publish
         if (toPublish) {
-            workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+            workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
             assertTrue(workflow.isIsPublished());
         }
         return workflow;
@@ -248,13 +248,13 @@ public class GeneralWorkflowIT extends BaseIT {
         assertTrue("there should be at least 4 versions, there are " + count4, 4 <= count4);
 
         // attempt to publish it
-        workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
 
         final long count5 = testingPostgres.runSelectStatement("select count(*) from workflow where ispublished='t'", long.class);
         assertEquals("there should be 1 published entry, there are " + count5, 1, count5);
 
         // unpublish
-        workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(false));
+        workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(false));
 
         final long count6 = testingPostgres.runSelectStatement("select count(*) from workflow where ispublished='t'", long.class);
         assertEquals("there should be 0 published entries, there are " + count6, 0, count6);
@@ -421,7 +421,7 @@ public class GeneralWorkflowIT extends BaseIT {
             SourceControl.GITHUB, "/Dockstore.cwl", false);
 
         // Publish workflow
-        workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+        workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
 
         // Restub
         try {
@@ -532,10 +532,10 @@ public class GeneralWorkflowIT extends BaseIT {
         workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // Publish workflow
-        workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+        workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
 
         // Unpublish workflow
-        workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(false));
+        workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(false));
 
         // Restub
         workflow = workflowsApi.restub(workflow.getId());
@@ -808,14 +808,14 @@ public class GeneralWorkflowIT extends BaseIT {
         assertEquals("testAuthor", workflow.getAuthor());
         assertEquals("testEmail", workflow.getEmail());
         // Unpublish
-        workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(false));
+        workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(false));
 
         // Alter workflow so that it has no valid tags
         testingPostgres.runUpdateStatement("UPDATE workflowversion SET valid='f'");
 
         // Now you shouldn't be able to publish the workflow
         try {
-            workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+            workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
         } catch (ApiException e) {
             assertTrue(e.getMessage().contains("Repository does not meet requirements to publish"));
         }
@@ -860,10 +860,10 @@ public class GeneralWorkflowIT extends BaseIT {
         workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // Can now publish workflow
-        workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+        workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
 
         // unpublish
-        workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(false));
+        workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(false));
 
         // Set paths to invalid
         workflow.setWorkflowPath("thisisnotarealpath.wdl");
@@ -876,7 +876,7 @@ public class GeneralWorkflowIT extends BaseIT {
 
         // should now not be able to publish
         try {
-            workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+            workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
         } catch (ApiException e) {
             assertTrue(e.getMessage().contains("Repository does not meet requirements to publish"));
         }
@@ -1014,7 +1014,7 @@ public class GeneralWorkflowIT extends BaseIT {
         });
 
         // publish
-        workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+        workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
         final long count4 = testingPostgres.runSelectStatement(
             "select count(*) from workflow where mode='FULL' and sourcecontrol = '" + SourceControl.GITLAB.toString()
                 + "' and organization = 'dockstore.test.user2' and repository = 'dockstore-workflow-example' and ispublished='t'",
@@ -1022,7 +1022,7 @@ public class GeneralWorkflowIT extends BaseIT {
         assertEquals("there should be 1 published workflow, there are " + count4, 1, count4);
 
         // unpublish
-        workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(false));
+        workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(false));
         final long count5 = testingPostgres.runSelectStatement(
             "select count(*) from workflow where mode='FULL' and sourcecontrol = '" + SourceControl.GITLAB.toString()
                 + "' and organization = 'dockstore.test.user2' and repository = 'dockstore-workflow-example' and ispublished='t'",

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -1353,7 +1353,7 @@ public class OrganizationIT extends BaseIT {
         // Publish a tool
         long entryId = 2;
         ContainersApi containersApi = new ContainersApi(webClientUser2);
-        PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         containersApi.publish(entryId, publishRequest);
 
         // Able to retrieve the collection and organization an entry is part of, even if there aren't any
@@ -1404,7 +1404,7 @@ public class OrganizationIT extends BaseIT {
         assertEquals("There should be 2 events of type ADD_TO_COLLECTION, there are " + count3, 2, count3);
 
         // Unpublish tool
-        PublishRequest unpublishRequest = SwaggerUtility.createPublishRequest(false);
+        PublishRequest unpublishRequest = CommonTestUtilities.createPublishRequest(false);
         containersApi.publish(entryId, unpublishRequest);
 
         // Collection should have one tool returned

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -175,7 +175,7 @@ public class SwaggerClientIT extends BaseIT {
 
         long containerId = container.getId();
 
-        PublishRequest pub = SwaggerUtility.createPublishRequest(true);
+        PublishRequest pub = CommonTestUtilities.createPublishRequest(true);
         thrown.expect(ApiException.class);
         containersApi.publish(containerId, pub);
     }
@@ -463,7 +463,7 @@ public class SwaggerClientIT extends BaseIT {
 
         long containerId = container.getId();
 
-        PublishRequest pub = SwaggerUtility.createPublishRequest(true);
+        PublishRequest pub = CommonTestUtilities.createPublishRequest(true);
 
         container = containersApi.publish(containerId, pub);
         assertTrue(container.isIsPublished());
@@ -471,7 +471,7 @@ public class SwaggerClientIT extends BaseIT {
         containers = containersApi.allPublishedContainers(null, null, null, null, null);
         assertEquals(2, containers.size());
 
-        pub = SwaggerUtility.createPublishRequest(false);
+        pub = CommonTestUtilities.createPublishRequest(false);
 
         container = containersApi.publish(containerId, pub);
         assertFalse(container.isIsPublished());
@@ -528,7 +528,7 @@ public class SwaggerClientIT extends BaseIT {
         long containerId = container.getId();
         assertEquals(1, containerId);
 
-        containersApi.publish(containerId, SwaggerUtility.createPublishRequest(false));
+        containersApi.publish(containerId, CommonTestUtilities.createPublishRequest(false));
         final ApiClient otherWebClient = getWebClient(GITHUB_ACCOUNT_USERNAME, testingPostgres);
         assertNotNull(new UsersApi(otherWebClient).getUser());
         boolean expectedFailure = false;
@@ -578,7 +578,7 @@ public class SwaggerClientIT extends BaseIT {
         WorkflowsApi workflowsApi = new WorkflowsApi(apiClient);
         ApiClient adminApiClient = getAdminWebClient();
         WorkflowsApi adminWorkflowsApi = new WorkflowsApi(adminApiClient);
-        PublishRequest publishRequest = SwaggerUtility.createPublishRequest(false);
+        PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(false);
         adminWorkflowsApi.publish(11L, publishRequest);
         try {
             workflowsApi.starEntry(11L, STAR_REQUEST);
@@ -874,7 +874,7 @@ public class SwaggerClientIT extends BaseIT {
         assertTrue(deleteVersionFromWorkflow1.getWorkflowVersions().size() == 0);
 
         // Publishing the workflow should fail
-        final PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        final PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         try {
             user2WorkflowsApi.publish(hostedWorkflow1.getId(), publishRequest);
             Assert.fail("User 2 can unexpectedly publish a read/write workflow");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -204,7 +204,7 @@ public class WorkflowIT extends BaseIT {
 
         // Publish
         if (toPublish) {
-            workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+            workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
         }
         assertEquals(workflow.isIsPublished(), toPublish);
         return workflow;
@@ -380,7 +380,7 @@ public class WorkflowIT extends BaseIT {
             .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, "testCWL");
         assertTrue("could not get content via optional auth", adminToolDescriptor != null && !adminToolDescriptor.getContent().isEmpty());
 
-        workflowApi.publish(refreshGithub.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowApi.publish(refreshGithub.getId(), CommonTestUtilities.createPublishRequest(true));
         // check on URLs for workflows via ga4gh calls
         FileWrapper toolDescriptor = adminGa4Ghv2Api
             .toolsIdVersionsVersionIdTypeDescriptorGet("CWL", "#workflow/" + DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW, "testCWL");
@@ -521,7 +521,7 @@ public class WorkflowIT extends BaseIT {
 
         // Download unpublished workflow version
         workflowApi.getWorkflowZip(workflowId, versionId);
-        byte[] arbitraryURL = SwaggerUtility.getArbitraryURL("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
+        byte[] arbitraryURL = CommonTestUtilities.getArbitraryURL("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
         }, webClient);
         File tempZip = File.createTempFile("temp", "zip");
         Path write = Files.write(tempZip.toPath(), arbitraryURL);
@@ -532,7 +532,7 @@ public class WorkflowIT extends BaseIT {
         // should not be able to get zip anonymously before publication
         boolean thrownException = false;
         try {
-            SwaggerUtility.getArbitraryURL("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
+            CommonTestUtilities.getArbitraryURL("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
             }, CommonTestUtilities.getWebClient(false, null, testingPostgres));
         } catch (Exception e) {
             thrownException = true;
@@ -541,8 +541,8 @@ public class WorkflowIT extends BaseIT {
         tempZip.deleteOnExit();
 
         // Download published workflow version
-        workflowApi.publish(workflowId, SwaggerUtility.createPublishRequest(true));
-        arbitraryURL = SwaggerUtility.getArbitraryURL("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
+        workflowApi.publish(workflowId, CommonTestUtilities.createPublishRequest(true));
+        arbitraryURL = CommonTestUtilities.getArbitraryURL("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
         }, CommonTestUtilities.getWebClient(false, null, testingPostgres));
         File tempZip2 = File.createTempFile("temp", "zip");
         write = Files.write(tempZip2.toPath(), arbitraryURL);
@@ -614,7 +614,7 @@ public class WorkflowIT extends BaseIT {
         }
 
         // Publish
-        PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         ownerWorkflowApi.publish(workflowId, publishRequest);
 
         // Try downloading published
@@ -679,7 +679,7 @@ public class WorkflowIT extends BaseIT {
         final ApiClient ownerWebClient = getWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi ownerWorkflowApi = new WorkflowsApi(ownerWebClient);
         Workflow refresh = registerGatkSvWorkflow(ownerWorkflowApi);
-        ownerWorkflowApi.publish(refresh.getId(), SwaggerUtility.createPublishRequest(true));
+        ownerWorkflowApi.publish(refresh.getId(), CommonTestUtilities.createPublishRequest(true));
         final List<io.dockstore.webservice.core.SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(refresh.getWorkflowVersions().stream()
                 .filter(workflowVersion -> GATK_SV_TAG.equals(workflowVersion.getName())).findFirst().get().getId());
         final Ga4GhApi ga4GhApi = new Ga4GhApi(ownerWebClient);
@@ -721,7 +721,7 @@ public class WorkflowIT extends BaseIT {
         workflowApi.getWorkflowZip(refresh.getId(), versionId);
 
         // Publish the workflow
-        workflowApi.publish(refresh.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowApi.publish(refresh.getId(), CommonTestUtilities.createPublishRequest(true));
 
         // Owner should still have access
         workflowApiNoAccess.getWorkflowZip(refresh.getId(), versionId);
@@ -730,7 +730,7 @@ public class WorkflowIT extends BaseIT {
         workflowApiNoAccess.getWorkflowZip(refresh.getId(), versionId);
 
         // Unpublish the workflow
-        workflowApi.publish(refresh.getId(), SwaggerUtility.createPublishRequest(false));
+        workflowApi.publish(refresh.getId(), CommonTestUtilities.createPublishRequest(false));
 
         // should not be able to download properly with incorrect credentials because the entry is not published
         try {
@@ -883,7 +883,7 @@ public class WorkflowIT extends BaseIT {
         workflowApi.updateWorkflow(mtaNf.getId(), mtaNf);
         workflowApi.refresh(mtaNf.getId(), false);
         // publish this way? (why is the auto-generated variable private?)
-        workflowApi.publish(mtaNf.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowApi.publish(mtaNf.getId(), CommonTestUtilities.createPublishRequest(true));
         mtaNf = workflowApi.getWorkflow(mtaNf.getId(), null);
         Assert.assertTrue("a workflow lacks a date", mtaNf.getLastModifiedDate() != null && mtaNf.getLastModified() != 0);
         assertNotNull("Nextflow workflow not found after update", mtaNf);
@@ -982,7 +982,7 @@ public class WorkflowIT extends BaseIT {
         workflowApi.refresh(workflowByPath.getId(), false);
 
         // publish one
-        final PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        final PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         workflowApi.publish(workflowByPath.getId(), publishRequest);
         assertEquals("should have one published, found  " + workflowApi.allPublishedWorkflows(null, null, null, null, null, false).size(),
             1, workflowApi.allPublishedWorkflows(null, null, null, null, null, false).size());
@@ -1030,7 +1030,7 @@ public class WorkflowIT extends BaseIT {
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
 
         // Make publish request (true)
-        final PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        final PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
 
         // Manually register workflow github
         Workflow githubWorkflow = workflowApi
@@ -1422,7 +1422,7 @@ public class WorkflowIT extends BaseIT {
 
         workflowApi.refresh(workflowByPathGithub.getId(), false);
         Assert.assertEquals("GNU General Public License v3.0", workflowByPathGithub.getLicenseInformation().getLicenseName());
-        workflowApi.publish(workflowByPathGithub.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowApi.publish(workflowByPathGithub.getId(), CommonTestUtilities.createPublishRequest(true));
 
         // check on URLs for workflows via ga4gh calls
         Ga4GhApi ga4Ghv2Api = new Ga4GhApi(webClient);
@@ -1450,7 +1450,7 @@ public class WorkflowIT extends BaseIT {
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath("github.com/dockstore-testing/viral-pipelines", null, false);
 
         workflowApi.refresh(workflowByPathGithub.getId(), false);
-        workflowApi.publish(workflowByPathGithub.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowApi.publish(workflowByPathGithub.getId(), CommonTestUtilities.createPublishRequest(true));
 
         // check on URLs for workflows via ga4gh calls
         Ga4GhApi ga4Ghv2Api = new Ga4GhApi(webClient);
@@ -1487,7 +1487,7 @@ public class WorkflowIT extends BaseIT {
         registeredTool = toolApi.refresh(registeredTool.getId());
 
         // Make publish request (true)
-        final PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        final PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         toolApi.publish(registeredTool.getId(), publishRequest);
 
         // look that branches and tags are typed correctly for tools
@@ -1663,7 +1663,7 @@ public class WorkflowIT extends BaseIT {
             .secondaryDescriptors(workflow.getId(), "rootTest", DescriptorLanguage.CWL.toString());
         assertEquals("should find 3 imports, found " + newRootImports.size(), 3, newRootImports.size());
 
-        workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
         // check on URLs for workflows via ga4gh calls
         Ga4GhApi ga4Ghv2Api = new Ga4GhApi(webClient);
         FileWrapper toolDescriptor = ga4Ghv2Api
@@ -1768,12 +1768,12 @@ public class WorkflowIT extends BaseIT {
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
         final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
-        workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
 
         Workflow md5workflow = workflowApi.manualRegister(SourceControl.GITHUB.getFriendlyName(), "DockstoreTestUser2/md5sum-checker",
             "/checker-workflow-wrapping-workflow.cwl", "test", "cwl", null);
         workflowApi.refresh(md5workflow.getId(), false);
-        workflowApi.publish(md5workflow.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowApi.publish(md5workflow.getId(), CommonTestUtilities.createPublishRequest(true));
 
         // give the workflow a few aliases
         EntriesApi genericApi = new EntriesApi(webClient);
@@ -1882,7 +1882,7 @@ public class WorkflowIT extends BaseIT {
         final Workflow workflow = userWorkflowsApi.refresh(workflowByPathGithub.getId(), true);
 
         // Publish workflow, which will also add a topic
-        userWorkflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+        userWorkflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
 
         // Should not be able to create a topic for the same workflow
         try {
@@ -1893,8 +1893,8 @@ public class WorkflowIT extends BaseIT {
         }
 
         // Unpublish and publish, should not throw error
-        Workflow unpublishedWf = userWorkflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(false));
-        Workflow publishedWf = userWorkflowsApi.publish(unpublishedWf.getId(), SwaggerUtility.createPublishRequest(true));
+        Workflow unpublishedWf = userWorkflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(false));
+        Workflow publishedWf = userWorkflowsApi.publish(unpublishedWf.getId(), CommonTestUtilities.createPublishRequest(true));
         assertEquals("Topic id should remain the same.", unpublishedWf.getTopicId(), publishedWf.getTopicId());
     }
 
@@ -1949,7 +1949,7 @@ public class WorkflowIT extends BaseIT {
         WorkflowVersion workflowVersion2 = optionalWorkflowVersion2.get();
         // Check validation works.  It should be valid
         Assert.assertTrue(workflowVersion2.isValid());
-        userWorkflowsApi.publish(workflowByPathGithub2.getId(), SwaggerUtility.createPublishRequest(true));
+        userWorkflowsApi.publish(workflowByPathGithub2.getId(), CommonTestUtilities.createPublishRequest(true));
     }
 
     private Workflow registerGatkSvWorkflow(WorkflowsApi ownerWorkflowApi) {
@@ -1968,7 +1968,7 @@ public class WorkflowIT extends BaseIT {
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
         final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
-        workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
 
         Assert.assertTrue(workflow.getWorkflowVersions().stream().anyMatch(versions -> "master".equals(versions.getName())));
         Optional<WorkflowVersion> optionalWorkflowVersion = workflow.getWorkflowVersions().stream()
@@ -2018,7 +2018,7 @@ public class WorkflowIT extends BaseIT {
         final Workflow workflowByPathGithub = workflowApi.getWorkflowByPath(DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, null, false);
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
         final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
-        workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
 
         Assert.assertTrue(workflow.getWorkflowVersions().stream().anyMatch(versions -> "master".equals(versions.getName())));
         Optional<WorkflowVersion> optionalWorkflowVersion = workflow.getWorkflowVersions().stream()
@@ -2167,7 +2167,7 @@ public class WorkflowIT extends BaseIT {
         }
 
         // sourcefiles can be viewed by others once published
-        workflow = workflowsApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+        workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
         sourceFiles = user1WorkflowsOpenApi.getWorkflowVersionsSourcefiles(workflow.getId(), workflowVersion.getId(), null);
         Assert.assertNotNull(sourceFiles);
         Assert.assertEquals(1, sourceFiles.size());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -20,9 +20,14 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import javax.ws.rs.core.GenericType;
+
+import com.google.gson.Gson;
 import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.messages.Container;
@@ -31,6 +36,7 @@ import io.dropwizard.Application;
 import io.dropwizard.testing.DropwizardTestSupport;
 import io.dropwizard.testing.ResourceHelpers;
 import io.swagger.client.ApiClient;
+import io.swagger.client.model.PublishRequest;
 import org.apache.commons.configuration2.INIConfiguration;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
@@ -364,5 +370,29 @@ public final class CommonTestUtilities {
                 System.err.println("Problems restarting Docker container");
             }
         }
+    }
+
+    // These two functions are duplicated from SwaggerUtility in dockstore-client to prevent importing dockstore-client
+    // This cannot be moved to dockstore-common because PublishRequest requires built dockstore-webservice
+
+    /**
+     * These serialization/deserialization hacks should not be necessary.
+     * Why does this version of codegen remove the setters?
+     * Probably because someone dun goof'd the restful implementation of publish
+     * @param bool
+     * @return
+     */
+    public static PublishRequest createPublishRequest(Boolean bool) {
+        Map<String, Object> publishRequest = new HashMap<>();
+        publishRequest.put("publish", bool);
+        Gson gson = new Gson();
+        String s = gson.toJson(publishRequest);
+        return gson.fromJson(s, PublishRequest.class);
+    }
+
+    public static <T> T getArbitraryURL(String url, GenericType<T> type, ApiClient client) {
+        return client
+                .invokeAPI(url, "GET", new ArrayList<>(), null, new HashMap<>(), new HashMap<>(), "application/zip", "application/zip",
+                        new String[] { "BEARER" }, type).getData();
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SearchResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SearchResourceIT.java
@@ -16,7 +16,6 @@
 package io.dockstore.webservice;
 
 import io.dockstore.client.cli.BaseIT;
-import io.dockstore.client.cli.SwaggerUtility;
 import io.dockstore.client.cli.WorkflowIT;
 import io.dockstore.common.CommonTestUtilities;
 import io.swagger.client.ApiClient;
@@ -110,8 +109,8 @@ public class SearchResourceIT extends BaseIT {
         // do targeted refresh, should promote workflow to fully-fleshed out workflow
         final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
         entriesApi.addAliases(workflow.getId(), "potatoAlias");
-        workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(false));
-        workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(false));
+        workflowApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
         waitForIndexRefresh(1, extendedGa4GhApi,  0);
         // after publication index should include workflow
         String s = extendedGa4GhApi.toolsIndexSearch(exampleESQuery);
@@ -155,7 +154,7 @@ public class SearchResourceIT extends BaseIT {
         // do targetted refresh, should promote workflow to fully-fleshed out workflow
         final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
 
-        workflowApi.publish(workflow.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
 
         waitForIndexRefresh(1, extendedGa4GhApi,  0);
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Objects;
 
 import io.dockstore.client.cli.BaseIT;
-import io.dockstore.client.cli.SwaggerUtility;
 import io.dockstore.client.cli.WorkflowIT;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
@@ -261,7 +260,7 @@ public class UserResourceIT extends BaseIT {
         adminWorkflowsApi.getWorkflowByPath(SourceControl.GITHUB + "/" + serviceRepo, null, true);
 
         // publish one
-        workflowsApi.publish(workflowByPath.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowsApi.publish(workflowByPath.getId(), CommonTestUtilities.createPublishRequest(true));
 
         assertFalse(userApi.getExtendedUserData().isCanChangeUsername());
 
@@ -273,7 +272,7 @@ public class UserResourceIT extends BaseIT {
         }
         assertTrue(expectedFailToDelete);
         // then unpublish them
-        workflowsApi.publish(workflowByPath.getId(), SwaggerUtility.createPublishRequest(false));
+        workflowsApi.publish(workflowByPath.getId(), CommonTestUtilities.createPublishRequest(false));
         assertTrue(userApi.getExtendedUserData().isCanChangeUsername());
         assertTrue(userApi.selfDestruct());
         //TODO need to test that profiles are cascaded to and cleared

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import com.google.common.collect.Lists;
 import io.dockstore.client.cli.BaseIT;
 import io.dockstore.client.cli.BasicIT;
-import io.dockstore.client.cli.SwaggerUtility;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.DescriptorLanguage;
@@ -480,7 +479,7 @@ public class WebhookIT extends BaseIT {
         } catch (io.dockstore.openapi.client.ApiException e) {
             assertEquals("Cannot change descriptor type of a valid workflow", e.getMessage());
         }
-        PublishRequest publishRequest = SwaggerUtility.createPublishRequest(true);
+        PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         client.publish(workflow.getId(), publishRequest);
         try {
             workflowsApi.updateDescriptorType(workflow.getId(), DescriptorLanguage.WDL.toString());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/languages/GalaxyPluginIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/languages/GalaxyPluginIT.java
@@ -24,7 +24,6 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import io.dockstore.client.cli.BaseIT;
-import io.dockstore.client.cli.SwaggerUtility;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.Constants;
@@ -182,8 +181,8 @@ public class GalaxyPluginIT {
                         "", DescriptorLanguage.GXFORMAT2.getShortName(), "");
         workflowApi.refresh(wdlWorkflow.getId(), false);
         workflowApi.refresh(galaxyWorkflow.getId(), false);
-        workflowApi.publish(wdlWorkflow.getId(), SwaggerUtility.createPublishRequest(true));
-        workflowApi.publish(galaxyWorkflow.getId(), SwaggerUtility.createPublishRequest(true));
+        workflowApi.publish(wdlWorkflow.getId(), CommonTestUtilities.createPublishRequest(true));
+        workflowApi.publish(galaxyWorkflow.getId(), CommonTestUtilities.createPublishRequest(true));
 
         io.dockstore.openapi.client.ApiClient newWebClient = new io.dockstore.openapi.client.ApiClient();
         File configFile = FileUtils.getFile("src", "test", "resources", "config");

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.url>scm:git:git@github.com:dockstore/dockstore.git</github.url>
 
-        <dockstore-client.version>1.10.0</dockstore-client.version>
         <!--
         The following properties are mostly used in the plugins section
         as the versions for the dependency section are provided


### PR DESCRIPTION
Part 2 of 2 for preliminary investigation to https://ucsc-cgl.atlassian.net/browse/SEAB-2622

Part 1: https://github.com/dockstore/dockstore-cli/pull/60

First step is to move client tests back to client. This allows for easier debugging (more info than "System Exit(3)")

Optionally removed dockstore-client dependency by duplicating 2 methods from SwaggerUtility.  I consider it the lesser evil (especially once we fix the PublishRequest constructor/setter)