### PR TITLE
Don't expose tokens to users

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -64,7 +64,7 @@ import io.swagger.client.model.SharedWorkflows;
 import io.swagger.client.model.SourceFile;
 import io.swagger.client.model.StarRequest;
 import io.swagger.client.model.Tag;
-import io.swagger.client.model.Token;
+import io.swagger.client.model.TokenUser;
 import io.swagger.client.model.ToolDescriptor;
 import io.swagger.client.model.ToolDockerfile;
 import io.swagger.client.model.ToolVersionV1;
@@ -482,7 +482,7 @@ public class SwaggerClientIT extends BaseIT {
         UsersApi usersApi = new UsersApi(client);
         User user = usersApi.getUser();
 
-        List<Token> tokens = usersApi.getUserTokens(user.getId());
+        List<TokenUser> tokens = usersApi.getUserTokens(user.getId());
 
         assertFalse(tokens.isEmpty());
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
@@ -156,7 +156,7 @@ public class TokenResourceIT {
     @Test
     public void getGoogleTokenNewUser() {
         TokensApi tokensApi = new TokensApi(getWebClient(false, "n/a", testingPostgres));
-        io.swagger.client.model.Token token = tokensApi.addGoogleToken(getSatellizer(SUFFIX3, true));
+        io.swagger.client.model.TokenAuth token = tokensApi.addGoogleToken(getSatellizer(SUFFIX3, true));
 
         // check that the user has the correct two tokens
         List<Token> tokens = tokenDAO.findByUserId(token.getUserId());
@@ -235,7 +235,7 @@ public class TokenResourceIT {
 
         // now register user2, should autogenerate a name
         TokensApi tokensApi2 = new TokensApi(getWebClient(false, "n/a", testingPostgres));
-        io.swagger.client.model.Token token = tokensApi2.addToken(getSatellizer(SUFFIX2, true));
+        io.swagger.client.model.TokenAuth token = tokensApi2.addToken(getSatellizer(SUFFIX2, true));
         UsersApi usersApi2 = new UsersApi(getWebClient(true, token.getUsername(), testingPostgres));
         assertNotEquals(usersApi2.getUser().getUsername(), CUSTOM_USERNAME2);
         assertEquals(usersApi2.changeUsername("better.name").getUsername(), "better.name");
@@ -264,12 +264,12 @@ public class TokenResourceIT {
         registerAndLinkUnavailableTokens(unAuthenticatedTokensApi);
 
         // Login with Google still works
-        io.swagger.client.model.Token token = unAuthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
+        io.swagger.client.model.TokenAuth token = unAuthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
         Assert.assertEquals(CUSTOM_USERNAME2, token.getUsername());
         Assert.assertEquals(TokenType.DOCKSTORE.toString(), token.getTokenSource());
 
         // Login with GitHub still works
-        io.swagger.client.model.Token fakeGitHubCode = unAuthenticatedTokensApi.addToken(getSatellizer(SUFFIX1, false));
+        io.swagger.client.model.TokenAuth fakeGitHubCode = unAuthenticatedTokensApi.addToken(getSatellizer(SUFFIX1, false));
         Assert.assertEquals(CUSTOM_USERNAME2, fakeGitHubCode.getUsername());
         Assert.assertEquals(TokenType.DOCKSTORE.toString(), fakeGitHubCode.getTokenSource());
     }
@@ -317,7 +317,7 @@ public class TokenResourceIT {
      * @param unAuthenticatedTokensApi TokensApi without any authentication
      */
     private void createAccount1(TokensApi unAuthenticatedTokensApi) {
-        io.swagger.client.model.Token account1DockstoreToken = unAuthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, true));
+        io.swagger.client.model.TokenAuth account1DockstoreToken = unAuthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, true));
         Assert.assertEquals(GOOGLE_ACCOUNT_USERNAME1, account1DockstoreToken.getUsername());
         User testUser = userDAO.findById(account1DockstoreToken.getUserId());
         testUser.setUsername(CUSTOM_USERNAME1);
@@ -326,7 +326,7 @@ public class TokenResourceIT {
     }
 
     private void createAccount2(TokensApi unAuthenticatedTokensApi) {
-        io.swagger.client.model.Token otherGoogleUserToken = unAuthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX4, true));
+        io.swagger.client.model.TokenAuth otherGoogleUserToken = unAuthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX4, true));
         Assert.assertEquals(GOOGLE_ACCOUNT_USERNAME2, otherGoogleUserToken.getUsername());
         User testUser = userDAO.findById(otherGoogleUserToken.getUserId());
         testUser.setUsername(CUSTOM_USERNAME2);
@@ -363,8 +363,8 @@ public class TokenResourceIT {
         UsersApi mainUsersApi = new UsersApi(getWebClient(true, GOOGLE_ACCOUNT_USERNAME1, testingPostgres));
         Boolean aBoolean = mainUsersApi.selfDestruct(null);
         assertTrue(aBoolean);
-        io.swagger.client.model.Token recreatedGoogleToken = unAuthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, true));
-        io.swagger.client.model.Token recreatedGitHubToken = unAuthenticatedTokensApi.addToken(getSatellizer(SUFFIX1, true));
+        io.swagger.client.model.TokenAuth recreatedGoogleToken = unAuthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, true));
+        io.swagger.client.model.TokenAuth recreatedGitHubToken = unAuthenticatedTokensApi.addToken(getSatellizer(SUFFIX1, true));
         assertNotSame(recreatedGitHubToken.getUserId(), recreatedGoogleToken.getUserId());
     }
 
@@ -425,19 +425,19 @@ public class TokenResourceIT {
     @Ignore("this is probably different now, todo")
     public void getGoogleTokenCase135() {
         TokensApi tokensApi = new TokensApi(getWebClient(false, "n/a", testingPostgres));
-        io.swagger.client.model.Token case5Token = tokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
+        io.swagger.client.model.TokenAuth case5Token = tokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
         // Case 5 check (No Google account, no GitHub account)
         Assert.assertEquals(GOOGLE_ACCOUNT_USERNAME1, case5Token.getUsername());
         // Google account dockstore token + Google account Google token
         checkTokenCount(initialTokenCount + 2);
-        io.swagger.client.model.Token case3Token = tokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
+        io.swagger.client.model.TokenAuth case3Token = tokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
         // Case 3 check (Google account with Google token, no GitHub account)
         Assert.assertEquals(GOOGLE_ACCOUNT_USERNAME1, case3Token.getUsername());
         TokensApi googleTokensApi = new TokensApi(getWebClient(true, GOOGLE_ACCOUNT_USERNAME1, testingPostgres));
         googleTokensApi.deleteToken(case3Token.getId());
         // Google account dockstore token
         checkTokenCount(initialTokenCount + 1);
-        io.swagger.client.model.Token case1Token = tokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
+        io.swagger.client.model.TokenAuth case1Token = tokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
         // Case 1 check (Google account without Google token, no GitHub account)
         Assert.assertEquals(GOOGLE_ACCOUNT_USERNAME1, case1Token.getUsername());
     }
@@ -464,7 +464,7 @@ public class TokenResourceIT {
     @Ignore("this is probably different now, todo")
     public void getGoogleTokenCase24() {
         TokensApi unauthenticatedTokensApi = new TokensApi(getWebClient(false, "n/a", testingPostgres));
-        io.swagger.client.model.Token token = unauthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
+        io.swagger.client.model.TokenAuth token = unauthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
         // Check token properly added (redundant assertion)
         long googleUserID = token.getUserId();
         Assert.assertEquals(token.getUsername(), GOOGLE_ACCOUNT_USERNAME1);
@@ -475,7 +475,7 @@ public class TokenResourceIT {
         gitHubTokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
         // GitHub account Google token, Google account dockstore token, Google account Google token
         checkTokenCount(initialTokenCount + 3);
-        io.swagger.client.model.Token case4Token = unauthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
+        io.swagger.client.model.TokenAuth case4Token = unauthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
         // Case 4 (Google account with Google token, GitHub account with Google token)
         Assert.assertEquals(GOOGLE_ACCOUNT_USERNAME1, case4Token.getUsername());
         TokensApi googleUserTokensApi = new TokensApi(getWebClient(true, GOOGLE_ACCOUNT_USERNAME1, testingPostgres));
@@ -483,7 +483,7 @@ public class TokenResourceIT {
         List<Token> googleByUserId = tokenDAO.findGoogleByUserId(googleUserID);
 
         googleUserTokensApi.deleteToken(googleByUserId.get(0).getId());
-        io.swagger.client.model.Token case2Token = unauthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
+        io.swagger.client.model.TokenAuth case2Token = unauthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
         // Case 2 Google account without Google token, GitHub account with Google token
         Assert.assertEquals(GITHUB_ACCOUNT_USERNAME, case2Token.getUsername());
     }
@@ -514,7 +514,7 @@ public class TokenResourceIT {
         TokensApi unauthenticatedTokensApi = new TokensApi(getWebClient(false, "n/a", testingPostgres));
         // GitHub account Google token
         checkTokenCount(initialTokenCount + 1);
-        io.swagger.client.model.Token case6Token = unauthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
+        io.swagger.client.model.TokenAuth case6Token = unauthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
 
         // Case 6 check (No Google account, have GitHub account with Google token)
         Assert.assertEquals(GITHUB_ACCOUNT_USERNAME, case6Token.getUsername());
@@ -541,7 +541,7 @@ public class TokenResourceIT {
         assertTrue(byUserId.stream().anyMatch(t -> t.getTokenSource() == TokenType.DOCKSTORE));
 
         TokensApi tokensApi = new TokensApi(getWebClient(true, GITHUB_ACCOUNT_USERNAME, testingPostgres));
-        io.swagger.client.model.Token token = tokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
+        io.swagger.client.model.TokenAuth token = tokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
 
         // check that the user ends up with the correct two tokens
         byUserId = tokenDAO.findByUserId(token.getUserId());
@@ -579,7 +579,7 @@ public class TokenResourceIT {
         assertTrue(byUserId.stream().anyMatch(t -> t.getTokenSource() == TokenType.DOCKSTORE));
 
         // going back to the first user, we want to add a github token to their profile
-        io.swagger.client.model.Token token = tokensApi.addGithubToken(getFakeCode(SUFFIX1));
+        io.swagger.client.model.TokenAuth token = tokensApi.addGithubToken(getFakeCode(SUFFIX1));
 
         // check that the user ends up with the correct two tokens
         byUserId = tokenDAO.findByUserId(id);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
@@ -579,7 +579,7 @@ public class TokenResourceIT {
         assertTrue(byUserId.stream().anyMatch(t -> t.getTokenSource() == TokenType.DOCKSTORE));
 
         // going back to the first user, we want to add a github token to their profile
-        io.swagger.client.model.TokenAuth token = tokensApi.addGithubToken(getFakeCode(SUFFIX1));
+        io.swagger.client.model.TokenUser token = tokensApi.addGithubToken(getFakeCode(SUFFIX1));
 
         // check that the user ends up with the correct two tokens
         byUserId = tokenDAO.findByUserId(id);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
@@ -87,39 +87,39 @@ public class Token implements Comparable<Token> {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "token_id_seq")
     @SequenceGenerator(name = "token_id_seq", sequenceName = "token_id_seq", allocationSize = 1)
-    @ApiModelProperty(value = "Implementation specific ID for the token in this web service", readOnly = true)
+    @ApiModelProperty(value = "Implementation specific ID for the token in this web service", position = 0, readOnly = true)
     @Column(columnDefinition = "bigint default nextval('token_id_seq')")
     @JsonView(TokenViews.User.class)
     private long id;
 
     @Column(nullable = false)
     @Convert(converter = TokenTypeConverter.class)
-    @ApiModelProperty(value = "Source website for this token", dataType = "string")
+    @ApiModelProperty(value = "Source website for this token", position = 1, dataType = "string")
     @JsonView(TokenViews.User.class)
     private TokenType tokenSource;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "Contents of the access token")
+    @ApiModelProperty(value = "Contents of the access token", position = 2)
     @JsonView(TokenViews.Auth.class)
     private String content;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "When an integrated service is not aware of the username, we store it")
+    @ApiModelProperty(value = "When an integrated service is not aware of the username, we store it", position = 3)
     @JsonView(TokenViews.User.class)
     private String username;
 
     @Column()
-    @ApiModelProperty(value = "The ID of the user on the integrated service.")
+    @ApiModelProperty(value = "The ID of the user on the integrated service.", position = 7)
     @JsonView(TokenViews.User.class)
     private Long onlineProfileId;
 
     @Column
-    @ApiModelProperty
+    @ApiModelProperty(position = 4)
     @JsonView(TokenViews.Auth.class)
     private String refreshToken;
 
     @Column
-    @ApiModelProperty
+    @ApiModelProperty(position = 5)
     @JsonView(TokenViews.User.class)
     private long userId;
 
@@ -173,7 +173,7 @@ public class Token implements Comparable<Token> {
         return id;
     }
 
-    @ApiModelProperty(value = "Contents of the access token")
+    @ApiModelProperty(value = "Contents of the access token", position = 6)
     @JsonView(TokenViews.Auth.class)
     public String getToken() {
         return content;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
@@ -109,8 +109,7 @@ public class Token implements Comparable<Token> {
     private String username;
 
     @Column()
-    @ApiModelProperty(value = "The ID of the user on the integrated service.", position = 7)
-    @JsonView(TokenViews.User.class)
+    @JsonIgnore
     private Long onlineProfileId;
 
     @Column

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
@@ -34,7 +34,7 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
 import io.swagger.annotations.ApiModel;
@@ -76,9 +76,9 @@ import org.hibernate.annotations.UpdateTimestamp;
             query = "SELECT t FROM Token t WHERE t.username = :username AND t.tokenSource = 'github.com'"),
     @NamedQuery(name = "io.dockstore.webservice.core.Token.findTokenByUserNameAndTokenSource",
             query = "SELECT t FROM Token t WHERE t.username = :username AND t.tokenSource = :tokenSource"),
-        @NamedQuery(name = "io.dockstore.webservice.core.Token.findTokenByOnlineProfileIdAndTokenSource",
-                query = "SELECT t FROM Token t WHERE t.onlineProfileId = :onlineProfileId AND t.tokenSource = :tokenSource"),
-        @NamedQuery(name = "io.dockstore.webservice.core.Token.findAllGitHubTokens", query = "SELECT t FROM Token t WHERE t.tokenSource = 'github.com'")
+    @NamedQuery(name = "io.dockstore.webservice.core.Token.findTokenByOnlineProfileIdAndTokenSource",
+            query = "SELECT t FROM Token t WHERE t.onlineProfileId = :onlineProfileId AND t.tokenSource = :tokenSource"),
+    @NamedQuery(name = "io.dockstore.webservice.core.Token.findAllGitHubTokens", query = "SELECT t FROM Token t WHERE t.tokenSource = 'github.com'")
 })
 
 @SuppressWarnings("checkstyle:magicnumber")
@@ -87,33 +87,40 @@ public class Token implements Comparable<Token> {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "token_id_seq")
     @SequenceGenerator(name = "token_id_seq", sequenceName = "token_id_seq", allocationSize = 1)
-    @ApiModelProperty(value = "Implementation specific ID for the token in this web service", position = 0, readOnly = true)
+    @ApiModelProperty(value = "Implementation specific ID for the token in this web service", readOnly = true)
     @Column(columnDefinition = "bigint default nextval('token_id_seq')")
+    @JsonView(TokenViews.User.class)
     private long id;
 
     @Column(nullable = false)
     @Convert(converter = TokenTypeConverter.class)
-    @ApiModelProperty(value = "Source website for this token", position = 1, dataType = "string")
+    @ApiModelProperty(value = "Source website for this token", dataType = "string")
+    @JsonView(TokenViews.User.class)
     private TokenType tokenSource;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "Contents of the access token", position = 2)
+    @ApiModelProperty(value = "Contents of the access token")
+    @JsonView(TokenViews.Auth.class)
     private String content;
 
     @Column(nullable = false)
-    @ApiModelProperty(value = "When an integrated service is not aware of the username, we store it", position = 3)
+    @ApiModelProperty(value = "When an integrated service is not aware of the username, we store it")
+    @JsonView(TokenViews.User.class)
     private String username;
 
     @Column()
-    @ApiModelProperty(value = "The ID of the user on the integrated service.", position = 3)
+    @ApiModelProperty(value = "The ID of the user on the integrated service.")
+    @JsonView(TokenViews.User.class)
     private Long onlineProfileId;
 
     @Column
-    @ApiModelProperty(position = 4)
+    @ApiModelProperty
+    @JsonView(TokenViews.Auth.class)
     private String refreshToken;
 
     @Column
-    @ApiModelProperty(position = 5)
+    @ApiModelProperty
+    @JsonView(TokenViews.User.class)
     private long userId;
 
     // Null means don't know or not applicable.
@@ -132,12 +139,14 @@ public class Token implements Comparable<Token> {
     @CreationTimestamp
     @ApiModelProperty(dataType = "long")
     @Schema(type = "integer", format = "int64")
+    @JsonView(TokenViews.User.class)
     private Timestamp dbCreateDate;
 
     @Column()
     @UpdateTimestamp
     @ApiModelProperty(dataType = "long")
     @Schema(type = "integer", format = "int64")
+    @JsonView(TokenViews.User.class)
     private Timestamp dbUpdateDate;
 
     public Token() {
@@ -160,23 +169,20 @@ public class Token implements Comparable<Token> {
         return null;
     }
 
-    @JsonProperty
     public long getId() {
         return id;
     }
 
-    @JsonProperty
-    @ApiModelProperty(value = "Contents of the access token", position = 6)
+    @ApiModelProperty(value = "Contents of the access token")
+    @JsonView(TokenViews.Auth.class)
     public String getToken() {
         return content;
     }
 
-    @JsonProperty
     public String getContent() {
         return content;
     }
 
-    @JsonProperty
     public String getUsername() {
         return username;
     }
@@ -184,7 +190,6 @@ public class Token implements Comparable<Token> {
     /**
      * @return the tokenSource
      */
-    @JsonProperty
     public TokenType getTokenSource() {
         return tokenSource;
     }
@@ -235,7 +240,6 @@ public class Token implements Comparable<Token> {
     /**
      * @return the userId
      */
-    @JsonProperty
     public long getUserId() {
         return userId;
     }
@@ -247,12 +251,10 @@ public class Token implements Comparable<Token> {
         this.userId = userId;
     }
 
-    @JsonProperty
     public Timestamp getDbCreateDate() {
         return dbCreateDate;
     }
 
-    @JsonProperty
     public Timestamp getDbUpdateDate() {
         return dbUpdateDate;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/TokenViews.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/TokenViews.java
@@ -1,0 +1,7 @@
+package io.dockstore.webservice.core;
+
+public class TokenViews {
+    public static class User { } // View for User API responses. Does not reveal the actual token.
+
+    public static class Auth extends User { } // View for Token API responses. Reveals the actual token.
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/TokenViews.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/TokenViews.java
@@ -1,7 +1,7 @@
 package io.dockstore.webservice.core;
 
 public class TokenViews {
-    public static class User { } // View for User API responses. Does not reveal the actual token.
+    public static class User { } // View that does not reveal the actual token in the API response.
 
-    public static class Auth extends User { } // View for Token API responses. Reveals the actual token.
+    public static class Auth extends User { } // View that reveals the actual token in the API response.
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -189,11 +189,11 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
 
     @GET
     @Path("/{tokenId}")
-    @JsonView(TokenViews.Auth.class)
+    @JsonView(TokenViews.User.class)
     @Timed
     @UnitOfWork(readOnly = true)
-    @Operation(operationId = "listToken", description = "Get a specific token by id.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
-    @ApiOperation(value = "Get a specific token by id.", authorizations = {
+    @Operation(operationId = "listToken", description = "Get information about a specific token by id.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
+    @ApiOperation(value = "Get information about a specific token by id.", authorizations = {
             @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Token.class)
     @ApiResponses({ @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = "Invalid ID supplied"),
             @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "Token not found") })

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -209,7 +209,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @Timed
     @UnitOfWork
     @Path("/quay.io")
-    @JsonView(TokenViews.Auth.class)
+    @JsonView(TokenViews.User.class)
     @Operation(operationId = "addQuayToken", description = "Add a new quay IO token.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Add a new quay IO token.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "This is used as part of the OAuth 2 web flow. Once a user has approved permissions for CollaboratoryTheir browser will load the redirect URI which should resolve here", response = Token.class)
     public Token addQuayToken(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user, @QueryParam("access_token") String accessToken) {
@@ -272,7 +272,6 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
 
     @DELETE
     @Path("/{tokenId}")
-    @JsonView(TokenViews.Auth.class)
     @UnitOfWork
     @Operation(operationId = "deleteToken", description = "Delete a token.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Delete a token.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
@@ -305,7 +304,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @Timed
     @UnitOfWork
     @Path("/gitlab.com")
-    @JsonView(TokenViews.Auth.class)
+    @JsonView(TokenViews.User.class)
     @Operation(operationId = "addGitlabToken", description = "Add a new gitlab.com token.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Add a new gitlab.com token.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "This is used as part of the OAuth 2 web flow. Once a user has approved permissions for CollaboratoryTheir browser will load the redirect URI which should resolve here", response = Token.class)
     public Token addGitlabToken(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user, @QueryParam("code") String code) {
@@ -531,7 +530,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @Timed
     @UnitOfWork
     @Path("/github.com")
-    @JsonView(TokenViews.Auth.class)
+    @JsonView(TokenViews.User.class)
     @Operation(operationId = "addGithubToken", description = "Add a new github.com token, used by accounts page.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Add a new github.com token, used by accounts page.", authorizations = {
             @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "This is used as part of the OAuth 2 web flow. "
@@ -643,7 +642,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @Timed
     @UnitOfWork
     @Path("/bitbucket.org")
-    @JsonView(TokenViews.Auth.class)
+    @JsonView(TokenViews.User.class)
     @Operation(operationId = "addBitbucketToken", description = "Add a new bitbucket.org token, used by quay.io redirect.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Add a new bitbucket.org token, used by quay.io redirect.", authorizations = {
             @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "This is used as part of the OAuth 2 web flow. "
@@ -701,7 +700,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @Timed
     @UnitOfWork
     @Path("/orcid.org")
-    @JsonView(TokenViews.Auth.class)
+    @JsonView(TokenViews.User.class)
     @ApiOperation(value = orcidSummary, authorizations = {@Authorization(value = JWT_SECURITY_DEFINITION_NAME)},
             notes = orcidDescription, response = Token.class)
     @Operation(operationId = "addOrcidToken", summary = orcidSummary, description = orcidDescription,
@@ -778,7 +777,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @Timed
     @UnitOfWork
     @Path("/zenodo.org")
-    @JsonView(TokenViews.Auth.class)
+    @JsonView(TokenViews.User.class)
     @Operation(operationId = "addZenodoToken", description = "Add a new zenodo.org token, used by accounts page.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Add a new zenodo.org token, used by accounts page.", authorizations = {
             @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "This is used as part of the OAuth 2 web flow. "

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -40,6 +40,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
 import com.google.api.client.auth.oauth2.BearerToken;
 import com.google.api.client.auth.oauth2.ClientParametersAuthentication;
@@ -63,6 +64,7 @@ import io.dockstore.webservice.core.TOSVersion;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.TokenScope;
 import io.dockstore.webservice.core.TokenType;
+import io.dockstore.webservice.core.TokenViews;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.helpers.DeletedUserHelper;
 import io.dockstore.webservice.helpers.GitHubHelper;
@@ -187,6 +189,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
 
     @GET
     @Path("/{tokenId}")
+    @JsonView(TokenViews.Auth.class)
     @Timed
     @UnitOfWork(readOnly = true)
     @Operation(operationId = "listToken", description = "Get a specific token by id.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
@@ -206,6 +209,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @Timed
     @UnitOfWork
     @Path("/quay.io")
+    @JsonView(TokenViews.Auth.class)
     @Operation(operationId = "addQuayToken", description = "Add a new quay IO token.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Add a new quay IO token.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "This is used as part of the OAuth 2 web flow. Once a user has approved permissions for CollaboratoryTheir browser will load the redirect URI which should resolve here", response = Token.class)
     public Token addQuayToken(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user, @QueryParam("access_token") String accessToken) {
@@ -268,6 +272,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
 
     @DELETE
     @Path("/{tokenId}")
+    @JsonView(TokenViews.Auth.class)
     @UnitOfWork
     @Operation(operationId = "deleteToken", description = "Delete a token.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Delete a token.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) })
@@ -300,6 +305,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @Timed
     @UnitOfWork
     @Path("/gitlab.com")
+    @JsonView(TokenViews.Auth.class)
     @Operation(operationId = "addGitlabToken", description = "Add a new gitlab.com token.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Add a new gitlab.com token.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "This is used as part of the OAuth 2 web flow. Once a user has approved permissions for CollaboratoryTheir browser will load the redirect URI which should resolve here", response = Token.class)
     public Token addGitlabToken(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user, @QueryParam("code") String code) {
@@ -390,6 +396,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @Timed
     @UnitOfWork
     @Path("/google")
+    @JsonView(TokenViews.Auth.class)
     @Operation(operationId = "addGoogleToken", description = "Allow satellizer to post a new Google token to Dockstore.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Allow satellizer to post a new Google token to Dockstore.", authorizations = {
             @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "A post method is required by satellizer to send the Google token", response = Token.class)
@@ -508,6 +515,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @Timed
     @UnitOfWork
     @Path("/github")
+    @JsonView(TokenViews.Auth.class)
     @Operation(operationId = "addToken", description = "Allow satellizer to post a new GitHub token to dockstore, used by login, can create new users.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Allow satellizer to post a new GitHub token to dockstore, used by login, can create new users.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "A post method is required by satellizer to send the GitHub token", response = Token.class)
@@ -523,6 +531,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @Timed
     @UnitOfWork
     @Path("/github.com")
+    @JsonView(TokenViews.Auth.class)
     @Operation(operationId = "addGithubToken", description = "Add a new github.com token, used by accounts page.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Add a new github.com token, used by accounts page.", authorizations = {
             @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "This is used as part of the OAuth 2 web flow. "
@@ -634,6 +643,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @Timed
     @UnitOfWork
     @Path("/bitbucket.org")
+    @JsonView(TokenViews.Auth.class)
     @Operation(operationId = "addBitbucketToken", description = "Add a new bitbucket.org token, used by quay.io redirect.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Add a new bitbucket.org token, used by quay.io redirect.", authorizations = {
             @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "This is used as part of the OAuth 2 web flow. "
@@ -691,6 +701,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @Timed
     @UnitOfWork
     @Path("/orcid.org")
+    @JsonView(TokenViews.Auth.class)
     @ApiOperation(value = orcidSummary, authorizations = {@Authorization(value = JWT_SECURITY_DEFINITION_NAME)},
             notes = orcidDescription, response = Token.class)
     @Operation(operationId = "addOrcidToken", summary = orcidSummary, description = orcidDescription,
@@ -767,6 +778,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @Timed
     @UnitOfWork
     @Path("/zenodo.org")
+    @JsonView(TokenViews.Auth.class)
     @Operation(operationId = "addZenodoToken", description = "Add a new zenodo.org token, used by accounts page.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Add a new zenodo.org token, used by accounts page.", authorizations = {
             @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "This is used as part of the OAuth 2 web flow. "

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -47,6 +47,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.google.common.collect.Lists;
 import io.dockstore.common.Registry;
 import io.dockstore.common.Repository;
@@ -70,6 +71,7 @@ import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.SourceControlOrganization;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.TokenType;
+import io.dockstore.webservice.core.TokenViews;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
@@ -409,8 +411,9 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Timed
     @UnitOfWork(readOnly = true)
     @Path("/{userId}/tokens")
-    @Operation(operationId = "getUserTokens", description = "Get tokens with user id.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
-    @ApiOperation(value = "Get tokens with user id.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Token.class, responseContainer = "List")
+    @JsonView(TokenViews.User.class)
+    @Operation(operationId = "getUserTokens", description = "Get information about tokens with user id.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
+    @ApiOperation(value = "Get information about tokens with user id.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Token.class, responseContainer = "List")
     public List<Token> getUserTokens(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,
             @ApiParam("User to return") @PathParam("userId") long userId) {
         checkUser(user, userId);

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -8013,9 +8013,6 @@ components:
         id:
           type: integer
           format: int64
-        onlineProfileId:
-          type: integer
-          format: int64
         refreshToken:
           type: string
         token:
@@ -8046,9 +8043,6 @@ components:
           type: integer
           format: int64
         id:
-          type: integer
-          format: int64
-        onlineProfileId:
           type: integer
           format: int64
         tokenSource:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -591,7 +591,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                $ref: '#/components/schemas/Token_Auth'
           description: default response
       security:
       - bearer: []
@@ -612,7 +612,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                $ref: '#/components/schemas/Token_Auth'
           description: default response
       security:
       - bearer: []
@@ -632,7 +632,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                $ref: '#/components/schemas/Token_Auth'
           description: default response
       security:
       - bearer: []
@@ -652,7 +652,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                $ref: '#/components/schemas/Token_Auth'
           description: default response
       security:
       - bearer: []
@@ -672,7 +672,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                $ref: '#/components/schemas/Token_Auth'
           description: default response
       security:
       - bearer: []
@@ -693,7 +693,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                $ref: '#/components/schemas/Token_Auth'
           description: default response
       security:
       - bearer: []
@@ -714,7 +714,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                $ref: '#/components/schemas/Token_Auth'
           description: default response
       security:
       - bearer: []
@@ -734,7 +734,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                $ref: '#/components/schemas/Token_Auth'
           description: default response
       security:
       - bearer: []
@@ -775,7 +775,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token'
+                $ref: '#/components/schemas/Token_Auth'
           description: default response
       security:
       - bearer: []
@@ -4991,7 +4991,7 @@ paths:
       - users
   /users/{userId}/tokens:
     get:
-      description: Get tokens with user id.
+      description: Get information about tokens with user id.
       operationId: getUserTokens
       parameters:
       - in: path
@@ -5007,7 +5007,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Token'
+                  $ref: '#/components/schemas/Token_User'
           description: default response
       security:
       - bearer: []
@@ -7999,7 +7999,7 @@ components:
       required:
       - name
       - reference
-    Token:
+    Token_Auth:
       type: object
       properties:
         content:
@@ -8020,6 +8020,37 @@ components:
           type: string
         token:
           type: string
+        tokenSource:
+          type: string
+          enum:
+          - quay.io
+          - github.com
+          - dockstore
+          - bitbucket.org
+          - gitlab.com
+          - zenodo.org
+          - google.com
+          - orcid.org
+        userId:
+          type: integer
+          format: int64
+        username:
+          type: string
+    Token_User:
+      type: object
+      properties:
+        dbCreateDate:
+          type: integer
+          format: int64
+        dbUpdateDate:
+          type: integer
+          format: int64
+        id:
+          type: integer
+          format: int64
+        onlineProfileId:
+          type: integer
+          format: int64
         tokenSource:
           type: string
           enum:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -591,7 +591,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token_Auth'
+                $ref: '#/components/schemas/Token_User'
           description: default response
       security:
       - bearer: []
@@ -632,7 +632,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token_Auth'
+                $ref: '#/components/schemas/Token_User'
           description: default response
       security:
       - bearer: []
@@ -652,7 +652,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token_Auth'
+                $ref: '#/components/schemas/Token_User'
           description: default response
       security:
       - bearer: []
@@ -693,7 +693,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token_Auth'
+                $ref: '#/components/schemas/Token_User'
           description: default response
       security:
       - bearer: []
@@ -714,7 +714,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token_Auth'
+                $ref: '#/components/schemas/Token_User'
           description: default response
       security:
       - bearer: []
@@ -734,7 +734,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token_Auth'
+                $ref: '#/components/schemas/Token_User'
           description: default response
       security:
       - bearer: []

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -761,7 +761,7 @@ paths:
       tags:
       - tokens
     get:
-      description: Get a specific token by id.
+      description: Get information about a specific token by id.
       operationId: listToken
       parameters:
       - in: path
@@ -775,7 +775,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Token_Auth'
+                $ref: '#/components/schemas/Token_User'
           description: default response
       security:
       - bearer: []

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -7710,11 +7710,6 @@ definitions:
         type: "string"
         position: 6
         description: "Contents of the access token"
-      onlineProfileId:
-        type: "integer"
-        format: "int64"
-        position: 7
-        description: "The ID of the user on the integrated service."
     description: "Access tokens for this web service and integrated services like\
       \ quay.io and github"
   Token_User:
@@ -7744,11 +7739,6 @@ definitions:
         type: "integer"
         format: "int64"
         position: 5
-      onlineProfileId:
-        type: "integer"
-        format: "int64"
-        position: 7
-        description: "The ID of the user on the integrated service."
     description: "Access tokens for this web service and integrated services like\
       \ quay.io and github"
   Tool:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -1111,7 +1111,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token"
+            $ref: "#/definitions/Token_Auth"
       security:
       - BEARER: []
   /auth/tokens/github:
@@ -1135,7 +1135,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token"
+            $ref: "#/definitions/Token_Auth"
       security:
       - BEARER: []
   /auth/tokens/github.com:
@@ -1158,7 +1158,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token"
+            $ref: "#/definitions/Token_Auth"
       security:
       - BEARER: []
   /auth/tokens/gitlab.com:
@@ -1181,7 +1181,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token"
+            $ref: "#/definitions/Token_Auth"
       security:
       - BEARER: []
   /auth/tokens/google:
@@ -1204,7 +1204,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token"
+            $ref: "#/definitions/Token_Auth"
       security:
       - BEARER: []
   /auth/tokens/orcid.org:
@@ -1226,7 +1226,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token"
+            $ref: "#/definitions/Token_Auth"
       security:
       - BEARER: []
   /auth/tokens/quay.io:
@@ -1249,7 +1249,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token"
+            $ref: "#/definitions/Token_Auth"
       security:
       - BEARER: []
   /auth/tokens/zenodo.org:
@@ -1272,7 +1272,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token"
+            $ref: "#/definitions/Token_Auth"
       security:
       - BEARER: []
   /auth/tokens/{tokenId}:
@@ -1295,7 +1295,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token"
+            $ref: "#/definitions/Token_Auth"
         400:
           description: "Invalid ID supplied"
         404:
@@ -4551,7 +4551,7 @@ paths:
     get:
       tags:
       - "users"
-      summary: "Get tokens with user id."
+      summary: "Get information about tokens with user id."
       description: ""
       operationId: "getUserTokens"
       produces:
@@ -4569,7 +4569,7 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/Token"
+              $ref: "#/definitions/Token_User"
       security:
       - BEARER: []
   /users/{userId}/workflows:
@@ -7672,52 +7672,72 @@ definitions:
         type: "string"
         position: 108
     description: "This describes one tag associated with a container."
-  Token:
+  Token_Auth:
     type: "object"
     properties:
+      content:
+        type: "string"
+        description: "Contents of the access token"
       dbCreateDate:
         type: "integer"
         format: "int64"
-        readOnly: true
       dbUpdateDate:
         type: "integer"
         format: "int64"
-        readOnly: true
       id:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the token in this web service"
         readOnly: true
-      tokenSource:
-        type: "string"
-        position: 1
-        description: "Source website for this token"
-      content:
-        type: "string"
-        position: 2
-        description: "Contents of the access token"
       onlineProfileId:
         type: "integer"
         format: "int64"
-        position: 3
         description: "The ID of the user on the integrated service."
-      username:
-        type: "string"
-        position: 3
-        description: "When an integrated service is not aware of the username, we\
-          \ store it"
       refreshToken:
         type: "string"
-        position: 4
+      token:
+        type: "string"
+        description: "Contents of the access token"
+      tokenSource:
+        type: "string"
+        description: "Source website for this token"
       userId:
         type: "integer"
         format: "int64"
-        position: 5
-      token:
+      username:
         type: "string"
-        position: 6
-        description: "Contents of the access token"
+        description: "When an integrated service is not aware of the username, we\
+          \ store it"
+    description: "Access tokens for this web service and integrated services like\
+      \ quay.io and github"
+  Token_User:
+    type: "object"
+    properties:
+      dbCreateDate:
+        type: "integer"
+        format: "int64"
+      dbUpdateDate:
+        type: "integer"
+        format: "int64"
+      id:
+        type: "integer"
+        format: "int64"
+        description: "Implementation specific ID for the token in this web service"
         readOnly: true
+      onlineProfileId:
+        type: "integer"
+        format: "int64"
+        description: "The ID of the user on the integrated service."
+      tokenSource:
+        type: "string"
+        description: "Source website for this token"
+      userId:
+        type: "integer"
+        format: "int64"
+      username:
+        type: "string"
+        description: "When an integrated service is not aware of the username, we\
+          \ store it"
     description: "Access tokens for this web service and integrated services like\
       \ quay.io and github"
   Tool:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -1111,7 +1111,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token_Auth"
+            $ref: "#/definitions/Token_User"
       security:
       - BEARER: []
   /auth/tokens/github:
@@ -1158,7 +1158,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token_Auth"
+            $ref: "#/definitions/Token_User"
       security:
       - BEARER: []
   /auth/tokens/gitlab.com:
@@ -1181,7 +1181,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token_Auth"
+            $ref: "#/definitions/Token_User"
       security:
       - BEARER: []
   /auth/tokens/google:
@@ -1226,7 +1226,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token_Auth"
+            $ref: "#/definitions/Token_User"
       security:
       - BEARER: []
   /auth/tokens/quay.io:
@@ -1249,7 +1249,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token_Auth"
+            $ref: "#/definitions/Token_User"
       security:
       - BEARER: []
   /auth/tokens/zenodo.org:
@@ -1272,7 +1272,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token_Auth"
+            $ref: "#/definitions/Token_User"
       security:
       - BEARER: []
   /auth/tokens/{tokenId}:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -1279,7 +1279,7 @@ paths:
     get:
       tags:
       - "tokens"
-      summary: "Get a specific token by id."
+      summary: "Get information about a specific token by id."
       description: ""
       operationId: "listToken"
       produces:
@@ -1295,7 +1295,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/Token_Auth"
+            $ref: "#/definitions/Token_User"
         400:
           description: "Invalid ID supplied"
         404:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -7675,9 +7675,6 @@ definitions:
   Token_Auth:
     type: "object"
     properties:
-      content:
-        type: "string"
-        description: "Contents of the access token"
       dbCreateDate:
         type: "integer"
         format: "int64"
@@ -7689,25 +7686,35 @@ definitions:
         format: "int64"
         description: "Implementation specific ID for the token in this web service"
         readOnly: true
-      onlineProfileId:
-        type: "integer"
-        format: "int64"
-        description: "The ID of the user on the integrated service."
-      refreshToken:
-        type: "string"
-      token:
-        type: "string"
-        description: "Contents of the access token"
       tokenSource:
         type: "string"
+        position: 1
         description: "Source website for this token"
+      content:
+        type: "string"
+        position: 2
+        description: "Contents of the access token"
+      username:
+        type: "string"
+        position: 3
+        description: "When an integrated service is not aware of the username, we\
+          \ store it"
+      refreshToken:
+        type: "string"
+        position: 4
       userId:
         type: "integer"
         format: "int64"
-      username:
+        position: 5
+      token:
         type: "string"
-        description: "When an integrated service is not aware of the username, we\
-          \ store it"
+        position: 6
+        description: "Contents of the access token"
+      onlineProfileId:
+        type: "integer"
+        format: "int64"
+        position: 7
+        description: "The ID of the user on the integrated service."
     description: "Access tokens for this web service and integrated services like\
       \ quay.io and github"
   Token_User:
@@ -7724,20 +7731,24 @@ definitions:
         format: "int64"
         description: "Implementation specific ID for the token in this web service"
         readOnly: true
-      onlineProfileId:
-        type: "integer"
-        format: "int64"
-        description: "The ID of the user on the integrated service."
       tokenSource:
         type: "string"
+        position: 1
         description: "Source website for this token"
+      username:
+        type: "string"
+        position: 3
+        description: "When an integrated service is not aware of the username, we\
+          \ store it"
       userId:
         type: "integer"
         format: "int64"
-      username:
-        type: "string"
-        description: "When an integrated service is not aware of the username, we\
-          \ store it"
+        position: 5
+      onlineProfileId:
+        type: "integer"
+        format: "int64"
+        position: 7
+        description: "The ID of the user on the integrated service."
     description: "Access tokens for this web service and integrated services like\
       \ quay.io and github"
   Tool:


### PR DESCRIPTION
For [SEAB-1713](https://ucsc-cgl.atlassian.net/browse/SEAB-1713)

Modified the response for the user endpoint `GET /users/{userId}/tokens` so that the `token`, `content`, and `refreshToken` fields are not shown. I used JsonView to hide these fields, so I created the class TokenViews. Please let me know if there's a better place to put this class, since I couldn't find any other Views classes. Below is what the modified response looks like: 
```
[
  {
    "id": 0,
    "tokenSource": "quay.io",
    "username": "string",
    "userId": 0,
    "dbCreateDate": 0,
    "dbUpdateDate": 0
  }
]
```
This still allows the UI to retrieve the information it needs for the accounts page, like the username and whether an account is linked or not, without requiring any further changes in the UI (aside from fixing model names, since in swagger, it's no longer Token - it's TokenAuth or TokenUser).

Since the token id is shown, the response for the tokens endpoint `GET /auth/tokens/{tokenId}` is also modified to not show `token`, `content`, and `refreshToken` so the user can't go to the swagger-ui and retrieve their token there.

I noticed that all the token endpoints `auth/tokens/...` also reveal the actual token in the response. I hid the `token`, `content`, and `refreshToken` fields for the token endpoints **NOT** used for login. The response for token endpoints that are used for login (`POST /auth/tokens/github` and `POST /auth/tokens/google`) are unchanged because the token content is required to login properly (the actual token content returned is the dockstore token, not the corresponding github or google token). 

For reference, this is the full response:
```
{
  "id": 0,
  "tokenSource": "quay.io",
  "content": "string",
  "username": "string",
  "refreshToken": "string",
  "userId": 0,
  "dbCreateDate": 0,
  "dbUpdateDate": 0,
  "token": "string"
}
```
EDIT: `onlineProfileId` is hidden because Google user id's may not be available publicly. Although the UI currently requires the GitHub user id, my next PR in the UI for this ticket will remove this requirement.