### PR TITLE
search term length limit

### DIFF
--- a/dockstore-common/generated/src/main/resources/.flattened-pom.xml
+++ b/dockstore-common/generated/src/main/resources/.flattened-pom.xml
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>org.broadinstitute</groupId>
       <artifactId>wdl-draft3_2.12</artifactId>
-      <version>57</version>
+      <version>60</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>org.broadinstitute</groupId>
       <artifactId>wdl-draft2_2.12</artifactId>
-      <version>57</version>
+      <version>60</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -192,7 +192,7 @@
     <dependency>
       <groupId>org.broadinstitute</groupId>
       <artifactId>wdl-biscayne_2.12</artifactId>
-      <version>57</version>
+      <version>60</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -224,7 +224,7 @@
     <dependency>
       <groupId>org.broadinstitute</groupId>
       <artifactId>language-factory-core_2.12</artifactId>
-      <version>57</version>
+      <version>60</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -242,7 +242,7 @@
     <dependency>
       <groupId>org.broadinstitute</groupId>
       <artifactId>cromwell-core_2.12</artifactId>
-      <version>57</version>
+      <version>60</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -278,7 +278,7 @@
     <dependency>
       <groupId>org.broadinstitute</groupId>
       <artifactId>cromwell-wom_2.12</artifactId>
-      <version>57</version>
+      <version>60</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -290,7 +290,7 @@
     <dependency>
       <groupId>org.broadinstitute</groupId>
       <artifactId>cromwell-common_2.12</artifactId>
-      <version>57</version>
+      <version>60</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -302,25 +302,25 @@
     <dependency>
       <groupId>org.broadinstitute</groupId>
       <artifactId>cromwell-wdl-transforms-new-base_2.12</artifactId>
-      <version>57</version>
+      <version>60</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.broadinstitute</groupId>
       <artifactId>cromwell-wdl-transforms-draft3_2.12</artifactId>
-      <version>57</version>
+      <version>60</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.broadinstitute</groupId>
       <artifactId>cromwell-wdl-model-draft3_2.12</artifactId>
-      <version>57</version>
+      <version>60</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.broadinstitute</groupId>
       <artifactId>cromwell-wdl-model-draft2_2.12</artifactId>
-      <version>57</version>
+      <version>60</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/.flattened-pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/.flattened-pom.xml
@@ -698,7 +698,7 @@
     <dependency>
       <groupId>org.broadinstitute</groupId>
       <artifactId>cromwell-wdl-transforms-draft3_2.12</artifactId>
-      <version>57</version>
+      <version>60</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -215,18 +215,21 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
         if (!config.getEsConfiguration().getHostname().isEmpty()) {
             // Performing a search on the UI sends multiple POST requests. When the search term ("include" key in request payload) is large,
             // one of these POST requests will fail, but the others will continue to pass.
-            JSONObject json = new JSONObject(query);
-            try {
-                String include = json.getJSONObject("aggs").getJSONObject("autocomplete").getJSONObject("terms").getString("include");
-                if (include.length() > SEARCH_TERM_LIMIT) {
-                    include.isEmpty();
-                    throw new CustomWebApplicationException("Search request exceeds limit", HttpStatus.SC_REQUEST_TOO_LONG);
-                }
+            if (query != null) {
+                JSONObject json = new JSONObject(query);
+                try {
+                    String include = json.getJSONObject("aggs").getJSONObject("autocomplete").getJSONObject("terms").getString("include");
+                    if (include.length() > SEARCH_TERM_LIMIT) {
+                        include.isEmpty();
+                        throw new CustomWebApplicationException("Search request exceeds limit", HttpStatus.SC_REQUEST_TOO_LONG);
+                    }
 
-            } catch (JSONException ex) {
-                // The "include" key doesn't exist in a lot of the request bodies, so it's okay for the exception to get thrown.
-                LOG.debug("Couldn't parse search payload request.");
+                } catch (JSONException ex) {
+                    // The "include" key doesn't exist in a lot of the request bodies, so it's okay for the exception to get thrown.
+                    LOG.debug("Couldn't parse search payload request.");
+                }
             }
+
             try {
                 RestClient restClient = ElasticSearchHelper.restClient();
                 Map<String, String> parameters = new HashMap<>();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -60,6 +60,8 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,6 +79,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
     private static final String TOOLS_INDEX = ElasticListener.TOOLS_INDEX;
     private static final String WORKFLOWS_INDEX = ElasticListener.WORKFLOWS_INDEX;
     private static final String ALL_INDICES = ElasticListener.ALL_INDICES;
+    private static final int SEARCH_TERM_LIMIT = 500;
 
     private static ToolDAO toolDAO = null;
     private static WorkflowDAO workflowDAO = null;
@@ -210,6 +213,20 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
     @Override
     public Response toolsIndexSearch(String query, MultivaluedMap<String, String> queryParameters, SecurityContext securityContext) {
         if (!config.getEsConfiguration().getHostname().isEmpty()) {
+            // Performing a search on the UI sends multiple POST requests. When the search term ("include" key in request payload) is large,
+            // one of these POST requests will fail, but the others will continue to pass.
+            JSONObject json = new JSONObject(query);
+            try {
+                String include = json.getJSONObject("aggs").getJSONObject("autocomplete").getJSONObject("terms").getString("include");
+                if (include.length() > SEARCH_TERM_LIMIT) {
+                    include.isEmpty();
+                    throw new CustomWebApplicationException("Search request exceeds limit", HttpStatus.SC_REQUEST_TOO_LONG);
+                }
+
+            } catch (JSONException ex) {
+                // The "include" key doesn't exist in a lot of the request bodies, so it's okay for the exception to get thrown.
+                LOG.debug("Couldn't parse search payload request.");
+            }
             try {
                 RestClient restClient = ElasticSearchHelper.restClient();
                 Map<String, String> parameters = new HashMap<>();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -220,12 +220,11 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
                 try {
                     String include = json.getJSONObject("aggs").getJSONObject("autocomplete").getJSONObject("terms").getString("include");
                     if (include.length() > SEARCH_TERM_LIMIT) {
-                        include.isEmpty();
                         throw new CustomWebApplicationException("Search request exceeds limit", HttpStatus.SC_REQUEST_TOO_LONG);
                     }
 
                 } catch (JSONException ex) {
-                    // The "include" key doesn't exist in a lot of the request bodies, so it's okay for the exception to get thrown.
+                    // The request bodies all look pretty different, so it's okay for the exception to get thrown.
                     LOG.debug("Couldn't parse search payload request.");
                 }
             }


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-2515

The UI makes severals calls to this endpoint every time a search is done/page is loaded. Only one of those calls seems to "break" elastic search and it's when the search term is too long. This code looks for that specific call/payload in the series of requests and throws an exception, but ignores the rest of calls since those don't seem to cause errors.

There's a UI PR that's already been approved a while back that will show this error. Because the UI only handles one message at a time, it disappears after a few seconds.

Let me know if that's okay...if not I can put more effort into making the calls that are "okay" actually fail as well.