### PR TITLE
multiple authors & ORCID authors in .dockstore.yml

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/AbstractYamlService.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/AbstractYamlService.java
@@ -15,6 +15,7 @@
  */
 package io.dockstore.common.yaml;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -29,9 +30,13 @@ public abstract class AbstractYamlService {
      */
     private String name;
     /**
-     * The service's author
+     * (TO BE DEPRECATED) The service's author
      */
     private String author;
+    /**
+     * The service's authors
+     */
+    private List<YamlAuthor> authors = new ArrayList<>();
     /**
      * The service's description
      */
@@ -70,6 +75,14 @@ public abstract class AbstractYamlService {
 
     public void setAuthor(final String author) {
         this.author = author;
+    }
+
+    public List<YamlAuthor> getAuthors() {
+        return authors;
+    }
+
+    public void setAuthors(final List<YamlAuthor> authors) {
+        this.authors = authors;
     }
 
     public String getName() {

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlAuthor.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlAuthor.java
@@ -1,0 +1,72 @@
+/*
+ *    Copyright 2021 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.dockstore.common.yaml;
+
+import javax.validation.constraints.NotNull;
+
+public class YamlAuthor {
+
+    @NotNull
+    private String name;
+
+    private String role;
+
+    private String affiliation;
+
+    private String email;
+
+    private String orcid;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(final String role) {
+        this.role = role;
+    }
+
+    public String getAffiliation() {
+        return affiliation;
+    }
+
+    public void setAffiliation(final String affiliation) {
+        this.affiliation = affiliation;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(final String email) {
+        this.email = email;
+    }
+
+    public String getOrcid() {
+        return orcid;
+    }
+
+    public void setOrcid(final String orcid) {
+        this.orcid = orcid;
+    }
+}

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
@@ -51,6 +51,8 @@ public class YamlWorkflow {
 
     private Filters filters = new Filters();
 
+    private List<YamlAuthor> authors = new ArrayList<>();
+
     private List<String> testParameterFiles = new ArrayList<>();
 
 
@@ -95,6 +97,14 @@ public class YamlWorkflow {
 
     public void setFilters(final Filters filters) {
         this.filters = filters;
+    }
+
+    public List<YamlAuthor> getAuthors() {
+        return authors;
+    }
+
+    public void setAuthors(final List<YamlAuthor> authors) {
+        this.authors = authors;
     }
 
     public List<String> getTestParameterFiles() {

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -105,6 +105,10 @@ public class DockstoreYamlTest {
         final List<String> tags = filters.getTags();
         assertEquals(1, tags.size());
         assertEquals("gwas*", tags.get(0));
+        List<YamlAuthor> authors = workflow.getAuthors();
+        assertEquals(2, authors.size());
+        assertEquals("0000-0002-6130-1021", authors.get(0).getOrcid());
+        assertEquals("UCSC", authors.get(1).getAffiliation());
 
         workflow = workflows.get(1);
         assertFalse(workflow.getPublish());
@@ -114,6 +118,9 @@ public class DockstoreYamlTest {
         final Service12 service = dockstoreYaml.getService();
         assertNotNull(service);
         assertTrue(service.getPublish());
+        authors = service.getAuthors();
+        assertEquals(1, authors.size());
+        assertEquals("Institute", authors.get(0).getRole());
     }
 
     @Test

--- a/dockstore-common/src/test/resources/fixtures/dockstore12.yml
+++ b/dockstore-common/src/test/resources/fixtures/dockstore12.yml
@@ -2,6 +2,12 @@ version: 1.2
 workflows:
   -  name: foobar
      subclass: wdl
+     authors:
+       - name: Denis Yuen
+         orcid: 0000-0002-6130-1021
+       - name: UCSC Genomics Institute
+         role: Institute
+         affiliation: UCSC
      publish: true
      primaryDescriptorPath: /Dockstore2.wdl
      testParameterFiles:
@@ -26,6 +32,10 @@ service:
   subclass: DOCKER_COMPOSE
   name: UCSC Xena Browser
   author: UCSC Genomics Institute
+  authors:
+    - name: UCSC Genomics Institute
+      role: Institute
+      affiliation: UCSC
   description: |
     The UCSC Xena browser is an exploration tool for public and private,
     multi-omic and clinical/phenotype data.

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -734,7 +734,7 @@ public class WebhookIT extends BaseIT {
         WorkflowsApi client = new WorkflowsApi(webClient);
 
         client.handleGitHubRelease(githubFiltersRepo, BasicIT.USER_2_USERNAME, "refs/heads/authors", installationId);
-        final Workflow workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", "", false);
+        final Workflow workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", "versions", false);
         final WorkflowVersion version = workflow.getWorkflowVersions().get(0);
         final List<Author> authors = version.getAuthors();
         assertEquals(2, authors.size());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -37,7 +37,9 @@ import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
+import io.swagger.client.model.Author;
 import io.swagger.client.model.LambdaEvent;
+import io.swagger.client.model.OrcidAuthor;
 import io.swagger.client.model.PublishRequest;
 import io.swagger.client.model.Validation;
 import io.swagger.client.model.Workflow;
@@ -719,5 +721,24 @@ public class WebhookIT extends BaseIT {
         client.handleGitHubRelease(githubFiltersRepo, BasicIT.USER_2_USERNAME, "refs/heads/unpublish", installationId);
         workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", "", false);
         assertFalse(workflow.isIsPublished());
+    }
+
+    /**
+     * This tests multiple authors functionality in .dockstore.yml
+     * @throws Exception
+     */
+    @Test
+    public void testDockstoreYmlAuthors() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+        final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        WorkflowsApi client = new WorkflowsApi(webClient);
+
+        client.handleGitHubRelease(githubFiltersRepo, BasicIT.USER_2_USERNAME, "refs/heads/authors", installationId);
+        final Workflow workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", "", false);
+        final WorkflowVersion version = workflow.getWorkflowVersions().get(0);
+        final List<Author> authors = version.getAuthors();
+        assertEquals(2, authors.size());
+        final List<OrcidAuthor> orcidAuthors = version.getOrcidAuthors();
+        assertEquals(2, orcidAuthors.size());
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -734,7 +734,7 @@ public class WebhookIT extends BaseIT {
         WorkflowsApi client = new WorkflowsApi(webClient);
 
         client.handleGitHubRelease(githubFiltersRepo, BasicIT.USER_2_USERNAME, "refs/heads/authors", installationId);
-        final Workflow workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", "versions", false);
+        final Workflow workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", "versions,authors", false);
         final WorkflowVersion version = workflow.getWorkflowVersions().get(0);
         final List<Author> authors = version.getAuthors();
         assertEquals(2, authors.size());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -52,6 +52,7 @@ import io.dockstore.webservice.core.Image;
 import io.dockstore.webservice.core.Label;
 import io.dockstore.webservice.core.LambdaEvent;
 import io.dockstore.webservice.core.Notification;
+import io.dockstore.webservice.core.OrcidAuthor;
 import io.dockstore.webservice.core.Organization;
 import io.dockstore.webservice.core.OrganizationUser;
 import io.dockstore.webservice.core.ParsedInformation;
@@ -179,7 +180,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
     private final HibernateBundle<DockstoreWebserviceConfiguration> hibernate = new HibernateBundle<>(Token.class, Tool.class, User.class,
             Tag.class, Label.class, SourceFile.class, Workflow.class, CollectionOrganization.class, WorkflowVersion.class, FileFormat.class,
             Organization.class, Notification.class, OrganizationUser.class, Event.class, Collection.class, Validation.class, BioWorkflow.class, Service.class, VersionMetadata.class, Image.class, Checksum.class, LambdaEvent.class,
-            ParsedInformation.class, EntryVersion.class, DeletedUsername.class, CloudInstance.class, Author.class) {
+            ParsedInformation.class, EntryVersion.class, DeletedUsername.class, CloudInstance.class, Author.class, OrcidAuthor.class) {
         @Override
         public DataSourceFactory getDataSourceFactory(DockstoreWebserviceConfiguration configuration) {
             return configuration.getDataSourceFactory();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Author.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Author.java
@@ -80,6 +80,22 @@ public class Author {
         this.name = name;
     }
 
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(final String role) {
+        this.role = role;
+    }
+
+    public String getAffiliation() {
+        return affiliation;
+    }
+
+    public void setAffiliation(final String affiliation) {
+        this.affiliation = affiliation;
+    }
+
     public String getEmail() {
         return email;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/OrcidAuthor.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/OrcidAuthor.java
@@ -37,6 +37,9 @@ public class OrcidAuthor {
     @UpdateTimestamp
     private Timestamp dbUpdateDate;
 
+    public OrcidAuthor() {
+    }
+
     public OrcidAuthor(String orchid) {
         this.orcid = orchid;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/OrcidAuthor.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/OrcidAuthor.java
@@ -1,0 +1,47 @@
+package io.dockstore.webservice.core;
+
+import java.sql.Timestamp;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@ApiModel(value = "OrcidAuthor", description = "This describes an ORCID-author of a version in Dockstore")
+@Entity
+@Table(name = "orcidauthor")
+public class OrcidAuthor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @ApiModelProperty(value = "Implementation specific ID for the author in this web service", required = true, position = 0)
+    private long id;
+
+    @Column(columnDefinition = "varchar(50)", nullable = false)
+    @ApiModelProperty(value = "ORCID id of the author", required = true, position = 1)
+    private String orcid;
+
+    // database timestamps
+    @Column(updatable = false)
+    @CreationTimestamp
+    private Timestamp dbCreateDate;
+
+    @Column()
+    @UpdateTimestamp
+    private Timestamp dbUpdateDate;
+
+    public OrcidAuthor(String orchid) {
+        this.orcid = orchid;
+    }
+
+    public String getOrcid() {
+        return orcid;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -190,7 +190,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @ApiModelProperty(value = "Non-ORCID Authors for each version.")
     private Set<Author> authors = new HashSet<>();
 
-    @ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     @JoinTable(name = "version_orcidauthor", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id", columnDefinition = "bigint"), inverseJoinColumns = @JoinColumn(name = "orcidauthorid", referencedColumnName = "id", columnDefinition = "bigint"))
     @ApiModelProperty(value = "ORCID Authors for versions.")
     private Set<OrcidAuthor> orcidAuthors = new HashSet<>();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -190,7 +190,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @ApiModelProperty(value = "Non-ORCID Authors for each version.")
     private Set<Author> authors = new HashSet<>();
 
-    @ManyToMany(fetch = FetchType.LAZY)
+    @ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinTable(name = "version_orcidauthor", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id", columnDefinition = "bigint"), inverseJoinColumns = @JoinColumn(name = "orcidauthorid", referencedColumnName = "id", columnDefinition = "bigint"))
     @ApiModelProperty(value = "ORCID Authors for versions.")
     private Set<OrcidAuthor> orcidAuthors = new HashSet<>();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -190,6 +190,11 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @ApiModelProperty(value = "Non-ORCID Authors for each version.")
     private Set<Author> authors = new HashSet<>();
 
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(name = "version_orcidauthor", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id", columnDefinition = "bigint"), inverseJoinColumns = @JoinColumn(name = "orcidauthorid", referencedColumnName = "id", columnDefinition = "bigint"))
+    @ApiModelProperty(value = "ORCID Authors for versions.")
+    private Set<OrcidAuthor> orcidAuthors = new HashSet<>();
+
     @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
     @JoinTable(name = "version_validation", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id", columnDefinition = "bigint"), inverseJoinColumns = @JoinColumn(name = "validationid", referencedColumnName = "id", columnDefinition = "bigint"))
     @ApiModelProperty(value = "Cached validations for each version.", position = 14)
@@ -459,6 +464,10 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     public void setAuthors(final Set<Author> authors) {
         this.authors = authors;
+    }
+
+    public void setOrcidAuthors(final Set<OrcidAuthor> orcidAuthors) {
+        this.orcidAuthors = orcidAuthors;
     }
 
     public ReferenceType getReferenceType() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -435,6 +435,14 @@ public abstract class Version<T extends Version> implements Comparable<T> {
         }
     }
 
+    public Set<Author> getAuthors() {
+        return authors;
+    }
+
+    public Set<OrcidAuthor> getOrcidAuthors() {
+        return orcidAuthors;
+    }
+
     public void setDoiStatus(DOIStatus doiStatus) {
         this.getVersionMetadata().doiStatus = doiStatus;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -190,7 +190,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @ApiModelProperty(value = "Non-ORCID Authors for each version.")
     private Set<Author> authors = new HashSet<>();
 
-    @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinTable(name = "version_orcidauthor", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id", columnDefinition = "bigint"), inverseJoinColumns = @JoinColumn(name = "orcidauthorid", referencedColumnName = "id", columnDefinition = "bigint"))
     @ApiModelProperty(value = "ORCID Authors for versions.")
     private Set<OrcidAuthor> orcidAuthors = new HashSet<>();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -457,6 +457,10 @@ public abstract class Version<T extends Version> implements Comparable<T> {
         }
     }
 
+    public void setAuthors(final Set<Author> authors) {
+        this.authors = authors;
+    }
+
     public ReferenceType getReferenceType() {
         return referenceType;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -21,9 +21,11 @@ import io.dockstore.common.DescriptorLanguageSubclass;
 import io.dockstore.common.yaml.DockstoreYaml12;
 import io.dockstore.common.yaml.DockstoreYamlHelper;
 import io.dockstore.common.yaml.Service12;
+import io.dockstore.common.yaml.YamlAuthor;
 import io.dockstore.common.yaml.YamlWorkflow;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
+import io.dockstore.webservice.core.Author;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Checksum;
 import io.dockstore.webservice.core.LambdaEvent;
@@ -437,9 +439,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 String workflowName = wf.getName();
                 Boolean publish = wf.getPublish();
                 final var defaultVersion = wf.getLatestTagAsDefault();
+                final List<YamlAuthor> yamlAuthors = wf.getAuthors();
 
                 Workflow workflow = createOrGetWorkflow(BioWorkflow.class, repository, user, workflowName, subclass, gitHubSourceCodeRepo);
-                addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion);
+                addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion, yamlAuthors);
 
                 if (publish != null && workflow.getIsPublished() != publish) {
                     LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, user.getUsername(), LambdaEvent.LambdaEventType.PUBLISH);
@@ -481,9 +484,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             final DescriptorLanguageSubclass subclass = service.getSubclass();
             final Boolean publish = service.getPublish();
             final var defaultVersion = service.getLatestTagAsDefault();
+            final List<YamlAuthor> yamlAuthors = service.getAuthors();
 
             Workflow workflow = createOrGetWorkflow(Service.class, repository, user, "", subclass.getShortName(), gitHubSourceCodeRepo);
-            addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion);
+            addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion, yamlAuthors);
 
             if (publish != null && workflow.getIsPublished() != publish) {
                 LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, user.getUsername(), LambdaEvent.LambdaEventType.PUBLISH);
@@ -561,13 +565,15 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @return New or updated workflow
      */
     private Workflow addDockstoreYmlVersionToWorkflow(String repository, String gitReference, SourceFile dockstoreYml,
-            GitHubSourceCodeRepo gitHubSourceCodeRepo, Workflow workflow, boolean latestTagAsDefault) {
+            GitHubSourceCodeRepo gitHubSourceCodeRepo, Workflow workflow, boolean latestTagAsDefault, final List<YamlAuthor> yamlAuthors) {
         Instant startTime = Instant.now();
         try {
             // Create version and pull relevant files
             WorkflowVersion remoteWorkflowVersion = gitHubSourceCodeRepo
                     .createVersionForWorkflow(repository, gitReference, workflow, dockstoreYml);
             remoteWorkflowVersion.setReferenceType(getReferenceTypeFromGitRef(gitReference));
+            // Add authors
+            addDockstoreYmlAuthorsToVersion(yamlAuthors, remoteWorkflowVersion);
 
             // So we have workflowversion which is the new version, we want to update the version and associated source files
             WorkflowVersion existingWorkflowVersion = workflowVersionDAO.getWorkflowVersionByWorkflowIdAndVersionName(workflow.getId(), remoteWorkflowVersion.getName());
@@ -615,6 +621,27 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         long timeElasped = Duration.between(startTime, endTime).toSeconds();
         LOG.info("Processing .dockstore.yml workflow version " + gitReference + " for repo: " + repository + " took " + timeElasped + " seconds");
         return workflow;
+    }
+
+    private void addDockstoreYmlAuthorsToVersion(final List<YamlAuthor> yamlAuthors, Version version) {
+        final Set<Author> authors = yamlAuthors.stream()
+                .filter(yamlAuthor -> yamlAuthor.getOrcid() == null)
+                .map(yamlAuthor -> {
+                    Author author = new Author();
+                    author.setName(yamlAuthor.getName());
+                    author.setRole(yamlAuthor.getRole());
+                    author.setAffiliation(yamlAuthor.getAffiliation());
+                    author.setEmail(yamlAuthor.getEmail());
+                    return author;
+                })
+                .collect(Collectors.toSet());
+        version.setAuthors(authors);
+        yamlAuthors.stream()
+                .filter(yamlAuthor -> yamlAuthor.getOrcid() != null)
+                .map(yamlAuthor -> {
+                    return yamlAuthor.getOrcid();
+                })
+                .collect(Collectors.toSet());
     }
 
     private Version.ReferenceType getReferenceTypeFromGitRef(String gitRef) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -29,6 +29,7 @@ import io.dockstore.webservice.core.Author;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Checksum;
 import io.dockstore.webservice.core.LambdaEvent;
+import io.dockstore.webservice.core.OrcidAuthor;
 import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Token;
@@ -636,12 +637,13 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 })
                 .collect(Collectors.toSet());
         version.setAuthors(authors);
-        yamlAuthors.stream()
+        final Set<OrcidAuthor> orcidAuthors = yamlAuthors.stream()
                 .filter(yamlAuthor -> yamlAuthor.getOrcid() != null)
                 .map(yamlAuthor -> {
-                    return yamlAuthor.getOrcid();
+                    return new OrcidAuthor(yamlAuthor.getOrcid());
                 })
                 .collect(Collectors.toSet());
+        version.setOrcidAuthors(orcidAuthors);
     }
 
     private Version.ReferenceType getReferenceTypeFromGitRef(String gitRef) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -645,7 +645,8 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         final Set<OrcidAuthor> orcidAuthors = yamlAuthors.stream()
                 .filter(yamlAuthor -> yamlAuthor.getOrcid() != null)
                 .map(yamlAuthor -> {
-                    return new OrcidAuthor(yamlAuthor.getOrcid());
+                    final OrcidAuthor orcidAuthor = new OrcidAuthor(yamlAuthor.getOrcid());
+                    return orcidAuthor;
                 })
                 .collect(Collectors.toSet());
         version.setOrcidAuthors(orcidAuthors);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -624,6 +624,11 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         return workflow;
     }
 
+    /**
+     * Add authors from .dockstore.yml to a version
+     * @param yamlAuthors
+     * @param version
+     */
     private void addDockstoreYmlAuthorsToVersion(final List<YamlAuthor> yamlAuthors, Version version) {
         final Set<Author> authors = yamlAuthors.stream()
                 .filter(yamlAuthor -> yamlAuthor.getOrcid() == null)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -162,6 +162,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     private static final String VALIDATIONS = "validations";
     private static final String IMAGES = "images";
     private static final String VERSIONS = "versions";
+    private static final String AUTHORS = "authors";
     private static final String SHA_TYPE_FOR_SOURCEFILES = "SHA-1";
 
     private final ToolDAO toolDAO;
@@ -1735,6 +1736,9 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         }
         if (checkIncludes(include, VERSIONS)) {
             Hibernate.initialize(workflow.getWorkflowVersions());
+        }
+        if (checkIncludes(include, AUTHORS)) {
+            workflow.getWorkflowVersions().forEach(workflowVersion -> Hibernate.initialize(workflowVersion.getOrcidAuthors()));
         }
     }
 

--- a/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
@@ -300,6 +300,6 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addForeignKeyConstraint baseColumnNames="orcidauthorid" baseTableName="version_orcidauthor" constraintName="fk_version_orcidauthor" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="orcidauthor" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="orcidauthorid" baseTableName="version_orcidauthor" constraintName="fk_version_orcidauthor" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="orcidauthor"/>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.11.0.xml
@@ -280,4 +280,26 @@
             WHERE author IS NOT NULL;
         </sql>
     </changeSet>
+
+    <changeSet author="ghogue (generated)" id="yamlOrcidAuthors">
+        <createTable tableName="version_orcidauthor">
+            <column name="versionid" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="version_orcidauthor_pkey"/>
+            </column>
+            <column name="orcidauthorid" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="version_orcidauthor_pkey"/>
+            </column>
+        </createTable>
+        <createTable tableName="orcidauthor">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="orcidauthor_pkey"/>
+            </column>
+            <column name="dbcreatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="dbupdatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="orcid" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addForeignKeyConstraint baseColumnNames="orcidauthorid" baseTableName="version_orcidauthor" constraintName="fk_version_orcidauthor" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="orcidauthor" validate="true"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -6685,6 +6685,17 @@ components:
       properties:
         content:
           type: string
+    Author:
+      type: object
+      properties:
+        affiliation:
+          type: string
+        email:
+          type: string
+        name:
+          type: string
+        role:
+          type: string
     BioWorkflow:
       type: object
       allOf:
@@ -7521,6 +7532,11 @@ components:
           enum:
           - SITEWIDE
           - NEWSBODY
+    OrcidAuthor:
+      type: object
+      properties:
+        orcid:
+          type: string
     Organization:
       type: object
       properties:
@@ -7906,6 +7922,12 @@ components:
       properties:
         author:
           type: string
+        authors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Author'
+          uniqueItems: true
+          writeOnly: true
         automated:
           type: boolean
         commitID:
@@ -7963,6 +7985,12 @@ components:
           description: "Implementation specific, can be a quay.io or docker hub tag\
             \ name"
           example: latest
+        orcidAuthors:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrcidAuthor'
+          uniqueItems: true
+          writeOnly: true
         output_file_formats:
           type: array
           items:
@@ -8444,6 +8472,12 @@ components:
       properties:
         author:
           type: string
+        authors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Author'
+          uniqueItems: true
+          writeOnly: true
         commitID:
           type: string
         dbUpdateDate:
@@ -8490,6 +8524,12 @@ components:
           description: "Implementation specific, can be a quay.io or docker hub tag\
             \ name"
           example: latest
+        orcidAuthors:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrcidAuthor'
+          uniqueItems: true
+          writeOnly: true
         output_file_formats:
           type: array
           items:
@@ -8716,6 +8756,12 @@ components:
             $ref: '#/components/schemas/Alias'
         author:
           type: string
+        authors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Author'
+          uniqueItems: true
+          writeOnly: true
         commitID:
           type: string
         dbUpdateDate:
@@ -8767,6 +8813,12 @@ components:
           description: "Implementation specific, can be a quay.io or docker hub tag\
             \ name"
           example: latest
+        orcidAuthors:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrcidAuthor'
+          uniqueItems: true
+          writeOnly: true
         output_file_formats:
           type: array
           items:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -7927,7 +7927,6 @@ components:
           items:
             $ref: '#/components/schemas/Author'
           uniqueItems: true
-          writeOnly: true
         automated:
           type: boolean
         commitID:
@@ -7990,7 +7989,6 @@ components:
           items:
             $ref: '#/components/schemas/OrcidAuthor'
           uniqueItems: true
-          writeOnly: true
         output_file_formats:
           type: array
           items:
@@ -8477,7 +8475,6 @@ components:
           items:
             $ref: '#/components/schemas/Author'
           uniqueItems: true
-          writeOnly: true
         commitID:
           type: string
         dbUpdateDate:
@@ -8529,7 +8526,6 @@ components:
           items:
             $ref: '#/components/schemas/OrcidAuthor'
           uniqueItems: true
-          writeOnly: true
         output_file_formats:
           type: array
           items:
@@ -8761,7 +8757,6 @@ components:
           items:
             $ref: '#/components/schemas/Author'
           uniqueItems: true
-          writeOnly: true
         commitID:
           type: string
         dbUpdateDate:
@@ -8818,7 +8813,6 @@ components:
           items:
             $ref: '#/components/schemas/OrcidAuthor'
           uniqueItems: true
-          writeOnly: true
         output_file_formats:
           type: array
           items:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -6214,6 +6214,25 @@ definitions:
     properties:
       content:
         type: "string"
+  Author:
+    type: "object"
+    required:
+    - "name"
+    properties:
+      affiliation:
+        type: "string"
+        description: "Affiliation of the author"
+      email:
+        type: "string"
+        description: "Email of the author"
+      role:
+        type: "string"
+        description: "Role of the author"
+      name:
+        type: "string"
+        position: 1
+        description: "Name of the author"
+    description: "This describes a non-ORCID author of a version in Dockstore"
   BioWorkflow:
     allOf:
     - $ref: "#/definitions/Workflow"
@@ -7170,6 +7189,16 @@ definitions:
         format: "int64"
         position: 6
         description: "Timestamp at which the notification was last updated"
+  OrcidAuthor:
+    type: "object"
+    required:
+    - "orcid"
+    properties:
+      orcid:
+        type: "string"
+        position: 1
+        description: "ORCID id of the author"
+    description: "This describes an ORCID-author of a version in Dockstore"
   Organization:
     type: "object"
     required:
@@ -7501,11 +7530,23 @@ definitions:
     - "name"
     - "reference"
     properties:
+      authors:
+        type: "array"
+        description: "Non-ORCID Authors for each version."
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/Author"
       id:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the tag in this web service"
         readOnly: true
+      orcidAuthors:
+        type: "array"
+        description: "ORCID Authors for versions."
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/OrcidAuthor"
       versionMetadata:
         $ref: "#/definitions/VersionMetadata"
       reference:
@@ -8160,11 +8201,23 @@ definitions:
     - "name"
     - "reference"
     properties:
+      authors:
+        type: "array"
+        description: "Non-ORCID Authors for each version."
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/Author"
       id:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the tag in this web service"
         readOnly: true
+      orcidAuthors:
+        type: "array"
+        description: "ORCID Authors for versions."
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/OrcidAuthor"
       versionMetadata:
         $ref: "#/definitions/VersionMetadata"
       workingDirectory:
@@ -8550,6 +8603,12 @@ definitions:
         description: "aliases can be used as an alternate unique id for workflow versions"
         additionalProperties:
           $ref: "#/definitions/Alias"
+      authors:
+        type: "array"
+        description: "Non-ORCID Authors for each version."
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/Author"
       id:
         type: "integer"
         format: "int64"
@@ -8557,6 +8616,12 @@ definitions:
         readOnly: true
       legacyVersion:
         type: "boolean"
+      orcidAuthors:
+        type: "array"
+        description: "ORCID Authors for versions."
+        uniqueItems: true
+        items:
+          $ref: "#/definitions/OrcidAuthor"
       versionMetadata:
         $ref: "#/definitions/VersionMetadata"
       workingDirectory:


### PR DESCRIPTION
Main issue: https://ucsc-cgl.atlassian.net/browse/SEAB-2544
Previous draft PR: #4062

This PR adds an authors field in .dockstore.yml for workflows & services.
Authors with ORCID ids are handled as a ManyToMany relation on Version, separate from non-ORCID Authors (OneToMany).