### PR TITLE
Fix descriptor and .dockstore.yml authors

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
@@ -363,6 +363,7 @@ public class CRUDClientIT extends BaseIT {
         file.setPath("/Dockstore.cwl");
         file.setAbsolutePath("/Dockstore.cwl");
         Workflow dockstoreWorkflow = api.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file));
+        // Workflow only has one author (who also has an email)
         assertTrue(!dockstoreWorkflow.getAuthor().isEmpty() && !dockstoreWorkflow.getEmail().isEmpty());
     }
 
@@ -378,7 +379,8 @@ public class CRUDClientIT extends BaseIT {
         file.setPath("/Dockstore.wdl");
         file.setAbsolutePath("/Dockstore.wdl");
         Workflow dockstoreWorkflow = api.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file));
-        assertTrue(!dockstoreWorkflow.getAuthor().isEmpty() && !dockstoreWorkflow.getEmail().isEmpty());
+        // Workflow has multiple authors, but only one author has an email. The author returned may be one of the authors without an email.
+        assertTrue(!dockstoreWorkflow.getAuthor().isEmpty());
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -764,7 +764,7 @@ public class WebhookIT extends BaseIT {
         assertEquals(1, version.getAuthors().size());
         assertEquals(0, version.getOrcidAuthors().size());
 
-        // Workflow containing multiple descriptor authors and no .dockstore.yml authors
+        // Workflow containing multiple descriptor authors separated by a comma ("Author 1, Author 2") and no .dockstore.yml authors
         client.handleGitHubRelease(authorsRepo, BasicIT.USER_2_USERNAME, "refs/heads/multipleDescriptorAuthors", installationId);
         workflow = client.getWorkflowByPath("github.com/" + authorsRepo + "/foobar", "versions,authors", BIOWORKFLOW);
         version = workflow.getWorkflowVersions().stream().filter(v -> v.getName().equals("multipleDescriptorAuthors")).findFirst().get();

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -45,6 +45,7 @@ import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
+import io.swagger.client.model.Author;
 import io.swagger.client.model.LambdaEvent;
 import io.swagger.client.model.PublishRequest;
 import io.swagger.client.model.Validation;
@@ -742,6 +743,10 @@ public class WebhookIT extends BaseIT {
         version = workflow.getWorkflowVersions().stream().filter(v -> v.getName().equals("main")).findFirst().get();
         assertEquals(3, version.getAuthors().size());
         assertEquals(2, version.getOrcidAuthors().size());
+        Optional<Author> descriptorAuthor = version.getAuthors().stream().filter(author -> author.getName().equals("Descriptor Author")).findFirst();
+        assertTrue(descriptorAuthor.isPresent());
+        assertEquals("Descriptor Author", descriptorAuthor.get().getName());
+        assertEquals("Email should be set for descriptor author", "descriptor.author@gmail.com", descriptorAuthor.get().getEmail());
 
         // Workflow containing only .dockstore.yml authors
         client.handleGitHubRelease(authorsRepo, BasicIT.USER_2_USERNAME, "refs/heads/onlyDockstoreYmlAuthors", installationId);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -450,19 +450,20 @@ public abstract class Version<T extends Version> implements Comparable<T> {
         this.getVersionMetadata().descriptionSource = newDescriptionSource;
     }
 
+    // remove this method when author is removed from VersionMetadata
     public void setAuthor(String newAuthor) {
-        this.getVersionMetadata().author = newAuthor;  // remove this line when author is removed from VersionMetadata
-        boolean isNewAuthor = authors.stream().noneMatch(author -> author.getName().equals(newAuthor));
-        if (newAuthor != null && isNewAuthor) {
-            authors.add(new Author(newAuthor));
-        }
+        this.getVersionMetadata().author = newAuthor;
     }
 
-    public void setEmail(String newAuthor, String newEmail) {
-        this.getVersionMetadata().email = newEmail;  // remove this line when author is removed from VersionMetadata
-        Optional<Author> existingAuthor = authors.stream().filter(author -> author.getName().equals(newAuthor)).findFirst();
-        if (existingAuthor.isPresent() && existingAuthor.get().getEmail() == null) {
-            existingAuthor.get().setEmail(newEmail);
+    // remove this method when author is removed from VersionMetadata
+    public void setEmail(String newEmail) {
+        this.getVersionMetadata().email = newEmail;
+    }
+
+    public void addAuthor(final Author author) {
+        boolean isNewAuthor = this.authors.stream().noneMatch(existingAuthor -> existingAuthor.getName().equals(author.getName()));
+        if (isNewAuthor) {
+            this.authors.add(author);
         }
     }
 
@@ -559,7 +560,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
      */
     public void setVersionMetadata(VersionMetadata newVersionMetadata) {
         this.setAuthor(newVersionMetadata.author);
-        this.setEmail(newVersionMetadata.author, newVersionMetadata.email);
+        this.setEmail(newVersionMetadata.email);
         this.setDescriptionAndDescriptionSource(newVersionMetadata.description, newVersionMetadata.descriptionSource);
         this.getVersionMetadata().setParsedInformationSet(newVersionMetadata.parsedInformationSet);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -452,19 +452,17 @@ public abstract class Version<T extends Version> implements Comparable<T> {
 
     public void setAuthor(String newAuthor) {
         this.getVersionMetadata().author = newAuthor;  // remove this line when author is removed from VersionMetadata
-        authors.clear();
-        if (newAuthor != null) {
+        boolean isNewAuthor = authors.stream().noneMatch(author -> author.getName().equals(newAuthor));
+        if (newAuthor != null && isNewAuthor) {
             authors.add(new Author(newAuthor));
         }
     }
 
-    public void setEmail(String newEmail) {
+    public void setEmail(String newAuthor, String newEmail) {
         this.getVersionMetadata().email = newEmail;  // remove this line when author is removed from VersionMetadata
-        if (authors.size() == 1) {
-            Optional<Author> author = authors.stream().findFirst();
-            if (author.isPresent() && author.get().getEmail() == null) {
-                author.get().setEmail(newEmail);
-            }
+        Optional<Author> existingAuthor = authors.stream().filter(author -> author.getName().equals(newAuthor)).findFirst();
+        if (existingAuthor.isPresent() && existingAuthor.get().getEmail() == null) {
+            existingAuthor.get().setEmail(newEmail);
         }
     }
 
@@ -561,7 +559,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
      */
     public void setVersionMetadata(VersionMetadata newVersionMetadata) {
         this.setAuthor(newVersionMetadata.author);
-        this.setEmail(newVersionMetadata.email);
+        this.setEmail(newVersionMetadata.author, newVersionMetadata.email);
         this.setDescriptionAndDescriptionSource(newVersionMetadata.description, newVersionMetadata.descriptionSource);
         this.getVersionMetadata().setParsedInformationSet(newVersionMetadata.parsedInformationSet);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -130,12 +130,15 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                     LOG.info("Description not found!");
                 }
 
-                String dctKey = "dct:creator";
-                String schemaKey = "s:author";
-                if (map.containsKey(schemaKey)) {
-                    processAuthor(version, map, schemaKey, "s:name", "s:email", "Author not found!");
-                } else if (map.containsKey(dctKey)) {
-                    processAuthor(version, map, dctKey, "foaf:name", "foaf:mbox", "Creator not found!");
+                // Add authors from descriptor if there are no .dockstore.yml authors
+                if (version.getAuthors().isEmpty()) {
+                    String dctKey = "dct:creator";
+                    String schemaKey = "s:author";
+                    if (map.containsKey(schemaKey)) {
+                        processAuthor(version, map, schemaKey, "s:name", "s:email", "Author not found!");
+                    } else if (map.containsKey(dctKey)) {
+                        processAuthor(version, map, dctKey, "foaf:name", "foaf:mbox", "Creator not found!");
+                    }
                 }
 
                 LOG.info("Repository has Dockstore.cwl");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -177,7 +177,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
             version.setAuthor(author);
             String email = (String)map.get(emailKey);
             if (!Strings.isNullOrEmpty(email)) {
-                version.setEmail(email.replaceFirst("^mailto:", ""));
+                version.setEmail(author, email.replaceFirst("^mailto:", ""));
             }
         } else {
             LOG.info(errorMessage);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -33,6 +33,7 @@ import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.DockerImageReference;
 import io.dockstore.common.VersionTypeValidation;
 import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Author;
 import io.dockstore.webservice.core.DescriptionSource;
 import io.dockstore.webservice.core.FileFormat;
 import io.dockstore.webservice.core.ParsedInformation;
@@ -174,11 +175,12 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
         map = (Map)o;
         if (map != null) {
             String author = (String)map.get(authorKey);
-            version.setAuthor(author);
+            Author newAuthor = new Author(author);
             String email = (String)map.get(emailKey);
             if (!Strings.isNullOrEmpty(email)) {
-                version.setEmail(author, email.replaceFirst("^mailto:", ""));
+                newAuthor.setEmail(email.replaceFirst("^mailto:", ""));
             }
+            version.addAuthor(newAuthor);
         } else {
             LOG.info(errorMessage);
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -63,9 +63,11 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
     public Version parseWorkflowContent(String filepath, String content, Set<SourceFile> sourceFiles, Version version) {
         final MinimalLanguageInterface.WorkflowMetadata workflowMetadata = minimalLanguageInterface
             .parseWorkflowForMetadata(filepath, content, new HashMap<>());
-        Author author = new Author(workflowMetadata.getAuthor());
-        author.setEmail(workflowMetadata.getEmail());
-        version.addAuthor(author);
+        if (workflowMetadata.getAuthor() != null) {
+            Author author = new Author(workflowMetadata.getAuthor());
+            author.setEmail(workflowMetadata.getEmail());
+            version.addAuthor(author);
+        }
         version.setDescriptionAndDescriptionSource(workflowMetadata.getDescription(), DescriptionSource.DESCRIPTOR);
         // TODO: hook up validation object to version for parsing metadata
         return version;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -63,7 +63,7 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
         final MinimalLanguageInterface.WorkflowMetadata workflowMetadata = minimalLanguageInterface
             .parseWorkflowForMetadata(filepath, content, new HashMap<>());
         version.setAuthor(workflowMetadata.getAuthor());
-        version.setEmail(workflowMetadata.getEmail());
+        version.setEmail(workflowMetadata.getAuthor(), workflowMetadata.getEmail());
         version.setDescriptionAndDescriptionSource(workflowMetadata.getDescription(), DescriptionSource.DESCRIPTOR);
         // TODO: hook up validation object to version for parsing metadata
         return version;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -63,7 +63,8 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
     public Version parseWorkflowContent(String filepath, String content, Set<SourceFile> sourceFiles, Version version) {
         final MinimalLanguageInterface.WorkflowMetadata workflowMetadata = minimalLanguageInterface
             .parseWorkflowForMetadata(filepath, content, new HashMap<>());
-        if (workflowMetadata.getAuthor() != null) {
+        // Add authors from descriptor if there are no .dockstore.yml authors
+        if (workflowMetadata.getAuthor() != null && version.getAuthors().isEmpty()) {
             Author author = new Author(workflowMetadata.getAuthor());
             author.setEmail(workflowMetadata.getEmail());
             version.addAuthor(author);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -22,6 +22,7 @@ import io.dockstore.language.CompleteLanguageInterface;
 import io.dockstore.language.MinimalLanguageInterface;
 import io.dockstore.language.RecommendedLanguageInterface;
 import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Author;
 import io.dockstore.webservice.core.DescriptionSource;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Version;
@@ -62,8 +63,9 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
     public Version parseWorkflowContent(String filepath, String content, Set<SourceFile> sourceFiles, Version version) {
         final MinimalLanguageInterface.WorkflowMetadata workflowMetadata = minimalLanguageInterface
             .parseWorkflowForMetadata(filepath, content, new HashMap<>());
-        version.setAuthor(workflowMetadata.getAuthor());
-        version.setEmail(workflowMetadata.getAuthor(), workflowMetadata.getEmail());
+        Author author = new Author(workflowMetadata.getAuthor());
+        author.setEmail(workflowMetadata.getEmail());
+        version.addAuthor(author);
         version.setDescriptionAndDescriptionSource(workflowMetadata.getDescription(), DescriptionSource.DESCRIPTOR);
         // TODO: hook up validation object to version for parsing metadata
         return version;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -24,6 +24,7 @@ import io.dockstore.common.DockerParameter;
 import io.dockstore.common.NextflowUtilities;
 import io.dockstore.common.VersionTypeValidation;
 import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Author;
 import io.dockstore.webservice.core.DescriptionSource;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Validation;
@@ -79,7 +80,11 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
                 descriptionInProgress = version.getDescription();
             }
             if (configuration.containsKey("manifest.author")) {
-                version.setAuthor(configuration.getString("manifest.author"));
+                String[] authors = configuration.getString("manifest.author").split(",");
+                for (String author : authors) {
+                    Author newAuthor = new Author(author.trim());
+                    version.addAuthor(newAuthor);
+                }
             }
             // look for extended help message from nf-core workflows when it is available
             String mainScriptPath = "main.nf";

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -79,7 +79,8 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
                 version.setDescriptionAndDescriptionSource(configuration.getString("manifest.description"), DescriptionSource.DESCRIPTOR);
                 descriptionInProgress = version.getDescription();
             }
-            if (configuration.containsKey("manifest.author")) {
+            // Add authors from descriptor if there are no .dockstore.yml authors
+            if (configuration.containsKey("manifest.author") && version.getAuthors().isEmpty()) {
                 String[] authors = configuration.getString("manifest.author").split(",");
                 for (String author : authors) {
                     Author newAuthor = new Author(author.trim());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -159,7 +159,7 @@ public class WDLHandler implements LanguageHandlerInterface {
                     version.setAuthor(String.join(", ", authors));
                 }
                 if (!emails.isEmpty()) {
-                    version.setEmail(String.join(", ", emails));
+                    version.setEmail(String.join(", ", authors), String.join(", ", emails));
                 }
                 if (!Strings.isNullOrEmpty(mainDescription[0])) {
                     version.setDescriptionAndDescriptionSource(mainDescription[0], DescriptionSource.DESCRIPTOR);
@@ -173,7 +173,7 @@ public class WDLHandler implements LanguageHandlerInterface {
                 version.addOrUpdateValidation(new Validation(DescriptorLanguage.FileType.DOCKSTORE_WDL, false, validationMessageObject));
                 version.setAuthor(null);
                 version.setDescriptionAndDescriptionSource(null, null);
-                version.setEmail(null);
+                version.setEmail(null, null);
                 return version;
             }
         } catch (IOException e) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -158,7 +158,8 @@ public class WDLHandler implements LanguageHandlerInterface {
                     }
                 });
 
-                if (!authors.isEmpty()) {
+                // Add authors from descriptor if there are no .dockstore.yml authors
+                if (!authors.isEmpty() && version.getAuthors().isEmpty()) {
                     // Only set emails for authors if every author has an email.
                     // Otherwise, ignore emails because we don't know which email belongs to which author
                     if (!emails.isEmpty() && authors.size() == emails.size()) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -27,6 +27,7 @@ import io.dockstore.common.LanguageHandlerHelper;
 import io.dockstore.common.VersionTypeValidation;
 import io.dockstore.common.WdlBridge;
 import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Author;
 import io.dockstore.webservice.core.DescriptionSource;
 import io.dockstore.webservice.core.ParsedInformation;
 import io.dockstore.webservice.core.SourceFile;
@@ -45,11 +46,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -128,8 +131,8 @@ public class WDLHandler implements LanguageHandlerInterface {
             Files.asCharSink(tempMainDescriptor, StandardCharsets.UTF_8).write(content);
             try {
                 List<Map<String, String>> metadata = wdlBridge.getMetadata(tempMainDescriptor.getAbsolutePath(), filepath);
-                Set<String> authors = new HashSet<>();
-                Set<String> emails = new HashSet<>();
+                Queue<String> authors = new LinkedList<>();
+                Queue<String> emails = new LinkedList<>();
                 final String[] mainDescription = { null };
 
                 metadata.forEach(metaBlock -> {
@@ -156,11 +159,23 @@ public class WDLHandler implements LanguageHandlerInterface {
                 });
 
                 if (!authors.isEmpty()) {
-                    version.setAuthor(String.join(", ", authors));
+                    // Only set emails for authors if every author has an email.
+                    // Otherwise, ignore emails because we don't know which email belongs to which author
+                    if (!emails.isEmpty() && authors.size() == emails.size()) {
+                        while (!authors.isEmpty()) {
+                            Author author = new Author();
+                            author.setName(authors.remove());
+                            author.setEmail(emails.remove());
+                            version.addAuthor(author);
+                        }
+                    } else {
+                        while (!authors.isEmpty()) {
+                            Author author = new Author(authors.remove());
+                            version.addAuthor(author);
+                        }
+                    }
                 }
-                if (!emails.isEmpty()) {
-                    version.setEmail(String.join(", ", authors), String.join(", ", emails));
-                }
+
                 if (!Strings.isNullOrEmpty(mainDescription[0])) {
                     version.setDescriptionAndDescriptionSource(mainDescription[0], DescriptionSource.DESCRIPTOR);
                 }
@@ -171,11 +186,9 @@ public class WDLHandler implements LanguageHandlerInterface {
                 errorMessage = getUnsupportedWDLVersionErrorString(tempMainDescriptor.getAbsolutePath()).orElse(errorMessage);
                 validationMessageObject.put(filepath, errorMessage);
                 version.addOrUpdateValidation(new Validation(DescriptorLanguage.FileType.DOCKSTORE_WDL, false, validationMessageObject));
-                version.setAuthor(null);
                 version.setDescriptionAndDescriptionSource(null, null);
-                version.setEmail(null, null);
-                version.setAuthors(new HashSet<>());
-                version.setOrcidAuthors(new HashSet<>());
+                version.getAuthors().clear();
+                version.getOrcidAuthors().clear();
                 return version;
             }
         } catch (IOException e) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -174,6 +174,8 @@ public class WDLHandler implements LanguageHandlerInterface {
                 version.setAuthor(null);
                 version.setDescriptionAndDescriptionSource(null, null);
                 version.setEmail(null, null);
+                version.setAuthors(new HashSet<>());
+                version.setOrcidAuthors(new HashSet<>());
                 return version;
             }
         } catch (IOException e) {

--- a/dockstore-webservice/src/test/java/core/NFLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/NFLParseTest.java
@@ -50,7 +50,7 @@ public class NFLParseTest {
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.NEXTFLOW_CONFIG);
         Version entry = sInterface
             .parseWorkflowContent(filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new WorkflowVersion());
-        assertTrue("incorrect author", entry.getAuthor().split(",").length >= 2);
+        assertEquals(2, entry.getAuthors().size());
         assertTrue("incorrect description", entry.getDescription().startsWith("Nextflow RNA-Seq analysis pipeline, part of the nf-core community."));
     }
 

--- a/dockstore-webservice/src/test/java/core/WDLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/WDLParseTest.java
@@ -26,6 +26,7 @@ import com.google.common.io.Files;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.VersionTypeValidation;
 import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Author;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Tag;
 import io.dockstore.webservice.core.Validation;
@@ -74,8 +75,11 @@ public class WDLParseTest {
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_WDL);
         Version entry = sInterface
             .parseWorkflowContent(filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
-        assertTrue("incorrect author", entry.getAuthor().split(",").length >= 2);
-        assertNull("incorrect email", entry.getEmail());
+        Set<Author> authors = entry.getAuthors();
+        assertEquals(2, authors.size());
+        for (Author author : authors) {
+            assertNull(author.getEmail());
+        }
     }
 
     @Test
@@ -84,8 +88,8 @@ public class WDLParseTest {
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_WDL);
         Version entry = sInterface
             .parseWorkflowContent(filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
-        assertTrue("incorrect author", entry.getAuthor().split(",").length >= 2);
-        assertEquals("incorrect email", "This is a cool workflow", entry.getDescription());
+        assertEquals(3, entry.getAuthors().size());
+        assertEquals("incorrect description", "This is a cool workflow", entry.getDescription());
     }
 
     @Test

--- a/dockstore-webservice/src/test/java/core/WDLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/WDLParseTest.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import org.apache.commons.io.FileUtils;
@@ -76,7 +77,7 @@ public class WDLParseTest {
         Version entry = sInterface
             .parseWorkflowContent(filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
         Set<Author> authors = entry.getAuthors();
-        assertEquals(2, authors.size());
+        assertEquals(3, authors.size());
         for (Author author : authors) {
             assertNull(author.getEmail());
         }
@@ -88,7 +89,12 @@ public class WDLParseTest {
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_WDL);
         Version entry = sInterface
             .parseWorkflowContent(filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
-        assertEquals(3, entry.getAuthors().size());
+        Set<Author> authors = entry.getAuthors();
+        assertEquals(3, authors.size());
+        Optional<Author> authorWithEmail = authors.stream().filter(author -> author.getName().equals("Mr. Foo")).findFirst();
+        assertTrue(authorWithEmail.isPresent());
+        assertEquals("foo@foo.com", authorWithEmail.get().getEmail());
+        authors.stream().filter(author -> !author.getName().equals("Mr. Foo")).forEach(authorWithoutEmail -> assertNull(authorWithoutEmail.getEmail()));
         assertEquals("incorrect description", "This is a cool workflow", entry.getDescription());
     }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
@@ -8,7 +8,6 @@ import com.google.gson.Gson;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.BioWorkflow;
-import io.dockstore.webservice.core.DescriptionSource;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.SourceControlOrganization;
 import io.dockstore.webservice.core.SourceFile;
@@ -51,19 +50,14 @@ public class WDLHandlerTest {
     public void getWorkflowContent() throws IOException {
         final WDLHandler wdlHandler = new WDLHandler();
         final Version workflow = new WorkflowVersion();
-        workflow.setAuthor("Jane Doe");
-        workflow.setDescriptionAndDescriptionSource("A good description", DescriptionSource.DESCRIPTOR);
-        workflow.setEmail("Jane Doe", "janedoe@example.org");
 
         final String validFilePath = ResourceHelpers.resourceFilePath("valid_description_example.wdl");
 
         final String goodWdl = FileUtils.readFileToString(new File(validFilePath), StandardCharsets.UTF_8);
         Version version = wdlHandler.parseWorkflowContent(validFilePath, goodWdl, Collections.emptySet(), workflow);
-        Assert.assertEquals(version.getAuthor(), "Mr. Foo");
-        Assert.assertEquals(version.getEmail(), "foo@foo.com");
-        Assert.assertEquals(version.getDescription(),
-                "This is a cool workflow trying another line \n## This is a header\n* First Bullet\n* Second bullet");
-
+        Assert.assertEquals("Mr. Foo", version.getAuthor());
+        Assert.assertEquals("foo@foo.com", version.getEmail());
+        Assert.assertEquals("This is a cool workflow trying another line \n## This is a header\n* First Bullet\n* Second bullet", version.getDescription());
 
         final String invalidFilePath = ResourceHelpers.resourceFilePath("invalid_description_example.wdl");
         final String invalidDescriptionWdl = FileUtils.readFileToString(new File(invalidFilePath), StandardCharsets.UTF_8);

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
@@ -53,7 +53,7 @@ public class WDLHandlerTest {
         final Version workflow = new WorkflowVersion();
         workflow.setAuthor("Jane Doe");
         workflow.setDescriptionAndDescriptionSource("A good description", DescriptionSource.DESCRIPTOR);
-        workflow.setEmail("janedoe@example.org");
+        workflow.setEmail("Jane Doe", "janedoe@example.org");
 
         final String validFilePath = ResourceHelpers.resourceFilePath("valid_description_example.wdl");
 

--- a/dockstore-webservice/src/test/resources/metadata_example1.wdl
+++ b/dockstore-webservice/src/test/resources/metadata_example1.wdl
@@ -130,7 +130,8 @@ task metasoft_scatter {
     }
 
     meta {
-        author: "Francois Aguet"
+        author: "Francois Aguet, Not Francois Aguet"
+        email: "not.francois.aguet@gmail.com"
     }
 }
 


### PR DESCRIPTION
For [SEAB-2544](https://ucsc-cgl.atlassian.net/browse/SEAB-2544)

Workflows with a combination of descriptor authors and .dockstore.yml authors weren't working as expected because `version.authors` was being cleared everytime `version.setAuthor` was called so only the descriptor author was showing up in the Author table. I'm not entirely sure what the intent behind that was, but if we want both descriptor authors and .dockstore.yml authors to be in the new Author table, then I don't think it should be cleared.

Also changed it so descriptor author is only added if there's no other author with that name, but now that I'm thinking about it, if `"Test Author"` was defined in both the .dockstore.yml and descriptor file, then only the .dockstore.yml author definition would be in the Author table (because .dockstore.yml authors are added first).

If it was a workflow containing both descriptor author and .dockstore.yml authors, the email for the descriptor author was not being set because the number of authors was always greater than 1. Changed it so that the email for a descriptor author is set if there's an existing author with that name, instead of depending on the number of authors being 1.

**Question:** if multiple descriptor authors is defined in one string like `"Author 1, Author 2"`, should this be 2 authors in the Author table? In this PR, I have it as only 1 author in the Author table
- Follow-up thoughts: If there's no email defined, or if the email is formatted like `"author1@gmail.com, author2@gmail.com"`, then it should be straight-forward to assign the emails to the authors, but if there's only one email given, then which author do we assign the email to? Both of them?