### PR TITLE
Change is_checker to isChecker

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
@@ -56,7 +56,6 @@ public class BioWorkflow extends Workflow {
     private Entry parentEntry;
 
     @Column(columnDefinition = "boolean default false")
-    @JsonProperty("is_checker")
     @ApiModelProperty(position = 23)
     private boolean isChecker = false;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
@@ -56,7 +56,6 @@ public class BioWorkflow extends Workflow {
     private Entry parentEntry;
 
     @Column(columnDefinition = "boolean default false")
-    @ApiModelProperty(position = 23)
     private boolean isChecker = false;
 
     public EntryType getEntryType() {

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -6691,8 +6691,6 @@ components:
       - $ref: '#/components/schemas/Workflow'
       - type: object
         properties:
-          is_checker:
-            type: boolean
           parent_id:
             type: integer
             format: int64

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -6223,9 +6223,6 @@ definitions:
           type: "integer"
           format: "int64"
           readOnly: true
-        isChecker:
-          type: "boolean"
-          position: 23
       description: "This describes one workflow in the dockstore"
   Checksum:
     type: "object"

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -6223,7 +6223,7 @@ definitions:
           type: "integer"
           format: "int64"
           readOnly: true
-        is_checker:
+        isChecker:
           type: "boolean"
           position: 23
       description: "This describes one workflow in the dockstore"


### PR DESCRIPTION
swagger and openapi said isChecker in some places. However, the backend returns it to the frontend as is_checker. I'm now making it consistently isChecker.

The decision to choose camelCase instead of snake case is because JSON doesn't have a standard naming convention, but Javascript and Java does. They both use camelCase.

The openapi/swagger looks like I completely removed it from bioworkflow. In truth, workflow (extended by bioworkflow) already has the property.