### PR TITLE
Updated ORCID scope in dockstore.yml

### DIFF
--- a/dockstore-integration-testing/src/test/resources/dockstore.yml
+++ b/dockstore-integration-testing/src/test/resources/dockstore.yml
@@ -127,7 +127,7 @@ uiConfig:
 
   orcidAuthUrl: https://sandbox.orcid.org/oauth/authorize
   orcidRedirectPath: /auth/orcid.org
-  orcidScope: /authenticate
+  orcidScope: /activities/update
 
   googleScope: profile email
 

--- a/dockstore-integration-testing/src/test/resources/dockstore.yml
+++ b/dockstore-integration-testing/src/test/resources/dockstore.yml
@@ -127,7 +127,7 @@ uiConfig:
 
   orcidAuthUrl: https://sandbox.orcid.org/oauth/authorize
   orcidRedirectPath: /auth/orcid.org
-  orcidScope: /authorize
+  orcidScope: /authenticate
 
   googleScope: profile email
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -722,7 +722,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
         String scope;
         long expirationTime;
 
-        if (code.isEmpty()) {
+        if (code == null || code.isEmpty()) {
             throw new CustomWebApplicationException("Please provide an access code", HttpStatus.SC_BAD_REQUEST);
         }
 


### PR DESCRIPTION
2 minor suggestions:
1. `/authorize` is an invalid scope for ORCID requests. According to their [docs](https://info.orcid.org/faq/what-is-an-oauth-scope-and-which-scopes-does-orcid-support/), it should be `/authenticate`. We can see this as the [default in the UI](https://github.com/dockstore/dockstore-ui2/blob/063dc3adff758c1123b4b21d4ac7f4d594f71a63/src/app/shared/dockstore.model.ts#L70).
2. If you deny ORCID authorization (click 'link account' then click 'deny access'), the returned value for `code` is null, so adding `if (code == null || ...)`. Makes the webservice throw a 400 rather than a 500 for NPE.


