### PR TITLE
Fail snapshot if workflow version contains images specified with no tag, latest tag, or parameter

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -1106,6 +1106,7 @@ public class WorkflowIT extends BaseIT {
         try {
             noTagImageVersion.setFrozen(true);
             workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(noTagImageVersion));
+            Assert.fail("Should not be able to snapshot a workflow version containing an image with no tag.");
         } catch (ApiException ex) {
             Assert.assertTrue(ex.getMessage().contains("Snapshot for workflow version noTagImage failed because not all images are specified using a digest or a valid tag."));
         }
@@ -1114,6 +1115,7 @@ public class WorkflowIT extends BaseIT {
         try {
             latestTagImageVersion.setFrozen(true);
             workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(latestTagImageVersion));
+            Assert.fail("Should not be able to snapshot a workflow version containing an image with the 'latest' tag.");
         } catch (ApiException ex) {
             Assert.assertTrue(ex.getMessage().contains("Snapshot for workflow version latestTagImage failed because not all images are specified using a digest or a valid tag."));
         }
@@ -1122,6 +1124,7 @@ public class WorkflowIT extends BaseIT {
         try {
             parameterImageVersion.setFrozen(true);
             workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(parameterImageVersion));
+            Assert.fail("Should not be able to snapshot a workflow version containing an image specified using a parameter.");
         } catch (ApiException ex) {
             Assert.assertTrue(ex.getMessage().contains("Snapshot for workflow version parameterImage failed because not all images are specified using a digest or a valid tag."));
         }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -1101,6 +1101,7 @@ public class WorkflowIT extends BaseIT {
         WorkflowVersion noTagImageVersion = workflow.getWorkflowVersions().stream().filter(v -> v.getName().equals("noTagImage")).findFirst().get();
         WorkflowVersion latestTagImageVersion = workflow.getWorkflowVersions().stream().filter(v -> v.getName().equals("latestTagImage")).findFirst().get();
         WorkflowVersion parameterImageVersion = workflow.getWorkflowVersions().stream().filter(v -> v.getName().equals("parameterImage")).findFirst().get();
+        String errorMessage = "Snapshot for workflow version %s failed because not all images are specified using a digest nor a valid tag.";
 
         // Test that the snapshot fails for a workflow version containing an image with no tag
         try {
@@ -1108,7 +1109,7 @@ public class WorkflowIT extends BaseIT {
             workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(noTagImageVersion));
             Assert.fail("Should not be able to snapshot a workflow version containing an image with no tag.");
         } catch (ApiException ex) {
-            Assert.assertTrue(ex.getMessage().contains("Snapshot for workflow version noTagImage failed because not all images are specified using a digest or a valid tag."));
+            Assert.assertTrue(ex.getMessage().contains(String.format(errorMessage, noTagImageVersion.getName())));
         }
 
         // Test that the snapshot fails for a workflow version containing an image with the 'latest' tag
@@ -1117,7 +1118,7 @@ public class WorkflowIT extends BaseIT {
             workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(latestTagImageVersion));
             Assert.fail("Should not be able to snapshot a workflow version containing an image with the 'latest' tag.");
         } catch (ApiException ex) {
-            Assert.assertTrue(ex.getMessage().contains("Snapshot for workflow version latestTagImage failed because not all images are specified using a digest or a valid tag."));
+            Assert.assertTrue(ex.getMessage().contains(String.format(errorMessage, latestTagImageVersion.getName())));
         }
 
         // Test that the snapshot fails for a workflow version containing an image specified using a parameter
@@ -1126,7 +1127,7 @@ public class WorkflowIT extends BaseIT {
             workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(parameterImageVersion));
             Assert.fail("Should not be able to snapshot a workflow version containing an image specified using a parameter.");
         } catch (ApiException ex) {
-            Assert.assertTrue(ex.getMessage().contains("Snapshot for workflow version parameterImage failed because not all images are specified using a digest or a valid tag."));
+            Assert.assertTrue(ex.getMessage().contains(String.format(errorMessage, parameterImageVersion.getName())));
         }
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -492,16 +492,14 @@ public class WorkflowIT extends BaseIT {
         branchToolJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", branchVersion.getId()), String.class);
         assertNull(branchToolJson);
 
-        // Test freezing versions
-        tagVersion.setFrozen(true);
-
-        List<WorkflowVersion> versions = workflowApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(tagVersion));
-        WorkflowVersion frozenVersion = versions.stream().filter(version -> version.getName().equals("test")).findFirst().get();
+        // Test freezing versions (uses a different workflow that has versioned images)
+        WorkflowVersion frozenVersion = snapshotWorkflowVersion(workflowApi, "dockstore-testing/hello_world", DescriptorType.CWL.toString(), "/hello_world.cwl", "1.0.1");
         String frozenDagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", frozenVersion.getId()), String.class);
         String frozenToolTableJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", frozenVersion.getId()), String.class);
         assertNotNull(frozenDagJson);
         assertNotNull(frozenToolTableJson);
     }
+
     /**
      * This tests that you are able to download zip files for versions of a workflow
      */
@@ -1090,6 +1088,43 @@ public class WorkflowIT extends BaseIT {
         verifyImageChecksumsAreSaved(versionWithDuplicateImages);
         versions = ga4Ghv20Api.toolsIdVersionsGet("#workflow/github.com/dockstore-testing/zhanghj-8555114");
         verifyTRSImageConversion(versions, "1.0", 3);
+    }
+
+    /**
+     * Tests that snapshotting a workflow version fails if any of the images have no tag, use the 'latest' tag, or are specified using a parameter.
+     */
+    @Test
+    public void testSnapshotImageFailures() {
+        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowsApi = new WorkflowsApi(webClient);
+        Workflow workflow = manualRegisterAndPublish(workflowsApi, "dockstore-testing/hello-wdl-workflow", "", DescriptorType.WDL.toString(), SourceControl.GITHUB, "/Dockstore.wdl", false);
+        WorkflowVersion noTagImageVersion = workflow.getWorkflowVersions().stream().filter(v -> v.getName().equals("noTagImage")).findFirst().get();
+        WorkflowVersion latestTagImageVersion = workflow.getWorkflowVersions().stream().filter(v -> v.getName().equals("latestTagImage")).findFirst().get();
+        WorkflowVersion parameterImageVersion = workflow.getWorkflowVersions().stream().filter(v -> v.getName().equals("parameterImage")).findFirst().get();
+
+        // Test that the snapshot fails for a workflow version containing an image with no tag
+        try {
+            noTagImageVersion.setFrozen(true);
+            workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(noTagImageVersion));
+        } catch (ApiException ex) {
+            Assert.assertTrue(ex.getMessage().contains("Snapshot for workflow version noTagImage failed because not all images are specified using a digest or a valid tag."));
+        }
+
+        // Test that the snapshot fails for a workflow version containing an image with the 'latest' tag
+        try {
+            latestTagImageVersion.setFrozen(true);
+            workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(latestTagImageVersion));
+        } catch (ApiException ex) {
+            Assert.assertTrue(ex.getMessage().contains("Snapshot for workflow version latestTagImage failed because not all images are specified using a digest or a valid tag."));
+        }
+
+        // Test that the snapshot fails for a workflow version containing an image specified using a parameter
+        try {
+            parameterImageVersion.setFrozen(true);
+            workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(parameterImageVersion));
+        } catch (ApiException ex) {
+            Assert.assertTrue(ex.getMessage().contains("Snapshot for workflow version parameterImage failed because not all images are specified using a digest or a valid tag."));
+        }
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -730,13 +730,13 @@ public interface LanguageHandlerInterface {
                     }
                 }
                 if (!imageFound) {
-                    LOG.error("Unable to get find image with digest: " + specifierName + " from Quay in repo " + repo);
+                    LOG.error("Unable to find image with digest: {} from Quay in repo {}", specifierName, repo);
                     return quayImages;
                 }
             } else {
                 QuayTag tag = quayRepo.getTags().get(specifierName);
                 if (tag == null) {
-                    LOG.error("Unable to get find tag: " + specifierName + " from Quay in repo " + repo);
+                    LOG.error("Unable to find tag: {} from Quay in repo {}", specifierName, repo);
                     return quayImages;
                 }
                 final String digest = tag.getManifestDigest();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -346,8 +346,7 @@ public interface LanguageHandlerInterface {
      * @throws CustomWebApplicationException if there is at least one image that is specified by 'latest' tag, no tag, or parameter.
      */
     default void checkSnapshotImages(final String versionName, final String toolsJSONTable) throws CustomWebApplicationException {
-        List<Map<String, String>> dockerTools = new ArrayList<>();
-        dockerTools = (ArrayList<Map<String, String>>)GSON.fromJson(toolsJSONTable, dockerTools.getClass());
+        List<Map<String, String>> dockerTools = (ArrayList<Map<String, String>>)GSON.fromJson(toolsJSONTable, ArrayList.class);
 
         // Eliminate duplicate docker strings
         Map<String, DockerSpecifier> dockerStrings = dockerTools.stream().collect(Collectors.toMap(
@@ -374,7 +373,7 @@ public interface LanguageHandlerInterface {
                     .map(image -> image.getKey())
                     .collect(Collectors.toList());
             StringBuilder errorMessage = new StringBuilder(String.format(
-                    "Snapshot for workflow version %s failed because not all images are specified using a digest or a valid tag.",
+                    "Snapshot for workflow version %s failed because not all images are specified using a digest nor a valid tag.",
                     versionName));
 
             if (parameterImages.size() > 1) {
@@ -517,8 +516,7 @@ public interface LanguageHandlerInterface {
 
     // TODO: Implement then gitlab, seven bridges, amazon, google if possible;
     default Set<Image> getImagesFromRegistry(String toolsJSONTable) {
-        List<Map<String, String>> dockerTools = new ArrayList<>();
-        dockerTools = (ArrayList<Map<String, String>>)GSON.fromJson(toolsJSONTable, dockerTools.getClass());
+        List<Map<String, String>> dockerTools = (ArrayList<Map<String, String>>)GSON.fromJson(toolsJSONTable, ArrayList.class);
 
         // Eliminate duplicate docker strings
         Map<String, DockerSpecifier> dockerStrings = dockerTools.stream().collect(Collectors.toMap(dockertool -> dockertool.get("docker"), dockertool -> DockerSpecifier.valueOf(dockertool.get("specifier")), (x, y) -> x));


### PR DESCRIPTION
#4275 

- The snapshot fails and throws an error if there are any images specified with no tag, latest tag, or parameter.
- I also check if a workflow version's `tooltablejson` in the DB contains the field `specifier`. If it doesn't, then a new `tooltablejson` is created, which will contain `specifier`. This new `tooltablejson` is saved to the DB if the workflow version isn't frozen.
- Added a test to check that snapshots fail for each type of "invalid" image. 
  - Added a new repo to dockstore-testing for this purpose: https://github.com/dockstore-testing/hello-wdl-workflow

Screenshots of the error in the UI:
![Screenshot 2021-06-09 at 16-03-05 Dockstore My Workflows](https://user-images.githubusercontent.com/25287123/121423158-f70dd900-c93d-11eb-825a-d6f33562e7df.png)
![Screenshot 2021-06-09 at 16-06-05 Dockstore My Workflows](https://user-images.githubusercontent.com/25287123/121423168-fa08c980-c93d-11eb-9cb8-00d2f5028f19.png)
![Screenshot 2021-06-09 at 16-06-41 Dockstore My Workflows](https://user-images.githubusercontent.com/25287123/121423181-fbd28d00-c93d-11eb-9b06-7b3019a5eb1b.png)