### PR TITLE
Fix previous migration

### DIFF
--- a/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
@@ -191,4 +191,11 @@
         <alterSequence sequenceName="tag_id_seq" incrementBy="1" />
         <alterSequence sequenceName="token_id_seq" incrementBy="1" />
     </changeSet>
+    <!-- This fixes the previous incorrect orcidTokenExpansion -->
+    <changeSet id="existingORCIDScopeSet" author="gluu">
+        <update tableName="token">
+            <column name="scope" value="AUTHENTICATE"/>
+            <where>tokensource = 'orcid.org'</where>
+        </update>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
For #4207 

Previous migration was wrong. It set it to /authenticate instead of AUTHENTICATE.

Issue was reproduced by linking an ORCID account with the new scope. Then manually changing it in db using: `update token set scope='/authenticate' where username='Potato'`

Issue was fixed temporarily when i manually did: `update token set scope='AUTHENTICATE' where username='Potato'`