### PR TITLE
Feature/hook up sonar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,23 +44,26 @@ workflows:
     jobs:
       - build:
           <<: *common_filters
-          context: sonarcloud
       - unit_test:
           <<: *common_filters
           requires:
             - build
+          context: sonarcloud
       - workflow-integration-tests:
           <<: *common_filters
           requires:
             - build
+          context: sonarcloud
       - tool-integration-tests:
           <<: *common_filters
           requires:
             - build
+          context: sonarcloud
       - integration-tests:
           <<: *common_filters
           requires:
             - build
+          context: sonarcloud
       - regression-integration-tests:
           filters:
             branches:
@@ -146,9 +149,6 @@ jobs:
           root: .
           paths:
             - .
-      - run:
-          name: SonarCloud scan
-          command: mvn verify sonar:sonar
       - run:
           name: check generated flattened POMs match checked-in files.
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,6 +238,9 @@ jobs:
       - store_artifacts:
           path: ~/junit
       - run:
+          name: SonarCloud scan - coverage
+          command: mvn sonar:sonar
+      - run:
           name: Make jar directory
           command: mkdir /tmp/artifacts
       - run:
@@ -361,6 +364,9 @@ commands:
       - run:
           name: send coverage
           command: bash <(curl -s https://codecov.io/bash) -F ${TESTING_PROFILE//-} || echo "Codecov did not collect coverage reports"
+      - run:
+          name: SonarCloud scan - coverage
+          command: mvn sonar:sonar
   save_test_results:
     steps:
       - save_cache:

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <sonar.organization>dockstore</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/reports/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <!-- end sonarcloud properties -->
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
         <!-- this is not an aggregated path -->      
-	<sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/jacoco.exec,${project.basedir}/target/jacoco-it.exec,${project.basedir}/../reports/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+	<sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/jacoco.xml,${project.basedir}/target/jacoco-it.xml,${project.basedir}/../reports/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <!-- end sonarcloud properties -->
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <sonar.organization>dockstore</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
-        <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/reports/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../reports/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <!-- end sonarcloud properties -->
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,8 @@
         <sonar.organization>dockstore</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
-        <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../reports/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <!-- this is not an aggregated path -->      
+        <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/jacoco.exec</sonar.coverage.jacoco.xmlReportPaths>
         <!-- end sonarcloud properties -->
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
         <!-- this is not an aggregated path -->      
-        <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/jacoco.exec</sonar.coverage.jacoco.xmlReportPaths>
+	<sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/jacoco.exec,${project.basedir}/target/jacoco-it.exec,${project.basedir}/../reports/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <!-- end sonarcloud properties -->
     </properties>
 


### PR DESCRIPTION
Some pain, but hooking this up to PR to see the github status.
Hopefully, this avoids PRs failing the quality gate only due to coverage such as https://github.com/dockstore/dockstore/pull/4245

Coverage doesn't quite match codecov but I can't see any details on what files are covered in SonarCloud. It does say 44.6% coverage estimated so I wonder if merging gains access to some new reports

Question: Contexts don't work quite the way I expected, can you could tie them to specific tasks rather than whole jobs?
This seems to expose sonarcloud credentials to all tasks.  