### PR TITLE
Feature/seab 2860/bitbucket rate limit

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -339,7 +339,8 @@ public class GeneralIT extends BaseIT {
         tool.setDefaultCWLTestParameterFile("/test.cwl.json");
         tool.setDefaultWDLTestParameterFile("/test.wdl.json");
         tool.setIsPublished(false);
-        tool.setGitUrl("git@bitbucket.org:dockstoretestuser2/dockstore-whalesay-2.git");
+        // This actually exists: https://bitbucket.org/DockstoreTestUser/dockstore-whalesay-2/src/master/
+        tool.setGitUrl("git@bitbucket.org:DockstoreTestUser/dockstore-whalesay-2.git");
         tool.setToolname("alternate");
         tool.setPrivateAccess(false);
         return tool;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -242,7 +242,7 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
             LOG.warn(gitUsername + ": apiexception on reading tags" + e.getMessage(), e);
             // this is not so critical to warrant a http error code
         }
-        throw new CustomWebApplicationException("Not a Bitbucket branch or tag", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        throw new CustomWebApplicationException(name + " is not a Bitbucket branch or tag in " + repositoryId, HttpStatus.SC_INTERNAL_SERVER_ERROR);
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -223,12 +223,14 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
         String repoSlug = repositoryId.split("/")[1];
         String name = version.getReference();
         RefsApi refsApi = new RefsApi(apiClient);
+        // There isn't exactly a single Bitbucket endpoint to get a version which then allows us to determine if it's a branch or tag.
+        // This code checks two endpoints (branches and tags) to see if it belongs in which.
         try {
-            refsApi.repositoriesUsernameRepoSlugRefsBranchesNameGet(workspace, version.getReference(), repoSlug);
+            refsApi.repositoriesUsernameRepoSlugRefsBranchesNameGet(workspace, name, repoSlug);
             version.setReferenceType(Version.ReferenceType.BRANCH);
             return;
         } catch (ApiException e) {
-            LOG.error(gitUsername + ": apiexception on reading branches" + e.getMessage(), e);
+            LOG.warn(gitUsername + ": apiexception on reading branches" + e.getMessage(), e);
             // this is not so critical to warrant a http error code
         }
 
@@ -237,7 +239,7 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
             version.setReferenceType(Version.ReferenceType.TAG);
             return;
         } catch (ApiException e) {
-            LOG.error(gitUsername + ": apiexception on reading tags" + e.getMessage(), e);
+            LOG.warn(gitUsername + ": apiexception on reading tags" + e.getMessage(), e);
             // this is not so critical to warrant a http error code
         }
         throw new CustomWebApplicationException("Not a Bitbucket branch or tag", HttpStatus.SC_INTERNAL_SERVER_ERROR);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -46,10 +46,8 @@ import io.swagger.bitbucket.client.Configuration;
 import io.swagger.bitbucket.client.api.RefsApi;
 import io.swagger.bitbucket.client.api.RepositoriesApi;
 import io.swagger.bitbucket.client.model.Branch;
-import io.swagger.bitbucket.client.model.PaginatedBranches;
 import io.swagger.bitbucket.client.model.PaginatedRefs;
 import io.swagger.bitbucket.client.model.PaginatedRepositories;
-import io.swagger.bitbucket.client.model.PaginatedTags;
 import io.swagger.bitbucket.client.model.PaginatedTreeentries;
 import io.swagger.bitbucket.client.model.Repository;
 import io.swagger.bitbucket.client.model.Tag;
@@ -115,7 +113,6 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
         RepositoriesApi repositoriesApi = new RepositoriesApi(apiClient);
         try {
             List<String> files = new ArrayList<>();
-            System.out.println("Invoked: repositoriesUsernameRepoSlugSrcNodePathGet" + repositoryId.split("/")[0]);
             PaginatedTreeentries paginatedTreeentries = repositoriesApi
                 .repositoriesUsernameRepoSlugSrcNodePathGet(repositoryId.split("/")[0], reference, pathToDirectory,
                     repositoryId.split("/")[1], null, null, null);
@@ -143,7 +140,6 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
         RepositoriesApi repositoriesApi = new RepositoriesApi(apiClient);
         try {
             Map<String, String> collect = new HashMap<>();
-            System.out.println("Invoked: repositoriesUsernameGet" + gitUsername);
             PaginatedRepositories contributor = repositoriesApi.repositoriesUsernameGet(gitUsername, "contributor");
             while (contributor != null) {
                 collect.putAll(contributor.getValues().stream().collect(Collectors
@@ -180,7 +176,6 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
      */
     private <T> T getArbitraryURL(String url, GenericType<T> type) throws ApiException {
         String substring = url.substring(BITBUCKET_V2_API_URL.length() - 1);
-        System.out.println("Invoked: " + url);
         return apiClient
             .invokeAPI(substring, "GET", new ArrayList<>(), null, new HashMap<>(), new HashMap<>(), "application/json", "application/json",
                 new String[] { "api_key", "basic", "oauth2" }, type).getData();
@@ -229,7 +224,6 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
         String name = version.getReference();
         RefsApi refsApi = new RefsApi(apiClient);
         try {
-            System.out.println("Invoked: repositoriesUsernameRepoSlugRefsBranchesNameGet");
             refsApi.repositoriesUsernameRepoSlugRefsBranchesNameGet(workspace, version.getReference(), repoSlug);
             version.setReferenceType(Version.ReferenceType.BRANCH);
             return;
@@ -239,7 +233,6 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
         }
 
         try {
-            System.out.println("Invoked: repositoriesUsernameRepoSlugRefsTagsNameGet");
             refsApi.repositoriesUsernameRepoSlugRefsTagsNameGet(workspace, name, repoSlug);
             version.setReferenceType(Version.ReferenceType.TAG);
             return;
@@ -254,7 +247,6 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
     protected String getCommitID(String repositoryId, Version version) {
         RefsApi refsApi = new RefsApi(apiClient);
         try {
-            System.out.println("Invoked: repositoriesUsernameRepoSlugRefsBranchesNameGet" + repositoryId.split("/")[0] + version.getReference() + repositoryId.split("/")[1]);
             Branch branch = refsApi.repositoriesUsernameRepoSlugRefsBranchesNameGet(repositoryId.split("/")[0], version.getReference(),
                 repositoryId.split("/")[1]);
             if (branch != null) {
@@ -266,7 +258,6 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
         }
 
         try {
-            System.out.println("Invoked: repositoriesUsernameRepoSlugRefsTagsNameGet" + repositoryId.split("/")[0] + version.getReference() + repositoryId.split("/")[1]);
             Tag tag = refsApi.repositoriesUsernameRepoSlugRefsTagsNameGet(repositoryId.split("/")[0], version.getReference(),
                     repositoryId.split("/")[1]);
             if (tag != null) {
@@ -303,7 +294,6 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
         Map<String, WorkflowVersion> existingDefaults, Optional<String> versionName, boolean hardRefresh) {
         RefsApi refsApi = new RefsApi(apiClient);
         try {
-            System.out.println("Invoked: repositoriesUsernameRepoSlugRefsGet" + repositoryId.split("/")[0] + repositoryId.split("/")[1]);
             PaginatedRefs paginatedRefs = refsApi
                 .repositoriesUsernameRepoSlugRefsGet(repositoryId.split("/")[0], repositoryId.split("/")[1]);
             // this pagination structure is repetitive and should be refactored


### PR DESCRIPTION
For https://ucsc-cgl.atlassian.net/browse/SEAB-2860

The calls all seem to be unique at a glance. So we're probably not doing something terribly inefficient.

This PR reduces total calls by about 1/6

We probably only triggered the rate limit during extra-ordinary circumstances (like me testing for OOM many times). Probably not worth hoverfly mocking it.