### PR TITLE
Feature/2988/auto default version set

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/AbstractYamlService.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/AbstractYamlService.java
@@ -62,7 +62,7 @@ public abstract class AbstractYamlService {
      */
     private Map<String, DataSet> data;
 
-    private DefaultVersion defaultVersion;
+    private boolean latestTagAsDefault = false;
 
     public String getAuthor() {
         return author;
@@ -136,12 +136,12 @@ public abstract class AbstractYamlService {
         this.data = data;
     }
 
-    public DefaultVersion getDefaultVersion() {
-        return defaultVersion;
+    public boolean getLatestTagAsDefault() {
+        return latestTagAsDefault;
     }
 
-    public void setDefaultVersion(DefaultVersion defaultVersion) {
-        this.defaultVersion = defaultVersion;
+    public void setLatestTagAsDefault(boolean latestTagAsDefault) {
+        this.latestTagAsDefault = latestTagAsDefault;
     }
 
     /**

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/AbstractYamlService.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/AbstractYamlService.java
@@ -62,6 +62,8 @@ public abstract class AbstractYamlService {
      */
     private Map<String, DataSet> data;
 
+    private DefaultVersion defaultVersion;
+
     public String getAuthor() {
         return author;
     }
@@ -132,6 +134,14 @@ public abstract class AbstractYamlService {
 
     public void setData(final Map<String, DataSet> data) {
         this.data = data;
+    }
+
+    public DefaultVersion getDefaultVersion() {
+        return defaultVersion;
+    }
+
+    public void setDefaultVersion(DefaultVersion defaultVersion) {
+        this.defaultVersion = defaultVersion;
     }
 
     /**

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DefaultVersion.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DefaultVersion.java
@@ -1,5 +1,0 @@
-package io.dockstore.common.yaml;
-
-public enum DefaultVersion {
-    TAG, BRANCH, MANUAL
-}

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DefaultVersion.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DefaultVersion.java
@@ -1,0 +1,5 @@
+package io.dockstore.common.yaml;
+
+public enum DefaultVersion {
+    TAG, BRANCH, MANUAL
+}

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
@@ -46,7 +46,8 @@ public class YamlWorkflow {
      */
     private Boolean publish;
 
-    private DefaultVersion defaultVersion;
+    // If true, the most recent tag that Dockstore processes from AWS lambda becomes the default version
+    private boolean latestTagAsDefault = false;
 
     private Filters filters = new Filters();
 
@@ -104,11 +105,11 @@ public class YamlWorkflow {
         this.testParameterFiles = testParameterFiles;
     }
 
-    public DefaultVersion getDefaultVersion() {
-        return defaultVersion;
+    public boolean getLatestTagAsDefault() {
+        return latestTagAsDefault;
     }
 
-    public void setDefaultVersion(DefaultVersion defaultVersion) {
-        this.defaultVersion = defaultVersion;
+    public void setLatestTagAsDefault(boolean latestTagAsDefault) {
+        this.latestTagAsDefault = latestTagAsDefault;
     }
 }

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
@@ -46,6 +46,8 @@ public class YamlWorkflow {
      */
     private Boolean publish;
 
+    private DefaultVersion defaultVersion;
+
     private Filters filters = new Filters();
 
     private List<String> testParameterFiles = new ArrayList<>();
@@ -100,5 +102,13 @@ public class YamlWorkflow {
 
     public void setTestParameterFiles(final List<String> testParameterFiles) {
         this.testParameterFiles = testParameterFiles;
+    }
+
+    public DefaultVersion getDefaultVersion() {
+        return defaultVersion;
+    }
+
+    public void setDefaultVersion(DefaultVersion defaultVersion) {
+        this.defaultVersion = defaultVersion;
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -327,12 +327,12 @@ public class WebhookIT extends BaseIT {
         io.dockstore.openapi.client.model.Workflow workflow2 = getFoobar2Workflow(client);
         assertNull(workflow2.getDefaultVersion());
         io.dockstore.openapi.client.model.Workflow workflow = getFoobar1Workflow(client);
-        assertEquals("master", workflow.getDefaultVersion());
+        assertEquals(null, workflow.getDefaultVersion());
         client.handleGitHubRelease("refs/tags/0.4", installationId, workflowRepo, BasicIT.USER_2_USERNAME);
         workflow2 = getFoobar2Workflow(client);
-        assertEquals("0.4", workflow2.getDefaultVersion());
+        assertEquals("The new tag says the latest tag should be the default version", "0.4", workflow2.getDefaultVersion());
         workflow = getFoobar1Workflow(client);
-        assertEquals("master", workflow.getDefaultVersion());
+        assertEquals(null, workflow.getDefaultVersion());
 
     }
     

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -85,7 +85,7 @@ public class WebhookIT extends BaseIT {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    private static final String workflowRepo = "DockstoreTestUser2/workflow-dockstore-yml";
+    private final String workflowRepo = "DockstoreTestUser2/workflow-dockstore-yml";
     private final String githubFiltersRepo = "DockstoreTestUser2/dockstoreyml-github-filters-test";
     private final String installationId = "1179416";
     private FileDAO fileDAO;
@@ -336,16 +336,16 @@ public class WebhookIT extends BaseIT {
 
     }
     
-    private static io.dockstore.openapi.client.model.Workflow getFoobar1Workflow(io.dockstore.openapi.client.api.WorkflowsApi client) {
+    private io.dockstore.openapi.client.model.Workflow getFoobar1Workflow(io.dockstore.openapi.client.api.WorkflowsApi client) {
         return client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "versions", false);
     }
 
-    private static io.dockstore.openapi.client.model.Workflow getFoobar2Workflow(io.dockstore.openapi.client.api.WorkflowsApi client) {
+    private Workflow getFoobar1Workflow(WorkflowsApi client) {
+        return client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "versions", false);
+    }
+
+    private io.dockstore.openapi.client.model.Workflow getFoobar2Workflow(io.dockstore.openapi.client.api.WorkflowsApi client) {
         return client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar2", "versions", false);
-    }
-
-    private static Workflow getFoobar1Workflow(WorkflowsApi client) {
-        return client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "versions", false);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -484,7 +484,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             final var defaultVersion = service.getDefaultVersion();
 
             Workflow workflow = createOrGetWorkflow(Service.class, repository, user, "", subclass.getShortName(), gitHubSourceCodeRepo);
-            workflow = addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion);
+            addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion);
 
             if (publish != null && workflow.getIsPublished() != publish) {
                 LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, user.getUsername(), LambdaEvent.LambdaEventType.PUBLISH);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -437,10 +437,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 String subclass = wf.getSubclass();
                 String workflowName = wf.getName();
                 Boolean publish = wf.getPublish();
-                final DefaultVersion defaultVersion = wf.getDefaultVersion();
+                final var defaultVersion = wf.getDefaultVersion();
 
                 Workflow workflow = createOrGetWorkflow(BioWorkflow.class, repository, user, workflowName, subclass, gitHubSourceCodeRepo);
-                workflow = addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion);
+                addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion);
 
                 if (publish != null && workflow.getIsPublished() != publish) {
                     LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, user.getUsername(), LambdaEvent.LambdaEventType.PUBLISH);
@@ -481,7 +481,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             }
             final DescriptorLanguageSubclass subclass = service.getSubclass();
             final Boolean publish = service.getPublish();
-            final DefaultVersion defaultVersion = service.getDefaultVersion();
+            final var defaultVersion = service.getDefaultVersion();
 
             Workflow workflow = createOrGetWorkflow(Service.class, repository, user, "", subclass.getShortName(), gitHubSourceCodeRepo);
             workflow = addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.Sets;
 import io.dockstore.common.DescriptorLanguageSubclass;
+import io.dockstore.common.yaml.DefaultVersion;
 import io.dockstore.common.yaml.DockstoreYaml12;
 import io.dockstore.common.yaml.DockstoreYamlHelper;
 import io.dockstore.common.yaml.Service12;
@@ -436,9 +437,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 String subclass = wf.getSubclass();
                 String workflowName = wf.getName();
                 Boolean publish = wf.getPublish();
+                final DefaultVersion defaultVersion = wf.getDefaultVersion();
 
                 Workflow workflow = createOrGetWorkflow(BioWorkflow.class, repository, user, workflowName, subclass, gitHubSourceCodeRepo);
-                workflow = addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow);
+                workflow = addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion);
 
                 if (publish != null && workflow.getIsPublished() != publish) {
                     LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, user.getUsername(), LambdaEvent.LambdaEventType.PUBLISH);
@@ -451,7 +453,6 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                     }
                     lambdaEventDAO.create(lambdaEvent);
                 }
-
                 updatedWorkflows.add(workflow);
             }
             return updatedWorkflows;
@@ -480,9 +481,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             }
             final DescriptorLanguageSubclass subclass = service.getSubclass();
             final Boolean publish = service.getPublish();
+            final DefaultVersion defaultVersion = service.getDefaultVersion();
 
             Workflow workflow = createOrGetWorkflow(Service.class, repository, user, "", subclass.getShortName(), gitHubSourceCodeRepo);
-            workflow = addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow);
+            workflow = addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion);
 
             if (publish != null && workflow.getIsPublished() != publish) {
                 LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, user.getUsername(), LambdaEvent.LambdaEventType.PUBLISH);
@@ -560,7 +562,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @return New or updated workflow
      */
     private Workflow addDockstoreYmlVersionToWorkflow(String repository, String gitReference, SourceFile dockstoreYml,
-            GitHubSourceCodeRepo gitHubSourceCodeRepo, Workflow workflow) {
+            GitHubSourceCodeRepo gitHubSourceCodeRepo, Workflow workflow, DefaultVersion defaultVersion) {
         Instant startTime = Instant.now();
         try {
             // Create version and pull relevant files
@@ -594,12 +596,17 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 if (workflow.getLastModified() == null || (addedVersion.getLastModified() != null && workflow.getLastModifiedDate().before(addedVersion.getLastModified()))) {
                     workflow.setLastModified(addedVersion.getLastModified());
                 }
-
                 // Update file formats for the version and then the entry.
                 // TODO: We were not adding file formats to .dockstore.yml versions before, so this only handles new/updated versions. Need to add a way to update all .dockstore.yml versions in a workflow
                 Set<WorkflowVersion> workflowVersions = new HashSet<>();
                 workflowVersions.add(addedVersion);
                 FileFormatHelper.updateFileFormats(workflow, workflowVersions, fileFormatDAO, false);
+                if ((DefaultVersion.TAG.equals(defaultVersion)
+                        && Version.ReferenceType.TAG.equals(addedVersion.getReferenceType()))
+                        || (DefaultVersion.BRANCH.equals(defaultVersion)
+                        && Version.ReferenceType.BRANCH.equals(addedVersion.getReferenceType()))) {
+                    workflow.setActualDefaultVersion(addedVersion);
+                }
             }
 
             LOG.info("Version " + remoteWorkflowVersion.getName() + " has been added to workflow " + workflow.getWorkflowPath() + ".");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -7,7 +7,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;


### PR DESCRIPTION
For #2988 and #3683

Didn't save the default version setting in the DB for simplicity. The version/tag that was just pushed is presumably the latest (which works for most cases). Doesn't work if you push a tag that says default should be branch (until you push a branch that says default should be branch)