### PR TITLE
Add sonarcloud scanning to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ workflows:
     jobs:
       - build:
           <<: *common_filters
+          context: sonarcloud
       - unit_test:
           <<: *common_filters
           requires:
@@ -136,6 +137,9 @@ jobs:
           root: .
           paths:
             - .
+      - run:
+          name: SonarCloud scan
+          command: mvn verify sonar:sonar
   unit_test: # runs not using Workflows must have a `build` job as entry point
     docker: # run the steps with Docker
       - image: cimg/openjdk:11.0.9

--- a/pom.xml
+++ b/pom.xml
@@ -698,6 +698,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>3.8.0.2131</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <sonar.projectKey>dockstore_dockstore</sonar.projectKey>
         <sonar.organization>dockstore</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.moduleKey>${artifactId}</sonar.moduleKey>
         <!-- end sonarcloud properties -->
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
         <skipTests>false</skipTests>
         <skipITs>true</skipITs>
         <skipSignatureCheck>true</skipSignatureCheck>
+        <!-- for sonarcloud -->
+        <sonar.projectKey>dockstore_dockstore</sonar.projectKey>
+        <sonar.organization>dockstore</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <!-- end sonarcloud properties -->
     </properties>
 
     <organization>


### PR DESCRIPTION
* Adds sonarcloud scanning to CI
* Added a context in CircleCI for SONAR_KEY
* Uploads results to https://sonarcloud.io/dashboard?id=dockstore_dockstore

Hoping that after this merges we will get the entirety of the code scanned. The results currently there were uploaded manually from my machine and so we may have to do some reconfiguration if there's a collision or problem updating.