### PR TITLE
Use maven version from github actions

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar


### PR DESCRIPTION
Unlike most builds, you're looking at the GitHub action

There isn't much to see though except that we have access to Maven 3.8.1 from https://github.com/actions/virtual-environments/blob/ubuntu20/20210606.1/images/linux/Ubuntu2004-README.md 
and it enforces https from https://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291

We should be able to use Maven wrapper built into Maven as of 3.7 but the documentation has issues https://issues.apache.org/jira/projects/MWRAPPER/issues/MWRAPPER-13?filter=allopenissues