### PR TITLE
Check not frozen before saving DAG

### DIFF
--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-common</artifactId>
-  <version>1.11.0-beta.3</version>
+  <version>1.11.0-beta.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/dockstore-event-consumer/generated/src/main/resources/pom.xml
+++ b/dockstore-event-consumer/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-event-consumer</artifactId>
-  <version>1.11.0-beta.3</version>
+  <version>1.11.0-beta.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,13 +30,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-integration-testing</artifactId>
-  <version>1.11.0-beta.3</version>
+  <version>1.11.0-beta.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -54,13 +54,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>openapi-java-client</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -819,6 +819,12 @@ public class GeneralWorkflowIT extends BaseIT {
         } catch (ApiException e) {
             assertTrue(e.getMessage().contains("Repository does not meet requirements to publish"));
         }
+
+        // Tests that a frozen version without a saved DAG could generate a DAG does not try to save it
+        testingPostgres.runUpdateStatement("update workflowversion set frozen='t'");
+        String workflowDag = workflowsApi.getWorkflowDag(workflow.getId(), defaultVersionNumber);
+        Assert.assertTrue(workflowDag.contains("nodes"));
+        Assert.assertTrue(workflowDag.contains("edges"));
     }
 
     /**

--- a/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-language-plugin-parent</artifactId>
-  <version>1.11.0-beta.3</version>
+  <version>1.11.0-beta.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-webservice</artifactId>
-  <version>1.11.0-beta.3</version>
+  <version>1.11.0-beta.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -60,37 +60,37 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-quay-client</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-sam-client</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-bitbucket-client</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-discourse-client</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-language-plugin-parent</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-zenodo-client</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1360,8 +1360,9 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             LanguageHandlerInterface lInterface = LanguageHandlerFactory.getInterface(workflow.getFileType());
             final String dagJson = lInterface.getCleanDAG(workflowVersion.getWorkflowPath(), mainDescriptor.getContent(), secondaryDescContent,
                     LanguageHandlerInterface.Type.DAG, toolDAO);
-
-            workflowVersion.setDagJson(dagJson);
+            if (!workflowVersion.isFrozen()) {
+                workflowVersion.setDagJson(dagJson);
+            }
             return dagJson;
         }
         return null;

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -13,7 +13,7 @@ info:
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
   termsOfService: TBD
   title: Dockstore API
-  version: 1.11.0-beta.3
+  version: 1.11.0-beta.4-SNAPSHOT
 servers:
 - description: Current server when hosted on AWS
   url: /api

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5,7 +5,7 @@ info:
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images. Explore swagger.json for a Swagger 2.0 description\
     \ of our API and explore openapi.yaml for OpenAPI 3.0 descriptions."
-  version: "1.11.0-beta.3"
+  version: "1.11.0-beta.4-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/openapi-java-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>openapi-java-client</artifactId>
-  <version>1.11.0-beta.3</version>
+  <version>1.11.0-beta.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/reports/generated/src/main/resources/pom.xml
+++ b/reports/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>reports</artifactId>
-  <version>1.11.0-beta.3</version>
+  <version>1.11.0-beta.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,19 +30,19 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-integration-testing</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/swagger-java-bitbucket-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-bitbucket-client/generated/src/main/resources/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-bitbucket-client</artifactId>
-  <version>1.11.0-beta.3</version>
+  <version>1.11.0-beta.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-client</artifactId>
-  <version>1.11.0-beta.3</version>
+  <version>1.11.0-beta.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.11.0-beta.3</version>
+      <version>1.11.0-beta.4-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/swagger-java-discourse-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-discourse-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-discourse-client</artifactId>
-  <version>1.11.0-beta.3</version>
+  <version>1.11.0-beta.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-quay-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-quay-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-quay-client</artifactId>
-  <version>1.11.0-beta.3</version>
+  <version>1.11.0-beta.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-sam-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-sam-client/generated/src/main/resources/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-sam-client</artifactId>
-  <version>1.11.0-beta.3</version>
+  <version>1.11.0-beta.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/swagger-java-zenodo-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-zenodo-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-zenodo-client</artifactId>
-  <version>1.11.0-beta.3</version>
+  <version>1.11.0-beta.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>


### PR DESCRIPTION
For #4284 

Very unique case where there's a workflow that we didn't save the DAG for and then it was snapshotted before we had the DAG-saving code.

Can't really make a test case easily because the endpoint that sets a frozen version also saves a DAG...i need a version that's frozen but has no DAG saved 