### PR TITLE
Get more github ids

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -86,7 +86,8 @@ import org.hibernate.annotations.UpdateTimestamp;
     @NamedQuery(name = "io.dockstore.webservice.core.User.findByGoogleUserId", query = "SELECT t FROM User t JOIN t.userProfiles p where( KEY(p) = 'google.com' AND p.onlineProfileId = :id)"),
     @NamedQuery(name = "io.dockstore.webservice.core.User.countPublishedEntries", query = "SELECT count(e) FROM User u INNER JOIN u.entries e where e.isPublished=true and u.username = :username"),
     @NamedQuery(name = "io.dockstore.webservice.core.User.findByGitHubUsername", query = "SELECT t FROM User t JOIN t.userProfiles p where( KEY(p) = 'github.com' AND p.username = :username)"),
-    @NamedQuery(name = "io.dockstore.webservice.core.User.findByGitHubUserId", query = "SELECT t FROM User t JOIN t.userProfiles p where(KEY(p) = 'github.com' AND p.onlineProfileId = :id)")
+    @NamedQuery(name = "io.dockstore.webservice.core.User.findByGitHubUserId", query = "SELECT t FROM User t JOIN t.userProfiles p where(KEY(p) = 'github.com' AND p.onlineProfileId = :id)"),
+    @NamedQuery(name = "io.dockstore.webservice.core.User.findAllGitHubUsers", query = "SELECT t FROM User t JOIN t.userProfiles p where(KEY(p) = 'github.com')"),
 })
 @SuppressWarnings("checkstyle:magicnumber")
 public class User implements Principal, Comparable<User>, Serializable {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/UserDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/UserDAO.java
@@ -84,6 +84,10 @@ public class UserDAO extends AbstractDockstoreDAO<User> {
         return uniqueResult(this.currentSession().getNamedQuery("io.dockstore.webservice.core.User.findByGitHubUserId").setParameter("id", id));
     }
 
+    public List<User> findAllGitHubUsers() {
+        return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.User.findAllGitHubUsers"));
+    }
+
     public long findPublishedEntries(String username)  {
         final Query query = namedQuery("io.dockstore.webservice.core.User.countPublishedEntries").setParameter("username", username);
         return (long)query.uniqueResult();

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/UserResourceTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/UserResourceTest.java
@@ -2,6 +2,7 @@ package io.dockstore.webservice.resources;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
 
 import io.dockstore.webservice.CustomWebApplicationException;
 import org.junit.Assert;
@@ -20,6 +21,18 @@ public class UserResourceTest {
             } catch (CustomWebApplicationException ex) {
                 Assert.assertTrue(ex.errorMessage.contains("because it contains one or more of the following keywords:"));
             }
+        }
+    }
+
+    @Test
+    public void gitHubIdRegexTest() {
+        List<String> avatarUrls = new ArrayList<>(List.of("https://avatars3.githubusercontent.com/u/11111?v=4", "https://avatars2.githubusercontent.com/u/1234567?v=4",
+                "https://avatars.githubusercontent.com/u/999999999?v=4", "https://avatars3.githubusercontent.com/u/987654?v=3"));
+        List<String> ids = new ArrayList<>(List.of("11111", "1234567", "999999999", "987654"));
+        for (String avatarUrl : avatarUrls) {
+            Matcher m = UserResource.GITHUB_ID_PATTERN.matcher(avatarUrl);
+            Assert.assertTrue(m.matches());
+            Assert.assertTrue(ids.stream().anyMatch(id -> id.equals(m.group(1))));
         }
     }
 


### PR DESCRIPTION
First attempt to the github id by using the token which I think is the best way, but if that is unsuccessful then use the avatarurl we have stored for them and grab the user id from there so we can grab more of the GitHub ids. I'm also going through the users by using the user_profile table and not the token table since there are a few more user_profiles than tokens.

There are more users we need to ban/delete. You can look at the list by checking the bottom of this document https://docs.google.com/document/d/1CNFzhYbmn-WgvNQ98vq-Sl4-uDq7dGjICgPBSGD7n-g/edit

I'm not sure what to do about the test failure about the poms?
