### PR TITLE
Upload image digest to S3 on quay build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ jobs:
             docker build -t quay.io/dockstore/dockstore-webservice:$dockerVersion .
             echo "$QUAY_PASSWORD" | docker login -u=$QUAY_USERNAME --password-stdin quay.io
             # Gather the checksum information
-            docker inspect --format='{{index .RepoDigests 0}}' quay.io/dockstore/dockstore-webservice:$dockerVersion | grep -oPm1 'sha256:\K\w+' > image-digest.txt
+            docker inspect quay.io/dockstore/dockstore-webservice:$dockerVersion | grep -A 1 RepoDigests | grep -oPm1 'sha256:\K\w+' > image-digest.txt
             docker push quay.io/dockstore/dockstore-webservice:$dockerVersion
       - aws-s3/copy:
           from: image-digest.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  aws-s3: circleci/aws-s3@1.0.0
 executors:
   integration_test_exec:
     docker: # run the steps with Docker
@@ -48,7 +50,9 @@ workflows:
           <<: *common_filters
           requires:
             - build
-          context: sonarcloud
+          context:
+            - sonarcloud
+            - aws
       - workflow-integration-tests:
           <<: *common_filters
           requires:
@@ -156,6 +160,10 @@ jobs:
           environment:
             TESTING_PROFILE: automated-review
   unit_test: # runs not using Workflows must have a `build` job as entry point
+    parameters:
+      aws_bucket:
+        type: string
+        default: "${AWS_BUCKET}"
     docker: # run the steps with Docker
       - image: cimg/openjdk:11.0.10
         environment:
@@ -265,7 +273,12 @@ jobs:
             export dockerVersion=${tagOrBranch//\//_}
             docker build -t quay.io/dockstore/dockstore-webservice:$dockerVersion .
             echo "$QUAY_PASSWORD" | docker login -u=$QUAY_USERNAME --password-stdin quay.io
+            # Gather the checksum information
+            docker inspect --format='{{index .RepoDigests 0}}' quay.io/dockstore/dockstore-webservice:$dockerVersion | grep -oPm1 'sha256:\K\w+' > image-digest.txt
             docker push quay.io/dockstore/dockstore-webservice:$dockerVersion
+      - aws-s3/copy:
+          from: image-digest.txt
+          to: 's3://${AWS_BUCKET}/${CIRCLE_TAG:-$CIRCLE_BRANCH}-$(echo $CIRCLE_SHA1 | cut -c -7)/image-digest.txt'
 commands:
   install-git-secrets:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,6 +276,7 @@ jobs:
             # Gather the checksum information
             docker inspect quay.io/dockstore/dockstore-webservice:$dockerVersion | grep -A 1 RepoDigests | grep -oPm1 'sha256:\K\w+' > image-digest.txt
             docker push quay.io/dockstore/dockstore-webservice:$dockerVersion
+      - install-pip
       - aws-s3/copy:
           from: image-digest.txt
           to: 's3://${AWS_BUCKET}/${CIRCLE_TAG:-$CIRCLE_BRANCH}-$(echo $CIRCLE_SHA1 | cut -c -7)/image-digest.txt'
@@ -289,6 +290,17 @@ commands:
             tar -zxf git-secrets-1.3.0.tar.gz
             cd git-secrets-1.3.0
             sudo make install
+  install-pip:
+    steps:
+      - run:
+          name: install pip
+          command: |
+            sudo apt update
+            sudo apt install python3-distutils python3-dev python3-pip
+            # For debug purposes, a python3 version was installed in the image, pip is untagged
+            python3 --version
+            pip3 --version
+            alias pip=pip3
   setup_postgres:
     steps:
       - run:
@@ -339,16 +351,7 @@ commands:
           key: dockstore-web-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_SEGMENTED_VERSION }}-segmented
   setup_integration_test:
     steps:
-      - run:
-          name: install pip
-          command: |
-            sudo apt update
-            sudo apt install python3-distutils python3-dev
-            curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-            python3 get-pip.py
-            # For debug purposes, a python3 version was installed in the image, pip is untagged
-            python3 --version
-            pip3 --version
+      - install-pip
       - run:
           name: install pip dependencies
           command: scripts/install-tests.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,8 +274,9 @@ jobs:
             docker build -t quay.io/dockstore/dockstore-webservice:$dockerVersion .
             echo "$QUAY_PASSWORD" | docker login -u=$QUAY_USERNAME --password-stdin quay.io
             # Gather the checksum information
-            docker inspect quay.io/dockstore/dockstore-webservice:$dockerVersion | grep -A 1 RepoDigests | grep -oPm1 'sha256:\K\w+' > image-digest.txt
             docker push quay.io/dockstore/dockstore-webservice:$dockerVersion
+            docker inspect quay.io/dockstore/dockstore-webservice:$dockerVersion | grep -A 1 RepoDigests
+            docker inspect quay.io/dockstore/dockstore-webservice:$dockerVersion | grep -A 1 RepoDigests | grep -oPm1 'sha256:\K\w+' > image-digest.txt
       - install-pip
       - aws-s3/copy:
           from: image-digest.txt

--- a/.gitallowed
+++ b/.gitallowed
@@ -106,7 +106,7 @@ dockstore-common/src/test/resources/fixtures/dockerImagesPre10.wdl:56:.*sha256:f
 
 
 # dockstore-webservice/src/main/java/io/swagger/model/ToolDockerfile.java
-dockstore-webservice/src/main/java/io/swagger/model/ToolDockerfile.java:71:.*pcawg_delly_workflow/c83478829802b4d36374870843821abe1b625a71
+dockstore-webservice/src/main/java/io/swagger/model/ToolDockerfile.java:.*pcawg_delly_workflow/c83478829802b4d36374870843821abe1b625a71
 
 # swagger-java-sam-client/pom.xml
 swagger-java-sam-client/pom.xml:.*broadinstitute/sam/de13d1d


### PR DESCRIPTION
It can be difficult to browse historic builds using CircleCI UI so this PR is being offered to ease automation for image verification. With the image digest in S3 we can provide a more straightforward way of verification before deploy.

* Added AWS API keys for circle to `aws` context
* Refactored pip installation so it can be reused (awscli needs it)
* Added logic to gather digest after image is created and upload to s3

For review you can see this PR uploaded `image-digest.txt` to `s3://dockstore.ui.builds/feature/seab-2881/image-digest-af57d1c/image-digest.txt`

You can then download the image using `docker pull quay.io/dockstore/dockstore-webservice:feature_seab-2881_image-digest` and observe the digest or run `docker inspect quay.io/dockstore/dockstore-webservice:feature_seab-2881_image-digest | grep -A 1 RepoDigests`. The content after `sha256:` should match what is in the `image-digest.txt`.

This PR will likely go with changes in dockstore-deploy to complete verifying automation. Either way, the S3 bucket itself can ease the manual verification process.