### PR TITLE
Add TRS V2 image_name test

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -493,7 +493,8 @@ public class WorkflowIT extends BaseIT {
         assertNull(branchToolJson);
 
         // Test freezing versions (uses a different workflow that has versioned images)
-        WorkflowVersion frozenVersion = snapshotWorkflowVersion(workflowApi, "dockstore-testing/hello_world", DescriptorType.CWL.toString(), "/hello_world.cwl", "1.0.1");
+        workflow = manualRegisterAndPublish(workflowApi, "dockstore-testing/hello_world", "", DescriptorType.CWL.toString(), SourceControl.GITHUB, "/hello_world.cwl", true);
+        WorkflowVersion frozenVersion = snapshotWorkflowVersion(workflowApi, workflow, "1.0.1");
         String frozenDagJson = testingPostgres.runSelectStatement(String.format("select dagjson from workflowversion where id = '%s'", frozenVersion.getId()), String.class);
         String frozenToolTableJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", frozenVersion.getId()), String.class);
         assertNotNull(frozenDagJson);
@@ -1075,7 +1076,8 @@ public class WorkflowIT extends BaseIT {
         Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openAPIClient);
 
         //Check image info is grabbed
-        WorkflowVersion version = snapshotWorkflowVersion(workflowsApi, "dockstore-testing/hello_world", DescriptorType.CWL.toString(), "/hello_world.cwl", "1.0.1");
+        Workflow workflow = manualRegisterAndPublish(workflowsApi, "dockstore-testing/hello_world", "", DescriptorType.CWL.toString(), SourceControl.GITHUB, "/hello_world.cwl", true);
+        WorkflowVersion version = snapshotWorkflowVersion(workflowsApi, workflow, "1.0.1");
         assertEquals("Should only be one image in this workflow", 1, version.getImages().size());
         verifyImageChecksumsAreSaved(version);
 
@@ -1083,7 +1085,8 @@ public class WorkflowIT extends BaseIT {
         verifyTRSImageConversion(versions, "1.0.1", 1);
 
         // Test that a workflow version that contains duplicate images will not store multiples
-        WorkflowVersion versionWithDuplicateImages = snapshotWorkflowVersion(workflowsApi, "dockstore-testing/zhanghj-8555114", DescriptorType.CWL.toString(), "/main.cwl", "1.0");
+        workflow = manualRegisterAndPublish(workflowsApi, "dockstore-testing/zhanghj-8555114", "", DescriptorType.CWL.toString(), SourceControl.GITHUB, "/main.cwl", true);
+        WorkflowVersion versionWithDuplicateImages = snapshotWorkflowVersion(workflowsApi, workflow, "1.0");
         assertEquals("Should have grabbed 3 images", 3, versionWithDuplicateImages.getImages().size());
         verifyImageChecksumsAreSaved(versionWithDuplicateImages);
         versions = ga4Ghv20Api.toolsIdVersionsGet("#workflow/github.com/dockstore-testing/zhanghj-8555114");
@@ -1098,36 +1101,30 @@ public class WorkflowIT extends BaseIT {
         final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(webClient);
         Workflow workflow = manualRegisterAndPublish(workflowsApi, "dockstore-testing/hello-wdl-workflow", "", DescriptorType.WDL.toString(), SourceControl.GITHUB, "/Dockstore.wdl", false);
-        WorkflowVersion noTagImageVersion = workflow.getWorkflowVersions().stream().filter(v -> v.getName().equals("noTagImage")).findFirst().get();
-        WorkflowVersion latestTagImageVersion = workflow.getWorkflowVersions().stream().filter(v -> v.getName().equals("latestTagImage")).findFirst().get();
-        WorkflowVersion parameterImageVersion = workflow.getWorkflowVersions().stream().filter(v -> v.getName().equals("parameterImage")).findFirst().get();
         String errorMessage = "Snapshot for workflow version %s failed because not all images are specified using a digest nor a valid tag.";
 
         // Test that the snapshot fails for a workflow version containing an image with no tag
         try {
-            noTagImageVersion.setFrozen(true);
-            workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(noTagImageVersion));
+            snapshotWorkflowVersion(workflowsApi, workflow, "noTagImage");
             Assert.fail("Should not be able to snapshot a workflow version containing an image with no tag.");
         } catch (ApiException ex) {
-            Assert.assertTrue(ex.getMessage().contains(String.format(errorMessage, noTagImageVersion.getName())));
+            Assert.assertTrue(ex.getMessage().contains(String.format(errorMessage, "noTagImage")));
         }
 
         // Test that the snapshot fails for a workflow version containing an image with the 'latest' tag
         try {
-            latestTagImageVersion.setFrozen(true);
-            workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(latestTagImageVersion));
+            snapshotWorkflowVersion(workflowsApi, workflow, "latestTagImage");
             Assert.fail("Should not be able to snapshot a workflow version containing an image with the 'latest' tag.");
         } catch (ApiException ex) {
-            Assert.assertTrue(ex.getMessage().contains(String.format(errorMessage, latestTagImageVersion.getName())));
+            Assert.assertTrue(ex.getMessage().contains(String.format(errorMessage, "latestTagImage")));
         }
 
         // Test that the snapshot fails for a workflow version containing an image specified using a parameter
         try {
-            parameterImageVersion.setFrozen(true);
-            workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(parameterImageVersion));
+            snapshotWorkflowVersion(workflowsApi, workflow, "parameterImage");
             Assert.fail("Should not be able to snapshot a workflow version containing an image specified using a parameter.");
         } catch (ApiException ex) {
-            Assert.assertTrue(ex.getMessage().contains(String.format(errorMessage, parameterImageVersion.getName())));
+            Assert.assertTrue(ex.getMessage().contains(String.format(errorMessage, "parameterImage")));
         }
     }
 
@@ -1230,8 +1227,7 @@ public class WorkflowIT extends BaseIT {
         WorkflowVersion snapshotVersion = workflow2.getWorkflowVersions().stream().filter(v -> v.getName().equals("1.0.1")).findFirst().get();
         List<io.dockstore.webservice.core.SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(snapshotVersion.getId());
         assertNotNull(sourceFiles);
-        snapshotVersion.setFrozen(true);
-        workflowsApi.updateWorkflowVersion(workflow2.getId(), Collections.singletonList(snapshotVersion));
+        snapshotWorkflowVersion(workflowsApi, workflow2, "1.0.1");
         verifySourcefileChecksumsSaved(sourceFiles);
 
         // Make sure refresh does not error.
@@ -1290,8 +1286,58 @@ public class WorkflowIT extends BaseIT {
         assertTrue("Snapshotted version should be in the list", snapshotInList);
     }
 
-    private WorkflowVersion snapshotWorkflowVersion(WorkflowsApi workflowsApi, String workflowPath, String descriptorType, String descriptorPath, String versionName) {
-        Workflow workflow = manualRegisterAndPublish(workflowsApi, workflowPath, "", descriptorType, SourceControl.GITHUB, descriptorPath, true);
+    /**
+     * Test that the image_name is set correctly after TRS image conversion.
+     * This is a separate test from verifyTRSImageConversion because it's difficult to map the snapshot version's images to the
+     * TRS version's images if there's more than 1 Docker reference in the workflow.
+     * This test works with workflows containing 1 Docker reference (may not necessarily have only 1 image because DockerHub can provide
+     * multiple images for a single version, one for each os/architecture).
+     */
+    @Test
+    public void testTRSImageName() {
+        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowsApi = new WorkflowsApi(webClient);
+        final io.dockstore.openapi.client.ApiClient openAPIClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openAPIClient);
+        WorkflowVersion snapshotVersion;
+        ToolVersion trsVersion;
+
+        Workflow workflow = manualRegisterAndPublish(workflowsApi, "dockstore-testing/hello-wdl-workflow", "",
+                DescriptorType.WDL.toString(), SourceControl.GITHUB, "/Dockstore.wdl", true);
+
+        // Workflow with Quay image specified using a tag
+        String quayTagVersionName = "1.0";
+        snapshotVersion = snapshotWorkflowVersion(workflowsApi, workflow, quayTagVersionName);
+        assertEquals("Should only be one image in this workflow", 1, snapshotVersion.getImages().size());
+        trsVersion = ga4Ghv20Api.toolsIdVersionsVersionIdGet("#workflow/github.com/dockstore-testing/hello-wdl-workflow", quayTagVersionName);
+        trsVersion.getImages().stream().forEach(image -> assertEquals("quay.io/ga4gh-dream/dockstore-tool-helloworld:1.0.2", image.getImageName()));
+
+        // Workflow with Quay image specified using a digest
+        String quayDigestVersionName = "quayDigestImage";
+        snapshotVersion = snapshotWorkflowVersion(workflowsApi, workflow, quayDigestVersionName);
+        assertEquals("Should only be one image in this workflow", 1, snapshotVersion.getImages().size());
+        trsVersion = ga4Ghv20Api.toolsIdVersionsVersionIdGet("#workflow/github.com/dockstore-testing/hello-wdl-workflow", quayDigestVersionName);
+        trsVersion.getImages().stream().forEach(image -> assertEquals(
+                "quay.io/ga4gh-dream/dockstore-tool-helloworld@sha256:3a854fd1ebd970011fa57c8c099347314eda36cc746fd831f4deff9a1d433718",
+                image.getImageName()));
+
+        // Workflow with Docker Hub image specified using a tag (6 images actually retrieved, one per architecture type)
+        String dockerHubTagVersionName = "dockerHubTagImage";
+        snapshotVersion = snapshotWorkflowVersion(workflowsApi, workflow, dockerHubTagVersionName);
+        assertEquals("Should only be six images in this workflow", 6, snapshotVersion.getImages().size()); // 1 image per architecture type
+        trsVersion = ga4Ghv20Api.toolsIdVersionsVersionIdGet("#workflow/github.com/dockstore-testing/hello-wdl-workflow", dockerHubTagVersionName);
+        trsVersion.getImages().stream().forEach(image -> assertEquals("library/ubuntu:16.04", image.getImageName()));
+
+        // Workflow with Docker Hub image specified using a digest
+        String dockerHubDigestVersionName = "dockerHubDigestImage";
+        snapshotVersion = snapshotWorkflowVersion(workflowsApi, workflow, dockerHubDigestVersionName);
+        assertEquals("Should only be one image in this workflow", 1, snapshotVersion.getImages().size());
+        trsVersion = ga4Ghv20Api.toolsIdVersionsVersionIdGet("#workflow/github.com/dockstore-testing/hello-wdl-workflow", dockerHubDigestVersionName);
+        trsVersion.getImages().stream().forEach(image ->
+            assertEquals("library/ubuntu@sha256:d7bb0589725587f2f67d0340edb81fd1fcba6c5f38166639cf2a252c939aa30c", image.getImageName()));
+    }
+
+    private WorkflowVersion snapshotWorkflowVersion(WorkflowsApi workflowsApi, Workflow workflow, String versionName) {
         WorkflowVersion version = workflow.getWorkflowVersions().stream().filter(v -> v.getName().equals(versionName)).findFirst().get();
         version.setFrozen(true);
         workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(version));
@@ -1317,7 +1363,8 @@ public class WorkflowIT extends BaseIT {
 
         // Test that a version of an official dockerhub image will get an image per architecture. (python 2.7) Also check that regular
         // DockerHub images are grabbed correctly broadinstitute/gatk:4.0.1.1
-        WorkflowVersion version = snapshotWorkflowVersion(workflowsApi, "dockstore-testing/broad-prod-wgs-germline-snps-indels", DescriptorType.WDL.toString(), "/JointGenotypingWf.wdl", "1.1.2");
+        Workflow workflow = manualRegisterAndPublish(workflowsApi, "dockstore-testing/broad-prod-wgs-germline-snps-indels", "", DescriptorType.WDL.toString(), SourceControl.GITHUB, "/JointGenotypingWf.wdl", true);
+        WorkflowVersion version = snapshotWorkflowVersion(workflowsApi, workflow, "1.1.2");
         assertEquals("Should 10 images in this workflow", 10, version.getImages().size());
         verifyImageChecksumsAreSaved(version);
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -1286,6 +1286,8 @@ public class WorkflowIT extends BaseIT {
         assertTrue("Snapshotted version should be in the list", snapshotInList);
     }
 
+
+
     /**
      * Test that the image_name is set correctly after TRS image conversion.
      * This is a separate test from verifyTRSImageConversion because it's difficult to map the snapshot version's images to the
@@ -1310,6 +1312,7 @@ public class WorkflowIT extends BaseIT {
         snapshotVersion = snapshotWorkflowVersion(workflowsApi, workflow, quayTagVersionName);
         assertEquals("Should only be one image in this workflow", 1, snapshotVersion.getImages().size());
         trsVersion = ga4Ghv20Api.toolsIdVersionsVersionIdGet("#workflow/github.com/dockstore-testing/hello-wdl-workflow", quayTagVersionName);
+        assertEquals("Should be one image in this TRS version", 1, trsVersion.getImages().size());
         trsVersion.getImages().stream().forEach(image -> assertEquals("quay.io/ga4gh-dream/dockstore-tool-helloworld:1.0.2", image.getImageName()));
 
         // Workflow with Quay image specified using a digest
@@ -1317,6 +1320,7 @@ public class WorkflowIT extends BaseIT {
         snapshotVersion = snapshotWorkflowVersion(workflowsApi, workflow, quayDigestVersionName);
         assertEquals("Should only be one image in this workflow", 1, snapshotVersion.getImages().size());
         trsVersion = ga4Ghv20Api.toolsIdVersionsVersionIdGet("#workflow/github.com/dockstore-testing/hello-wdl-workflow", quayDigestVersionName);
+        assertEquals("Should be one image in this TRS version", 1, trsVersion.getImages().size());
         trsVersion.getImages().stream().forEach(image -> assertEquals(
                 "quay.io/ga4gh-dream/dockstore-tool-helloworld@sha256:3a854fd1ebd970011fa57c8c099347314eda36cc746fd831f4deff9a1d433718",
                 image.getImageName()));
@@ -1326,6 +1330,7 @@ public class WorkflowIT extends BaseIT {
         snapshotVersion = snapshotWorkflowVersion(workflowsApi, workflow, dockerHubTagVersionName);
         assertEquals("Should only be six images in this workflow", 6, snapshotVersion.getImages().size()); // 1 image per architecture type
         trsVersion = ga4Ghv20Api.toolsIdVersionsVersionIdGet("#workflow/github.com/dockstore-testing/hello-wdl-workflow", dockerHubTagVersionName);
+        assertEquals("Should be six images in this TRS version", 6, trsVersion.getImages().size());
         trsVersion.getImages().stream().forEach(image -> assertEquals("library/ubuntu:16.04", image.getImageName()));
 
         // Workflow with Docker Hub image specified using a digest
@@ -1333,6 +1338,8 @@ public class WorkflowIT extends BaseIT {
         snapshotVersion = snapshotWorkflowVersion(workflowsApi, workflow, dockerHubDigestVersionName);
         assertEquals("Should only be one image in this workflow", 1, snapshotVersion.getImages().size());
         trsVersion = ga4Ghv20Api.toolsIdVersionsVersionIdGet("#workflow/github.com/dockstore-testing/hello-wdl-workflow", dockerHubDigestVersionName);
+        assertEquals("Should be one image in this TRS version", 1, trsVersion.getImages().size());
+        // library/ubuntu@sha256:d7bb0589725587f2f67d0340edb81fd1fcba6c5f38166639cf2a252c939aa30c refers to ubuntu version 16.04, amd64 os/arch
         trsVersion.getImages().stream().forEach(image ->
             assertEquals("library/ubuntu@sha256:d7bb0589725587f2f67d0340edb81fd1fcba6c5f38166639cf2a252c939aa30c", image.getImageName()));
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -640,7 +640,8 @@ public interface LanguageHandlerInterface {
                         // For every version, DockerHub can provide multiple images, one for each os/architecture
                         images.stream().forEach(dockerHubImage -> {
                             final String manifestDigest = dockerHubImage.getDigest();
-                            if (manifestDigest.equals(specifierName)) {
+                            // Must perform null check for manifestDigest because there are Docker Hub images where the digest is null
+                            if (manifestDigest != null && manifestDigest.equals(specifierName)) {
                                 String tagName = r.getName(); // Tag that's associated with the image specified by digest
                                 Checksum checksum = new Checksum(manifestDigest.split(":")[0], manifestDigest.split(":")[1]);
                                 List<Checksum> checksums = Collections.singletonList(checksum);
@@ -694,7 +695,7 @@ public interface LanguageHandlerInterface {
         } while (response.isPresent() && !versionFound && dockerHubTag.getNext() != null);
 
         if (!versionFound) {
-            LOG.error("Unable to find image with digest: {} from Docker Hub in repo {}", specifierName, repo);
+            LOG.error("Unable to find image with {}: {} from Docker Hub in repo {}", specifierType.name(), specifierName, repo);
         }
 
         return dockerHubImages;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -81,9 +81,11 @@ public interface LanguageHandlerInterface {
     Pattern AMAZON_ECR_PATTERN = Pattern.compile("(.+)(\\.dkr\\.ecr\\.)(.+)(\\.amazonaws.com/)(.+)");
     Pattern GOOGLE_PATTERN = Pattern.compile("((us|eu|asia)(.))?(gcr\\.io)(.+)");
     // <org>/<repository>:<version> -> broadinstitute/gatk:4.0.1.1
-    Pattern DOCKER_HUB = Pattern.compile("(\\w)+/(.*):(.+)");
+    // <org>/<repository>@sha256:<digest> -> broadinstitute/gatk@sha256:98b2f223dce4282c144d249e7e1f47d400ae349404409d01e87df2efeebac439
+    Pattern DOCKER_HUB = Pattern.compile("(\\w)+/(.*)(:|@sha256:)(.+)");
     // <repo>:<version> -> postgres:9.6 Official Docker Hub images belong to the org "library", but that's not included when pulling the image
-    Pattern OFFICIAL_DOCKER_HUB_IMAGE = Pattern.compile("(\\w|-)+:(.+)");
+    // <repo>@256:<digest> -> ubuntu@sha256:d7bb0589725587f2f67d0340edb81fd1fcba6c5f38166639cf2a252c939aa30c
+    Pattern OFFICIAL_DOCKER_HUB_IMAGE = Pattern.compile("(\\w|-)+(:|@sha256:)(.+)");
     Pattern IMAGE_TAG_PATTERN = Pattern.compile("([^:]++):?(\\S++)?");
     Pattern IMAGE_DIGEST_PATTERN = Pattern.compile("([^@]++)@?(\\S++)?");
 
@@ -690,6 +692,11 @@ public interface LanguageHandlerInterface {
                 }
             }
         } while (response.isPresent() && !versionFound && dockerHubTag.getNext() != null);
+
+        if (!versionFound) {
+            LOG.error("Unable to find image with digest: {} from Docker Hub in repo {}", specifierName, repo);
+        }
+
         return dockerHubImages;
     }
 

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
@@ -30,6 +30,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
@@ -261,8 +262,12 @@ public final class ToolsImplCommon {
         if (specifier == null || specifier == DockerSpecifier.TAG) {
             return String.join(":", fullRepositoryName, image.getTag());
         } else if (specifier == DockerSpecifier.DIGEST) {
-            // The image's checksum is the image's digest
-            String imageDigest = image.getChecksums().get(0).toString();
+            // The image's sha256 checksum is the image's digest
+            String imageDigest = image.getChecksums().stream()
+                    .filter(checksum -> checksum.getType().equals("sha256"))
+                    .collect(Collectors.toList())
+                    .get(0)
+                    .toString();
             return String.join("@", fullRepositoryName, imageDigest);
         } else {
             // Shouldn't really get here because all saved images are specified by tag or digest

--- a/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
+++ b/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
@@ -133,7 +133,7 @@ public class ToolsImplCommonTest {
         tag.setReference("sampleReference");
         tag.setValid(true);
         List<Checksum> checksums = Collections.singletonList(new Checksum("SHA-1", "fakeChecksum"));
-        Set<Image> image = Collections.singleton(new Image(checksums, "sampleRepo", "sampleTag", "SampleImageId", Registry.QUAY_IO, null, null));
+        Set<Image> image = Collections.singleton(new Image(checksums, "test_org/test6", "sampleTag", "SampleImageId", Registry.QUAY_IO, null, null));
         tag.setImages(image);
         Tag hiddenTag = new Tag();
         hiddenTag.setImageId("hiddenImageId");
@@ -209,7 +209,7 @@ public class ToolsImplCommonTest {
         expectedToolVersion.setVerified(false);
         expectedToolVersion.setVerifiedSource("[]");
         expectedToolVersion.setRegistryUrl("quay.io");
-        expectedToolVersion.setImageName("quay.io/test_org/test6");
+        expectedToolVersion.setImageName("quay.io/test_org/test6:sampleTag");
         List<ToolVersion> expectedToolVersions = new ArrayList<>();
         expectedToolVersions.add(expectedToolVersion);
         expectedTool.setVersions(expectedToolVersions);


### PR DESCRIPTION
[SEAB-3013](https://ucsc-cgl.atlassian.net/browse/SEAB-3013)

- Changed how the TRS `image_name` is constructed
- Modified the Docker Hub image regexes to include images referenced by digest
- An interesting note is that the digest for a Docker Hub image can be null. While creating the test, I've run into null pointer exceptions for official Docker Hub images referenced by an invalid digest, like ubuntu or python. Added a null check for this.