### PR TITLE
Move test, limit memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ executors:
     docker: # run the steps with Docker
       - image: cimg/openjdk:11.0.10
         environment:
+          JAVA_TOOL_OPTIONS: -Xmx512m # Nothing to do with surefire plugin, it has its own JVM. The two of these plus ES (1.3 GB) must add up to a bit less than 6GB.
           PGHOST: 127.0.0.1
       - image: circleci/postgres:11.8
         command: postgres -c max_connections=200

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiIT.java
@@ -19,6 +19,7 @@ package io.dockstore.client.cli;
 import javax.ws.rs.core.Response;
 
 import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.NonConfidentialTest;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dropwizard.client.JerseyClientBuilder;
@@ -30,10 +31,12 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
+import static io.dockstore.common.CommonTestUtilities.PUBLIC_CONFIG_PATH;
 import static io.dockstore.common.CommonTestUtilities.WAIT_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author dyuen
  */
+@Category(NonConfidentialTest.class)
 public class OpenApiIT {
 
     public static final DropwizardTestSupport<DockstoreWebserviceConfiguration> SUPPORT = new DropwizardTestSupport<>(
@@ -60,7 +64,7 @@ public class OpenApiIT {
 
     @BeforeClass
     public static void dumpDBAndCreateSchema() throws Exception {
-        CommonTestUtilities.dropAndRecreateNoTestData(SUPPORT);
+        CommonTestUtilities.dropAndRecreateNoTestData(SUPPORT, PUBLIC_CONFIG_PATH);
         SUPPORT.before();
         client = new JerseyClientBuilder(SUPPORT.getEnvironment()).build("test client").property(ClientProperties.READ_TIMEOUT, WAIT_TIME);
     }


### PR DESCRIPTION
For https://ucsc-cgl.atlassian.net/browse/SEAB-2797 again

There are 4 sources of memory usage:

mvn jacoco java agent (this is what starts the test but doesn’t run it itself. memory is set by the JAVA_TOOL_OPTIONS in .circleci/config.yml)

maven surefire-plugin (this actually runs the test and uses high cpu and memory. memory is set in the surefire-plugin config in the pom.xml)

elasticsearch (which is probably just elasticsearch, but not sure why top shows the command as java)

misc (this includes external things like nextflow and other things not monitored by java)

My current PR makes it so that the maximum is roughly:

0.5 GB + 4 GB  + 1.3 GB + ? =  5.8 GB which should generally work on our 6 GB CircleCI VM.

I changed and moved the OpenAPI test to the non-confidential integration tests because it took up 2.5 GB of RAM and non-confidential integration tests typically have more memory to spare

There must be one other test in the integration-tests that also cause a spike in memory usage but i have yet to find it

🙏 

Next try is to reduce the maven-surefire-plugin memory depending on what the next failure is (f nextflow client or ES uses too much memory).