### PR TITLE
seab-2571/ Google ids through endpoint.

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -694,8 +694,10 @@ public class UserResourceIT extends BaseIT {
         // Additionally, the API call should go through and sync DockstoreTestUser2's GitHub data
         userApi.updateUserMetadataToGetIds();
         String userId = "17859829";
-        userProfile = userApi.getUser().getUserProfiles().get("github.com");
-        assertEquals(userId, userProfile.getOnlineProfileId());
+        io.dockstore.openapi.client.model.User user = userApi.getUser();
+        userProfile = user.getUserProfiles().get("github.com");
+        String onlineProfileId = testingPostgres.runSelectStatement("SELECT onlineprofileid FROM user_profile WHERE id = '" + user.getId() + "'", String.class);
+        assertEquals(userId, onlineProfileId);
         assertEquals("dockstore.test.user2@gmail.com", userProfile.getEmail());
         assertTrue(userProfile.getAvatarURL().endsWith("githubusercontent.com/u/17859829?v=4"));
         assertEquals("Toronto", userProfile.getLocation());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -693,7 +693,7 @@ public class UserResourceIT extends BaseIT {
         // The API call updateUserMetadataToGetIds() should not throw an error and exit if any users' tokens are out of date or absent
         // Additionally, the API call should go through and sync DockstoreTestUser2's GitHub data
         userApi.updateUserMetadataToGetIds();
-        Long userId = 17859829L;
+        String userId = "17859829";
         userProfile = userApi.getUser().getUserProfiles().get("github.com");
         assertEquals(userId, userProfile.getOnlineProfileId());
         assertEquals("dockstore.test.user2@gmail.com", userProfile.getEmail());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
@@ -78,7 +78,8 @@ import org.hibernate.annotations.UpdateTimestamp;
             query = "SELECT t FROM Token t WHERE t.username = :username AND t.tokenSource = :tokenSource"),
     @NamedQuery(name = "io.dockstore.webservice.core.Token.findTokenByOnlineProfileIdAndTokenSource",
             query = "SELECT t FROM Token t WHERE t.onlineProfileId = :onlineProfileId AND t.tokenSource = :tokenSource"),
-    @NamedQuery(name = "io.dockstore.webservice.core.Token.findAllGitHubTokens", query = "SELECT t FROM Token t WHERE t.tokenSource = 'github.com'")
+    @NamedQuery(name = "io.dockstore.webservice.core.Token.findAllGitHubTokens", query = "SELECT t FROM Token t WHERE t.tokenSource = 'github.com'"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Token.findAllGoogleTokens", query = "SELECT t FROM Token t WHERE t.tokenSource = 'google.com'")
 })
 
 @SuppressWarnings("checkstyle:magicnumber")
@@ -110,7 +111,7 @@ public class Token implements Comparable<Token> {
 
     @Column()
     @JsonIgnore
-    private Long onlineProfileId;
+    private String onlineProfileId;
 
     @Column
     @ApiModelProperty(position = 4)
@@ -151,12 +152,13 @@ public class Token implements Comparable<Token> {
     public Token() {
     }
 
-    public Token(String content, String refreshToken, long userId, String username, TokenType tokenSource) {
+    public Token(String content, String refreshToken, long userId, String username, TokenType tokenSource, String onlineProfileId) {
         this.setContent(content);
         this.setRefreshToken(refreshToken);
         this.setUserId(userId);
         this.setUsername(username);
         this.setTokenSource(tokenSource);
+        this.setOnlineProfileId(onlineProfileId);
     }
 
     public static Token extractToken(List<Token> tokens, TokenType source) {
@@ -228,11 +230,11 @@ public class Token implements Comparable<Token> {
         this.refreshToken = refreshToken;
     }
 
-    public Long getOnlineProfileId() {
+    public String getOnlineProfileId() {
         return onlineProfileId;
     }
 
-    public void setOnlineProfileId(final Long onlineProfileId) {
+    public void setOnlineProfileId(final String onlineProfileId) {
         this.onlineProfileId = onlineProfileId;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -566,6 +566,7 @@ public class User implements Principal, Comparable<User>, Serializable {
         @Column(columnDefinition = "text")
         public String username;
         @Column
+        @JsonIgnore
         public String onlineProfileId;
 
         @Column(updatable = false)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -83,6 +83,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 @NamedQueries({ @NamedQuery(name = "io.dockstore.webservice.core.User.findAll", query = "SELECT t FROM User t"),
     @NamedQuery(name = "io.dockstore.webservice.core.User.findByUsername", query = "SELECT t FROM User t WHERE t.username = :username"),
     @NamedQuery(name = "io.dockstore.webservice.core.User.findByGoogleEmail", query = "SELECT t FROM User t JOIN t.userProfiles p where( KEY(p) = 'google.com' AND p.email = :email)"),
+    @NamedQuery(name = "io.dockstore.webservice.core.User.findByGoogleUserId", query = "SELECT t FROM User t JOIN t.userProfiles p where( KEY(p) = 'google.com' AND p.onlineProfileId = :id)"),
     @NamedQuery(name = "io.dockstore.webservice.core.User.countPublishedEntries", query = "SELECT count(e) FROM User u INNER JOIN u.entries e where e.isPublished=true and u.username = :username"),
     @NamedQuery(name = "io.dockstore.webservice.core.User.findByGitHubUsername", query = "SELECT t FROM User t JOIN t.userProfiles p where( KEY(p) = 'github.com' AND p.username = :username)"),
     @NamedQuery(name = "io.dockstore.webservice.core.User.findByGitHubUserId", query = "SELECT t FROM User t JOIN t.userProfiles p where(KEY(p) = 'github.com' AND p.onlineProfileId = :id)")
@@ -319,7 +320,7 @@ public class User implements Principal, Comparable<User>, Serializable {
             return false;
         } else {
             Token googleToken = googleByUserId.get(0);
-            return GoogleHelper.updateGoogleUserData(googleToken.getContent(), this);
+            return GoogleHelper.updateGoogleUserData(googleToken, this);
         }
     }
 
@@ -565,7 +566,7 @@ public class User implements Principal, Comparable<User>, Serializable {
         @Column(columnDefinition = "text")
         public String username;
         @Column
-        public Long onlineProfileId;
+        public String onlineProfileId;
 
         @Column(updatable = false)
         @CreationTimestamp

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1064,7 +1064,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
     public User.Profile getProfile(final User user, final GHUser ghUser) throws IOException {
         User.Profile profile = new User.Profile();
-        profile.onlineProfileId = ghUser.getId();
+        profile.onlineProfileId = String.valueOf(ghUser.getId());
         profile.username = ghUser.getLogin();
         profile.name = ghUser.getName();
         profile.avatarURL = ghUser.getAvatarUrl();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GoogleHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GoogleHelper.java
@@ -49,10 +49,12 @@ public final class GoogleHelper {
      * @param token The Google access token
      * @param user  The pre-updated user
      */
-    public static boolean updateGoogleUserData(String token, User user) {
-        return userinfoplusFromToken(token)
+    public static boolean updateGoogleUserData(Token token, User user) {
+        return userinfoplusFromToken(token.getToken())
                 .map(userinfoPlus -> {
                     updateUserFromGoogleUserinfoplus(userinfoPlus, user);
+                    token.setUsername(userinfoPlus.getEmail());
+                    token.setOnlineProfileId(userinfoPlus.getId());
                     return true;
                 })
                 .orElse(false);
@@ -69,6 +71,7 @@ public final class GoogleHelper {
         profile.email = userinfo.getEmail();
         profile.name = userinfo.getName();
         profile.username = userinfo.getEmail();
+        profile.onlineProfileId = userinfo.getId();
         user.setAvatarUrl(userinfo.getPicture());
         Map<String, User.Profile> userProfile = user.getUserProfiles();
         userProfile.put(TokenType.GOOGLE_COM.toString(), profile);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/TokenDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/TokenDAO.java
@@ -98,11 +98,15 @@ public class TokenDAO extends AbstractDAO<Token> {
         return uniqueResult(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Token.findTokenByUserNameAndTokenSource").setParameter("username", username).setParameter("tokenSource", tokenSource));
     }
 
-    public Token findTokenByOnlineProfileIdAndTokenSource(Long onlineProfileId, TokenType tokenSource) {
+    public Token findTokenByOnlineProfileIdAndTokenSource(String onlineProfileId, TokenType tokenSource) {
         return uniqueResult(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Token.findTokenByOnlineProfileIdAndTokenSource").setParameter("onlineProfileId", onlineProfileId).setParameter("tokenSource", tokenSource));
     }
 
     public List<Token> findAllGitHubTokens() {
         return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Token.findAllGitHubTokens"));
+    }
+
+    public List<Token> findAllGoogleTokens() {
+        return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Token.findAllGoogleTokens"));
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/UserDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/UserDAO.java
@@ -70,13 +70,17 @@ public class UserDAO extends AbstractDockstoreDAO<User> {
         return (User)query.uniqueResult();
     }
 
+    public User findByGoogleOnlineProfileId(String id) {
+        return uniqueResult(this.currentSession().getNamedQuery("io.dockstore.webservice.core.User.findByGoogleUserId").setParameter("id", id));
+    }
+
     public User findByGitHubUsername(String username) {
         final Query query = namedQuery("io.dockstore.webservice.core.User.findByGitHubUsername")
             .setParameter("username", username);
         return (User)query.uniqueResult();
     }
 
-    public User findByGitHubUserId(long id) {
+    public User findByGitHubUserId(String id) {
         return uniqueResult(this.currentSession().getNamedQuery("io.dockstore.webservice.core.User.findByGitHubUserId").setParameter("id", id));
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -737,15 +737,30 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @RolesAllowed("admin")
     @Path("/updateUserMetadataToGetIds")
     @Deprecated
-    @Operation(operationId = "updateUserMetadataToGetIds", description = "Update metadata of all GitHub users and returns list of Dockstore users who could not be updated.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
-    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Get list Dockstore users we were unable to get GitHub IDs for.", content = @Content(
+    @Operation(operationId = "updateUserMetadataToGetIds", description = "Attempt to update the metadata of all GitHub and Google users and then returns a list of Dockstore users who could not be updated.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Get list Dockstore users we were unable to get GitHub/Google IDs for.", content = @Content(
             mediaType = "application/json",
             array = @ArraySchema(schema = @Schema(implementation = User.class))))
     @ApiOperation(value = "See OpenApi for details", hidden = true)
     public List<User> updateUserMetadataToGetIds(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user) {
+        List<Token> googleTokens = tokenDAO.findAllGoogleTokens();
         List<Token> gitHubTokens = tokenDAO.findAllGitHubTokens();
         List<User> usersNotUpdatedWithToken = new ArrayList<>();
-        List<User> usersNotUpdatedWithTokenOrUsername = new ArrayList<>();
+        List<User> usersCouldNotBeUpdated = new ArrayList<>();
+
+        for (Token t : googleTokens) {
+            User currentUser = userDAO.findById(t.getUserId());
+            if (currentUser != null) {
+                updateGoogleAccessToken(currentUser.getId());
+                try {
+                    currentUser.updateUserMetadata(tokenDAO, TokenType.GOOGLE_COM, true);
+                } catch (Exception ex) {
+                    LOG.info("Could not retrieve Google ID for user: " + currentUser.getUsername());
+                    usersCouldNotBeUpdated.add(currentUser);
+                }
+
+            }
+        }
 
         for (Token t : gitHubTokens) {
             User currentUser = userDAO.findById(t.getUserId());
@@ -766,12 +781,12 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
             try {
                 gitHubSourceCodeRepo.syncUserMetadataFromGitHubByUsername(u, tokenDAO);
             } catch (Exception ex) {
-                usersNotUpdatedWithTokenOrUsername.add(u);
+                usersCouldNotBeUpdated.add(u);
                 LOG.info(ex.getMessage());
             }
         }
 
-        return usersNotUpdatedWithTokenOrUsername;
+        return usersCouldNotBeUpdated;
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -745,9 +745,10 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     public List<User> updateUserMetadataToGetIds(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user) {
         List<Token> googleTokens = tokenDAO.findAllGoogleTokens();
         List<Token> gitHubTokens = tokenDAO.findAllGitHubTokens();
-        List<User> usersNotUpdatedWithToken = new ArrayList<>();
+        List<User> gitHubUsersNotUpdatedWithToken = new ArrayList<>();
         List<User> usersCouldNotBeUpdated = new ArrayList<>();
 
+        // Try to update Google metadata using user's token. This is the only option for Google.
         for (Token t : googleTokens) {
             User currentUser = userDAO.findById(t.getUserId());
             if (currentUser != null) {
@@ -755,13 +756,14 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
                 try {
                     currentUser.updateUserMetadata(tokenDAO, TokenType.GOOGLE_COM, true);
                 } catch (Exception ex) {
-                    LOG.info("Could not retrieve Google ID for user: " + currentUser.getUsername());
+                    LOG.info("Could not retrieve Google ID for user: " + currentUser.getUsername(), ex);
                     usersCouldNotBeUpdated.add(currentUser);
                 }
 
             }
         }
 
+        // Try to update Google metadata using user's token and getMyself(). If not, try by using username in block below.
         for (Token t : gitHubTokens) {
             User currentUser = userDAO.findById(t.getUserId());
             if (currentUser != null) {
@@ -769,7 +771,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
                     GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(t);
                     gitHubSourceCodeRepo.syncUserMetadataFromGitHub(currentUser, Optional.of(tokenDAO));
                 } catch (Exception ex) {
-                    usersNotUpdatedWithToken.add(currentUser);
+                    gitHubUsersNotUpdatedWithToken.add(currentUser);
                 }
             }
         }
@@ -777,12 +779,12 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
         // Get the GitHub token of the admin making this call to avoid rate limiting
         Token t = tokenDAO.findGithubByUserId(user.getId()).get(0);
         GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(t);
-        for (User u : usersNotUpdatedWithToken) {
+        for (User u : gitHubUsersNotUpdatedWithToken) {
             try {
                 gitHubSourceCodeRepo.syncUserMetadataFromGitHubByUsername(u, tokenDAO);
             } catch (Exception ex) {
                 usersCouldNotBeUpdated.add(u);
-                LOG.info(ex.getMessage());
+                LOG.info(ex.getMessage(), ex);
             }
         }
 

--- a/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
@@ -215,4 +215,12 @@
             CREATE UNIQUE INDEX one_token_link_per_identify2 ON token USING btree (username, tokensource) WHERE onlineprofileid IS NULL;
         </sql>
     </changeSet>
+    <changeSet author="natalieperez (generated)" id="fix_onlineprofileid_datatype">
+        <sql dbms="postgresql">
+            UPDATE token SET onlineprofileid = null WHERE true;
+            UPDATE user_profile SET onlineprofileid = null WHERE true;
+        </sql>
+        <modifyDataType columnName="onlineprofileid" newDataType="varchar(255)" tableName="token"/>
+        <modifyDataType columnName="onlineprofileid" newDataType="varchar(255)" tableName="user_profile"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
@@ -217,8 +217,8 @@
     </changeSet>
     <changeSet author="natalieperez (generated)" id="fix_onlineprofileid_datatype">
         <sql dbms="postgresql">
-            UPDATE token SET onlineprofileid = null WHERE true;
-            UPDATE user_profile SET onlineprofileid = null WHERE true;
+            UPDATE token SET onlineprofileid = null;
+            UPDATE user_profile SET onlineprofileid = null;
         </sql>
         <modifyDataType columnName="onlineprofileid" newDataType="varchar(255)" tableName="token"/>
         <modifyDataType columnName="onlineprofileid" newDataType="varchar(255)" tableName="user_profile"/>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -7651,8 +7651,6 @@ components:
           type: string
         name:
           type: string
-        onlineProfileId:
-          type: string
         username:
           type: string
     PublishRequest:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -4423,8 +4423,8 @@ paths:
   /users/updateUserMetadataToGetIds:
     get:
       deprecated: true
-      description: Update metadata of all GitHub users and returns list of Dockstore
-        users who could not be updated.
+      description: Attempt to update the metadata of all GitHub and Google users and
+        then returns a list of Dockstore users who could not be updated.
       operationId: updateUserMetadataToGetIds
       responses:
         "200":
@@ -4434,7 +4434,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/User'
-          description: Get list Dockstore users we were unable to get GitHub IDs for.
+          description: Get list Dockstore users we were unable to get GitHub/Google
+            IDs for.
       security:
       - bearer: []
       tags:
@@ -7651,8 +7652,7 @@ components:
         name:
           type: string
         onlineProfileId:
-          type: integer
-          format: int64
+          type: string
         username:
           type: string
     PublishRequest:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -7351,8 +7351,7 @@ definitions:
       name:
         type: "string"
       onlineProfileId:
-        type: "integer"
-        format: "int64"
+        type: "string"
       username:
         type: "string"
   PublishRequest:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -7350,8 +7350,6 @@ definitions:
         type: "string"
       name:
         type: "string"
-      onlineProfileId:
-        type: "string"
       username:
         type: "string"
   PublishRequest:


### PR DESCRIPTION
Gather Google ids through endpoint.
Change the id type from long to string to accommodate Google. Also cleared the profile ids that were gathered on dev with the SQL in the migrations file since i already ran the endpoint on dev. But I could also just do this directly on the instance instead?
Do Google login by id, or by username if by id is not successful.
Update/get Google id upon login.

After migration there are:
288 null onlineprofileids for Google user_profiles ( out 464 Google user_profiles)
157 null onlineprofileids for Dockstore users that only have login via google

We'll be keeping login by username and id for Google for a yet to be determined amount of time.
