### PR TITLE
Add BatchSize to improve performance

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -220,6 +220,7 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     @Column(name = "path", nullable = false, columnDefinition = "text")
     @MapKeyColumn(name = "filetype")
     @CollectionTable(uniqueConstraints = @UniqueConstraint(name = "unique_paths", columnNames = { "entry_id", "filetype", "path" }))
+    @BatchSize(size = 25)
     private Map<DescriptorLanguage.FileType, String> defaultPaths = new HashMap<>();
 
     @Column

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -188,11 +188,13 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @OneToMany(fetch = FetchType.EAGER, orphanRemoval = true, cascade = CascadeType.ALL)
     @JoinColumn(name = "versionid", referencedColumnName = "id", nullable = false)
     @ApiModelProperty(value = "Non-ORCID Authors for each version.")
+    @BatchSize(size = 25)
     private Set<Author> authors = new HashSet<>();
 
     @ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinTable(name = "version_orcidauthor", joinColumns = @JoinColumn(name = "versionid", referencedColumnName = "id", columnDefinition = "bigint"), inverseJoinColumns = @JoinColumn(name = "orcidauthorid", referencedColumnName = "id", columnDefinition = "bigint"))
     @ApiModelProperty(value = "ORCID Authors for versions.")
+    @BatchSize(size = 25)
     private Set<OrcidAuthor> orcidAuthors = new HashSet<>();
 
     @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)


### PR DESCRIPTION
#4338

Created against hotfix branch, since we're doing another build anyway. Seems safe, but we can re-target it if we feel uncomfortable.

Difference is much more noticeable locally time-wise:

```
 curl -X GET "http://localhost:8080/ga4gh/trs/v2/tools?toolClass=Workflow&limit=1000" -H  "accept: application/json" > /dev/null

With fix: ~50 seconds
Without fix: ~ 90 seconds
```

Number of SQL statements went down from 28,811 to 8,707 (which is still pretty high, sigh).
