### PR TITLE
feature/addMoreLogging

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1063,6 +1063,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     }
 
     public User.Profile getProfile(final User user, final GHUser ghUser) throws IOException {
+        LOG.info("GitHub user profile id is " + ghUser.getId() + " and GitHub username is " + ghUser.getLogin() + " for Dockstore user " + user.getUsername());
         User.Profile profile = new User.Profile();
         profile.onlineProfileId = String.valueOf(ghUser.getId());
         profile.username = ghUser.getLogin();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1063,7 +1063,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     }
 
     public User.Profile getProfile(final User user, final GHUser ghUser) throws IOException {
-        LOG.info("GitHub user profile id is " + ghUser.getId() + " and GitHub username is " + ghUser.getLogin() + " for Dockstore user " + user.getUsername());
+        LOG.info("GitHub user profile id is {} and GitHub username is {} for Dockstore user {}", ghUser.getId(), ghUser.getLogin(), user.getUsername());
         User.Profile profile = new User.Profile();
         profile.onlineProfileId = String.valueOf(ghUser.getId());
         profile.username = ghUser.getLogin();


### PR DESCRIPTION
Add more logging so that we can see the endpoint is still running AND so that it's not necessary to debug if the endpoint somehow fails and we need to look up more users

I created this ticket https://ucsc-cgl.atlassian.net/browse/SEAB-2987 and this document https://docs.google.com/document/d/1CNFzhYbmn-WgvNQ98vq-Sl4-uDq7dGjICgPBSGD7n-g/edit
