### PR TITLE
multiple authors & ORCID authors in dockstore.yml

### DIFF
--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-common</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-common</artifactId>
-  <version>1.12.0-alpha.0-SNAPSHOT</version>
+  <version>1.11.0-beta.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.11.0-alpha.3-SNAPSHOT</version>
+        <version>1.12.0-alpha.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-common</artifactId>

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/AbstractYamlService.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/AbstractYamlService.java
@@ -15,6 +15,7 @@
  */
 package io.dockstore.common.yaml;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -29,9 +30,13 @@ public abstract class AbstractYamlService {
      */
     private String name;
     /**
-     * The service's author
+     * (TO BE DEPRECATED) The service's author
      */
     private String author;
+    /**
+     * The service's authors
+     */
+    private List<YamlAuthor> authors = new ArrayList<>();
     /**
      * The service's description
      */
@@ -70,6 +75,14 @@ public abstract class AbstractYamlService {
 
     public void setAuthor(final String author) {
         this.author = author;
+    }
+
+    public List<YamlAuthor> getAuthors() {
+        return authors;
+    }
+
+    public void setAuthors(final List<YamlAuthor> authors) {
+        this.authors = authors;
     }
 
     public String getName() {

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/AbstractYamlService.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/AbstractYamlService.java
@@ -62,6 +62,8 @@ public abstract class AbstractYamlService {
      */
     private Map<String, DataSet> data;
 
+    private boolean latestTagAsDefault = false;
+
     public String getAuthor() {
         return author;
     }
@@ -132,6 +134,14 @@ public abstract class AbstractYamlService {
 
     public void setData(final Map<String, DataSet> data) {
         this.data = data;
+    }
+
+    public boolean getLatestTagAsDefault() {
+        return latestTagAsDefault;
+    }
+
+    public void setLatestTagAsDefault(boolean latestTagAsDefault) {
+        this.latestTagAsDefault = latestTagAsDefault;
     }
 
     /**

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlAuthor.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlAuthor.java
@@ -1,0 +1,72 @@
+/*
+ *    Copyright 2021 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.dockstore.common.yaml;
+
+import javax.validation.constraints.NotNull;
+
+public class YamlAuthor {
+
+    @NotNull
+    private String name;
+
+    private String role;
+
+    private String affiliation;
+
+    private String email;
+
+    private String orcid;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(final String role) {
+        this.role = role;
+    }
+
+    public String getAffiliation() {
+        return affiliation;
+    }
+
+    public void setAffiliation(final String affiliation) {
+        this.affiliation = affiliation;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(final String email) {
+        this.email = email;
+    }
+
+    public String getOrcid() {
+        return orcid;
+    }
+
+    public void setOrcid(final String orcid) {
+        this.orcid = orcid;
+    }
+}

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
@@ -46,6 +46,9 @@ public class YamlWorkflow {
      */
     private Boolean publish;
 
+    // If true, the most recent tag that Dockstore processes from AWS lambda becomes the default version
+    private boolean latestTagAsDefault = false;
+
     private Filters filters = new Filters();
 
     private List<String> testParameterFiles = new ArrayList<>();
@@ -100,5 +103,13 @@ public class YamlWorkflow {
 
     public void setTestParameterFiles(final List<String> testParameterFiles) {
         this.testParameterFiles = testParameterFiles;
+    }
+
+    public boolean getLatestTagAsDefault() {
+        return latestTagAsDefault;
+    }
+
+    public void setLatestTagAsDefault(boolean latestTagAsDefault) {
+        this.latestTagAsDefault = latestTagAsDefault;
     }
 }

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
@@ -51,6 +51,8 @@ public class YamlWorkflow {
 
     private Filters filters = new Filters();
 
+    private List<YamlAuthor> authors = new ArrayList<>();
+
     private List<String> testParameterFiles = new ArrayList<>();
 
 
@@ -95,6 +97,14 @@ public class YamlWorkflow {
 
     public void setFilters(final Filters filters) {
         this.filters = filters;
+    }
+
+    public List<YamlAuthor> getAuthors() {
+        return authors;
+    }
+
+    public void setAuthors(final List<YamlAuthor> authors) {
+        this.authors = authors;
     }
 
     public List<String> getTestParameterFiles() {

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -105,6 +105,10 @@ public class DockstoreYamlTest {
         final List<String> tags = filters.getTags();
         assertEquals(1, tags.size());
         assertEquals("gwas*", tags.get(0));
+        List<YamlAuthor> authors = workflow.getAuthors();
+        assertEquals(2, authors.size());
+        assertEquals("0000-0002-6130-1021", authors.get(0).getOrcid());
+        assertEquals("UCSC", authors.get(1).getAffiliation());
 
         workflow = workflows.get(1);
         assertFalse(workflow.getPublish());
@@ -114,6 +118,9 @@ public class DockstoreYamlTest {
         final Service12 service = dockstoreYaml.getService();
         assertNotNull(service);
         assertTrue(service.getPublish());
+        authors = service.getAuthors();
+        assertEquals(1, authors.size());
+        assertEquals("Institute", authors.get(0).getRole());
     }
 
     @Test

--- a/dockstore-common/src/test/resources/fixtures/dockstore12.yml
+++ b/dockstore-common/src/test/resources/fixtures/dockstore12.yml
@@ -2,6 +2,12 @@ version: 1.2
 workflows:
   -  name: foobar
      subclass: wdl
+     authors:
+       - name: Denis Yuen
+         orcid: 0000-0002-6130-1021
+       - name: UCSC Genomics Institute
+         role: Institute
+         affiliation: UCSC
      publish: true
      primaryDescriptorPath: /Dockstore2.wdl
      testParameterFiles:
@@ -26,6 +32,10 @@ service:
   subclass: DOCKER_COMPOSE
   name: UCSC Xena Browser
   author: UCSC Genomics Institute
+  authors:
+    - name: UCSC Genomics Institute
+      role: Institute
+      affiliation: UCSC
   description: |
     The UCSC Xena browser is an exploration tool for public and private,
     multi-omic and clinical/phenotype data.

--- a/dockstore-event-consumer/generated/src/main/resources/pom.xml
+++ b/dockstore-event-consumer/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-event-consumer</artifactId>
-  <version>1.12.0-alpha.0-SNAPSHOT</version>
+  <version>1.11.0-beta.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,13 +30,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-event-consumer/generated/src/main/resources/pom.xml
+++ b/dockstore-event-consumer/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-event-consumer</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,13 +30,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-event-consumer/pom.xml
+++ b/dockstore-event-consumer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.11.0-alpha.3-SNAPSHOT</version>
+        <version>1.12.0-alpha.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -30,12 +30,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-integration-testing</artifactId>
-  <version>1.12.0-alpha.0-SNAPSHOT</version>
+  <version>1.11.0-beta.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -54,13 +54,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>openapi-java-client</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-integration-testing</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -54,13 +54,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>openapi-java-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.11.0-alpha.3-SNAPSHOT</version>
+        <version>1.12.0-alpha.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-integration-testing</artifactId>
@@ -63,12 +63,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
             <!-- looks like these are excluded because they bring in duplicate liquibase.build.properties -->
             <exclusions>
                 <exclusion>
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
             <!-- looks like these are excluded because they bring in duplicate liquibase.build.properties -->
             <exclusions>
                 <exclusion>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-client</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -205,7 +205,7 @@ public class WebhookIT extends BaseIT {
         assertEquals(1, workflowCount);
 
         // Ensure that new workflow is created and is what is expected
-        io.dockstore.openapi.client.model.Workflow workflow = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "versions", false);
+        io.dockstore.openapi.client.model.Workflow workflow = getFoobar1Workflow(client);
         assertEquals("Should be a WDL workflow", io.dockstore.openapi.client.model.Workflow.DescriptorTypeEnum.WDL, workflow.getDescriptorType());
         assertEquals("Should be type DOCKSTORE_YML", io.dockstore.openapi.client.model.Workflow.ModeEnum.DOCKSTORE_YML, workflow.getMode());
         assertEquals("Should have one version 0.1", 1, workflow.getWorkflowVersions().size());
@@ -216,10 +216,10 @@ public class WebhookIT extends BaseIT {
         assertEquals(2, workflowCount);
 
         // Ensure that existing workflow is updated
-        workflow = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "", false);
+        workflow = getFoobar1Workflow(client);
 
         // Ensure that new workflow is created and is what is expected
-        io.dockstore.openapi.client.model.Workflow workflow2 = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar2", "versions", false);
+        io.dockstore.openapi.client.model.Workflow workflow2 = getFoobar2Workflow(client);
         assertEquals("Should be a CWL workflow", io.dockstore.openapi.client.model.Workflow.DescriptorTypeEnum.CWL, workflow2.getDescriptorType());
         assertEquals("Should be type DOCKSTORE_YML", io.dockstore.openapi.client.model.Workflow.ModeEnum.DOCKSTORE_YML, workflow2.getMode());
         assertEquals("Should have one version 0.2", 1, workflow2.getWorkflowVersions().size());
@@ -237,12 +237,12 @@ public class WebhookIT extends BaseIT {
             assertEquals("Should be able to get license after manual GitHub App version update", "Apache License 2.0", workflowIndividual.getLicenseInformation().getLicenseName());
         });
 
-        workflow = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "versions", false);
+        workflow = getFoobar1Workflow(client);
         assertTrue("Should have a master version.", workflow.getWorkflowVersions().stream().anyMatch((io.dockstore.openapi.client.model.WorkflowVersion version) -> Objects.equals(version.getName(), "master")));
         assertTrue("Should have a 0.1 version.", workflow.getWorkflowVersions().stream().anyMatch((io.dockstore.openapi.client.model.WorkflowVersion version) -> Objects.equals(version.getName(), "0.1")));
         assertTrue("Should have a 0.2 version.", workflow.getWorkflowVersions().stream().anyMatch((io.dockstore.openapi.client.model.WorkflowVersion version) -> Objects.equals(version.getName(), "0.2")));
 
-        workflow2 = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar2", "versions", false);
+        workflow2 = getFoobar2Workflow(client);
         assertTrue("Should have a master version.", workflow2.getWorkflowVersions().stream().anyMatch((io.dockstore.openapi.client.model.WorkflowVersion version) -> Objects.equals(version.getName(), "master")));
         assertTrue("Should have a 0.2 version.", workflow2.getWorkflowVersions().stream().anyMatch((io.dockstore.openapi.client.model.WorkflowVersion version) -> Objects.equals(version.getName(), "0.2")));
 
@@ -266,9 +266,9 @@ public class WebhookIT extends BaseIT {
 
         // Delete tag 0.2
         client.handleGitHubBranchDeletion(workflowRepo, BasicIT.USER_2_USERNAME, "refs/tags/0.2", installationId);
-        workflow = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "versions", false);
+        workflow = getFoobar1Workflow(client);
         assertTrue("Should not have a 0.2 version.", workflow.getWorkflowVersions().stream().noneMatch((io.dockstore.openapi.client.model.WorkflowVersion version) -> Objects.equals(version.getName(), "0.2")));
-        workflow2 = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar2", "versions", false);
+        workflow2 = getFoobar2Workflow(client);
         assertTrue("Should not have a 0.2 version.", workflow2.getWorkflowVersions().stream().noneMatch((io.dockstore.openapi.client.model.WorkflowVersion version) -> Objects.equals(version.getName(), "0.2")));
 
         // Add version that doesn't exist
@@ -317,10 +317,35 @@ public class WebhookIT extends BaseIT {
 
         // Try adding version with empty test parameter file (should work)
         client.handleGitHubRelease("refs/heads/emptytestparameter", installationId, workflowRepo, BasicIT.USER_2_USERNAME);
-        workflow2 = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar2", "versions", false);
-
+        workflow2 = getFoobar2Workflow(client);
         assertTrue("Should have emptytestparameter version that is valid", workflow2.getWorkflowVersions().stream().filter(workflowVersion -> Objects.equals(workflowVersion.getName(), "emptytestparameter")).findFirst().get().isValid());
         testValidationUpdate(client);
+        testDefaultVersion(client);
+    }
+
+    private void testDefaultVersion(io.dockstore.openapi.client.api.WorkflowsApi client) {
+        io.dockstore.openapi.client.model.Workflow workflow2 = getFoobar2Workflow(client);
+        assertNull(workflow2.getDefaultVersion());
+        io.dockstore.openapi.client.model.Workflow workflow = getFoobar1Workflow(client);
+        assertEquals(null, workflow.getDefaultVersion());
+        client.handleGitHubRelease("refs/tags/0.4", installationId, workflowRepo, BasicIT.USER_2_USERNAME);
+        workflow2 = getFoobar2Workflow(client);
+        assertEquals("The new tag says the latest tag should be the default version", "0.4", workflow2.getDefaultVersion());
+        workflow = getFoobar1Workflow(client);
+        assertEquals(null, workflow.getDefaultVersion());
+
+    }
+    
+    private io.dockstore.openapi.client.model.Workflow getFoobar1Workflow(io.dockstore.openapi.client.api.WorkflowsApi client) {
+        return client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "versions", false);
+    }
+
+    private Workflow getFoobar1Workflow(WorkflowsApi client) {
+        return client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "versions", false);
+    }
+
+    private io.dockstore.openapi.client.model.Workflow getFoobar2Workflow(io.dockstore.openapi.client.api.WorkflowsApi client) {
+        return client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar2", "versions", false);
     }
 
     /**
@@ -330,12 +355,12 @@ public class WebhookIT extends BaseIT {
     private void testValidationUpdate(io.dockstore.openapi.client.api.WorkflowsApi client) {
         testingPostgres.runUpdateStatement("update workflowversion set valid='f'");
 
-        io.dockstore.openapi.client.model.Workflow workflow2 = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar2", "versions", false);
+        io.dockstore.openapi.client.model.Workflow workflow2 = getFoobar2Workflow(client);
         Optional<io.dockstore.openapi.client.model.WorkflowVersion> masterVersion = workflow2.getWorkflowVersions().stream().filter((io.dockstore.openapi.client.model.WorkflowVersion version) -> Objects.equals(version.getName(), "master")).findFirst();
         assertFalse("Master version should be invalid because it was manually changed", masterVersion.get().isValid());
 
         client.handleGitHubRelease("refs/heads/master", installationId, workflowRepo, BasicIT.USER_2_USERNAME);
-        workflow2 = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar2", "versions", false);
+        workflow2 = getFoobar2Workflow(client);
         masterVersion = workflow2.getWorkflowVersions().stream().filter((io.dockstore.openapi.client.model.WorkflowVersion version) -> Objects.equals(version.getName(), "master")).findFirst();
         assertTrue("Master version should be valid after GitHub App triggered again", masterVersion.get().isValid());
     }
@@ -389,7 +414,7 @@ public class WebhookIT extends BaseIT {
         long workflowCount = testingPostgres.runSelectStatement("select count(*) from workflow", long.class);
         assertEquals(1, workflowCount);
 
-        Workflow workflow = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "versions", false);
+        Workflow workflow = getFoobar1Workflow(client);
         assertEquals("Should be able to get license after GitHub App register", "Apache License 2.0", workflow.getLicenseInformation().getLicenseName());
 
         // Ensure that new workflow is created and is what is expected
@@ -445,7 +470,7 @@ public class WebhookIT extends BaseIT {
         long workflowCount = testingPostgres.runSelectStatement("select count(*) from workflow", long.class);
         assertEquals(1, workflowCount);
         // Ensure that new workflow is created and is what is expected
-        Workflow workflow = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "versions", false);
+        Workflow workflow = getFoobar1Workflow(client);
         assertEquals("Should be a WDL workflow", Workflow.DescriptorTypeEnum.WDL, workflow.getDescriptorType());
         assertEquals("Should be type DOCKSTORE_YML", Workflow.ModeEnum.DOCKSTORE_YML, workflow.getMode());
         assertEquals("Should have one version", 1, workflow.getWorkflowVersions().size());
@@ -467,7 +492,7 @@ public class WebhookIT extends BaseIT {
         assertEquals(1, workflowCount);
 
         // Ensure that new workflow is created and is what is expected
-        workflow = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "versions", false);
+        workflow = getFoobar1Workflow(client);
         assertEquals("Should be a WDL workflow", Workflow.DescriptorTypeEnum.WDL, workflow.getDescriptorType());
         assertEquals("Should be type DOCKSTORE_YML", Workflow.ModeEnum.DOCKSTORE_YML, workflow.getMode());
         assertEquals("Should have one version 0.1", 1, workflow.getWorkflowVersions().size());
@@ -508,7 +533,7 @@ public class WebhookIT extends BaseIT {
         assertEquals(1, workflowCount);
 
         // Ensure that new workflow is created and is what is expected
-        Workflow workflow = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "versions", false);
+        Workflow workflow = getFoobar1Workflow(client);
         assertEquals("Should be a WDL workflow", Workflow.DescriptorTypeEnum.WDL, workflow.getDescriptorType());
         assertEquals("Should be type DOCKSTORE_YML", Workflow.ModeEnum.DOCKSTORE_YML, workflow.getMode());
         assertEquals("Should have one version 0.1", 1, workflow.getWorkflowVersions().size());
@@ -580,7 +605,7 @@ public class WebhookIT extends BaseIT {
         WorkflowsApi client = new WorkflowsApi(webClient);
 
         client.handleGitHubRelease(workflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/master", installationId);
-        Workflow workflow = client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", "versions", false);
+        Workflow workflow = getFoobar1Workflow(client);
         WorkflowVersion version = workflow.getWorkflowVersions().get(0);
         List<SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(version.getId());
         assertTrue("Test file should have the expected path", sourceFiles.stream().filter(sourceFile -> sourceFile.getPath().equals("/dockstore.wdl.json")).findFirst().isPresent());

--- a/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-language-plugin-parent</artifactId>
-  <version>1.12.0-alpha.0-SNAPSHOT</version>
+  <version>1.11.0-beta.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-language-plugin-parent</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-language-plugin-parent/pom.xml
+++ b/dockstore-language-plugin-parent/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <version>1.11.0-alpha.3-SNAPSHOT</version>
+        <version>1.12.0-alpha.0-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.pf4j</groupId>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-webservice</artifactId>
-  <version>1.12.0-alpha.0-SNAPSHOT</version>
+  <version>1.11.0-beta.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -60,37 +60,37 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-quay-client</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-sam-client</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-bitbucket-client</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-discourse-client</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-language-plugin-parent</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-zenodo-client</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-webservice</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -60,37 +60,37 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-quay-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-sam-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-bitbucket-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-discourse-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-language-plugin-parent</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-zenodo-client</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
 
     <parent>
-        <version>1.11.0-alpha.3-SNAPSHOT</version>
+        <version>1.12.0-alpha.0-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -53,32 +53,32 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-quay-client</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-sam-client</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-bitbucket-client</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-discourse-client</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-language-plugin-parent</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.zafarkhaja</groupId>
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-zenodo-client</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
@@ -535,7 +535,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -52,6 +52,7 @@ import io.dockstore.webservice.core.Image;
 import io.dockstore.webservice.core.Label;
 import io.dockstore.webservice.core.LambdaEvent;
 import io.dockstore.webservice.core.Notification;
+import io.dockstore.webservice.core.OrcidAuthor;
 import io.dockstore.webservice.core.Organization;
 import io.dockstore.webservice.core.OrganizationUser;
 import io.dockstore.webservice.core.ParsedInformation;
@@ -179,7 +180,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
     private final HibernateBundle<DockstoreWebserviceConfiguration> hibernate = new HibernateBundle<>(Token.class, Tool.class, User.class,
             Tag.class, Label.class, SourceFile.class, Workflow.class, CollectionOrganization.class, WorkflowVersion.class, FileFormat.class,
             Organization.class, Notification.class, OrganizationUser.class, Event.class, Collection.class, Validation.class, BioWorkflow.class, Service.class, VersionMetadata.class, Image.class, Checksum.class, LambdaEvent.class,
-            ParsedInformation.class, EntryVersion.class, DeletedUsername.class, CloudInstance.class, Author.class) {
+            ParsedInformation.class, EntryVersion.class, DeletedUsername.class, CloudInstance.class, Author.class, OrcidAuthor.class) {
         @Override
         public DataSourceFactory getDataSourceFactory(DockstoreWebserviceConfiguration configuration) {
             return configuration.getDataSourceFactory();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -38,6 +38,7 @@ import io.dockstore.common.LanguagePluginManager;
 import io.dockstore.language.CompleteLanguageInterface;
 import io.dockstore.language.MinimalLanguageInterface;
 import io.dockstore.language.RecommendedLanguageInterface;
+import io.dockstore.webservice.core.Author;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Checksum;
 import io.dockstore.webservice.core.CloudInstance;
@@ -178,7 +179,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
     private final HibernateBundle<DockstoreWebserviceConfiguration> hibernate = new HibernateBundle<>(Token.class, Tool.class, User.class,
             Tag.class, Label.class, SourceFile.class, Workflow.class, CollectionOrganization.class, WorkflowVersion.class, FileFormat.class,
             Organization.class, Notification.class, OrganizationUser.class, Event.class, Collection.class, Validation.class, BioWorkflow.class, Service.class, VersionMetadata.class, Image.class, Checksum.class, LambdaEvent.class,
-            ParsedInformation.class, EntryVersion.class, DeletedUsername.class, CloudInstance.class) {
+            ParsedInformation.class, EntryVersion.class, DeletedUsername.class, CloudInstance.class, Author.class) {
         @Override
         public DataSourceFactory getDataSourceFactory(DockstoreWebserviceConfiguration configuration) {
             return configuration.getDataSourceFactory();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Author.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Author.java
@@ -1,0 +1,90 @@
+/*
+ *    Copyright 2021 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.dockstore.webservice.core;
+
+import java.sql.Timestamp;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@ApiModel(value = "Author", description = "This describes a non-ORCID author of a version in Dockstore")
+@Entity
+@Table(name = "author")
+public class Author {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @ApiModelProperty(value = "Implementation specific ID for the author in this web service", required = true, position = 0)
+    private long id;
+
+    @Column(columnDefinition = "varchar(255)", nullable = false)
+    @ApiModelProperty(value = "Name of the author", required = true, position = 1)
+    private String name;
+
+    @Column(columnDefinition = "varchar(255)")
+    @ApiModelProperty(value = "Role of the author")
+    private String role;
+
+    @Column(columnDefinition = "varchar(255)")
+    @ApiModelProperty(value = "Affiliation of the author")
+    private String affiliation;
+
+    @Column(columnDefinition = "varchar(255)")
+    @ApiModelProperty(value = "Email of the author")
+    private String email;
+
+    // database timestamps
+    @Column(updatable = false)
+    @CreationTimestamp
+    private Timestamp dbCreateDate;
+
+    @Column()
+    @UpdateTimestamp
+    private Timestamp dbUpdateDate;
+
+    public Author() {
+    }
+
+    public Author(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(final String email) {
+        this.email = email;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Author.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Author.java
@@ -80,6 +80,22 @@ public class Author {
         this.name = name;
     }
 
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(final String role) {
+        this.role = role;
+    }
+
+    public String getAffiliation() {
+        return affiliation;
+    }
+
+    public void setAffiliation(final String affiliation) {
+        this.affiliation = affiliation;
+    }
+
     public String getEmail() {
         return email;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/OrcidAuthor.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/OrcidAuthor.java
@@ -1,0 +1,47 @@
+package io.dockstore.webservice.core;
+
+import java.sql.Timestamp;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@ApiModel(value = "OrcidAuthor", description = "This describes an ORCID-author of a version in Dockstore")
+@Entity
+@Table(name = "orcidauthor")
+public class OrcidAuthor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @ApiModelProperty(value = "Implementation specific ID for the author in this web service", required = true, position = 0)
+    private long id;
+
+    @Column(columnDefinition = "varchar(50)", nullable = false)
+    @ApiModelProperty(value = "ORCID id of the author", required = true, position = 1)
+    private String orcid;
+
+    // database timestamps
+    @Column(updatable = false)
+    @CreationTimestamp
+    private Timestamp dbCreateDate;
+
+    @Column()
+    @UpdateTimestamp
+    private Timestamp dbUpdateDate;
+
+    public OrcidAuthor(String orchid) {
+        this.orcid = orchid;
+    }
+
+    public String getOrcid() {
+        return orcid;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -190,6 +190,11 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @ApiModelProperty(value = "Non-ORCID Authors for each version.")
     private Set<Author> authors = new HashSet<>();
 
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(name = "version_orcidauthor", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id", columnDefinition = "bigint"), inverseJoinColumns = @JoinColumn(name = "orcidauthorid", referencedColumnName = "id", columnDefinition = "bigint"))
+    @ApiModelProperty(value = "ORCID Authors for versions.")
+    private Set<OrcidAuthor> orcidAuthors = new HashSet<>();
+
     @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
     @JoinTable(name = "version_validation", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id", columnDefinition = "bigint"), inverseJoinColumns = @JoinColumn(name = "validationid", referencedColumnName = "id", columnDefinition = "bigint"))
     @ApiModelProperty(value = "Cached validations for each version.", position = 14)
@@ -459,6 +464,10 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     public void setAuthors(final Set<Author> authors) {
         this.authors = authors;
+    }
+
+    public void setOrcidAuthors(final Set<OrcidAuthor> orcidAuthors) {
+        this.orcidAuthors = orcidAuthors;
     }
 
     public ReferenceType getReferenceType() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -457,6 +457,10 @@ public abstract class Version<T extends Version> implements Comparable<T> {
         }
     }
 
+    public void setAuthors(final Set<Author> authors) {
+        this.authors = authors;
+    }
+
     public ReferenceType getReferenceType() {
         return referenceType;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1063,6 +1063,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     }
 
     public User.Profile getProfile(final User user, final GHUser ghUser) throws IOException {
+        LOG.info("GitHub user profile id is {} and GitHub username is {} for Dockstore user {}", ghUser.getId(), ghUser.getLogin(), user.getUsername());
         User.Profile profile = new User.Profile();
         profile.onlineProfileId = String.valueOf(ghUser.getId());
         profile.username = ghUser.getLogin();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -21,9 +21,11 @@ import io.dockstore.common.DescriptorLanguageSubclass;
 import io.dockstore.common.yaml.DockstoreYaml12;
 import io.dockstore.common.yaml.DockstoreYamlHelper;
 import io.dockstore.common.yaml.Service12;
+import io.dockstore.common.yaml.YamlAuthor;
 import io.dockstore.common.yaml.YamlWorkflow;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
+import io.dockstore.webservice.core.Author;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Checksum;
 import io.dockstore.webservice.core.LambdaEvent;
@@ -437,9 +439,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 String workflowName = wf.getName();
                 Boolean publish = wf.getPublish();
                 final var defaultVersion = wf.getLatestTagAsDefault();
+                final List<YamlAuthor> yamlAuthors = wf.getAuthors();
 
                 Workflow workflow = createOrGetWorkflow(BioWorkflow.class, repository, user, workflowName, subclass, gitHubSourceCodeRepo);
-                addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion);
+                addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion, yamlAuthors);
 
                 if (publish != null && workflow.getIsPublished() != publish) {
                     LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, user.getUsername(), LambdaEvent.LambdaEventType.PUBLISH);
@@ -481,9 +484,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             final DescriptorLanguageSubclass subclass = service.getSubclass();
             final Boolean publish = service.getPublish();
             final var defaultVersion = service.getLatestTagAsDefault();
+            final List<YamlAuthor> yamlAuthors = service.getAuthors();
 
             Workflow workflow = createOrGetWorkflow(Service.class, repository, user, "", subclass.getShortName(), gitHubSourceCodeRepo);
-            addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion);
+            addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion, yamlAuthors);
 
             if (publish != null && workflow.getIsPublished() != publish) {
                 LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, user.getUsername(), LambdaEvent.LambdaEventType.PUBLISH);
@@ -561,13 +565,15 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @return New or updated workflow
      */
     private Workflow addDockstoreYmlVersionToWorkflow(String repository, String gitReference, SourceFile dockstoreYml,
-            GitHubSourceCodeRepo gitHubSourceCodeRepo, Workflow workflow, boolean latestTagAsDefault) {
+            GitHubSourceCodeRepo gitHubSourceCodeRepo, Workflow workflow, boolean latestTagAsDefault, final List<YamlAuthor> yamlAuthors) {
         Instant startTime = Instant.now();
         try {
             // Create version and pull relevant files
             WorkflowVersion remoteWorkflowVersion = gitHubSourceCodeRepo
                     .createVersionForWorkflow(repository, gitReference, workflow, dockstoreYml);
             remoteWorkflowVersion.setReferenceType(getReferenceTypeFromGitRef(gitReference));
+            // Add authors
+            addDockstoreYmlAuthorsToVersion(yamlAuthors, remoteWorkflowVersion);
 
             // So we have workflowversion which is the new version, we want to update the version and associated source files
             WorkflowVersion existingWorkflowVersion = workflowVersionDAO.getWorkflowVersionByWorkflowIdAndVersionName(workflow.getId(), remoteWorkflowVersion.getName());
@@ -615,6 +621,27 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         long timeElasped = Duration.between(startTime, endTime).toSeconds();
         LOG.info("Processing .dockstore.yml workflow version " + gitReference + " for repo: " + repository + " took " + timeElasped + " seconds");
         return workflow;
+    }
+
+    private void addDockstoreYmlAuthorsToVersion(final List<YamlAuthor> yamlAuthors, Version version) {
+        final Set<Author> authors = yamlAuthors.stream()
+                .filter(yamlAuthor -> yamlAuthor.getOrcid() == null)
+                .map(yamlAuthor -> {
+                    Author author = new Author();
+                    author.setName(yamlAuthor.getName());
+                    author.setRole(yamlAuthor.getRole());
+                    author.setAffiliation(yamlAuthor.getAffiliation());
+                    author.setEmail(yamlAuthor.getEmail());
+                    return author;
+                })
+                .collect(Collectors.toSet());
+        version.setAuthors(authors);
+        yamlAuthors.stream()
+                .filter(yamlAuthor -> yamlAuthor.getOrcid() != null)
+                .map(yamlAuthor -> {
+                    return yamlAuthor.getOrcid();
+                })
+                .collect(Collectors.toSet());
     }
 
     private Version.ReferenceType getReferenceTypeFromGitRef(String gitRef) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -29,6 +29,7 @@ import io.dockstore.webservice.core.Author;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Checksum;
 import io.dockstore.webservice.core.LambdaEvent;
+import io.dockstore.webservice.core.OrcidAuthor;
 import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Token;
@@ -636,12 +637,13 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 })
                 .collect(Collectors.toSet());
         version.setAuthors(authors);
-        yamlAuthors.stream()
+        final Set<OrcidAuthor> orcidAuthors = yamlAuthors.stream()
                 .filter(yamlAuthor -> yamlAuthor.getOrcid() != null)
                 .map(yamlAuthor -> {
-                    return yamlAuthor.getOrcid();
+                    return new OrcidAuthor(yamlAuthor.getOrcid());
                 })
                 .collect(Collectors.toSet());
+        version.setOrcidAuthors(orcidAuthors);
     }
 
     private Version.ReferenceType getReferenceTypeFromGitRef(String gitRef) {

--- a/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
@@ -300,6 +300,6 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addForeignKeyConstraint baseColumnNames="orcidauthorid" baseTableName="version_orcidauthor" constraintName="fk_version_orcidauthor" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="orcidauthor" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="orcidauthorid" baseTableName="version_orcidauthor" constraintName="fk_version_orcidauthor" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="orcidauthor"/>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
@@ -280,4 +280,26 @@
             WHERE author IS NOT NULL;
         </sql>
     </changeSet>
+
+    <changeSet author="ghogue (generated)" id="yamlOrcidAuthors">
+        <createTable tableName="version_orcidauthor">
+            <column name="versionid" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="version_orcidauthor_pkey"/>
+            </column>
+            <column name="orcidauthorid" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="version_orcidauthor_pkey"/>
+            </column>
+        </createTable>
+        <createTable tableName="orcidauthor">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="orcidauthor_pkey"/>
+            </column>
+            <column name="dbcreatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="dbupdatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="orcid" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addForeignKeyConstraint baseColumnNames="orcidauthorid" baseTableName="version_orcidauthor" constraintName="fk_version_orcidauthor" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="orcidauthor" validate="true"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
@@ -149,7 +149,7 @@
             <where>tokensource = 'orcid.org'</where>
         </update>
     </changeSet>
-  
+
     <changeSet author="dyuen (generated)" id="date_more_things">
         <addColumn tableName="cloud_instance">
             <column name="dbcreatedate" type="timestamp"/>
@@ -182,6 +182,7 @@
             <column name="dbupdatedate" type="timestamp"/>
         </addColumn>
     </changeSet>
+
 
     <changeSet author="dyuen (generated)" id="standard_sequences">
         <alterSequence sequenceName="container_id_seq" incrementBy="1" />
@@ -252,5 +253,31 @@
                 <constraints nullable="false"/>
             </column>
         </addColumn>
+    </changeSet>
+
+    <changeSet author="ghogue (generated)" id="multipleAuthorsTable">
+        <createTable tableName="author">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="author_pkey"/>
+            </column>
+            <column name="affiliation" type="VARCHAR(255)"/>
+            <column name="dbcreatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="dbupdatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="email" type="VARCHAR(255)"/>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="role" type="VARCHAR(255)"/>
+            <column name="versionid" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="ghogue" id="multipleAuthorsMigrate">
+        <sql>
+            INSERT INTO author (versionid,name,email)
+            SELECT id,author,email FROM version_metadata
+            WHERE author IS NOT NULL;
+        </sql>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -13,7 +13,7 @@ info:
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
   termsOfService: TBD
   title: Dockstore API
-  version: 1.12.0-alpha.0-SNAPSHOT
+  version: 1.11.0-beta.1-SNAPSHOT
 servers:
 - description: Current server when hosted on AWS
   url: /api

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -6685,6 +6685,17 @@ components:
       properties:
         content:
           type: string
+    Author:
+      type: object
+      properties:
+        affiliation:
+          type: string
+        email:
+          type: string
+        name:
+          type: string
+        role:
+          type: string
     BioWorkflow:
       type: object
       allOf:
@@ -7519,6 +7530,11 @@ components:
           enum:
           - SITEWIDE
           - NEWSBODY
+    OrcidAuthor:
+      type: object
+      properties:
+        orcid:
+          type: string
     Organization:
       type: object
       properties:
@@ -7904,6 +7920,12 @@ components:
       properties:
         author:
           type: string
+        authors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Author'
+          uniqueItems: true
+          writeOnly: true
         automated:
           type: boolean
         commitID:
@@ -7961,6 +7983,12 @@ components:
           description: "Implementation specific, can be a quay.io or docker hub tag\
             \ name"
           example: latest
+        orcidAuthors:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrcidAuthor'
+          uniqueItems: true
+          writeOnly: true
         output_file_formats:
           type: array
           items:
@@ -8442,6 +8470,12 @@ components:
       properties:
         author:
           type: string
+        authors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Author'
+          uniqueItems: true
+          writeOnly: true
         commitID:
           type: string
         dbUpdateDate:
@@ -8488,6 +8522,12 @@ components:
           description: "Implementation specific, can be a quay.io or docker hub tag\
             \ name"
           example: latest
+        orcidAuthors:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrcidAuthor'
+          uniqueItems: true
+          writeOnly: true
         output_file_formats:
           type: array
           items:
@@ -8714,6 +8754,12 @@ components:
             $ref: '#/components/schemas/Alias'
         author:
           type: string
+        authors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Author'
+          uniqueItems: true
+          writeOnly: true
         commitID:
           type: string
         dbUpdateDate:
@@ -8765,6 +8811,12 @@ components:
           description: "Implementation specific, can be a quay.io or docker hub tag\
             \ name"
           example: latest
+        orcidAuthors:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrcidAuthor'
+          uniqueItems: true
+          writeOnly: true
         output_file_formats:
           type: array
           items:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5,7 +5,7 @@ info:
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images. Explore swagger.json for a Swagger 2.0 description\
     \ of our API and explore openapi.yaml for OpenAPI 3.0 descriptions."
-  version: "1.11.0-alpha.3-SNAPSHOT"
+  version: "1.12.0-alpha.0-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5,7 +5,7 @@ info:
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images. Explore swagger.json for a Swagger 2.0 description\
     \ of our API and explore openapi.yaml for OpenAPI 3.0 descriptions."
-  version: "1.12.0-alpha.0-SNAPSHOT"
+  version: "1.11.0-beta.1-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/openapi-java-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>openapi-java-client</artifactId>
-  <version>1.12.0-alpha.0-SNAPSHOT</version>
+  <version>1.11.0-beta.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/openapi-java-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>openapi-java-client</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/openapi-java-client/pom.xml
+++ b/openapi-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>openapi-java-client</name>
 
     <parent>
-        <version>1.11.0-alpha.3-SNAPSHOT</version>
+        <version>1.12.0-alpha.0-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -325,7 +325,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>io.dockstore</groupId>
     <artifactId>dockstore</artifactId>
-    <version>1.11.0-alpha.3-SNAPSHOT</version>
+    <version>1.12.0-alpha.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>dockstore</name>

--- a/reports/generated/src/main/resources/pom.xml
+++ b/reports/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>reports</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,19 +30,19 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-integration-testing</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/reports/generated/src/main/resources/pom.xml
+++ b/reports/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>reports</artifactId>
-  <version>1.12.0-alpha.0-SNAPSHOT</version>
+  <version>1.11.0-beta.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,19 +30,19 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-integration-testing</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.11.0-alpha.3-SNAPSHOT</version>
+        <version>1.12.0-alpha.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,17 +29,17 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-integration-testing</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/swagger-java-bitbucket-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-bitbucket-client/generated/src/main/resources/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-bitbucket-client</artifactId>
-  <version>1.12.0-alpha.0-SNAPSHOT</version>
+  <version>1.11.0-beta.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-bitbucket-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-bitbucket-client/generated/src/main/resources/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-bitbucket-client</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-bitbucket-client/pom.xml
+++ b/swagger-java-bitbucket-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.11.0-alpha.3-SNAPSHOT</version>
+        <version>1.12.0-alpha.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-client</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-alpha.3-SNAPSHOT</version>
+      <version>1.12.0-alpha.0-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/swagger-java-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-client</artifactId>
-  <version>1.12.0-alpha.0-SNAPSHOT</version>
+  <version>1.11.0-beta.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.0-alpha.0-SNAPSHOT</version>
+      <version>1.11.0-beta.1-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/swagger-java-client/pom.xml
+++ b/swagger-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-client</name>
 
     <parent>
-        <version>1.11.0-alpha.3-SNAPSHOT</version>
+        <version>1.12.0-alpha.0-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -255,7 +255,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.11.0-alpha.3-SNAPSHOT</version>
+            <version>1.12.0-alpha.0-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/swagger-java-discourse-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-discourse-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-discourse-client</artifactId>
-  <version>1.12.0-alpha.0-SNAPSHOT</version>
+  <version>1.11.0-beta.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-discourse-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-discourse-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-discourse-client</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-discourse-client/pom.xml
+++ b/swagger-java-discourse-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-discourse-client</name>
 
     <parent>
-        <version>1.11.0-alpha.3-SNAPSHOT</version>
+        <version>1.12.0-alpha.0-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-quay-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-quay-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-quay-client</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-quay-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-quay-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-quay-client</artifactId>
-  <version>1.12.0-alpha.0-SNAPSHOT</version>
+  <version>1.11.0-beta.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-quay-client/pom.xml
+++ b/swagger-java-quay-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-quay-client</name>
 
     <parent>
-        <version>1.11.0-alpha.3-SNAPSHOT</version>
+        <version>1.12.0-alpha.0-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>

--- a/swagger-java-sam-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-sam-client/generated/src/main/resources/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-sam-client</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-sam-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-sam-client/generated/src/main/resources/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-sam-client</artifactId>
-  <version>1.12.0-alpha.0-SNAPSHOT</version>
+  <version>1.11.0-beta.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-sam-client/pom.xml
+++ b/swagger-java-sam-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.11.0-alpha.3-SNAPSHOT</version>
+        <version>1.12.0-alpha.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/swagger-java-zenodo-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-zenodo-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-zenodo-client</artifactId>
-  <version>1.11.0-alpha.3-SNAPSHOT</version>
+  <version>1.12.0-alpha.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-zenodo-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-zenodo-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-zenodo-client</artifactId>
-  <version>1.12.0-alpha.0-SNAPSHOT</version>
+  <version>1.11.0-beta.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-zenodo-client/pom.xml
+++ b/swagger-java-zenodo-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-zenodo-client</name>
 
     <parent>
-        <version>1.11.0-alpha.3-SNAPSHOT</version>
+        <version>1.12.0-alpha.0-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>


### PR DESCRIPTION
Main issue: https://ucsc-cgl.atlassian.net/browse/SEAB-2544
Previous draft PR: #4062

This PR adds an `authors` field in .dockstore.yml for workflows & services.
Authors with ORCID ids are handled as a ManyToMany relation on Version, separate from non-ORCID Authors (OneToMany).