### PR TITLE
Feature/small api suggestions

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CloudInstanceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CloudInstanceIT.java
@@ -76,8 +76,9 @@ public class CloudInstanceIT extends BaseIT {
         }
 
         adminCloudInstancesApi.postCloudInstance(newCloudInstance);
+
+        newCloudInstance.setSupportsFileImports(true);
         try {
-            newCloudInstance.setSupportsFileImports(true);
             adminCloudInstancesApi.postCloudInstance(newCloudInstance);
             Assert.fail("Cannot create a new global launch with partner with the same URL even if slightly different");
         } catch (ApiException e) {
@@ -168,8 +169,8 @@ public class CloudInstanceIT extends BaseIT {
         newCloudInstance.setPartner(MEMBER_PARTNER_2);
         memberUsersApi.postUserCloudInstance(newCloudInstance, memberUserId);
 
+        newCloudInstance.setSupportsFileImports(true);
         try {
-            newCloudInstance.setSupportsFileImports(true);
             memberUsersApi.postUserCloudInstance(newCloudInstance, memberUserId);
             Assert.fail("Cannot create a new user launch with partner with the same URL even if slightly different");
         } catch (ApiException e) {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CloudInstanceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CloudInstanceIT.java
@@ -9,6 +9,7 @@ import io.dockstore.openapi.client.ApiException;
 import io.dockstore.openapi.client.api.CloudInstancesApi;
 import io.dockstore.openapi.client.api.UsersApi;
 import io.dockstore.openapi.client.model.CloudInstance;
+import io.dockstore.openapi.client.model.Language;
 import io.dockstore.openapi.client.model.User;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
@@ -62,6 +63,11 @@ public class CloudInstanceIT extends BaseIT {
         newCloudInstance.setSupportsFileImports(null);
         newCloudInstance.setSupportsHttpImports(null);
         newCloudInstance.setSupportedLanguages(new ArrayList<>());
+        // testing out languages
+        Language language = new Language();
+        language.setLanguage(Language.LanguageEnum.WDL);
+        language.setVersion("draft-1.0");
+        newCloudInstance.getSupportedLanguages().add(language);
         try {
             anonymousCloudInstancesApi.postCloudInstance(newCloudInstance);
             Assert.fail("Only admins can create a new cloud instance");
@@ -69,13 +75,17 @@ public class CloudInstanceIT extends BaseIT {
             Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, e.getCode());
         }
 
-        try {
-            memberCloudInstancesApi.postCloudInstance(newCloudInstance);
-            Assert.fail("Only admins can create a new cloud instance");
-        } catch (ApiException e) {
-            Assert.assertEquals(HttpStatus.SC_FORBIDDEN, e.getCode());
-        }
         adminCloudInstancesApi.postCloudInstance(newCloudInstance);
+        try {
+            newCloudInstance.setSupportsFileImports(true);
+            adminCloudInstancesApi.postCloudInstance(newCloudInstance);
+            Assert.fail("Cannot create a new global launch with partner with the same URL even if slightly different");
+        } catch (ApiException e) {
+            Assert.assertTrue(e.getMessage().contains("constraint"));
+            //TODO: catch and return a proper error code
+            //Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
+        }
+
         adminCloudInstances = adminCloudInstancesApi.getCloudInstances();
         memberCloudInstances = memberCloudInstancesApi.getCloudInstances();
         anonymousCloudInstances = anonymousCloudInstancesApi.getCloudInstances();
@@ -157,6 +167,17 @@ public class CloudInstanceIT extends BaseIT {
         adminUsersApi.postUserCloudInstance(newCloudInstance, adminUserId);
         newCloudInstance.setPartner(MEMBER_PARTNER_2);
         memberUsersApi.postUserCloudInstance(newCloudInstance, memberUserId);
+
+        try {
+            newCloudInstance.setSupportsFileImports(true);
+            memberUsersApi.postUserCloudInstance(newCloudInstance, memberUserId);
+            Assert.fail("Cannot create a new user launch with partner with the same URL even if slightly different");
+        } catch (ApiException e) {
+            Assert.assertTrue(e.getMessage().contains("constraint"));
+            //TODO: catch and return a proper error code
+            //Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
+        }
+
         memberUserCloudInstances = memberUsersApi.getUserCloudInstances(memberUserId);
         adminUserCloudInstances = adminUsersApi.getUserCloudInstances(adminUserId);
         Assert.assertEquals(2, memberUserCloudInstances.size());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/CloudInstance.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/CloudInstance.java
@@ -18,6 +18,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.annotations.ApiModel;
@@ -28,7 +29,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 @ApiModel(value = "CloudInstance", description = "Instances that launch-with cloud partners have")
 @Entity
-@Table(name = "cloud_instance")
+@Table(name = "cloud_instance", uniqueConstraints = @UniqueConstraint(name = "unique_user_instances", columnNames = { "url", "user_id",
+        "partner" }))
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.CloudInstance.findAllWithoutUser", query = "SELECT ci from CloudInstance ci where user_id is null")
 })

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Language.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Language.java
@@ -37,4 +37,20 @@ public class Language implements Serializable {
     @ApiModelProperty(dataType = "long")
     @Schema(type = "integer", format = "int64")
     private Timestamp dbUpdateDate;
+
+    public DescriptorLanguage getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(DescriptorLanguage language) {
+        this.language = language;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CloudInstanceResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CloudInstanceResource.java
@@ -28,6 +28,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.http.HttpStatus;
+import org.hibernate.Hibernate;
 import org.hibernate.SessionFactory;
 
 import static io.dockstore.webservice.resources.ResourceConstants.OPENAPI_JWT_SECURITY_DEFINITION_NAME;
@@ -50,7 +51,9 @@ public class CloudInstanceResource implements AuthenticatedResourceInterface {
     @ApiResponse(responseCode = HttpStatus.SC_OK
             + "", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = CloudInstance.class))))
     public List<CloudInstance> getCloudInstances() {
-        return this.cloudInstanceDAO.findAllWithoutUser();
+        List<CloudInstance> allWithoutUser = this.cloudInstanceDAO.findAllWithoutUser();
+        allWithoutUser.forEach(e -> Hibernate.initialize(e.getSupportedLanguages()));
+        return allWithoutUser;
     }
 
     @DELETE

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -1026,7 +1026,9 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
         @ApiParam(name = "userId", required = true, value = "User to update") @PathParam("userId") @Parameter(name = "userId", in = ParameterIn.PATH, description = "ID of user to get cloud instances for", required = true) long userId) {
         final User user = userDAO.findById(userId);
         checkUser(authUser, userId);
-        return user.getCloudInstances();
+        Set<CloudInstance> cloudInstances = user.getCloudInstances();
+        cloudInstances.forEach(e -> Hibernate.initialize(e.getSupportedLanguages()));
+        return cloudInstances;
     }
 
     @POST
@@ -1052,8 +1054,8 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
         cloudInstanceToBeAdded.setSupportedLanguages(cloudInstanceBody.getSupportedLanguages());
         // TODO: Figure how to make this not required (already adding the instance to the user)
         cloudInstanceToBeAdded.setUser(user);
-
         user.getCloudInstances().add(cloudInstanceToBeAdded);
+        user.getCloudInstances().forEach(e -> Hibernate.initialize(e.getSupportedLanguages()));
         return user.getCloudInstances();
     }
 

--- a/dockstore-webservice/src/main/resources/import.sql
+++ b/dockstore-webservice/src/main/resources/import.sql
@@ -26,6 +26,7 @@ CREATE UNIQUE INDEX partial_workflow_name ON workflow USING btree (sourcecontrol
 CREATE UNIQUE INDEX partial_tool_name ON tool USING btree (registry, namespace, name) WHERE toolname IS NULL;
 CREATE UNIQUE INDEX full_service_name ON service USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
 CREATE UNIQUE INDEX partial_service_name ON service USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
+CREATE UNIQUE INDEX partial_cloud_instance ON cloud_instance USING btree (url) WHERE user_id IS NULL;
 
 -- unable to convert these to JPA properly
 ALTER TABLE token ADD CONSTRAINT fk_userid_with_enduser FOREIGN KEY (userid) REFERENCES public.enduser (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION;

--- a/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
@@ -231,5 +231,10 @@
             <column name="partner"/>
         </createIndex>
     </changeSet>
+    <changeSet id="global_cloud_instances_constraint" author="dyuen">
+        <sql dbms="postgresql">
+            create unique index if not exists partial_cloud_instance ON cloud_instance USING btree (url) WHERE user_id IS NULL
+        </sql>
+    </changeSet>
 
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
@@ -223,4 +223,13 @@
         <modifyDataType columnName="onlineprofileid" newDataType="varchar(255)" tableName="token"/>
         <modifyDataType columnName="onlineprofileid" newDataType="varchar(255)" tableName="user_profile"/>
     </changeSet>
+
+    <changeSet author="dyuen (generated)" id="add_cloud_instances_constraint">
+        <createIndex indexName="unique_user_instances" tableName="cloud_instance" unique="true">
+            <column name="url"/>
+            <column name="user_id"/>
+            <column name="partner"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -7461,6 +7461,18 @@ components:
           - PUBLISH
     Language:
       type: object
+      properties:
+        language:
+          type: string
+          enum:
+          - CWL
+          - WDL
+          - gxformat2
+          - SWL
+          - NFL
+          - service
+        version:
+          type: string
     LicenseInformation:
       type: object
       properties:


### PR DESCRIPTION
 Working on #4163 and #4165
Implementing small suggestions
* unique constraint on duplicate cloud instances with the same url per users
* unique constraint on duplicate global cloud instances with the same url
* made languages visible when retrieving instances while keeping it lazy

Breaking out GXFORMAT2 rename, using cloud instances API to also drive single instance launch with, consistent responses