### PR TITLE
Downgrade to AWS version

### DIFF
--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -48,7 +48,7 @@ POM as their parent.
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>2.0.20</dropwizard.version>
         <dropwizard-annotations.version>4.1.18</dropwizard-annotations.version>
-        <elasticsearch-version>7.10.0</elasticsearch-version>
+        <elasticsearch-version>7.9.0</elasticsearch-version>
         <swagger-annotations-version>1.6.2</swagger-annotations-version>
         <openapi-annotations-version>2.1.1</openapi-annotations-version>
         <assertj.version>3.14.0</assertj.version>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 version: '2.2'
 services:
   es01:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.0
     container_name: es01
     environment:
       - node.name=es01


### PR DESCRIPTION
ES text search on dev is currently broken. No idea if this is going to work. I think Charles is testing to confirm if this is the reason.