### PR TITLE
Bump OpenJDK 11 Docker image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   integration_test_exec:
     docker: # run the steps with Docker
-      - image: cimg/openjdk:11.0.9
+      - image: cimg/openjdk:11.0.10
         environment:
           PGHOST: 127.0.0.1
       - image: circleci/postgres:11.8
@@ -117,7 +117,7 @@ jobs:
       - save_test_results
   build:
     docker: # run the steps with Docker
-      - image: cimg/openjdk:11.0.9
+      - image: cimg/openjdk:11.0.10
     steps: # a collection of executable commands
       - checkout # check out source code to working directory
       - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
@@ -150,7 +150,7 @@ jobs:
           command: mvn verify sonar:sonar
   unit_test: # runs not using Workflows must have a `build` job as entry point
     docker: # run the steps with Docker
-      - image: cimg/openjdk:11.0.9
+      - image: cimg/openjdk:11.0.10
         environment:
           PGHOST: 127.0.0.1
       - image: circleci/postgres:11.8
@@ -178,7 +178,7 @@ jobs:
           name: run the non-confidential integration tests
           command: |
             # Adding all "normal" certs into this local one that has the Hoverfly cert (instead of adding Hoverfly cert to the global one so it doesn't potentially affect other tests)
-            /usr/local/jdk-11.0.9/bin/keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore LocalTrustStore -srcstorepass changeit -deststorepass changeit
+            /usr/local/jdk-11.0.10/bin/keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore LocalTrustStore -srcstorepass changeit -deststorepass changeit
             export SKIP_SIGNATURE_CHECK=false
             if [[ -z "${CIRCLE_TAG}" ]]; then
               # If it is a branch, skip the signature check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.11-jdk
+FROM openjdk:11.0.10-jdk
 
 # Update the APT cache
 # prepare for Java download

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.9-jdk
+FROM openjdk:11.0.11-jdk
 
 # Update the APT cache
 # prepare for Java download


### PR DESCRIPTION
Changes the base image used for the webservice to JDK 11.0.10. Change CircleCI config to match, these were out of sync due to a previous PR upgrading the Docker image.