### PR TITLE
GitHub Container Registry Images support in Workflows

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/Registry.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/Registry.java
@@ -29,7 +29,8 @@ public enum Registry {
     DOCKER_HUB("registry.hub.docker.com", "Docker Hub", "https://hub.docker.com/", false, false),
     GITLAB("registry.gitlab.com", "GitLab", "https://gitlab.com/", false, false),
     AMAZON_ECR(null, "Amazon ECR", null, true, true),
-    SEVEN_BRIDGES(null, "Seven Bridges", null, true, true);
+    SEVEN_BRIDGES(null, "Seven Bridges", null, true, true),
+    GITHUB_CONTAINER_REGISTRY("ghcr.io", "GitHub Container Registry", "https://ghcr.io/", false, false);
 
     /**
      * this name is what is actually used in commands like docker pull

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerBlob.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerBlob.java
@@ -1,0 +1,48 @@
+/*
+ *    Copyright 2021 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.dockstore.webservice.core.docker;
+
+public class DockerBlob {
+    private String architecture;
+
+    private String created;
+
+    private String os;
+
+    public String getArchitecture() {
+        return architecture;
+    }
+
+    public void setArchitecture(String architecture) {
+        this.architecture = architecture;
+    }
+
+    public String getCreated() {
+        return created;
+    }
+
+    public void setCreated(String created) {
+        this.created = created;
+    }
+
+    public String getOs() {
+        return os;
+    }
+
+    public void setOs(String os) {
+        this.os = os;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerBlob.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerBlob.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2021 OICR
+ *    Copyright 2021 OICR and UCSC
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerImageManifest.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerImageManifest.java
@@ -15,12 +15,11 @@
  */
 package io.dockstore.webservice.core.docker;
 
-// This class describe's Docker's version 2 schema 2 image manifest.
-// Source: https://docs.docker.com/registry/spec/manifest-v2-2/#image-manifest
+// The image manifest provides a configuration and a set of layers for a container image
+// This class is compatible with both the Docker V2 schema 2 image manifest (https://docs.docker.com/registry/spec/manifest-v2-2/#image-manifest)
+// and the OCI image manifest specification (https://github.com/opencontainers/image-spec/blob/main/manifest.md).
 public class DockerImageManifest {
-    private int schemaVersion;
-
-    private String mediaType;
+    private int schemaVersion; // Should be 2 for both Docker V2 schema 2 and OCI
 
     private DockerLayer config;
 
@@ -32,14 +31,6 @@ public class DockerImageManifest {
 
     public void setSchemaVersion(int schemaVersion) {
         this.schemaVersion = schemaVersion;
-    }
-
-    public String getMediaType() {
-        return mediaType;
-    }
-
-    public void setMediaType(String mediaType) {
-        this.mediaType = mediaType;
     }
 
     public DockerLayer getConfig() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerImageManifest.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerImageManifest.java
@@ -1,0 +1,60 @@
+/*
+ *    Copyright 2021 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.dockstore.webservice.core.docker;
+
+// This class describe's Docker's version 2 schema 2 image manifest.
+// Source: https://docs.docker.com/registry/spec/manifest-v2-2/#image-manifest
+public class DockerImageManifest {
+    private int schemaVersion;
+
+    private String mediaType;
+
+    private DockerLayer config;
+
+    private DockerLayer[] layers;
+
+    public int getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    public void setSchemaVersion(int schemaVersion) {
+        this.schemaVersion = schemaVersion;
+    }
+
+    public String getMediaType() {
+        return mediaType;
+    }
+
+    public void setMediaType(String mediaType) {
+        this.mediaType = mediaType;
+    }
+
+    public DockerLayer getConfig() {
+        return config;
+    }
+
+    public void setConfig(DockerLayer config) {
+        this.config = config;
+    }
+
+    public DockerLayer[] getLayers() {
+        return layers;
+    }
+
+    public void setLayers(DockerLayer[] layers) {
+        this.layers = layers;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerImageManifest.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerImageManifest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2021 OICR
+ *    Copyright 2021 OICR and UCSC
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerLayer.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerLayer.java
@@ -1,0 +1,48 @@
+/*
+ *    Copyright 2021 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.dockstore.webservice.core.docker;
+
+public class DockerLayer {
+    private String mediaType;
+
+    private long size;
+
+    private String digest;
+
+    public String getMediaType() {
+        return mediaType;
+    }
+
+    public void setMediaType(String mediaType) {
+        this.mediaType = mediaType;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public void setSize(Long size) {
+        this.size = size;
+    }
+
+    public String getDigest() {
+        return digest;
+    }
+
+    public void setDigest(String digest) {
+        this.digest = digest;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerLayer.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerLayer.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2021 OICR
+ *    Copyright 2021 OICR and UCSC
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerManifestList.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerManifestList.java
@@ -1,0 +1,41 @@
+/*
+ *    Copyright 2021 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.dockstore.webservice.core.docker;
+
+// The manifest list is the “fat manifest” which points to specific image manifests for one or more platforms. It's used by multi-arch images.
+// This class is compatible with both the Docker V2 Schema 2 manifest list (https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list)
+// and the OCI image index specification (https://github.com/opencontainers/image-spec/blob/main/image-index.md)
+public class DockerManifestList {
+    private long schemaVersion; // Should be 2 for both Docker V2 schema 2 and OCI
+
+    private DockerPlatformManifest[] manifests;
+
+    public long getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    public void setSchemaVersion(long schemaVersion) {
+        this.schemaVersion = schemaVersion;
+    }
+
+    public DockerPlatformManifest[] getManifests() {
+        return manifests;
+    }
+
+    public void setManifests(DockerPlatformManifest[] manifests) {
+        this.manifests = manifests;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerManifestList.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerManifestList.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2021 OICR
+ *    Copyright 2021 OICR and UCSC
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerPlatform.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerPlatform.java
@@ -15,10 +15,22 @@
  */
 package io.dockstore.webservice.core.docker;
 
-public class DockerBlob {
+import com.google.gson.annotations.SerializedName;
+
+public class DockerPlatform {
     private String architecture;
 
     private String os;
+
+    @SerializedName("os.version")
+    private String osVersion;
+
+    @SerializedName("os.features")
+    private String[] osFeatures;
+
+    private String variant;
+
+    private String[] features;
 
     public String getArchitecture() {
         return architecture;
@@ -35,4 +47,38 @@ public class DockerBlob {
     public void setOs(String os) {
         this.os = os;
     }
+
+    public String getOsVersion() {
+        return osVersion;
+    }
+
+    public void setOsVersion(String osVersion) {
+        this.osVersion = osVersion;
+    }
+
+    public String[] getOsFeatures() {
+        return osFeatures;
+    }
+
+    public void setOsFeatures(String[] osFeatures) {
+        this.osFeatures = osFeatures;
+    }
+
+    public String getVariant() {
+        return variant;
+    }
+
+    public void setVariant(String variant) {
+        this.variant = variant;
+    }
+
+    public String[] getFeatures() {
+        return features;
+    }
+
+    public void setFeatures(String[] features) {
+        this.features = features;
+    }
 }
+
+

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerPlatform.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerPlatform.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2021 OICR
+ *    Copyright 2021 OICR and UCSC
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerPlatformManifest.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerPlatformManifest.java
@@ -1,0 +1,58 @@
+/*
+ *    Copyright 2021 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.dockstore.webservice.core.docker;
+
+public class DockerPlatformManifest {
+    private String mediaType;
+
+    private long size;
+
+    private String digest;
+
+    private DockerPlatform platform;
+
+    public String getMediaType() {
+        return mediaType;
+    }
+
+    public void setMediaType(String mediaType) {
+        this.mediaType = mediaType;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public void setSize(long size) {
+        this.size = size;
+    }
+
+    public String getDigest() {
+        return digest;
+    }
+
+    public void setDigest(String digest) {
+        this.digest = digest;
+    }
+
+    public DockerPlatform getPlatform() {
+        return platform;
+    }
+
+    public void setPlatform(DockerPlatform platform) {
+        this.platform = platform;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerPlatformManifest.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/DockerPlatformManifest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2021 OICR
+ *    Copyright 2021 OICR and UCSC
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/package-info.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/package-info.java
@@ -1,0 +1,21 @@
+/*
+ *    Copyright 2021 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+/**
+ * Models for responses from the Docker Registry HTTP API V2. Used right now just to grab checksum info for images. But if other fields are needed
+ * in the future, then the fields that are two words (ex: imageID) need something like @SerializedName("image_id").
+ * Created by looking at https://docs.docker.com/registry/spec/manifest-v2-2/#image-manifest
+ */
+package io.dockstore.webservice.core.docker;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/package-info.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/package-info.java
@@ -17,5 +17,7 @@
  * Models for responses from the Docker Registry HTTP API V2. Used right now just to grab image metadata, such as the image checksum.
  * But if other fields are needed in the future, then the fields that are two words (ex: imageID) need something like @SerializedName("image_id").
  * These models are compatible with both Docker V2 Schema 2 image manifests and Open Container Initiative (OCI) image manifest specifications.
+ * Compatibility matrix between OCI specifications and Docker V2 Schema 2 specifications:
+ * https://github.com/opencontainers/image-spec/blob/main/media-types.md#compatibility-matrix
  */
 package io.dockstore.webservice.core.docker;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/package-info.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/package-info.java
@@ -14,8 +14,8 @@
  *    limitations under the License.
  */
 /**
- * Models for responses from the Docker Registry HTTP API V2. Used right now just to grab checksum info for images. But if other fields are needed
- * in the future, then the fields that are two words (ex: imageID) need something like @SerializedName("image_id").
- * Created by looking at https://docs.docker.com/registry/spec/manifest-v2-2/#image-manifest
+ * Models for responses from the Docker Registry HTTP API V2. Used right now just to grab image metadata, such as the image checksum.
+ * But if other fields are needed in the future, then the fields that are two words (ex: imageID) need something like @SerializedName("image_id").
+ * These models are compatible with both Docker V2 Schema 2 image manifests and Open Container Initiative (OCI) image manifest specifications.
  */
 package io.dockstore.webservice.core.docker;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/package-info.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/docker/package-info.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2021 OICR
+ *    Copyright 2021 OICR and UCSC
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -447,15 +447,23 @@ public interface LanguageHandlerInterface {
 
         // Remove tag or digest if exists
         Matcher m;
-        // A specific architecture image from a multi-arch image is referenced by digest, but it may also include the tag for the multi-arch image
-        // Ex: ubuntu:18.04@sha256:c404618e908391e50953e1ead94fe05dbbddbf532bd5c89b935ef34a9ca130d3 is the linux/amd64 image for ubuntu:18.04
-        if (dockerSpecifier == DockerSpecifier.DIGEST && !dockerImage.contains(":")) {
+        if (dockerSpecifier == DockerSpecifier.DIGEST) {
             m = IMAGE_DIGEST_PATTERN.matcher(dockerImage);
         } else {
             m = IMAGE_TAG_PATTERN.matcher(dockerImage);
         }
         if (m.matches()) {
             dockerImage = m.group(1);
+        }
+
+        // A specific architecture image from a multi-arch image is referenced by digest, but it may also include the tag for the multi-arch image
+        // Ex: ubuntu:18.04@sha256:c404618e908391e50953e1ead94fe05dbbddbf532bd5c89b935ef34a9ca130d3 is the linux/amd64 image for ubuntu:18.04
+        // Check for tag and remove if necessary
+        if (dockerSpecifier == DockerSpecifier.DIGEST) {
+            m = IMAGE_TAG_PATTERN.matcher(dockerImage);
+            if (m.matches()) {
+                dockerImage = m.group(1);
+            }
         }
 
         if (dockerImage.isEmpty()) {
@@ -654,7 +662,7 @@ public interface LanguageHandlerInterface {
 
                     // A specific architecture image from a multi-arch image is referenced by digest, but it may also include the tag for the multi-arch image
                     // Ex: ubuntu:18.04@sha256:c404618e908391e50953e1ead94fe05dbbddbf532bd5c89b935ef34a9ca130d3 is the linux/amd64 image for ubuntu:18.04
-                    // Remove the left-over ":"
+                    // Remove the left-over tag
                     if (imageSpecifier == DockerSpecifier.DIGEST && imageName.contains(":")) {
                         imageName = imageName.split(":")[0];
                     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -861,7 +861,7 @@ public interface LanguageHandlerInterface {
     }
 
     /**
-     * Get a Docker image's manifest by calling the Docker Registry HTTP API V2 endpoint: GET /v2/<repo>/manifests/<reference>
+     * Get a Docker image's manifest by calling the Docker Registry HTTP API V2 endpoint: GET /v2/[repo]/manifests/[tag_or_digest]
      *
      * @param token Authentication token with pull access for the image's repository
      * @param registryDockerPath
@@ -889,7 +889,7 @@ public interface LanguageHandlerInterface {
     }
 
     /**
-     * Get a blob specified by digest for a Docker image by calling the Docker Registry HTTP API V2 endpoint: GET /v2/<repo>/blobs/<digest>
+     * Get a blob specified by digest for a Docker image by calling the Docker Registry HTTP API V2 endpoint: GET /v2/[repo]/blobs/[digest]
      *
      * @param token Authentication token with pull access for the image's repository
      * @param registryDockerPath

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -835,7 +835,7 @@ public interface LanguageHandlerInterface {
      * Source for manifest calculation: https://docs.docker.com/registry/spec/api/#content-digests
      *
      * @param manifestBody Docker Registry V2 Schema 2 image manifest body
-     * @return
+     * @return Docker image digest
      */
     default String calculateDockerImageDigest(String manifestBody) {
         return Hashing.sha256().hashString(manifestBody, StandardCharsets.UTF_8).toString();
@@ -867,7 +867,7 @@ public interface LanguageHandlerInterface {
      * @param registryDockerPath
      * @param repo
      * @param specifierName Value of the specifier. Either a tag or a digest
-     * @return
+     * @return HttpResponse
      * @throws URISyntaxException
      * @throws IOException
      * @throws InterruptedException

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -15,6 +15,8 @@
  */
 package io.dockstore.webservice.languages;
 
+import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
+
 import com.google.common.base.Strings;
 import com.google.common.hash.Hashing;
 import com.google.gson.Gson;
@@ -881,7 +883,7 @@ public interface LanguageHandlerInterface {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(new URI(getManifestURL))
                 .header(HttpHeaders.ACCEPT, acceptHeader)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .header(HttpHeaders.AUTHORIZATION, String.join(" ", JWT_SECURITY_DEFINITION_NAME, token))
                 .GET()
                 .build();
 
@@ -906,7 +908,7 @@ public interface LanguageHandlerInterface {
         String getBlobURL = String.format("https://%s/v2/%s/blobs/%s", registryDockerPath, repo, digest);
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(new URI(getBlobURL))
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .header(HttpHeaders.AUTHORIZATION, String.join(" ", JWT_SECURITY_DEFINITION_NAME, token))
                 .GET()
                 .build();
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -447,7 +447,9 @@ public interface LanguageHandlerInterface {
 
         // Remove tag or digest if exists
         Matcher m;
-        if (dockerSpecifier == DockerSpecifier.DIGEST) {
+        // A specific architecture image from a multi-arch image is referenced by digest, but it may also include the tag for the multi-arch image
+        // Ex: ubuntu:18.04@sha256:c404618e908391e50953e1ead94fe05dbbddbf532bd5c89b935ef34a9ca130d3 is the linux/amd64 image for ubuntu:18.04
+        if (dockerSpecifier == DockerSpecifier.DIGEST && !dockerImage.contains(":")) {
             m = IMAGE_DIGEST_PATTERN.matcher(dockerImage);
         } else {
             m = IMAGE_TAG_PATTERN.matcher(dockerImage);
@@ -649,6 +651,13 @@ public interface LanguageHandlerInterface {
                     String imageNameWithSpecifier = String.join("/", Arrays.asList(splitDocker).subList(2, splitDocker.length)); // image name can have slashes
                     splitSpecifier = imageNameWithSpecifier.split(specifierSymbol); // ["image-name", "1"]
                     String imageName = splitSpecifier[0];
+
+                    // A specific architecture image from a multi-arch image is referenced by digest, but it may also include the tag for the multi-arch image
+                    // Ex: ubuntu:18.04@sha256:c404618e908391e50953e1ead94fe05dbbddbf532bd5c89b935ef34a9ca130d3 is the linux/amd64 image for ubuntu:18.04
+                    // Remove the left-over ":"
+                    if (imageSpecifier == DockerSpecifier.DIGEST && imageName.contains(":")) {
+                        imageName = imageName.split(":")[0];
+                    }
 
                     String repo = String.join("/", owner, imageName);
                     String specifierName = splitSpecifier[1];

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1332,7 +1332,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                         // Check that a snapshot can occur (all images are referenced by tag or digest)
                         lInterface.checkSnapshotImages(existingTag.getName(), toolsJSONTable.get());
 
-                        Set<Image> images = lInterface.getImagesFromRegistry(toolsJSONTable.get(), client);
+                        Set<Image> images = lInterface.getImagesFromRegistry(toolsJSONTable.get());
                         existingTag.getImages().addAll(images);
                     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1332,7 +1332,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                         // Check that a snapshot can occur (all images are referenced by tag or digest)
                         lInterface.checkSnapshotImages(existingTag.getName(), toolsJSONTable.get());
 
-                        Set<Image> images = lInterface.getImagesFromRegistry(toolsJSONTable.get());
+                        Set<Image> images = lInterface.getImagesFromRegistry(toolsJSONTable.get(), client);
                         existingTag.getImages().addAll(images);
                     }
 

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -7099,6 +7099,7 @@ components:
           - GITLAB
           - AMAZON_ECR
           - SEVEN_BRIDGES
+          - GITHUB_CONTAINER_REGISTRY
         registry_string:
           type: string
         starredUsers:
@@ -7432,6 +7433,7 @@ components:
           - GITLAB
           - AMAZON_ECR
           - SEVEN_BRIDGES
+          - GITHUB_CONTAINER_REGISTRY
         imageUpdateDate:
           type: string
         os:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -6720,6 +6720,7 @@ definitions:
         - "GITLAB"
         - "AMAZON_ECR"
         - "SEVEN_BRIDGES"
+        - "GITHUB_CONTAINER_REGISTRY"
     description: "This describes one entry in the dockstore. Logically, this currently\
       \ means one tuple of registry (either quay or docker hub), organization, image\
       \ name, and toolname which can be\n * associated with CWL and Dockerfile documents"
@@ -7039,6 +7040,7 @@ definitions:
         - "GITLAB"
         - "AMAZON_ECR"
         - "SEVEN_BRIDGES"
+        - "GITHUB_CONTAINER_REGISTRY"
       architecture:
         type: "string"
         position: 6

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -175,6 +175,9 @@ public class CWLHandlerTest {
                 handler.getURLFromEntry("ghcr.io/foo/bar:1", toolDAO, DockerSpecifier.TAG));
         Assert.assertEquals("https://ghcr.io/foo/bar",
                 handler.getURLFromEntry("ghcr.io/foo/bar@sha256:123456789abc", toolDAO, DockerSpecifier.DIGEST));
+        // A specific architecture image is referenced by digest but it may also include a tag from the multi-arch image
+        Assert.assertEquals("https://ghcr.io/foo/bar",
+                handler.getURLFromEntry("ghcr.io/foo/bar:1@sha256:123456789abc", toolDAO, DockerSpecifier.DIGEST));
 
         // When toolDAO.findAllByPath() returns non-empty List<Tool>
         when(toolDAO.findAllByPath(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(List.of(Mockito.mock(Tool.class)));

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -242,7 +242,7 @@ public class CWLHandlerTest {
             Assert.fail("Could not retrieve manifest");
         }
         Assert.assertEquals(HttpStatus.SC_OK, manifestResponse.statusCode());
-        
+
         String manifestBody = manifestResponse.body();
         String calculatedDigest = String.format("sha256:%s", handler.calculateDockerImageDigest(manifestBody));
         Assert.assertEquals(digest, calculatedDigest);

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -138,6 +138,13 @@ public class CWLHandlerTest {
                 handler.getURLFromEntry("012345678912.dkr.ecr.us-east-1.amazonaws.com/foo@sha256:123456789abc", toolDAO,
                         DockerSpecifier.DIGEST));
 
+        Assert.assertEquals("https://ghcr.io/foo/bar",
+                handler.getURLFromEntry("ghcr.io/foo/bar", toolDAO, DockerSpecifier.NO_TAG));
+        Assert.assertEquals("https://ghcr.io/foo/bar",
+                handler.getURLFromEntry("ghcr.io/foo/bar:1", toolDAO, DockerSpecifier.TAG));
+        Assert.assertEquals("https://ghcr.io/foo/bar",
+                handler.getURLFromEntry("ghcr.io/foo/bar@sha256:123456789abc", toolDAO, DockerSpecifier.DIGEST));
+
         // When toolDAO.findAllByPath() returns null/empty
         when(toolDAO.findAllByPath(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(null);
         Assert.assertEquals("https://quay.io/repository/foo/bar",
@@ -161,6 +168,13 @@ public class CWLHandlerTest {
         Assert.assertEquals("https://012345678912.dkr.ecr.us-east-1.amazonaws.com/foo",
                 handler.getURLFromEntry("012345678912.dkr.ecr.us-east-1.amazonaws.com/foo@sha256:123456789abc", toolDAO,
                         DockerSpecifier.DIGEST));
+
+        Assert.assertEquals("https://ghcr.io/foo/bar",
+                handler.getURLFromEntry("ghcr.io/foo/bar", toolDAO, DockerSpecifier.NO_TAG));
+        Assert.assertEquals("https://ghcr.io/foo/bar",
+                handler.getURLFromEntry("ghcr.io/foo/bar:1", toolDAO, DockerSpecifier.TAG));
+        Assert.assertEquals("https://ghcr.io/foo/bar",
+                handler.getURLFromEntry("ghcr.io/foo/bar@sha256:123456789abc", toolDAO, DockerSpecifier.DIGEST));
 
         // When toolDAO.findAllByPath() returns non-empty List<Tool>
         when(toolDAO.findAllByPath(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(List.of(Mockito.mock(Tool.class)));
@@ -187,6 +201,13 @@ public class CWLHandlerTest {
         Assert.assertEquals("https://www.dockstore.org/containers/012345678912.dkr.ecr.us-east-1.amazonaws.com/foo",
                 handler.getURLFromEntry("012345678912.dkr.ecr.us-east-1.amazonaws.com/foo@sha256:123456789", toolDAO,
                         DockerSpecifier.DIGEST));
+
+        Assert.assertEquals("https://www.dockstore.org/containers/ghcr.io/foo/bar",
+                handler.getURLFromEntry("ghcr.io/foo/bar", toolDAO, DockerSpecifier.NO_TAG));
+        Assert.assertEquals("https://www.dockstore.org/containers/ghcr.io/foo/bar",
+                handler.getURLFromEntry("ghcr.io/foo/bar:1", toolDAO, DockerSpecifier.TAG));
+        Assert.assertEquals("https://www.dockstore.org/containers/ghcr.io/foo/bar",
+                handler.getURLFromEntry("ghcr.io/foo/bar@sha256:123456789abc", toolDAO, DockerSpecifier.DIGEST));
     }
 
     @Test

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -215,6 +215,45 @@ public class CWLHandlerTest {
                 handler.getURLFromEntry("ghcr.io/foo/bar@sha256:123456789abc", toolDAO, DockerSpecifier.DIGEST));
     }
 
+    @Test
+    public void testGetImageNameWithoutSpecifier() {
+        final LanguageHandlerInterface handler = Mockito.mock(LanguageHandlerInterface.class, Mockito.CALLS_REAL_METHODS);
+
+        Assert.assertEquals("foo/bar", handler.getImageNameWithoutSpecifier("foo/bar", DockerSpecifier.NO_TAG));
+        Assert.assertEquals("foo/bar", handler.getImageNameWithoutSpecifier("foo/bar:1", DockerSpecifier.TAG));
+        Assert.assertEquals("foo/bar", handler.getImageNameWithoutSpecifier("foo/bar@sha256:123456789abc", DockerSpecifier.DIGEST));
+        Assert.assertEquals("quay.io/foo/bar", handler.getImageNameWithoutSpecifier("quay.io/foo/bar:1", DockerSpecifier.TAG));
+        Assert.assertEquals("ghcr.io/foo/bar", handler.getImageNameWithoutSpecifier("ghcr.io/foo/bar:1@sha256:123456789abc", DockerSpecifier.DIGEST));
+    }
+
+    @Test
+    public void testGetRepositoryName() {
+        final LanguageHandlerInterface handler = Mockito.mock(LanguageHandlerInterface.class, Mockito.CALLS_REAL_METHODS);
+
+        Assert.assertEquals("foo/bar", handler.getRepositoryName(Registry.QUAY_IO, "quay.io/foo/bar:1", DockerSpecifier.TAG));
+        Assert.assertEquals("foo/bar", handler.getRepositoryName(Registry.QUAY_IO, "quay.io/foo/bar@sha256:123456789abc", DockerSpecifier.DIGEST));
+
+        Assert.assertEquals("library/foo", handler.getRepositoryName(Registry.DOCKER_HUB, "foo:1", DockerSpecifier.TAG));
+        Assert.assertEquals("foo/bar", handler.getRepositoryName(Registry.DOCKER_HUB, "foo/bar:1", DockerSpecifier.TAG));
+        Assert.assertEquals("foo/bar", handler.getRepositoryName(Registry.DOCKER_HUB, "foo/bar@sha256:123456789abc", DockerSpecifier.DIGEST));
+
+        Assert.assertEquals("foo/bar", handler.getRepositoryName(Registry.GITHUB_CONTAINER_REGISTRY, "ghcr.io/foo/bar:1", DockerSpecifier.TAG));
+        Assert.assertEquals("foo/bar/test", handler.getRepositoryName(Registry.GITHUB_CONTAINER_REGISTRY, "ghcr.io/foo/bar/test:1", DockerSpecifier.TAG));
+        Assert.assertEquals("foo/bar", handler.getRepositoryName(Registry.GITHUB_CONTAINER_REGISTRY, "ghcr.io/foo/bar@sha256:123456789abc", DockerSpecifier.DIGEST));
+        Assert.assertEquals("foo/bar", handler.getRepositoryName(Registry.GITHUB_CONTAINER_REGISTRY, "ghcr.io/foo/bar:1@sha256:123456789abc", DockerSpecifier.DIGEST));
+    }
+
+    @Test
+    public void testGetSpecifierName() {
+        final LanguageHandlerInterface handler = Mockito.mock(LanguageHandlerInterface.class, Mockito.CALLS_REAL_METHODS);
+
+        Assert.assertEquals("", handler.getSpecifierName("foo/bar", DockerSpecifier.NO_TAG));
+        Assert.assertEquals("1", handler.getSpecifierName("foo/bar:1", DockerSpecifier.TAG));
+        Assert.assertEquals("sha256:123456789abc", handler.getSpecifierName("foo@sha256:123456789abc", DockerSpecifier.DIGEST));
+        Assert.assertEquals("sha256:123456789abc", handler.getSpecifierName("ghcr.io/foo/bar/test@sha256:123456789abc", DockerSpecifier.DIGEST));
+        Assert.assertEquals("sha256:123456789abc", handler.getSpecifierName("ghcr.io/foo/bar/test:1@sha256:123456789abc", DockerSpecifier.DIGEST));
+    }
+
     /**
      * Test that the calculated digest matches the actual digest of the image.
      * @throws URISyntaxException


### PR DESCRIPTION
For #4002 part 1.

Draft PR to get some feedback on the approach I implemented to harvest the image checksum and its metadata. If it looks good, then I'll create some tests.

GitHub Container Registry images have the same problem as Amazon ECR images where we can't use the registry's API to get information about an image because it requires authentication. For GHCR images in particular, we need a personal access token that has the `read:packages` scope, even if it's for a public image.

I previously created #4330 to investigate how to get the checksum for Amazon ECR images, but since GHCR images also have this problem, I did some research and implemented a solution.  This solution is basically idea 5 from #4330 which uses Docker's Registry API.

This checksum harvesting solution makes 3 Docker Registry HTTP API V2 requests:
1) Get a token from Docker with pull access so we can use it for subsequent calls.
2) Get the image manifest. The purpose of this call is to get the image's digest and calculate the image size.
3) Get the blob of the config, which contains information about the image's architecture and os.

Image metadata that I could not retrieve using this method is `imageId` and `imageUpdateDate`. I'm not sure how important this metadata is and if it's a blocker for this solution.

Another problem is that it's not possible to get the corresponding tag for an image if the image is referenced by digest. In this case, I just set the tag to `null`. This tag info is arguably not very important if the image is specified by digest.

Pros of this solution: 
- It's likely more efficient for images referenced by digest because we know right away whether or not this digest is valid from the response of the 2nd API call where we get the image manifest. We don't need to look through all of the image's tags to find the matching digest.
- We can reuse this for Amazon ECR image checksum harvesting

Notes about the image manifest endpoint:
- There are 2 image manifest schemas: Schema 1 and Schema 2.
  - Schema 1 is deprecated, so if the response to the image manifest endpoint returns a Schema 1 image manifest, I log it and return (no checksum calculation). 
  - Should I worry about calculating the checksum for a Schema 1 image manifest?
- The headers of the response may or may not contain a `Docker-Content-Digest` header. This is the digest of the image. If it's present, we take the checksum for that. If not, we manually calculate it.
  -  I noticed that GHCR has this header, but Amazon ECR does not. It may just be the case that I haven't tested it on a wide variety images