### PR TITLE
Feature/postgres update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
         environment:
           JAVA_TOOL_OPTIONS: -Xmx512m # Nothing to do with surefire plugin, it has its own JVM. The two of these plus ES (1.3 GB) must add up to a bit less than 6GB.
           PGHOST: 127.0.0.1
-      - image: circleci/postgres:11.8
+      - image: circleci/postgres:13.3
         command: postgres -c max_connections=200
         environment:
           POSTGRES_USER: postgres

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -314,7 +314,7 @@ Lists of 357 third-party dependencies.
      (EPL 2.0) (GPL2 w/ CPE) OSGi resource locator (org.glassfish.hk2:osgi-resource-locator:1.0.3 - https://projects.eclipse.org/projects/ee4j/osgi-resource-locator)
      (MIT) parser (org.typelevel:jawn-parser_2.12:1.0.0 - http://github.com/typelevel/jawn)
      (The Apache Software License, Version 2.0) PF4J (org.pf4j:pf4j:3.2.0 - http://nexus.sonatype.org/oss-repository-hosting.html/pf4j-parent/pf4j)
-     (BSD-2-Clause) PostgreSQL JDBC Driver (org.postgresql:postgresql:42.2.19 - https://jdbc.postgresql.org)
+     (BSD-2-Clause) PostgreSQL JDBC Driver (org.postgresql:postgresql:42.2.21 - https://jdbc.postgresql.org)
      (The Apache Software License, Version 2.0) PowerMock (org.powermock:powermock-api-easymock:2.0.4 - http://www.powermock.org)
      (MIT) pprint_2.12 (com.lihaoyi:pprint_2.12:0.6.0 - https://github.com/lihaoyi/PPrint)
      (The Apache Software License, Version 2.0) rank-eval (org.elasticsearch.plugin:rank-eval-client:7.10.1 - https://github.com/elastic/elasticsearch)

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -56,7 +56,7 @@ POM as their parent.
         <logback.version>1.2.3</logback.version>
         <aws.version>2.16.22</aws.version>
         <powermock.version>2.0.4</powermock.version>
-        <postgresql.version>42.2.19</postgresql.version>
+        <postgresql.version>42.2.21</postgresql.version>
         <mockito.version>2.28.2</mockito.version>
         <cwlavro.version>2.0.4.4</cwlavro.version>
         <okhttp.version>4.7.0</okhttp.version>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     # networks:
       # - elastic
   postgres_db:
-    image: postgres:11.8
+    image: postgres:13.3
     container_name: postgres1
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust

--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.19</version>
+      <version>42.2.21</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -48,6 +48,7 @@ import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.StarRequest;
 import io.swagger.client.model.Tool;
 import org.apache.http.HttpStatus;
+import org.glassfish.jersey.client.ClientProperties;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
@@ -175,7 +176,7 @@ public class ServiceIT extends BaseIT {
      * @param path         Path of endpoint
      */
     private void testXTotalCount(Client jerseyClient, String path) {
-        Response response = jerseyClient.target(path).request().get();
+        Response response = jerseyClient.target(path).request().property(ClientProperties.READ_TIMEOUT,    0).get();
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         MultivaluedMap<String, Object> headers = response.getHeaders();
         Object xTotalCount = headers.getFirst("X-total-count");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -176,7 +176,7 @@ public class ServiceIT extends BaseIT {
      * @param path         Path of endpoint
      */
     private void testXTotalCount(Client jerseyClient, String path) {
-        Response response = jerseyClient.target(path).request().property(ClientProperties.READ_TIMEOUT,    0).get();
+        Response response = jerseyClient.target(path).request().property(ClientProperties.READ_TIMEOUT, 0).get();
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         MultivaluedMap<String, Object> headers = response.getHeaders();
         Object xTotalCount = headers.getFirst("X-total-count");

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -448,7 +448,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.19</version>
+      <version>42.2.21</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <swagger-annotations-version>1.6.0</swagger-annotations-version>
         <openapi-annotations-version>2.1.7</openapi-annotations-version>
         <!-- Used for liquibase maven plugin. Somehow use version from bom-internal instead -->
-        <postgresql.version>42.2.19</postgresql.version>
+        <postgresql.version>42.2.21</postgresql.version>
         <swagger-ui.version>3.25.0</swagger-ui.version>
         <maven-surefire.version>3.0.0-M5</maven-surefire.version>
         <maven-failsafe.version>2.21.0</maven-failsafe.version>


### PR DESCRIPTION
Looks like postgres stable version is already 13
Some modest performance improvements noted at https://aws.amazon.com/blogs/database/upgrading-from-amazon-rds-for-postgresql-version-9-5/

Didn't try a straight upgrade locally, but a dump, load, and migrate seems fine. 

snyk seems to be misbehaving
