### PR TITLE
Return 422 instead of 500 on nextflow parsing exception for nextflow config file

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -38,6 +38,7 @@ import groovyjarjarantlr.TokenStreamException;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.NextflowUtilities;
 import io.dockstore.common.VersionTypeValidation;
+import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.DescriptionSource;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Validation;
@@ -48,6 +49,7 @@ import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
 import org.codehaus.groovy.antlr.GroovySourceAST;
 import org.codehaus.groovy.antlr.parser.GroovyLexer;
 import org.codehaus.groovy.antlr.parser.GroovyRecognizer;
@@ -395,7 +397,13 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
 
         // nextflow uses the main script from the manifest as the main descriptor
         // add the Nextflow scripts
-        final Configuration configuration = NextflowUtilities.grabConfig(mainDescriptor);
+
+        Configuration configuration = null;
+        try {
+            configuration = NextflowUtilities.grabConfig(mainDescriptor);
+        } catch (NextflowUtilities.NextflowParsingException e) {
+            throw new CustomWebApplicationException(e.getMessage(), HttpStatus.SC_UNPROCESSABLE_ENTITY);
+        }
         String mainScriptPath = "main.nf";
         if (configuration.containsKey("manifest.mainScript")) {
             mainScriptPath = configuration.getString("manifest.mainScript");


### PR DESCRIPTION
When refeshing a Nextflow workflow with a malformed config file /{workflowId}/tools/{workflowVersionId} returns a 500. The new try catch block will return a 422 instead.
Addresses #3411 

To verify register a Nextflow workflow not using .dockstore.yml so there is a refresh button. Change the Nextflow config file in GitHub so it is malformed, open the browser inspector, and then click on the Refresh button in Dockstore. Verify that there are no 500 returns from the Dockstore API.