### PR TITLE
Add checksum harvesting for Amazon ECR images in workflows

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/Registry.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/Registry.java
@@ -28,7 +28,7 @@ public enum Registry {
     QUAY_IO("quay.io", "Quay.io", "https://quay.io/repository/", false, false),
     DOCKER_HUB("registry.hub.docker.com", "Docker Hub", "https://hub.docker.com/", false, false),
     GITLAB("registry.gitlab.com", "GitLab", "https://gitlab.com/", false, false),
-    AMAZON_ECR(null, "Amazon ECR", null, true, true),
+    AMAZON_ECR("public.ecr.aws", "Amazon ECR", null, true, false),
     SEVEN_BRIDGES(null, "Seven Bridges", null, true, true),
     GITHUB_CONTAINER_REGISTRY("ghcr.io", "GitHub Container Registry", "https://ghcr.io/", false, false);
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -1110,6 +1110,24 @@ public class WorkflowIT extends BaseIT {
         verifyTRSImageConversion(versions, "ghcrImages", 7);
     }
 
+    @Test
+    public void testGettingImagesFromAmazonECR() {
+        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowsApi = new WorkflowsApi(webClient);
+        final io.dockstore.openapi.client.ApiClient openAPIClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openAPIClient);
+
+        // Test that a versioned multi-architecture image gets an image per architecture: public.ecr.aws/ubuntu/ubuntu:18.04 -> 4 OS/Arch images
+        // Test that an image referenced by digest is grabbed correctly
+        Workflow workflow = manualRegisterAndPublish(workflowsApi, "dockstore-testing/hello-wdl-workflow", "", DescriptorType.WDL.toString(), SourceControl.GITHUB, "/Dockstore.wdl", true);
+        WorkflowVersion version = snapshotWorkflowVersion(workflowsApi, workflow, "ecrImages");
+        assertEquals(5, version.getImages().size());
+        verifyImageChecksumsAreSaved(version);
+
+        List<ToolVersion> versions = ga4Ghv20Api.toolsIdVersionsGet("#workflow/github.com/dockstore-testing/hello-wdl-workflow");
+        verifyTRSImageConversion(versions, "ecrImages", 5);
+    }
+
     /**
      * Tests that snapshotting a workflow version fails if any of the images have no tag, use the 'latest' tag, or are specified using a parameter.
      */


### PR DESCRIPTION
For #4330 

Uses the same checksum harvesting method as GitHub Container Registry images (idea 5 from the ticket). 

Oddly enough, I ran into rate limit issues for the `GET manifest` endpoint if I ran the Amazon ECR test around 5 times in a row, which doesn't happen with the GHCR test. I couldn't find any rate limit documentation for Amazon ECR's support of the Docker Registry API, and the responses don't have a rate limit header. Docker's is 100 per 6 hours for anonymous calls, but I don't think this is Amazon ECR's rate limit because I haven't had to wait 6 hours to re-run the tests. The rate limit issue was sporadic. The test would some times fail but then pass when I tried it again immediately. 

Got around the rate limit issue by implementing retries for the `GET manifest` call with exponentially back-off. In my testing, it only needed one retry to pass if there was a rate limit error.





