### PR TITLE
github account linking by id, let admins delete another user

### DIFF
--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-common</artifactId>
-  <version>1.11.0-alpha.2-SNAPSHOT</version>
+  <version>1.11.0-alpha.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/dockstore-event-consumer/generated/src/main/resources/pom.xml
+++ b/dockstore-event-consumer/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-event-consumer</artifactId>
-  <version>1.11.0-alpha.2-SNAPSHOT</version>
+  <version>1.11.0-alpha.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,13 +30,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-integration-testing</artifactId>
-  <version>1.11.0-alpha.2-SNAPSHOT</version>
+  <version>1.11.0-alpha.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -54,13 +54,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>openapi-java-client</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
@@ -361,7 +361,7 @@ public class TokenResourceIT {
      */
     private void registerNewUsersAfterSelfDestruct(TokensApi unAuthenticatedTokensApi) {
         UsersApi mainUsersApi = new UsersApi(getWebClient(true, GOOGLE_ACCOUNT_USERNAME1, testingPostgres));
-        Boolean aBoolean = mainUsersApi.selfDestruct();
+        Boolean aBoolean = mainUsersApi.selfDestruct(null);
         assertTrue(aBoolean);
         io.swagger.client.model.Token recreatedGoogleToken = unAuthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, true));
         io.swagger.client.model.Token recreatedGitHubToken = unAuthenticatedTokensApi.addToken(getSatellizer(SUFFIX1, true));

--- a/dockstore-integration-testing/src/test/resources/fixtures/GitHubUser2.json
+++ b/dockstore-integration-testing/src/test/resources/fixtures/GitHubUser2.json
@@ -1,6 +1,6 @@
 {
   "login": "fubar",
-  "id": 1,
+  "id": 2,
   "node_id": "MDQ6VXNlcjE=",
   "avatar_url": "https://github.com/images/error/octocat_happy.gif",
   "gravatar_id": "",

--- a/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-language-plugin-parent</artifactId>
-  <version>1.11.0-alpha.2-SNAPSHOT</version>
+  <version>1.11.0-alpha.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-webservice</artifactId>
-  <version>1.11.0-alpha.2-SNAPSHOT</version>
+  <version>1.11.0-alpha.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -60,37 +60,37 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-quay-client</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-sam-client</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-bitbucket-client</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-discourse-client</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-language-plugin-parent</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-zenodo-client</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
@@ -32,7 +32,6 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -51,7 +50,7 @@ import org.hibernate.annotations.UpdateTimestamp;
  */
 @ApiModel(value = "Token", description = "Access tokens for this web service and integrated services like quay.io and github")
 @Entity
-@Table(name = "token", uniqueConstraints = @UniqueConstraint(name = "one_token_link_per_identify", columnNames = { "username", "tokenSource" }))
+@Table(name = "token")
 @NamedQueries({
     @NamedQuery(name = "io.dockstore.webservice.core.Token.findByContent",
             query = "SELECT t FROM Token t WHERE t.content = :content"),
@@ -77,6 +76,8 @@ import org.hibernate.annotations.UpdateTimestamp;
             query = "SELECT t FROM Token t WHERE t.username = :username AND t.tokenSource = 'github.com'"),
     @NamedQuery(name = "io.dockstore.webservice.core.Token.findTokenByUserNameAndTokenSource",
             query = "SELECT t FROM Token t WHERE t.username = :username AND t.tokenSource = :tokenSource"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Token.findTokenByOnlineProfileIdAndTokenSource",
+                query = "SELECT t FROM Token t WHERE t.onlineProfileId = :onlineProfileId AND t.tokenSource = :tokenSource"),
         @NamedQuery(name = "io.dockstore.webservice.core.Token.findAllGitHubTokens", query = "SELECT t FROM Token t WHERE t.tokenSource = 'github.com'")
 })
 
@@ -102,6 +103,10 @@ public class Token implements Comparable<Token> {
     @Column(nullable = false)
     @ApiModelProperty(value = "When an integrated service is not aware of the username, we store it", position = 3)
     private String username;
+
+    @Column()
+    @ApiModelProperty(value = "The ID of the user on the integrated service.", position = 3)
+    private Long onlineProfileId;
 
     @Column
     @ApiModelProperty(position = 4)
@@ -217,6 +222,14 @@ public class Token implements Comparable<Token> {
      */
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    public Long getOnlineProfileId() {
+        return onlineProfileId;
+    }
+
+    public void setOnlineProfileId(final Long onlineProfileId) {
+        this.onlineProfileId = onlineProfileId;
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
@@ -76,7 +76,8 @@ import org.hibernate.annotations.UpdateTimestamp;
     @NamedQuery(name = "io.dockstore.webservice.core.Token.findTokenByGitHubUsername",
             query = "SELECT t FROM Token t WHERE t.username = :username AND t.tokenSource = 'github.com'"),
     @NamedQuery(name = "io.dockstore.webservice.core.Token.findTokenByUserNameAndTokenSource",
-            query = "SELECT t FROM Token t WHERE t.username = :username AND t.tokenSource = :tokenSource")
+            query = "SELECT t FROM Token t WHERE t.username = :username AND t.tokenSource = :tokenSource"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Token.findAllGitHubTokens", query = "SELECT t FROM Token t WHERE t.tokenSource = 'github.com'")
 })
 
 @SuppressWarnings("checkstyle:magicnumber")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -301,7 +301,7 @@ public class User implements Principal, Comparable<User>, Serializable {
             Token githubToken = githubByUserId.get(0);
             GitHubSourceCodeRepo sourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(githubToken);
             sourceCodeRepo.checkSourceCodeValidity();
-            sourceCodeRepo.syncUserMetadataFromGitHub(this);
+            sourceCodeRepo.syncUserMetadataFromGitHub(this, tokenDAO, true);
             return true;
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -301,7 +302,7 @@ public class User implements Principal, Comparable<User>, Serializable {
             Token githubToken = githubByUserId.get(0);
             GitHubSourceCodeRepo sourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(githubToken);
             sourceCodeRepo.checkSourceCodeValidity();
-            sourceCodeRepo.syncUserMetadataFromGitHub(this, tokenDAO, true);
+            sourceCodeRepo.syncUserMetadataFromGitHub(this, Optional.of(tokenDAO));
             return true;
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -83,7 +83,8 @@ import org.hibernate.annotations.UpdateTimestamp;
     @NamedQuery(name = "io.dockstore.webservice.core.User.findByUsername", query = "SELECT t FROM User t WHERE t.username = :username"),
     @NamedQuery(name = "io.dockstore.webservice.core.User.findByGoogleEmail", query = "SELECT t FROM User t JOIN t.userProfiles p where( KEY(p) = 'google.com' AND p.email = :email)"),
     @NamedQuery(name = "io.dockstore.webservice.core.User.countPublishedEntries", query = "SELECT count(e) FROM User u INNER JOIN u.entries e where e.isPublished=true and u.username = :username"),
-    @NamedQuery(name = "io.dockstore.webservice.core.User.findByGitHubUsername", query = "SELECT t FROM User t JOIN t.userProfiles p where( KEY(p) = 'github.com' AND p.username = :username)")
+    @NamedQuery(name = "io.dockstore.webservice.core.User.findByGitHubUsername", query = "SELECT t FROM User t JOIN t.userProfiles p where( KEY(p) = 'github.com' AND p.username = :username)"),
+    @NamedQuery(name = "io.dockstore.webservice.core.User.findByGitHubUserId", query = "SELECT t FROM User t JOIN t.userProfiles p where(KEY(p) = 'github.com' AND p.onlineProfileId = :id)")
 })
 @SuppressWarnings("checkstyle:magicnumber")
 public class User implements Principal, Comparable<User>, Serializable {
@@ -108,8 +109,7 @@ public class User implements Principal, Comparable<User>, Serializable {
 
     @ElementCollection(targetClass = Profile.class)
     @JoinTable(name = "user_profile", joinColumns = @JoinColumn(name = "id", columnDefinition = "bigint"), uniqueConstraints = {
-            @UniqueConstraint(columnNames = { "id", "token_type" }),
-            @UniqueConstraint(columnNames = { "username", "token_type" }) }, indexes = {
+            @UniqueConstraint(columnNames = { "id", "token_type" })}, indexes = {
             @Index(name = "profile_by_username", columnList = "username"), @Index(name = "profile_by_email", columnList = "email") })
     @MapKeyColumn(name = "token_type", columnDefinition = "text")
     @ApiModelProperty(value = "Profile information of the user retrieved from 3rd party sites (GitHub, Google, etc)")
@@ -563,6 +563,8 @@ public class User implements Principal, Comparable<User>, Serializable {
          */
         @Column(columnDefinition = "text")
         public String username;
+        @Column
+        public Long onlineProfileId;
 
         @Column(updatable = false)
         @CreationTimestamp

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -53,6 +53,7 @@ import io.dockstore.webservice.core.LicenseInformation;
 import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.SourceControlOrganization;
 import io.dockstore.webservice.core.SourceFile;
+import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.User;
@@ -61,6 +62,7 @@ import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowMode;
 import io.dockstore.webservice.core.WorkflowVersion;
+import io.dockstore.webservice.jdbi.TokenDAO;
 import okhttp3.OkHttpClient;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -1017,48 +1019,55 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
      * Updates a user object with metadata from GitHub
      * @param user the user to be updated
      */
-    public void syncUserMetadataFromGitHub(User user) {
+    public void syncUserMetadataFromGitHub(User user, TokenDAO tokenDAO, boolean updateToken) {
         // eGit user object
         try {
             GHMyself myself = github.getMyself();
-            User.Profile profile = new User.Profile();
-            profile.name = myself.getName();
+            User.Profile profile = getProfile(user, myself);
             profile.email = getEmail(myself);
-            profile.avatarURL = myself.getAvatarUrl();
-            profile.bio = myself.getBlog();  // ? not sure about this mapping in the new api
-            profile.location = myself.getLocation();
-            profile.company = myself.getCompany();
-            profile.username = myself.getLogin();
-            profile.onlineProfileId = myself.getId();
-            Map<String, User.Profile> userProfile = user.getUserProfiles();
-            userProfile.put(TokenType.GITHUB_COM.toString(), profile);
-            user.setAvatarUrl(myself.getAvatarUrl());
+
+            // Update token. Username on GitHub could have changed and need to collect the GitHub user id as well
+            if (updateToken) {
+                Token usersGitHubToken = tokenDAO.findGithubByUserId(user.getId()).get(0);
+                usersGitHubToken.setOnlineProfileId(profile.onlineProfileId);
+                usersGitHubToken.setUsername(profile.username);
+            }
         } catch (IOException ex) {
             LOG.info("Could not find user information for user " + user.getUsername(), ex);
         }
     }
 
-    public boolean syncUserMetadataFromGitHubByUsername(User user) {
+    // This function has no use outside of gathering user's GitHub IDs the first time. This uses the GitHub token of the admin user calling the new, one-time-use endpoint.
+    // This will attempt to get the GitHub profile info (including id) of users we were unable to get by calling the github.getMyself() function above.
+    public void syncUserMetadataFromGitHubByUsername(User user, TokenDAO tokenDAO) {
         // eGit user object
         try {
             GHUser ghUser = github.getUser(user.getUserProfiles().get(TokenType.GITHUB_COM.toString()).username);
-            User.Profile profile = new User.Profile();
-            profile.name = ghUser.getName();
+            User.Profile profile = getProfile(user, ghUser);
             profile.email = ghUser.getEmail();
-            profile.avatarURL = ghUser.getAvatarUrl();
-            profile.bio = ghUser.getBlog();  // ? not sure about this mapping in the new api
-            profile.location = ghUser.getLocation();
-            profile.company = ghUser.getCompany();
-            profile.username = ghUser.getLogin();
-            profile.onlineProfileId = ghUser.getId();
-            Map<String, User.Profile> userProfile = user.getUserProfiles();
-            userProfile.put(TokenType.GITHUB_COM.toString(), profile);
-            user.setAvatarUrl(ghUser.getAvatarUrl());
-            return true;
-        } catch (IOException | NullPointerException ex) {
+
+            // Update token. Username on GitHub could have changed and need to collect the GitHub user id as well
+            Token usersGitHubToken = tokenDAO.findGithubByUserId(user.getId()).get(0);
+            usersGitHubToken.setOnlineProfileId(profile.onlineProfileId);
+            usersGitHubToken.setUsername(profile.username);
+        } catch (IOException ex) {
             LOG.info("Could not find user information for user " + user.getUsername(), ex);
-            return false;
         }
+    }
+
+    public User.Profile getProfile(final User user, final GHUser ghUser) throws IOException {
+        User.Profile profile = new User.Profile();
+        profile.name = ghUser.getName();
+        profile.avatarURL = ghUser.getAvatarUrl();
+        profile.bio = ghUser.getBlog();  // ? not sure about this mapping in the new api
+        profile.location = ghUser.getLocation();
+        profile.company = ghUser.getCompany();
+        profile.username = ghUser.getLogin();
+        profile.onlineProfileId = ghUser.getId();
+        Map<String, User.Profile> userProfile = user.getUserProfiles();
+        userProfile.put(TokenType.GITHUB_COM.toString(), profile);
+        user.setAvatarUrl(ghUser.getAvatarUrl());
+        return profile;
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1019,7 +1019,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
      * Updates a user object with metadata from GitHub
      * @param user the user to be updated
      */
-    public void syncUserMetadataFromGitHub(User user, TokenDAO tokenDAO, boolean updateToken) {
+    public void syncUserMetadataFromGitHub(User user, Optional<TokenDAO> tokenDAO) {
         // eGit user object
         try {
             GHMyself myself = github.getMyself();
@@ -1027,8 +1027,8 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             profile.email = getEmail(myself);
 
             // Update token. Username on GitHub could have changed and need to collect the GitHub user id as well
-            if (updateToken) {
-                Token usersGitHubToken = tokenDAO.findGithubByUserId(user.getId()).get(0);
+            if (tokenDAO.isPresent()) {
+                Token usersGitHubToken = tokenDAO.get().findGithubByUserId(user.getId()).get(0);
                 usersGitHubToken.setOnlineProfileId(profile.onlineProfileId);
                 usersGitHubToken.setUsername(profile.username);
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/TokenDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/TokenDAO.java
@@ -98,6 +98,10 @@ public class TokenDAO extends AbstractDAO<Token> {
         return uniqueResult(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Token.findTokenByUserNameAndTokenSource").setParameter("username", username).setParameter("tokenSource", tokenSource));
     }
 
+    public Token findTokenByOnlineProfileIdAndTokenSource(Long onlineProfileId, TokenType tokenSource) {
+        return uniqueResult(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Token.findTokenByOnlineProfileIdAndTokenSource").setParameter("onlineProfileId", onlineProfileId).setParameter("tokenSource", tokenSource));
+    }
+
     public List<Token> findAllGitHubTokens() {
         return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Token.findAllGitHubTokens"));
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/TokenDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/TokenDAO.java
@@ -97,4 +97,8 @@ public class TokenDAO extends AbstractDAO<Token> {
     public Token findTokenByUserNameAndTokenSource(String username, TokenType tokenSource) {
         return uniqueResult(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Token.findTokenByUserNameAndTokenSource").setParameter("username", username).setParameter("tokenSource", tokenSource));
     }
+
+    public List<Token> findAllGitHubTokens() {
+        return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Token.findAllGitHubTokens"));
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/UserDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/UserDAO.java
@@ -76,6 +76,10 @@ public class UserDAO extends AbstractDockstoreDAO<User> {
         return (User)query.uniqueResult();
     }
 
+    public User findByGitHubUserId(long id) {
+        return uniqueResult(this.currentSession().getNamedQuery("io.dockstore.webservice.core.User.findByGitHubUserId").setParameter("id", id));
+    }
+
     public long findPublishedEntries(String username)  {
         final Query query = namedQuery("io.dockstore.webservice.core.User.countPublishedEntries").setParameter("username", username);
         return (long)query.uniqueResult();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -532,14 +532,16 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
         String githubLogin;
         Token dockstoreToken = null;
         Token githubToken = null;
+        Long gitHubId;
         try {
             GitHub github = new GitHubBuilder().withOAuthToken(accessToken).build();
             githubLogin = github.getMyself().getLogin();
+            gitHubId = github.getMyself().getId();
         } catch (IOException ex) {
             throw new CustomWebApplicationException("Token ignored due to IOException", HttpStatus.SC_CONFLICT);
         }
 
-        User user = userDAO.findByGitHubUsername(githubLogin);
+        User user = userDAO.findByGitHubUserId(gitHubId);
         long userID;
         if (registerUser) {
             // check that there was no previous user, but by default use the github login

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -539,7 +539,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
         String githubLogin;
         Token dockstoreToken = null;
         Token githubToken = null;
-        Long gitHubId;
+        long gitHubId;
         try {
             GitHub github = new GitHubBuilder().withOAuthToken(accessToken).build();
             githubLogin = github.getMyself().getLogin();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -606,7 +606,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
             tokenDAO.create(githubToken);
             user = userDAO.findById(userID);
             GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(githubToken);
-            gitHubSourceCodeRepo.syncUserMetadataFromGitHub(user, tokenDAO, false);
+            gitHubSourceCodeRepo.syncUserMetadataFromGitHub(user, Optional.empty());
         }
         return dockstoreToken;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -749,7 +749,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
             if (currentUser != null) {
                 try {
                     GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(t);
-                    gitHubSourceCodeRepo.syncUserMetadataFromGitHub(currentUser, tokenDAO, true);
+                    gitHubSourceCodeRepo.syncUserMetadataFromGitHub(currentUser, Optional.of(tokenDAO));
                 } catch (Exception ex) {
                     usersNotUpdatedWithToken.add(currentUser);
                 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -764,7 +764,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
                 gitHubSourceCodeRepo.syncUserMetadataFromGitHubByUsername(u, tokenDAO);
             } catch (Exception ex) {
                 usersNotUpdatedWithTokenOrUsername.add(u);
-                LOG.info("Unable to get GitHub user id for Dockstore user " + u.getUsername() + " " + u.getId());
+                LOG.info(ex.getMessage());
             }
         }
 

--- a/dockstore-webservice/src/main/resources/import.sql
+++ b/dockstore-webservice/src/main/resources/import.sql
@@ -46,3 +46,7 @@ CREATE UNIQUE INDEX unique_collection_entry_version ON collection_entry_version 
 
 ALTER TABLE user_profile DROP CONSTRAINT one_sign_in_method_by_profile;
 CREATE UNIQUE INDEX one_sign_in_method_by_profile ON user_profile USING btree (onlineprofileid, token_type) WHERE onlineprofileid IS NOT NULL;
+
+ALTER TABLE token DROP CONSTRAINT one_token_link_per_identify;
+CREATE UNIQUE INDEX one_token_link_per_identify ON token USING btree (onlineprofileid, tokensource) WHERE onlineprofileid IS NOT NULL;
+CREATE UNIQUE INDEX one_token_link_per_identify2 ON token USING btree (username, tokensource) WHERE onlineprofileid IS NULL;

--- a/dockstore-webservice/src/main/resources/import.sql
+++ b/dockstore-webservice/src/main/resources/import.sql
@@ -45,6 +45,7 @@ CREATE UNIQUE INDEX unique_collection_entry ON collection_entry_version USING bt
 CREATE UNIQUE INDEX unique_collection_entry_version ON collection_entry_version USING btree (collection_id, entry_id, version_id) WHERE version_id IS NOT NULL;
 
 ALTER TABLE user_profile DROP CONSTRAINT one_sign_in_method_by_profile;
+CREATE UNIQUE INDEX one_sign_in_method_by_profile_old ON user_profile USING btree (username, token_type) WHERE onlineprofileid IS NULL;
 CREATE UNIQUE INDEX one_sign_in_method_by_profile ON user_profile USING btree (onlineprofileid, token_type) WHERE onlineprofileid IS NOT NULL;
 
 ALTER TABLE token DROP CONSTRAINT one_token_link_per_identify;

--- a/dockstore-webservice/src/main/resources/import.sql
+++ b/dockstore-webservice/src/main/resources/import.sql
@@ -43,3 +43,6 @@ ALTER TABLE tag ADD CONSTRAINT parentid_constraint FOREIGN KEY(parentid) REFEREN
 
 CREATE UNIQUE INDEX unique_collection_entry ON collection_entry_version USING btree (collection_id, entry_id) WHERE version_id IS NULL;
 CREATE UNIQUE INDEX unique_collection_entry_version ON collection_entry_version USING btree (collection_id, entry_id, version_id) WHERE version_id IS NOT NULL;
+
+ALTER TABLE user_profile DROP CONSTRAINT one_sign_in_method_by_profile;
+CREATE UNIQUE INDEX one_sign_in_method_by_profile ON user_profile USING btree (onlineprofileid, token_type) WHERE onlineprofileid IS NOT NULL;

--- a/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
@@ -208,6 +208,7 @@
         </addColumn>
         <sql dbms="postgresql">
             ALTER TABLE user_profile DROP CONSTRAINT one_sign_in_method_by_profile;
+            CREATE UNIQUE INDEX one_sign_in_method_by_profile_old ON user_profile USING btree (username, token_type) WHERE onlineprofileid IS NULL;
             CREATE UNIQUE INDEX one_sign_in_method_by_profile ON user_profile USING btree (onlineprofileid, token_type) WHERE onlineprofileid IS NOT NULL;
             ALTER TABLE token DROP CONSTRAINT one_token_link_per_identify;
             CREATE UNIQUE INDEX one_token_link_per_identify ON token USING btree (onlineprofileid, tokensource) WHERE onlineprofileid IS NOT NULL;

--- a/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
@@ -199,13 +199,19 @@
         </update>
     </changeSet>
 
-    <changeSet author="natalieperez (generated)" id="1618951572157-1">
+    <changeSet author="natalieperez (generated)" id="add_ids_from_github">
         <addColumn tableName="user_profile">
+            <column name="onlineprofileid" type="int8"/>
+        </addColumn>
+        <addColumn tableName="token">
             <column name="onlineprofileid" type="int8"/>
         </addColumn>
         <sql dbms="postgresql">
             ALTER TABLE user_profile DROP CONSTRAINT one_sign_in_method_by_profile;
             CREATE UNIQUE INDEX one_sign_in_method_by_profile ON user_profile USING btree (onlineprofileid, token_type) WHERE onlineprofileid IS NOT NULL;
+            ALTER TABLE token DROP CONSTRAINT one_token_link_per_identify;
+            CREATE UNIQUE INDEX one_token_link_per_identify ON token USING btree (onlineprofileid, tokensource) WHERE onlineprofileid IS NOT NULL;
+            CREATE UNIQUE INDEX one_token_link_per_identify2 ON token USING btree (username, tokensource) WHERE onlineprofileid IS NULL;
         </sql>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
@@ -198,4 +198,14 @@
             <where>tokensource = 'orcid.org'</where>
         </update>
     </changeSet>
+
+    <changeSet author="natalieperez (generated)" id="1618951572157-1">
+        <addColumn tableName="user_profile">
+            <column name="onlineprofileid" type="int8"/>
+        </addColumn>
+        <sql dbms="postgresql">
+            ALTER TABLE user_profile DROP CONSTRAINT one_sign_in_method_by_profile;
+            CREATE UNIQUE INDEX one_sign_in_method_by_profile ON user_profile USING btree (onlineprofileid, token_type) WHERE onlineprofileid IS NOT NULL;
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -4422,18 +4422,19 @@ paths:
       - users
   /users/updateUserMetadataToGetIds:
     get:
+      deprecated: true
       description: Update metadata of all GitHub users and returns list of Dockstore
         users who could not be updated.
       operationId: updateUserMetadataToGetIds
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/User'
-          description: default response
+          description: Get list Dockstore users we were unable to get GitHub IDs for.
       security:
       - bearer: []
       tags:
@@ -8010,6 +8011,9 @@ components:
           type: integer
           format: int64
         id:
+          type: integer
+          format: int64
+        onlineProfileId:
           type: integer
           format: int64
         refreshToken:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -4420,10 +4420,36 @@ paths:
       - bearer: []
       tags:
       - users
+  /users/updateUserMetadataToGetIds:
+    get:
+      description: Update metadata of all GitHub users and returns list of Dockstore
+        users who could not be updated.
+      operationId: updateUserMetadataToGetIds
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+          description: default response
+      security:
+      - bearer: []
+      tags:
+      - users
   /users/user:
     delete:
       description: Delete user if possible.
       operationId: selfDestruct
+      parameters:
+      - description: Optional user id if deleting another user. Only admins can delete
+          another user.
+        in: query
+        name: userId
+        schema:
+          type: integer
+          format: int64
       responses:
         default:
           content:
@@ -7623,6 +7649,9 @@ components:
           type: string
         name:
           type: string
+        onlineProfileId:
+          type: integer
+          format: int64
         username:
           type: string
     PublishRequest:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -13,7 +13,7 @@ info:
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
   termsOfService: TBD
   title: Dockstore API
-  version: 1.11.0-alpha.2-SNAPSHOT
+  version: 1.11.0-alpha.3-SNAPSHOT
 servers:
 - description: Current server when hosted on AWS
   url: /api

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5,7 +5,7 @@ info:
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images. Explore swagger.json for a Swagger 2.0 description\
     \ of our API and explore openapi.yaml for OpenAPI 3.0 descriptions."
-  version: "1.11.0-alpha.2-SNAPSHOT"
+  version: "1.11.0-alpha.3-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4142,6 +4142,26 @@ paths:
               $ref: "#/definitions/User"
       security:
       - BEARER: []
+  /users/updateUserMetadataToGetIds:
+    get:
+      tags:
+      - "users"
+      summary: "Update metadata of all GitHub users and returns list of Dockstore\
+        \ users who could not be updated."
+      description: "Admin only."
+      operationId: "updateUserMetadataToGetIds"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/User"
+      security:
+      - BEARER: []
   /users/user:
     get:
       tags:
@@ -4167,7 +4187,14 @@ paths:
       operationId: "selfDestruct"
       produces:
       - "application/json"
-      parameters: []
+      parameters:
+      - name: "userId"
+        in: "query"
+        description: "Optional user id if deleting another user. Only admins can delete\
+          \ another user."
+        required: false
+        type: "integer"
+        format: "int64"
       responses:
         200:
           description: "successful operation"
@@ -7343,6 +7370,9 @@ definitions:
         type: "string"
       name:
         type: "string"
+      onlineProfileId:
+        type: "integer"
+        format: "int64"
       username:
         type: "string"
   PublishRequest:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4142,26 +4142,6 @@ paths:
               $ref: "#/definitions/User"
       security:
       - BEARER: []
-  /users/updateUserMetadataToGetIds:
-    get:
-      tags:
-      - "users"
-      summary: "Update metadata of all GitHub users and returns list of Dockstore\
-        \ users who could not be updated."
-      description: "Admin only."
-      operationId: "updateUserMetadataToGetIds"
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/User"
-      security:
-      - BEARER: []
   /users/user:
     get:
       tags:
@@ -7716,6 +7696,11 @@ definitions:
         type: "string"
         position: 2
         description: "Contents of the access token"
+      onlineProfileId:
+        type: "integer"
+        format: "int64"
+        position: 3
+        description: "The ID of the user on the integrated service."
       username:
         type: "string"
         position: 3

--- a/openapi-java-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>openapi-java-client</artifactId>
-  <version>1.11.0-alpha.2-SNAPSHOT</version>
+  <version>1.11.0-alpha.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/reports/generated/src/main/resources/pom.xml
+++ b/reports/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>reports</artifactId>
-  <version>1.11.0-alpha.2-SNAPSHOT</version>
+  <version>1.11.0-alpha.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,19 +30,19 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-integration-testing</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/swagger-java-bitbucket-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-bitbucket-client/generated/src/main/resources/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-bitbucket-client</artifactId>
-  <version>1.11.0-alpha.2-SNAPSHOT</version>
+  <version>1.11.0-alpha.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-client</artifactId>
-  <version>1.11.0-alpha.2-SNAPSHOT</version>
+  <version>1.11.0-alpha.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-alpha.2-SNAPSHOT</version>
+      <version>1.11.0-alpha.3-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/swagger-java-discourse-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-discourse-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-discourse-client</artifactId>
-  <version>1.11.0-alpha.2-SNAPSHOT</version>
+  <version>1.11.0-alpha.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-quay-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-quay-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-quay-client</artifactId>
-  <version>1.11.0-alpha.2-SNAPSHOT</version>
+  <version>1.11.0-alpha.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-sam-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-sam-client/generated/src/main/resources/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-sam-client</artifactId>
-  <version>1.11.0-alpha.2-SNAPSHOT</version>
+  <version>1.11.0-alpha.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-zenodo-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-zenodo-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-zenodo-client</artifactId>
-  <version>1.11.0-alpha.2-SNAPSHOT</version>
+  <version>1.11.0-alpha.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-2570
Created endpoint to get user's github account id by token, and if that fails then by username. Also needed to give admins the ability to delete another account because we will need to do that once this is release.

Need to do something similar for our Google accounts.
Added instructions here https://github.com/dockstore/dockstore-deploy/wiki/1.11-Checklist

The endpoint takes about 15 minutes to finish locally