### PR TITLE
Upgrade packages in the docker build to check if quay vulns are fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM openjdk:11.0.9-jdk
 # Update the APT cache
 # prepare for Java download
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
     software-properties-common \
     telnet \


### PR DESCRIPTION
This fixes some vulnerabilities, but not the "high" one that quay marks (which is against glibc). It does however drop the total vulnerability count by 19.

https://quay.io/repository/dockstore/dockstore-webservice/manifest/sha256:bbbb0980fb01c1333ad7eb774538be300f3d9f2ece37d535473665b3b8fddeb6?tab=vulnerabilities

https://ucsc-cgl.atlassian.net/browse/SEAB-2741

Not clear to me what is the best way to test this as the image used in circle uses the same base image but not the modifications. Should the circle config be changed to use the docker image we build to run the webservice within?