### PR TITLE
Feature/seab 2797/oom

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,28 @@ workflows:
       - build:
           <<: *common_filters
           context: sonarcloud
+      - unit_test:
+          <<: *common_filters
+          requires:
+            - build
+      - workflow-integration-tests:
+          <<: *common_filters
+          requires:
+            - build
+      - tool-integration-tests:
+          <<: *common_filters
+          requires:
+            - build
       - integration-tests:
           <<: *common_filters
+          requires:
+            - build
+      - regression-integration-tests:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release.*$/
           requires:
             - build
 jobs:
@@ -98,6 +118,8 @@ jobs:
   build:
     docker: # run the steps with Docker
       - image: cimg/openjdk:11.0.9
+        environment:
+          JAVA_TOOL_OPTIONS: -Xmx512m # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Nothing to do with surefire plugin, it has its own JVM. The two of these must add up to a bit less than 4GB.
     steps: # a collection of executable commands
       - checkout # check out source code to working directory
       - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,28 +44,8 @@ workflows:
       - build:
           <<: *common_filters
           context: sonarcloud
-      - unit_test:
-          <<: *common_filters
-          requires:
-            - build
-      - workflow-integration-tests:
-          <<: *common_filters
-          requires:
-            - build
-      - tool-integration-tests:
-          <<: *common_filters
-          requires:
-            - build
       - integration-tests:
           <<: *common_filters
-          requires:
-            - build
-      - regression-integration-tests:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release.*$/
           requires:
             - build
 jobs:
@@ -118,8 +98,6 @@ jobs:
   build:
     docker: # run the steps with Docker
       - image: cimg/openjdk:11.0.9
-        environment:
-          JAVA_TOOL_OPTIONS: -Xmx512m # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Nothing to do with surefire plugin, it has its own JVM. The two of these must add up to a bit less than 4GB.
     steps: # a collection of executable commands
       - checkout # check out source code to working directory
       - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,8 +118,6 @@ jobs:
   build:
     docker: # run the steps with Docker
       - image: cimg/openjdk:11.0.9
-        environment:
-          JAVA_TOOL_OPTIONS: -Xmx512m # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Nothing to do with surefire plugin, it has its own JVM. The two of these must add up to a bit less than 4GB.
     steps: # a collection of executable commands
       - checkout # check out source code to working directory
       - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
@@ -154,7 +152,6 @@ jobs:
     docker: # run the steps with Docker
       - image: cimg/openjdk:11.0.9
         environment:
-          JAVA_TOOL_OPTIONS: -Xmx512m # Java can read cgroup. Sadly the cgroup in CircleCI is wrong. Have to manually set. Nothing to do with surefire plugin, it has its own JVM. The two of these must add up to a bit less than 4GB.
           PGHOST: 127.0.0.1
       - image: circleci/postgres:11.8
         environment:


### PR DESCRIPTION
For https://ucsc-cgl.atlassian.net/browse/SEAB-2797

https://circleci.com/docs/2.0/java-oom/ mentions that as of June 3rd 2020, cgroup is no longer wrong. 

With the increase to medium+ executor and this, the end result is that java has more memory (1.25 GiB) than the previous 512 MB and the other services have more memory.

Ran 4 times successfully. Can't be certain that this works. Will see later.

PS: I'm continuously re-running the integration-tests until PR approved 