### PR TITLE
use payload body for auth

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceUtilities.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceUtilities.java
@@ -18,8 +18,6 @@ package io.dockstore.webservice.resources;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Optional;
 
 import org.apache.http.client.HttpClient;
@@ -71,15 +69,10 @@ public final class ResourceUtilities {
             throws UnsupportedEncodingException {
         HttpPost httpPost = new HttpPost(input);
         if (token == null) {
-            // if the client ID and the client secret are null then we assume
-            // they are passed as parameters in the request body via the payload variable
-            if (clientId != null && secret != null) {
-                String string = clientId + ':' + secret;
-                byte[] b = string.getBytes(StandardCharsets.UTF_8);
-                String encoding = Base64.getEncoder().encodeToString(b);
-
-                httpPost.addHeader("Authorization", "Basic " + encoding);
-            }
+            // client ID and the client secret should be passed as parameters
+            // in the request body via the payload variable
+            // because basic authentication, e.g. "httpPost.addHeader("Authorization", "Basic " + encoding)"
+            // is not a secure method and generates a SonarCloud warning
             StringEntity entity = new StringEntity(payload);
             entity.setContentType("application/x-www-form-urlencoded");
             httpPost.setEntity(entity);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceUtilities.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceUtilities.java
@@ -47,14 +47,9 @@ public final class ResourceUtilities {
         return getResponseAsString(buildHttpGet(input, token), client);
     }
 
-    public static Optional<String> refreshPost(String input, String token, HttpClient client, String clientId, String secret,
+    public static Optional<String> refreshPost(String input, String token, HttpClient client,
             String payload) throws UnsupportedEncodingException {
-        return getResponseAsString(buildHttpPost(input, token, clientId, secret, payload), client);
-    }
-
-    public static Optional<String> bitbucketPost(String input, String token, HttpClient client, String clientId, String secret,
-            String payload) throws UnsupportedEncodingException {
-        return getResponseAsString(buildHttpPost(input, token, clientId, secret, payload), client);
+        return getResponseAsString(buildHttpPost(input, token, payload), client);
     }
 
     private static HttpGet buildHttpGet(String input, String token) {
@@ -65,7 +60,7 @@ public final class ResourceUtilities {
         return httpGet;
     }
 
-    private static HttpPost buildHttpPost(String input, String token, String clientId, String secret, String payload)
+    private static HttpPost buildHttpPost(String input, String token, String payload)
             throws UnsupportedEncodingException {
         HttpPost httpPost = new HttpPost(input);
         if (token == null) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SourceControlResourceInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SourceControlResourceInterface.java
@@ -45,18 +45,20 @@ public interface SourceControlResourceInterface {
     /**
      * Refreshes user's Bitbucket token.
      *
-     * @param token
+     * @param bitbucketToken
      * @param client
      * @param tokenDAO
      * @param bitbucketClientID
      * @param bitbucketClientSecret
      */
-    default void refreshBitbucketToken(Token token, HttpClient client, TokenDAO tokenDAO, String bitbucketClientID,
+    default void refreshBitbucketToken(Token bitbucketToken, HttpClient client, TokenDAO tokenDAO, String bitbucketClientID,
         String bitbucketClientSecret) {
 
+        LOG.info("Refreshing the BitBucket Token");
         String refreshUrl = BITBUCKET_URL + "site/oauth2/access_token";
-        String payload = "grant_type=refresh_token&refresh_token=" + token.getRefreshToken();
-        refreshToken(refreshUrl, token, client, tokenDAO, bitbucketClientID, bitbucketClientSecret, payload);
+        String payload = "client_id=" + bitbucketClientID + "&client_secret=" + bitbucketClientSecret
+                + "&grant_type=refresh_token&refresh_token=" + bitbucketToken.getRefreshToken();
+        refreshToken(refreshUrl, bitbucketToken, client, tokenDAO, null, null, payload);
     }
 
     /**
@@ -128,9 +130,7 @@ public interface SourceControlResourceInterface {
 
         if (!tokens.isEmpty()) {
             Token bitbucketToken = tokens.get(0);
-            String refreshUrl = BITBUCKET_URL + "site/oauth2/access_token";
-            String payload = "grant_type=refresh_token&refresh_token=" + bitbucketToken.getRefreshToken();
-            refreshToken(refreshUrl, bitbucketToken, client, tokenDAO, bitbucketClientID, bitbucketClientSecret, payload);
+            refreshBitbucketToken(bitbucketToken, client, tokenDAO, bitbucketClientID, bitbucketClientSecret);
         }
 
         return tokenDAO.findByUserId(user.getId());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SourceControlResourceInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SourceControlResourceInterface.java
@@ -54,7 +54,7 @@ public interface SourceControlResourceInterface {
     default void refreshBitbucketToken(Token bitbucketToken, HttpClient client, TokenDAO tokenDAO, String bitbucketClientID,
         String bitbucketClientSecret) {
 
-        LOG.info("Refreshing the BitBucket Token");
+        LOG.info("Refreshing the Bitbucket Token");
         String refreshUrl = BITBUCKET_URL + "site/oauth2/access_token";
         String payload = "client_id=" + bitbucketClientID + "&client_secret=" + bitbucketClientSecret
                 + "&grant_type=refresh_token&refresh_token=" + bitbucketToken.getRefreshToken();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SourceControlResourceInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/SourceControlResourceInterface.java
@@ -58,7 +58,7 @@ public interface SourceControlResourceInterface {
         String refreshUrl = BITBUCKET_URL + "site/oauth2/access_token";
         String payload = "client_id=" + bitbucketClientID + "&client_secret=" + bitbucketClientSecret
                 + "&grant_type=refresh_token&refresh_token=" + bitbucketToken.getRefreshToken();
-        refreshToken(refreshUrl, bitbucketToken, client, tokenDAO, null, null, payload);
+        refreshToken(refreshUrl, bitbucketToken, client, tokenDAO, payload);
     }
 
     /**
@@ -68,17 +68,13 @@ public interface SourceControlResourceInterface {
      * @param token
      * @param client
      * @param tokenDAO
-     * @param clientID
-     * @param clientSecret
      * @param payload e.g. "grant_type=refresh_token&refresh_token=" + token.getRefreshToken()
      * @return the updated token
      */
-    default Token refreshToken(String refreshUrl, Token token, HttpClient client, TokenDAO tokenDAO, String clientID,
-            String clientSecret, String payload) {
+    default Token refreshToken(String refreshUrl, Token token, HttpClient client, TokenDAO tokenDAO, String payload) {
 
         try {
-            Optional<String> asString = ResourceUtilities.refreshPost(refreshUrl, null, client, clientID, clientSecret,
-                    payload);
+            Optional<String> asString = ResourceUtilities.refreshPost(refreshUrl, null, client, payload);
 
             if (asString.isPresent()) {
                 String accessToken;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -533,7 +533,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                 String refreshUrl = zenodoUrl + "/oauth/token";
                 String payload = "client_id=" + zenodoClientID + "&client_secret=" + zenodoClientSecret
                         + "&grant_type=refresh_token&refresh_token=" + zenodoToken.getRefreshToken();
-                refreshToken(refreshUrl, zenodoToken, client, tokenDAO, null, null, payload);
+                refreshToken(refreshUrl, zenodoToken, client, tokenDAO, payload);
             }
         }
         return tokenDAO.findByUserId(user.getId());


### PR DESCRIPTION
Addresses: https://ucsc-cgl.atlassian.net/browse/SEAB-2827

Put client ID and client secret in body of request instead of the header.

Bitbucket tokens are refreshed on every call where access to Bitbucket is needed. To verify that the call works 
Link your Bitbucket.org account in the Accounts page. 
Go to the Dockstore main page, then click on the user name drop down and click on My Workflows. You should see a call:
GET /users/github/organizations HTTP/1.1" 200
That call will have refreshed the Bitbucket token starting [here ](https://github.com/dockstore/dockstore/blob/aae19d6ee198e68ebba85f37024d1ddf865cc365/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java#L881)
