### PR TITLE
Update postgres of plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,8 @@
         -->
         <swagger-annotations-version>1.6.0</swagger-annotations-version>
         <openapi-annotations-version>2.1.7</openapi-annotations-version>
-        <postgresql.version>42.2.5</postgresql.version>
+        <!-- Used for liquibase maven plugin. Somehow use version from bom-internal instead -->
+        <postgresql.version>42.2.19</postgresql.version>
         <swagger-ui.version>3.25.0</swagger-ui.version>
         <maven-surefire.version>2.21.0</maven-surefire.version>
         <maven-failsafe.version>2.21.0</maven-failsafe.version>


### PR DESCRIPTION
For https://ucsc-cgl.atlassian.net/browse/SEAB-2647 and https://ucsc-cgl.atlassian.net/browse/SEAB-2638

dockstore-cli was removed as a dependency in the dockstore/dockstore repo already. Postgres dep was also updated to the newer version in the bom-internal already. Only thing that remains is the dep in the plugin which I cannot seem to link to the one in bom-internal

dockstore-cli just needs to use the new bom-internal version (once it's released)
