### PR TITLE
Bump version in generated files

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -38,6 +38,11 @@ dockstore-webservice/src/test/resources/not-really-recursive.*.https://raw.githu
 
 # dockstore-webservice/src/main/resources/openapi3/openapi.yaml:.*
 dockstore-webservice/src/main/resources/openapi3/openapi.yaml:.*checksum=
+dockstore-webservice/src/main/resources/openapi3/openapi.yaml:.*checksum:
+
+# dockstore-webservice/src/main/resources/openapi3/openapi.yaml:.*
+dockstore-webservice/src/main/resources/swagger.yaml:.*c83478829802b4d36374870843821abe1b625a71/delly_docker
+dockstore-webservice/src/main/resources/swagger.yaml:.*pcawg_delly_workflow/ea2a5db69bd20a42976838790bc29294df3af02b
 
 # dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java:.*
 dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java:.*https://raw.githubusercontent.com/denis-yuen/
@@ -92,6 +97,22 @@ dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Organization
 
 # dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java:.*
 dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java:.*https://raw.githubusercontent.com/denis-yuen/
+
+# dockstore-common/src/test/resources/fixtures/dockerImages10.wdl
+dockstore-common/src/test/resources/fixtures.*:60:.*f63e020c4062e0be8d081a50de16562f2ba161166e896655868efdb5527a8640
+
+# dockstore-common/src/test/resources/fixtures/dockerImagesPre10.wdl
+dockstore-common/src/test/resources/fixtures/dockerImagesPre10.wdl:56:.*sha256:f63e020c4062e0be8d081a50de16562f2ba161166e896655868efdb5527a8640
+
+
+# dockstore-webservice/src/main/java/io/swagger/model/ToolDockerfile.java
+dockstore-webservice/src/main/java/io/swagger/model/ToolDockerfile.java:71:.*pcawg_delly_workflow/c83478829802b4d36374870843821abe1b625a71
+
+# swagger-java-sam-client/pom.xml
+swagger-java-sam-client/pom.xml:.*broadinstitute/sam/de13d1d
+
+# dockstore-webservice/src/main/java/io/swagger/model/ToolDescriptor.java
+dockstore-webservice/src/main/java/io/swagger/model/ToolDescriptor.java:.*pcawg_delly_workflow/ea2a
 
 # README.md:.*
 README.md:.*https://github.com/dockstore/dockstore/blob/

--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-common</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/dockstore-event-consumer/generated/src/main/resources/pom.xml
+++ b/dockstore-event-consumer/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-event-consumer</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,13 +30,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-integration-testing</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -54,13 +54,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>openapi-java-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-language-plugin-parent</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-webservice</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -60,37 +60,37 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-quay-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-sam-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-bitbucket-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-discourse-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-language-plugin-parent</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-zenodo-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -13,7 +13,7 @@ info:
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
   termsOfService: TBD
   title: Dockstore API
-  version: 1.11.0-alpha.3-SNAPSHOT
+  version: 1.12.0-alpha.0-SNAPSHOT
 servers:
 - description: Current server when hosted on AWS
   url: /api

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5,7 +5,7 @@ info:
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images. Explore swagger.json for a Swagger 2.0 description\
     \ of our API and explore openapi.yaml for OpenAPI 3.0 descriptions."
-  version: "1.11.0-alpha.3-SNAPSHOT"
+  version: "1.12.0-alpha.0-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/openapi-java-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>openapi-java-client</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/reports/generated/src/main/resources/pom.xml
+++ b/reports/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>reports</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,19 +30,19 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-integration-testing</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/swagger-java-bitbucket-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-bitbucket-client/generated/src/main/resources/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-bitbucket-client</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-client</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/swagger-java-discourse-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-discourse-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-discourse-client</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-quay-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-quay-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-quay-client</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-sam-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-sam-client/generated/src/main/resources/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-sam-client</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-zenodo-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-zenodo-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-zenodo-client</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>


### PR DESCRIPTION
We started a new version and need to update the generated POMs in addition to running `mvn versions`

Also found some things that needed to be added to the gitallowed for git-secrets