### PR TITLE
Display Amazon ECR images in Tools and DAG tabs

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -78,10 +78,10 @@ public interface LanguageHandlerInterface {
     Gson GSON = new Gson();
     ApiClient API_CLIENT = Configuration.getDefaultApiClient();
     // public.ecr.aws/<registry_alias>/<repository_name>:<image_tag> -> public.ecr.aws/ubuntu/ubuntu:18.04
-    // public.ecr.aws/<registry_alias>/<repository_name>@sha256
-    Pattern AMAZON_ECR_PUBLIC_IMAGE = Pattern.compile("(public\\.ecr\\.aws/)(.+)/(.+)(:|@sha256)(.+)");
+    // public.ecr.aws/<registry_alias>/<repository_name>@sha256:<image_digest>
+    Pattern AMAZON_ECR_PUBLIC_IMAGE = Pattern.compile("(public\\.ecr\\.aws/)(.+)/(.+)(:|@sha256:)(.+)");
     // <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository_name>:<image_tag> -> 012345678912.dkr.ecr.us-east-1.amazonaws.com/test-repo:1
-    // <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository_name>@sha256<image_digest>
+    // <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository_name>@sha256:<image_digest>
     Pattern AMAZON_ECR_PRIVATE_IMAGE = Pattern.compile("(.+)(\\.dkr\\.ecr\\.)(.+)(\\.amazonaws.com/)(.+)(:|@sha256:)(.+)");
     Pattern GOOGLE_PATTERN = Pattern.compile("((us|eu|asia)(.))?(gcr\\.io)(.+)");
     // <org>/<repository>:<version> -> broadinstitute/gatk:4.0.1.1

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -79,10 +79,10 @@ public interface LanguageHandlerInterface {
     ApiClient API_CLIENT = Configuration.getDefaultApiClient();
     // public.ecr.aws/<registry_alias>/<repository_name>:<image_tag> -> public.ecr.aws/ubuntu/ubuntu:18.04
     // public.ecr.aws/<registry_alias>/<repository_name>@sha256:<image_digest>
-    Pattern AMAZON_ECR_PUBLIC_IMAGE = Pattern.compile("(public\\.ecr\\.aws/)(.+)/(.+)(:|@sha256:)(.+)");
+    Pattern AMAZON_ECR_PUBLIC_IMAGE = Pattern.compile("(public\\.ecr\\.aws/)([a-z0-9._-]++)/([a-z0-9._/-]++)(:|@sha256:)(.++)");
     // <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository_name>:<image_tag> -> 012345678912.dkr.ecr.us-east-1.amazonaws.com/test-repo:1
     // <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository_name>@sha256:<image_digest>
-    Pattern AMAZON_ECR_PRIVATE_IMAGE = Pattern.compile("(.+)(\\.dkr\\.ecr\\.)(.+)(\\.amazonaws.com/)(.+)(:|@sha256:)(.+)");
+    Pattern AMAZON_ECR_PRIVATE_IMAGE = Pattern.compile("([0-9]++)(\\.dkr\\.ecr\\.)([a-z0-9-]++)(\\.amazonaws.com/)([a-z0-9._/-]++)(:|@sha256:)(.++)");
     Pattern GOOGLE_PATTERN = Pattern.compile("((us|eu|asia)(.))?(gcr\\.io)(.+)");
     // <org>/<repository>:<version> -> broadinstitute/gatk:4.0.1.1
     // <org>/<repository>@sha256:<digest> -> broadinstitute/gatk@sha256:98b2f223dce4282c144d249e7e1f47d400ae349404409d01e87df2efeebac439
@@ -90,8 +90,8 @@ public interface LanguageHandlerInterface {
     // <repo>:<version> -> postgres:9.6 Official Docker Hub images belong to the org "library", but that's not included when pulling the image
     // <repo>@256:<digest> -> ubuntu@sha256:d7bb0589725587f2f67d0340edb81fd1fcba6c5f38166639cf2a252c939aa30c
     Pattern OFFICIAL_DOCKER_HUB_IMAGE = Pattern.compile("(\\w|-)+(:|@sha256:)(.+)");
-    Pattern IMAGE_TAG_PATTERN = Pattern.compile("([^:]++):?(\\S++)?");
-    Pattern IMAGE_DIGEST_PATTERN = Pattern.compile("([^@]++)@?(\\S++)?");
+    Pattern IMAGE_TAG_PATTERN = Pattern.compile("([^:]++):(\\S++)");
+    Pattern IMAGE_DIGEST_PATTERN = Pattern.compile("([^@]++)@(\\S++)");
 
     /**
      * Parses the content of the primary descriptor to get author, email, and description
@@ -362,21 +362,21 @@ public interface LanguageHandlerInterface {
         Map<String, DockerSpecifier> invalidSnapshotImages = dockerStrings.entrySet().stream()
                 .filter(image -> image.getValue() == DockerSpecifier.PARAMETER || image.getValue() == DockerSpecifier.LATEST
                         || image.getValue() == DockerSpecifier.NO_TAG)
-                .collect(Collectors.toMap(image -> image.getKey(), image -> image.getValue()));
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         // Create error message
         if (invalidSnapshotImages.size() > 0) {
             List<String> parameterImages = invalidSnapshotImages.entrySet().stream()
                     .filter(image -> image.getValue() == DockerSpecifier.PARAMETER)
-                    .map(image -> image.getKey())
+                    .map(Map.Entry::getKey)
                     .collect(Collectors.toList());
             List<String> latestImages = invalidSnapshotImages.entrySet().stream()
                     .filter(image -> image.getValue() == DockerSpecifier.LATEST)
-                    .map(image -> image.getKey())
+                    .map(Map.Entry::getKey)
                     .collect(Collectors.toList());
             List<String> noTagImages = invalidSnapshotImages.entrySet().stream()
                     .filter(image -> image.getValue() == DockerSpecifier.NO_TAG)
-                    .map(image -> image.getKey())
+                    .map(Map.Entry::getKey)
                     .collect(Collectors.toList());
             StringBuilder errorMessage = new StringBuilder(String.format(
                     "Snapshot for workflow version %s failed because not all images are specified using a digest nor a valid tag.",

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -77,7 +77,12 @@ public interface LanguageHandlerInterface {
     Logger LOG = LoggerFactory.getLogger(LanguageHandlerInterface.class);
     Gson GSON = new Gson();
     ApiClient API_CLIENT = Configuration.getDefaultApiClient();
-    Pattern AMAZON_ECR_PATTERN = Pattern.compile("(.+)(\\.dkr\\.ecr\\.)(.+)(\\.amazonaws.com/)(.+)");
+    // public.ecr.aws/<registry_alias>/<repository_name>:<image_tag> -> public.ecr.aws/ubuntu/ubuntu:18.04
+    // public.ecr.aws/<registry_alias>/<repository_name>@sha256
+    Pattern AMAZON_ECR_PUBLIC_IMAGE = Pattern.compile("(public\\.ecr\\.aws/)(.+)/(.+)(:|@sha256)(.+)");
+    // <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository_name>:<image_tag> -> 012345678912.dkr.ecr.us-east-1.amazonaws.com/test-repo:1
+    // <aws_account_id>.dkr.ecr.<region>.amazonaws.com/<repository_name>@sha256<image_digest>
+    Pattern AMAZON_ECR_PRIVATE_IMAGE = Pattern.compile("(.+)(\\.dkr\\.ecr\\.)(.+)(\\.amazonaws.com/)(.+)(:|@sha256:)(.+)");
     Pattern GOOGLE_PATTERN = Pattern.compile("((us|eu|asia)(.))?(gcr\\.io)(.+)");
     // <org>/<repository>:<version> -> broadinstitute/gatk:4.0.1.1
     // <org>/<repository>@sha256:<digest> -> broadinstitute/gatk@sha256:98b2f223dce4282c144d249e7e1f47d400ae349404409d01e87df2efeebac439
@@ -414,6 +419,7 @@ public interface LanguageHandlerInterface {
         String dockerHubPathR = "https://hub.docker.com/r/"; // For type repo/subrepo:tag
         String dockerHubPathUnderscore = "https://hub.docker.com/_/"; // For type repo:tag
         String dockstorePath = "https://www.dockstore.org/containers/"; // Update to tools once UI is updated to use /tools instead of /containers
+        String amazonECRPublicPath = "https://gallery.ecr.aws/"; // Amazon ECR Public Gallery
 
         String dockerImage = dockerEntry;
         String url;
@@ -447,8 +453,23 @@ public interface LanguageHandlerInterface {
                 // when we found a published tool, link to the tool on Dockstore
                 url = dockstorePath + dockerImage;
             }
+        } else if (registry.isPresent() && registry.get().equals(Registry.AMAZON_ECR)) {
+            List<Tool> publishedByPath = toolDAO.findAllByPath(dockerImage, true);
+            if (publishedByPath == null || publishedByPath.isEmpty()) {
+                // Regex for Amazon ECR image requires a tag or digest; add a fake "0" tag
+                if (AMAZON_ECR_PUBLIC_IMAGE.matcher(dockerEntry + ":0").matches()) {
+                    // When we cannot find a published tool on Dockstore, link to Amazon ECR Public Gallery if it's a public image
+                    url = dockerImage.replaceFirst("public\\.ecr\\.aws/", amazonECRPublicPath);
+                } else {
+                    // Return the entry as the url if it's a private Amazon ECR image
+                    url = "https://" + dockerImage;
+                }
+            } else {
+                // When we find a published tool, link to the tool on Dockstore
+                url = dockstorePath + dockerImage;
+            }
         } else if (registry.isEmpty() || !registry.get().equals(Registry.DOCKER_HUB)) {
-            // if the registry is neither Quay nor Docker Hub, return the entry as the url
+            // if the registry is neither Quay, Docker Hub nor Amazon ECR, return the entry as the url
             url = "https://" + dockerImage;
         } else {  // DOCKER_HUB
             String[] parts = dockerImage.split("/");
@@ -506,7 +527,7 @@ public interface LanguageHandlerInterface {
             return Optional.of(Registry.GITLAB);
         } else if (GOOGLE_PATTERN.matcher(image).matches()) {
             return Optional.empty();
-        } else if (AMAZON_ECR_PATTERN.matcher(image).matches()) {
+        } else if (AMAZON_ECR_PUBLIC_IMAGE.matcher(image).matches() || AMAZON_ECR_PRIVATE_IMAGE.matcher(image).matches()) {
             return Optional.of(Registry.AMAZON_ECR);
         } else if ((DOCKER_HUB.matcher(image).matches() || OFFICIAL_DOCKER_HUB_IMAGE.matcher(image).matches())) {
             return Optional.of(Registry.DOCKER_HUB);

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5018,7 +5018,7 @@ paths:
         type: "string"
       - name: "subclass"
         in: "query"
-        description: "Which Workflow subclass to retrieve. One of the folowwing: service,\
+        description: "Which Workflow subclass to retrieve. One of the following: service,\
           \ bioworkflow, apptool"
         required: false
         type: "string"
@@ -6219,7 +6219,7 @@ definitions:
     - $ref: "#/definitions/Workflow"
     - type: "object"
       properties: {}
-      description: "This describes one service in the dockstore as a special degenerate\
+      description: "This describes one app tool in dockstore as a special degenerate\
         \ case of a workflow"
   Author:
     type: "object"


### PR DESCRIPTION
For #4283 part 1: making sure that Amazon ECR images are displayed correctly in the Tools and DAG tabs.

![image](https://user-images.githubusercontent.com/25287123/124640722-d0b75c80-de5b-11eb-983f-88e9ecc04ba1.png)

![image](https://user-images.githubusercontent.com/25287123/124640998-360b4d80-de5c-11eb-80d6-d2abf5020bbc.png)

Checksum harvesting for Amazon ECR images is split out to another ticket because it requires a bit of thinking.

@denis-yuen Do we still want to add to the docs that we couldn’t implement checksum harvesting for Amazon ECR images? This was decided prior to discovering a more promising solution for Amazon ECR checksum harvesting.

Also, I think the swagger.yaml change was from GitHub Apps for Tools, but I guess it didn't make it into the PR? I included it here anyway since it was a small change but @NatalieEO, let me know if I should take it out.

