### PR TITLE
Revert "Feature/postgres update (#4303)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
         environment:
           JAVA_TOOL_OPTIONS: -Xmx512m # Nothing to do with surefire plugin, it has its own JVM. The two of these plus ES (1.3 GB) must add up to a bit less than 6GB.
           PGHOST: 127.0.0.1
-      - image: circleci/postgres:13.3
+      - image: circleci/postgres:11.8
         command: postgres -c max_connections=200
         environment:
           POSTGRES_USER: postgres

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -315,7 +315,7 @@ Lists of 358 third-party dependencies.
      (EPL 2.0) (GPL2 w/ CPE) OSGi resource locator (org.glassfish.hk2:osgi-resource-locator:1.0.3 - https://projects.eclipse.org/projects/ee4j/osgi-resource-locator)
      (MIT) parser (org.typelevel:jawn-parser_2.12:1.0.0 - http://github.com/typelevel/jawn)
      (The Apache Software License, Version 2.0) PF4J (org.pf4j:pf4j:3.2.0 - http://nexus.sonatype.org/oss-repository-hosting.html/pf4j-parent/pf4j)
-     (BSD-2-Clause) PostgreSQL JDBC Driver (org.postgresql:postgresql:42.2.21 - https://jdbc.postgresql.org)
+     (BSD-2-Clause) PostgreSQL JDBC Driver (org.postgresql:postgresql:42.2.19 - https://jdbc.postgresql.org)
      (The Apache Software License, Version 2.0) PowerMock (org.powermock:powermock-api-easymock:2.0.4 - http://www.powermock.org)
      (MIT) pprint_2.12 (com.lihaoyi:pprint_2.12:0.6.0 - https://github.com/lihaoyi/PPrint)
      (The Apache Software License, Version 2.0) rank-eval (org.elasticsearch.plugin:rank-eval-client:7.10.2 - https://github.com/elastic/elasticsearch)

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -56,7 +56,7 @@ POM as their parent.
         <logback.version>1.2.3</logback.version>
         <aws.version>2.16.103</aws.version>
         <powermock.version>2.0.4</powermock.version>
-        <postgresql.version>42.2.21</postgresql.version>
+        <postgresql.version>42.2.19</postgresql.version>
         <mockito.version>2.28.2</mockito.version>
         <cwlavro.version>2.0.4.6</cwlavro.version>
         <okhttp.version>4.7.0</okhttp.version>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     # networks:
       # - elastic
   postgres_db:
-    image: postgres:13.3
+    image: postgres:11.8
     container_name: postgres1
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust

--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.21</version>
+      <version>42.2.19</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -55,7 +55,6 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
-import org.glassfish.jersey.client.ClientProperties;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
@@ -179,7 +178,7 @@ public class ServiceIT extends BaseIT {
      * @param path         Path of endpoint
      */
     private void testXTotalCount(Client jerseyClient, String path) {
-        Response response = jerseyClient.target(path).request().property(ClientProperties.READ_TIMEOUT, 0).get();
+        Response response = jerseyClient.target(path).request().get();
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         MultivaluedMap<String, Object> headers = response.getHeaders();
         Object xTotalCount = headers.getFirst("X-total-count");

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -448,7 +448,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.21</version>
+      <version>42.2.19</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <swagger-annotations-version>1.6.0</swagger-annotations-version>
         <openapi-annotations-version>2.1.7</openapi-annotations-version>
         <!-- Used for liquibase maven plugin. Somehow use version from bom-internal instead -->
-        <postgresql.version>42.2.21</postgresql.version>
+        <postgresql.version>42.2.19</postgresql.version>
         <swagger-ui.version>3.25.0</swagger-ui.version>
         <maven-surefire.version>3.0.0-M5</maven-surefire.version>
         <maven-failsafe.version>2.21.0</maven-failsafe.version>


### PR DESCRIPTION
This reverts commit 2431a42b292dc6551ece186cffb8818e6f1dc163.

So far we have for performance on WebhookIT which seems to reflect the general slowdown
11.8: 177 seconds
11.10:  348 seconds - this would match AWS RDS
11.12: 374 seconds
12.0: 885 seconds
12.7: 846 seconds
13.3: 817 seconds

We might be dealing with one issue between postgres 11.8 and postgres 11.10 and another when going to 12
It might also only affect testing on CircleCI as opposed to in RDS, but that seems unclear. 

For now, reverting so that we can speed up PRs