### PR TITLE
return 422 on Galaxy plugin call lint exception

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -78,7 +78,12 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
             String content = null;
             if (mainDescriptor.isPresent()) {
                 content = mainDescriptor.get().getContent();
+            } else {
+                Map<String, String> validationMessage = new HashMap<>();
+                validationMessage.put("Unknown", "Missing the primary descriptor.");
+                return new VersionTypeValidation(false, validationMessage);
             }
+
             try {
                 return ((RecommendedLanguageInterface)minimalLanguageInterface).
                         validateWorkflowSet(primaryDescriptorFilePath, content, sourcefilesToIndexedFiles(sourcefiles));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -32,6 +32,7 @@ import io.dockstore.common.VersionTypeValidation;
 import io.dockstore.language.CompleteLanguageInterface;
 import io.dockstore.language.MinimalLanguageInterface;
 import io.dockstore.language.RecommendedLanguageInterface;
+import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.DescriptionSource;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Version;
@@ -39,6 +40,7 @@ import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,7 +79,12 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
             if (mainDescriptor.isPresent()) {
                 content = mainDescriptor.get().getContent();
             }
-            return ((RecommendedLanguageInterface)minimalLanguageInterface).validateWorkflowSet(primaryDescriptorFilePath, content, sourcefilesToIndexedFiles(sourcefiles));
+            try {
+                return ((RecommendedLanguageInterface)minimalLanguageInterface).
+                        validateWorkflowSet(primaryDescriptorFilePath, content, sourcefilesToIndexedFiles(sourcefiles));
+            } catch (Exception e) {
+                throw new CustomWebApplicationException(e.getMessage(), HttpStatus.SC_UNPROCESSABLE_ENTITY);
+            }
         } else {
             return new VersionTypeValidation(true, Collections.emptyMap());
         }


### PR DESCRIPTION
If user has a Galaxy workflow registered and the .ga descriptor file is malformed, for example:
`
**goat** {
    "a_galaxy_workflow": "true",
    "annotation": "Proof of concept 2 workflow accepting a tabular file as a single input. ",
    ...

`
and the Dockstore 'Refresh' button is clicked, the Galaxy plugin function validateWorkflowSet will throw an exception and the Dockstore API will return a 422 with this new catch block instead of a 500.
Addresses #3411 
