### PR TITLE
Return 4xx codes for User and Token endpoints

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/HttpStatusMessageConstants.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/HttpStatusMessageConstants.java
@@ -1,0 +1,20 @@
+package io.dockstore.common;
+
+/**
+ * Constants for Http Status code descriptions.
+ */
+public final class HttpStatusMessageConstants {
+    public static final String OK = "OK";
+    public static final String NO_CONTENT = "No content";
+    public static final String BAD_REQUEST = "Bad request";
+    public static final String UNAUTHORIZED = "Unauthorized";
+    public static final String FORBIDDEN = "Forbidden";
+    public static final String NOT_FOUND = "Not found";
+    public static final String CONFLICT = "Conflict";
+    public static final String EXPECTATION_FAILED = "Expectation failed";
+    public static final String INTERNAL_SERVER_ERROR = "Internal server error";
+
+    private HttpStatusMessageConstants() {
+        // hide the default constructor for a constant class
+    }
+}

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
@@ -190,7 +190,7 @@ public class TokenResourceIT {
                 tokensApi.listToken(currToken.getId());
                 fail("Should not be able to list a deleted token");
             } catch (ApiException e) {
-                boolean firstExceptionCheck = e.getMessage().contains("There was an error processing your request");
+                boolean firstExceptionCheck = "Token not found.".equals(e.getMessage());
                 boolean secondExceptionCheck = "Credentials are required to access this resource.".equals(e.getMessage());
                 Assert.assertTrue(firstExceptionCheck || secondExceptionCheck);
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Organization;
+import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.User;
 import java.util.List;
 import java.util.Optional;
@@ -231,6 +232,17 @@ public interface AuthenticatedResourceInterface {
             } else {
                 checkUser(user.get(), entry);
             }
+        }
+    }
+
+    /**
+     * Check if token is null
+     *
+     * @param token token to check if null
+     */
+    default void checkTokenExists(Token token) {
+        if (token == null) {
+            throw new CustomWebApplicationException("Token not found.", HttpStatus.SC_NOT_FOUND);
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
@@ -112,6 +112,17 @@ public interface AuthenticatedResourceInterface {
     }
 
     /**
+     * Check if user is null
+     *
+     * @param user user to check if null
+     */
+    default void checkUserExists(User user) {
+        if (user == null) {
+            throw new CustomWebApplicationException("User not found.", HttpStatus.SC_NOT_FOUND);
+        }
+    }
+
+    /**
      * Check if entry belongs to user
      *
      * @param user the user that is requesting something

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -127,6 +127,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     private static final PrivacyPolicyVersion CURRENT_PRIVACY_POLICY_VERSION = PrivacyPolicyVersion.PRIVACY_POLICY_VERSION_2_5;
     private static final Logger LOG = LoggerFactory.getLogger(TokenResource.class);
     private static final String TOKEN_NOT_FOUND_DESCRIPTION = "Token not found";
+    private static final String USER_NOT_FOUND_MESSAGE = "User not found";
 
     private final TokenDAO tokenDAO;
     private final UserDAO userDAO;
@@ -215,12 +216,12 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @UnitOfWork
     @Path("/quay.io")
     @JsonView(TokenViews.User.class)
-    @Operation(operationId = "addQuayToken", description = "Add a new quay IO token.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
-    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully added a new quay IO token", content = @Content(schema = @Schema(implementation = Token.class)))
+    @Operation(operationId = "addQuayToken", description = "Add a new Quay.io token.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully added a new Quay.io token", content = @Content(schema = @Schema(implementation = Token.class)))
     @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = HttpStatusMessageConstants.BAD_REQUEST)
     @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = HttpStatusMessageConstants.NOT_FOUND)
     @ApiResponse(responseCode = HttpStatus.SC_CONFLICT + "", description = HttpStatusMessageConstants.CONFLICT)
-    @ApiOperation(value = "Add a new quay IO token.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "This is used as part of the OAuth 2 web flow. Once a user has approved permissions for CollaboratoryTheir browser will load the redirect URI which should resolve here", response = Token.class)
+    @ApiOperation(value = "Add a new Quay.io token.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "This is used as part of the OAuth 2 web flow. Once a user has approved permissions for CollaboratoryTheir browser will load the redirect URI which should resolve here", response = Token.class)
     public Token addQuayToken(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user, @QueryParam("access_token") String accessToken) {
         if (accessToken.isEmpty()) {
             throw new CustomWebApplicationException("Please provide an access token.", HttpStatus.SC_BAD_REQUEST);
@@ -248,7 +249,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
             return tokenDAO.findById(create);
         } else {
             LOG.info("Could not find user");
-            throw new CustomWebApplicationException("User not found", HttpStatus.SC_NOT_FOUND);
+            throw new CustomWebApplicationException(USER_NOT_FOUND_MESSAGE, HttpStatus.SC_NOT_FOUND);
         }
     }
 
@@ -365,7 +366,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
             return tokenDAO.findById(create);
         } else {
             LOG.info("Could not find user");
-            throw new CustomWebApplicationException("User not found", HttpStatus.SC_NOT_FOUND);
+            throw new CustomWebApplicationException(USER_NOT_FOUND_MESSAGE, HttpStatus.SC_NOT_FOUND);
         }
 
     }
@@ -733,7 +734,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
             return tokenDAO.findById(create);
         } else {
             LOG.info("Could not find user");
-            throw new CustomWebApplicationException("User not found", HttpStatus.SC_NOT_FOUND);
+            throw new CustomWebApplicationException(USER_NOT_FOUND_MESSAGE, HttpStatus.SC_NOT_FOUND);
         }
     }
 
@@ -814,7 +815,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
             return tokenDAO.findById(create);
         } else {
             LOG.info("Could not find user");
-            throw new CustomWebApplicationException("User not found", HttpStatus.SC_NOT_FOUND);
+            throw new CustomWebApplicationException(USER_NOT_FOUND_MESSAGE, HttpStatus.SC_NOT_FOUND);
         }
     }
 
@@ -874,7 +875,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
             return tokenDAO.findById(create);
         } else {
             LOG.info("Could not find user");
-            throw new CustomWebApplicationException("User not found", HttpStatus.SC_NOT_FOUND);
+            throw new CustomWebApplicationException(USER_NOT_FOUND_MESSAGE, HttpStatus.SC_NOT_FOUND);
         }
     }
 
@@ -892,6 +893,6 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
             LOG.info("Username: {}", username);
             return username;
         }
-        throw new CustomWebApplicationException("User not found", HttpStatus.SC_NOT_FOUND);
+        throw new CustomWebApplicationException(USER_NOT_FOUND_MESSAGE, HttpStatus.SC_NOT_FOUND);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -26,6 +26,7 @@ import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_OFF
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.google.common.collect.Lists;
+import io.dockstore.common.HttpStatusMessageConstants;
 import io.dockstore.common.Registry;
 import io.dockstore.common.Repository;
 import io.dockstore.common.SourceControl;
@@ -139,6 +140,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     private static final Pattern USERNAME_CONTAINS_KEYWORD_PATTERN = Pattern.compile("(?i)(dockstore|admin|curator|system|manager)");
     private static final Pattern VALID_USERNAME_PATTERN = Pattern.compile("^[a-zA-Z]+[.a-zA-Z0-9-_]*$");
     private static final String CLOUD_INSTANCE_ID_DESCRIPTION = "ID of cloud instance to update/delete";
+    private static final String USER_NOT_FOUND_DESCRIPTION = "User not found";
     private final UserDAO userDAO;
     private final TokenDAO tokenDAO;
 
@@ -185,9 +187,9 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Path("/username/{username}")
     @Operation(operationId = "listUser", description = "Get a user by username.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A user with the specified username", content = @Content(schema = @Schema(implementation = User.class)))
-    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad request")
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = HttpStatusMessageConstants.BAD_REQUEST)
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     @ApiOperation(value = "Get a user by username.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
     public User listUser(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
             @ApiParam("Username of user to return") @PathParam("username") @NotBlank String username) {
@@ -204,8 +206,8 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Path("/{userId}")
     @Operation(operationId = "getSpecificUser", description = "Get user by id.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A user with the specified userId", content = @Content(schema = @Schema(implementation = User.class)))
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     @ApiOperation(nickname = "getSpecificUser", value = "Get user by id.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
     public User getUser(@ApiParam(hidden = true) @Parameter(hidden = true) @Auth User authUser, @ApiParam("User to return") @PathParam("userId") long userId) {
         checkUser(authUser, userId);
@@ -264,8 +266,8 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Path("/user/changeUsername")
     @Operation(operationId = "changeUsername", description = "Change username if possible.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully changed username", content = @Content(schema = @Schema(implementation = User.class)))
-    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad request")
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
+    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = HttpStatusMessageConstants.BAD_REQUEST)
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
     @ApiOperation(value = "Change username if possible.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
     public User changeUsername(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser, @ApiParam("Username to change to") @QueryParam("username") String username) {
         checkUser(authUser, authUser.getId());
@@ -317,8 +319,9 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Path("/user")
     @Operation(operationId = "selfDestruct", description = "Delete user if possible.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Boolean indicating if user was deleted successfully", content = @Content(schema = @Schema(implementation = Boolean.class)))
-    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad request")
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
+    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = HttpStatusMessageConstants.BAD_REQUEST)
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_INTERNAL_SERVER_ERROR + "", description = HttpStatusMessageConstants.INTERNAL_SERVER_ERROR)
     @ApiOperation(value = "Delete user if possible.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Boolean.class)
     public boolean selfDestruct(
             @ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth User authUser,
@@ -392,8 +395,8 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @RolesAllowed("admin")
     @Operation(operationId = "terminateUsers", description = "Terminate user if possible.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully deleted user", content = @Content(schema = @Schema(implementation = Boolean.class)))
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     @ApiOperation(value = "Terminate user if possible.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Boolean.class, nickname = "terminateUser")
     public boolean terminateUser(
         @ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,  @ApiParam("User to terminate") @PathParam("userId") long targetUserId) {
@@ -417,9 +420,9 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Operation(operationId = "checkUserExists", description = "Check if user with some username exists.", security = @SecurityRequirement(name = "bearer"))
     @ApiResponse(responseCode = HttpStatus.SC_OK
             + "", description = "Boolean indicating if a user with the specified username exists", content = @Content(schema = @Schema(implementation = Boolean.class)))
-    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad request")
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = HttpStatusMessageConstants.BAD_REQUEST)
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     public boolean checkUserExists(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,
                                    @ApiParam("User name to check") @PathParam("username") @NotBlank String username) {
         @SuppressWarnings("deprecation")
@@ -438,8 +441,8 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Operation(operationId = "getUserTokens", description = "Get information about tokens with user id.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK
             + "", description = "A list of tokens belonging to user specified by userId", content = @Content(array = @ArraySchema(schema = @Schema(implementation = Token.class))))
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     @ApiOperation(value = "Get information about tokens with user id.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Token.class, responseContainer = "List")
     public List<Token> getUserTokens(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,
             @ApiParam("User to return") @PathParam("userId") long userId) {
@@ -456,8 +459,8 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Path("/{userId}/containers/published")
     @Operation(operationId = "userPublishedContainers", description = "List all published tools from a user.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A list of published tools from a user", content = @Content(array = @ArraySchema(schema = @Schema(implementation = Tool.class))))
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     @ApiOperation(value = "List all published tools from a user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class, responseContainer = "List")
     public List<Tool> userPublishedContainers(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,
             @ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId) {
@@ -480,8 +483,8 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Operation(operationId = "userPublishedWorkflows", description = "List all published workflows from a user.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK
             + "", description = "A list of published workflows from a user", content = @Content(array = @ArraySchema(schema = @Schema(implementation = Workflow.class))))
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     @ApiOperation(value = "List all published workflows from a user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, responseContainer = "List")
     public List<Workflow> userPublishedWorkflows(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,
             @ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId) {
@@ -511,9 +514,9 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Operation(operationId = "refreshToolsByOrganization", description = "Refresh all tools owned by the authenticated user with specified organization.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK
             + "", description = "A list of tools owned by the user with the specified organization", content = @Content(array = @ArraySchema(schema = @Schema(implementation = Tool.class))))
-    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad request")
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = HttpStatusMessageConstants.BAD_REQUEST)
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     @ApiOperation(value = "Refresh all tools owned by the authenticated user with specified organization.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class, responseContainer = "List")
     public List<Tool> refreshToolsByOrganization(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
             @ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId,
@@ -579,8 +582,8 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Operation(operationId = "userWorkflows", description = "List all workflows owned by the authenticated user.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME), method = "GET")
     @ApiResponse(responseCode = HttpStatus.SC_OK
             + "", description = "A list of workflows owned by the user", content = @Content(array = @ArraySchema(schema = @Schema(implementation = Workflow.class))))
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     @ApiOperation(value = "List all workflows owned by the authenticated user.", nickname = "userWorkflows", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, responseContainer = "List")
     public List<Workflow> userWorkflows(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,
             @Parameter(name = "userId", description = "User ID", required = true, in = ParameterIn.PATH) @ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId) {
@@ -619,8 +622,8 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Operation(operationId = "userServices", description = "List all services owned by the authenticated user.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK
             + "", description = "A list of services owned by the user", content = @Content(array = @ArraySchema(schema = @Schema(implementation = Workflow.class))))
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     @ApiOperation(value = "List all services owned by the authenticated user.", nickname = "userServices", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, responseContainer = "List")
     public List<Workflow> userServices(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,
             @ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId) {
@@ -657,8 +660,8 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @UnitOfWork(readOnly = true)
     @Operation(operationId = "userContainers", description = "List all tools owned by the authenticated user.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A list of tools owned by the user", content = @Content(array = @ArraySchema(schema = @Schema(implementation = Tool.class))))
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     @ApiOperation(value = "List all tools owned by the authenticated user.", nickname = "userContainers", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class, responseContainer = "List")
     public List<Tool> userContainers(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,
             @ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId) {
@@ -801,7 +804,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Operation(operationId = "updateUserMetadata", description = "Update metadata of all users.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK
             + "", description = "Successfully updated metadata of all users", content = @Content(array = @ArraySchema(schema = @Schema(implementation = User.class))))
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
     @ApiOperation(value = "Update metadata of all users.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Admin only.", response = User.class, responseContainer = "List")
     public List<User> updateUserMetadata(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user) {
         List<User> users = userDAO.findAll();
@@ -824,7 +827,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Path("/user/updateUserMetadata")
     @Operation(operationId = "updateLoggedInUserMetadata", description = "Update metadata for logged in user.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully updated metadata for logged in user", content = @Content(schema = @Schema(implementation = User.class)))
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
     @ApiOperation(value = "Update metadata for logged in user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
     public User updateLoggedInUserMetadata(@ApiParam(hidden = true)@Parameter(hidden = true, name = "user")@Auth User user, @ApiParam(value = "Token source", allowableValues = "google.com, github.com") @QueryParam("source") TokenType source) {
         User dbuser = userDAO.findById(user.getId());
@@ -855,8 +858,8 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Path("/user/{userId}/limits")
     @Operation(operationId = "getUserLimits", description = "Returns the specified user's limits. ADMIN or CURATOR only", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A user's limits", content = @Content(schema = @Schema(implementation = Limits.class)))
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     @ApiOperation(value = "Returns the specified user's limits. ADMIN or CURATOR only", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Limits.class)
     public Limits getUserLimits(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
             @ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId) {
@@ -875,8 +878,8 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Path("/user/{userId}/limits")
     @Operation(operationId = "setUserLimits", description = "Update the specified user's limits. ADMIN or CURATOR only", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully updated the user's limits", content = @Content(schema = @Schema(implementation = Limits.class)))
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     @ApiOperation(value = "Update the specified user's limits. ADMIN or CURATOR only", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Limits.class)
     public Limits setUserLimits(@ApiParam(hidden = true)  @Parameter(hidden = true, name = "user", in = ParameterIn.HEADER)@Auth User authUser,
             @ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId,
@@ -897,7 +900,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Operation(operationId = "syncUserWithGitHub", description = "Syncs Dockstore account with GitHub App Installations.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK
             + "", description = "Successfully synced Dockstore account with GitHub App installations", content = @Content(array = @ArraySchema(schema = @Schema(implementation = Workflow.class))))
-    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad request")
+    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = HttpStatusMessageConstants.BAD_REQUEST)
     @ApiOperation(value = "Syncs Dockstore account with GitHub App Installations.", authorizations = {
             @Authorization(value = JWT_SECURITY_DEFINITION_NAME) },
             response = Workflow.class, responseContainer = "List")
@@ -915,7 +918,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Operation(operationId = "getMyGitHubOrgs", description = "Gets GitHub organizations for current user.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponses(value = {
             @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Descriptions of Github organizations (including but not limited to id, names)", content = @Content(array = @ArraySchema(schema = @Schema(implementation = SourceControlOrganization.class)))),
-            @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad request")
+            @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = HttpStatusMessageConstants.BAD_REQUEST)
     })
     public List<SourceControlOrganization> getMyGitHubOrgs(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser) {
         final User user = userDAO.findById(authUser.getId());
@@ -936,8 +939,8 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Operation(operationId = "addUserToDockstoreWorkflows", description = "Adds the logged-in user to any Dockstore workflows that they should have access to.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK
             + "", description = "Successfully added user to Dockstore workflows that they should have access to", content = @Content(array = @ArraySchema(schema = @Schema(implementation = Workflow.class))))
-    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad request")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = HttpStatusMessageConstants.BAD_REQUEST)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     public List<Workflow> addUserToDockstoreWorkflows(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
             @ApiParam(name = "userId", required = true, value = "User to update") @PathParam("userId") @Parameter(name = "userId", in = ParameterIn.PATH, description = "User to update", required = true) long userId,
             @ApiParam(name = "emptyBody", value = APPEASE_SWAGGER_PATCH) @Parameter(description = APPEASE_SWAGGER_PATCH, name = "emptyBody") String emptyBody) {
@@ -976,8 +979,8 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Consumes("application/json")
     @Operation(operationId = "setUserPrivileges", description = "Updates the provided userID to admin or curator status, ADMIN or CURATOR only", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully updated user to admin or curator status", content = @Content(schema = @Schema(implementation = User.class)))
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     @ApiOperation(value = "Updates the provided userID to admin or curator status, ADMIN or CURATOR only", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class, hidden = true)
     public User setUserPrivilege(@Parameter(hidden = true, name = "user")@Auth User authUser,
                                  @Parameter(name = "User ID", required = true) @PathParam("userId") Long userID,
@@ -1042,7 +1045,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Path("/registries/{gitRegistry}/organizations")
     @Operation(operationId = "getUserOrganizations", description = "Get all of the organizations for a given git registry accessible to the logged in user.", security = @SecurityRequirement(name = "bearer"))
     @ApiResponse(responseCode = HttpStatus.SC_OK
-            + "", description = "A list of organizations for a given git registry accessible to the logged in user", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class))))
+            + "", description = "A list of organizations for a given git registry accessible to the logged in user", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class), uniqueItems = true)))
     @ApiOperation(value = "See OpenApi for details")
     public Set<String> getUserOrganizations(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
                                             @Parameter(name = "gitRegistry", description = "Git registry", required = true, in = ParameterIn.PATH) @PathParam("gitRegistry") SourceControl gitRegistry) {
@@ -1076,9 +1079,9 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(value = "See OpenApi for details", hidden = true)
     @Operation(operationId = "getUserCloudInstances", description = "Get all cloud instances belonging to the user", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK
-            + "", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = CloudInstance.class))))
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+            + "", description = HttpStatusMessageConstants.OK, content = @Content(array = @ArraySchema(schema = @Schema(implementation = CloudInstance.class))))
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     public Set<CloudInstance> getUserCloudInstances(@Parameter(hidden = true, name = "user")@Auth User authUser,
         @ApiParam(name = "userId", required = true, value = "User to update") @PathParam("userId") @Parameter(name = "userId", in = ParameterIn.PATH, description = "ID of user to get cloud instances for", required = true) long userId) {
         final User user = userDAO.findById(userId);
@@ -1095,10 +1098,10 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Path("/{userId}/cloudInstances")
     @Operation(operationId = "postUserCloudInstance", description = "Create a new cloud instance belonging to the user", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiResponse(responseCode = HttpStatus.SC_NO_CONTENT + "", description = "No Content")
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_UNAUTHORIZED + "", description = "Unauthorized")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
+    @ApiResponse(responseCode = HttpStatus.SC_NO_CONTENT + "", description = HttpStatusMessageConstants.NO_CONTENT)
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_UNAUTHORIZED + "", description = HttpStatusMessageConstants.UNAUTHORIZED)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     @ApiOperation(value = "See OpenApi for details", hidden = true)
     public Set<CloudInstance> postUserCloudInstance(@Parameter(hidden = true, name = "user")@Auth User authUser,
             @PathParam("userId") @Parameter(name = "userId", in = ParameterIn.PATH, description = "ID of user to create the cloud instance for", required = true) long userId,
@@ -1125,10 +1128,10 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @UnitOfWork()
     @Path("/{userId}/cloudInstances/{cloudInstanceId}")
     @Operation(operationId = "deleteUserCloudInstance", description = "Delete a cloud instance belonging to the user", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
-    @ApiResponse(responseCode = HttpStatus.SC_NO_CONTENT + "", description = "No Content")
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_UNAUTHORIZED + "", description = "Unauthorized")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "Not Found")
+    @ApiResponse(responseCode = HttpStatus.SC_NO_CONTENT + "", description = HttpStatusMessageConstants.NO_CONTENT)
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_UNAUTHORIZED + "", description = HttpStatusMessageConstants.UNAUTHORIZED)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = HttpStatusMessageConstants.NOT_FOUND)
     @ApiOperation(value = "See OpenApi for details", hidden = true)
     public void deleteUserCloudInstance(@Parameter(hidden = true, name = "user")@Auth User authUser,
             @PathParam("userId") @Parameter(name = "userId", in = ParameterIn.PATH, description = "ID of user to delete the cloud instance for", required = true) long userId,
@@ -1149,10 +1152,10 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Operation(operationId = "putUserCloudInstance", description = "Update a cloud instance belonging to the user", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @Consumes(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "See OpenApi for details", hidden = true)
-    @ApiResponse(responseCode = HttpStatus.SC_NO_CONTENT + "", description = "No Content")
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "Forbidden")
-    @ApiResponse(responseCode = HttpStatus.SC_UNAUTHORIZED + "", description = "Unauthorized")
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "Not Found")
+    @ApiResponse(responseCode = HttpStatus.SC_NO_CONTENT + "", description = HttpStatusMessageConstants.NO_CONTENT)
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    @ApiResponse(responseCode = HttpStatus.SC_UNAUTHORIZED + "", description = HttpStatusMessageConstants.UNAUTHORIZED)
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = HttpStatusMessageConstants.NOT_FOUND)
     public void putUserCloudInstance(@Parameter(hidden = true, name = "user")@Auth User authUser,
             @PathParam("userId") @Parameter(name = "userId", in = ParameterIn.PATH, description = "ID of user to update the cloud instance for", required = true) long userId,
             @PathParam("cloudInstanceId") @Parameter(name = "cloudInstanceId", in = ParameterIn.PATH, description = CLOUD_INSTANCE_ID_DESCRIPTION, required = true) long cloudInstanceId,

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -702,6 +702,12 @@ paths:
           description: Bad request
         "401":
           description: Unauthorized
+        "403":
+          description: Forbidden
+        "409":
+          description: Conflict
+        "417":
+          description: Expectation failed
       security:
       - bearer: []
       tags:
@@ -752,8 +758,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Token_User'
           description: Successfully added a new quay IO token
+        "400":
+          description: Bad request
         "404":
-          description: Token not found
+          description: Not found
+        "409":
+          description: Conflict
       security:
       - bearer: []
       tags:
@@ -798,6 +808,8 @@ paths:
       responses:
         "204":
           description: Successfully deleted token
+        "403":
+          description: Forbidden
         "404":
           description: Token not found
       security:
@@ -4391,6 +4403,7 @@ paths:
                 type: array
                 items:
                   type: string
+                uniqueItems: true
           description: A list of organizations for a given git registry accessible
             to the logged in user
       security:
@@ -4544,6 +4557,8 @@ paths:
           description: Bad request
         "403":
           description: Forbidden
+        "500":
+          description: Internal server error
       security:
       - bearer: []
       tags:
@@ -4907,7 +4922,7 @@ paths:
         required: true
       responses:
         "204":
-          description: No Content
+          description: No content
         "401":
           description: Unauthorized
         "403":
@@ -4939,13 +4954,13 @@ paths:
           format: int64
       responses:
         "204":
-          description: No Content
+          description: No content
         "401":
           description: Unauthorized
         "403":
           description: Forbidden
         "404":
-          description: Not Found
+          description: Not found
       security:
       - bearer: []
       tags:
@@ -4977,13 +4992,13 @@ paths:
         required: true
       responses:
         "204":
-          description: No Content
+          description: No content
         "401":
           description: Unauthorized
         "403":
           description: Forbidden
         "404":
-          description: Not Found
+          description: Not found
       security:
       - bearer: []
       tags:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -587,12 +587,18 @@ paths:
         schema:
           type: string
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Token_User'
-          description: default response
+          description: Successfully added a new bitbucket.org token
+        "400":
+          description: Bad request
+        "404":
+          description: Not found
+        "409":
+          description: Conflict
       security:
       - bearer: []
       tags:
@@ -608,12 +614,18 @@ paths:
             schema:
               type: string
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Token_Auth'
-          description: default response
+          description: Satellizer successfully posted a new GitHub token to Dockstore
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "409":
+          description: Conflict
       security:
       - bearer: []
       tags:
@@ -628,12 +640,18 @@ paths:
         schema:
           type: string
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Token_User'
-          description: default response
+          description: Successfully added a new github.com token
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "409":
+          description: Conflict
       security:
       - bearer: []
       tags:
@@ -648,12 +666,18 @@ paths:
         schema:
           type: string
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Token_User'
-          description: default response
+          description: Successfully added a new gitlab.com token
+        "400":
+          description: Bad request
+        "404":
+          description: Not found
+        "409":
+          description: Conflict
       security:
       - bearer: []
       tags:
@@ -668,12 +692,16 @@ paths:
             schema:
               type: string
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Token_Auth'
-          description: default response
+          description: Successfully posted a new Google token to Dockstore
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
       security:
       - bearer: []
       tags:
@@ -689,12 +717,20 @@ paths:
         schema:
           type: string
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Token_User'
-          description: default response
+          description: Successfully added orcid.org token
+        "400":
+          description: Bad request
+        "404":
+          description: Not found
+        "409":
+          description: Conflict
+        "500":
+          description: Internal server error
       security:
       - bearer: []
       summary: Add a new orcid.org token
@@ -710,12 +746,14 @@ paths:
         schema:
           type: string
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Token_User'
-          description: default response
+          description: Successfully added a new quay IO token
+        "404":
+          description: Token not found
       security:
       - bearer: []
       tags:
@@ -730,12 +768,18 @@ paths:
         schema:
           type: string
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Token_User'
-          description: default response
+          description: Successfully added a new zenodo.org token
+        "400":
+          description: Bad request
+        "404":
+          description: Not found
+        "409":
+          description: Conflict
       security:
       - bearer: []
       tags:
@@ -752,10 +796,10 @@ paths:
           type: integer
           format: int64
       responses:
-        default:
-          content:
-            application/json: {}
-          description: default response
+        "204":
+          description: Successfully deleted token
+        "404":
+          description: Token not found
       security:
       - bearer: []
       tags:
@@ -771,12 +815,14 @@ paths:
           type: integer
           format: int64
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Token_User'
-          description: default response
+          description: A token specified by id
+        "404":
+          description: Token not found
       security:
       - bearer: []
       tags:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -744,7 +744,7 @@ paths:
       - tokens
   /auth/tokens/quay.io:
     get:
-      description: Add a new quay IO token.
+      description: Add a new Quay.io token.
       operationId: addQuayToken
       parameters:
       - in: query
@@ -757,7 +757,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Token_User'
-          description: Successfully added a new quay IO token
+          description: Successfully added a new Quay.io token
         "400":
           description: Bad request
         "404":

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -4188,12 +4188,18 @@ paths:
         schema:
           type: string
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: boolean
-          description: default response
+          description: Boolean indicating if a user with the specified username exists
+        "400":
+          description: Bad request
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -4287,14 +4293,14 @@ paths:
           format: int32
           default: 100
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/LambdaEvent'
-          description: default response
+          description: A list of GitHub Events for the logged in user
       security:
       - bearer: []
       tags:
@@ -4324,14 +4330,16 @@ paths:
       description: Syncs Dockstore account with GitHub App Installations.
       operationId: syncUserWithGitHub
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Workflow'
-          description: default response
+          description: Successfully synced Dockstore account with GitHub App installations
+        "400":
+          description: Bad request
       security:
       - bearer: []
       tags:
@@ -4341,7 +4349,7 @@ paths:
       description: Get all of the git registries accessible to the logged in user.
       operationId: getUserRegistries
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
@@ -4353,7 +4361,7 @@ paths:
                   - github.com
                   - bitbucket.org
                   - gitlab.com
-          description: default response
+          description: A list of the git registries accessible to the logged in user
       security:
       - bearer: []
       tags:
@@ -4376,15 +4384,15 @@ paths:
           - bitbucket.org
           - gitlab.com
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   type: string
-                uniqueItems: true
-          description: default response
+          description: A list of organizations for a given git registry accessible
+            to the logged in user
       security:
       - bearer: []
       tags:
@@ -4413,14 +4421,15 @@ paths:
         schema:
           type: string
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Repository'
-          description: default response
+          description: A list of repositories for an organization for a given git
+            registry accessible to the logged in user
       security:
       - bearer: []
       tags:
@@ -4430,15 +4439,14 @@ paths:
       description: Get the authenticated user's starred organizations.
       operationId: getStarredOrganizations
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Organization'
-                uniqueItems: true
-          description: default response
+          description: A list of the authenticated user's starred organizations
       security:
       - bearer: []
       tags:
@@ -4465,15 +4473,14 @@ paths:
       description: Get the authenticated user's starred tools.
       operationId: getStarredTools
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Entry'
-                uniqueItems: true
-          description: default response
+          description: A list of the authenticated user's starred tools
       security:
       - bearer: []
       tags:
@@ -4483,15 +4490,14 @@ paths:
       description: Get the authenticated user's starred workflows.
       operationId: getStarredWorkflows
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Entry'
-                uniqueItems: true
-          description: default response
+          description: A list of the authenticated user's starred workflows
       security:
       - bearer: []
       tags:
@@ -4501,14 +4507,16 @@ paths:
       description: Update metadata of all users.
       operationId: updateUserMetadata
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/User'
-          description: default response
+          description: Successfully updated metadata of all users
+        "403":
+          description: Forbidden
       security:
       - bearer: []
       tags:
@@ -4526,12 +4534,16 @@ paths:
           type: integer
           format: int64
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: boolean
-          description: default response
+          description: Boolean indicating if user was deleted successfully
+        "400":
+          description: Bad request
+        "403":
+          description: Forbidden
       security:
       - bearer: []
       tags:
@@ -4540,12 +4552,12 @@ paths:
       description: Get the logged-in user.
       operationId: getUser
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
-          description: default response
+          description: The logged-in user
       security:
       - bearer: []
       tags:
@@ -4560,12 +4572,16 @@ paths:
         schema:
           type: string
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
-          description: default response
+          description: Successfully changed username
+        "400":
+          description: Bad request
+        "403":
+          description: Forbidden
       security:
       - bearer: []
       tags:
@@ -4575,12 +4591,12 @@ paths:
       description: Get additional information about the authenticated user.
       operationId: getExtendedUserData
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ExtendedUserData'
-          description: default response
+          description: Additional information about the authenticated user
       security:
       - bearer: []
       tags:
@@ -4590,15 +4606,14 @@ paths:
       description: Get the logged-in user's memberships.
       operationId: getUserMemberships
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/OrganizationUser'
-                uniqueItems: true
-          description: default response
+          description: A set of the logged-in user's memberships
       security:
       - bearer: []
       tags:
@@ -4637,12 +4652,14 @@ paths:
           - google.com
           - orcid.org
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
-          description: default response
+          description: Successfully updated metadata for logged in user
+        "403":
+          description: Forbidden
       security:
       - bearer: []
       tags:
@@ -4659,12 +4676,16 @@ paths:
           type: integer
           format: int64
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: boolean
-          description: default response
+          description: Successfully deleted user
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -4681,12 +4702,16 @@ paths:
           type: integer
           format: int64
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Limits'
-          description: default response
+          description: A user's limits
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -4707,12 +4732,16 @@ paths:
             schema:
               $ref: '#/components/schemas/Limits'
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Limits'
-          description: default response
+          description: Successfully updated the user's limits
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -4728,12 +4757,18 @@ paths:
         schema:
           type: string
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
-          description: default response
+          description: A user with the specified username
+        "400":
+          description: Bad request
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -4755,14 +4790,14 @@ paths:
         schema:
           type: string
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/EntryUpdateTime'
-          description: default response
+          description: A list of the entries for a user
       security:
       - bearer: []
       tags:
@@ -4785,14 +4820,14 @@ paths:
         schema:
           type: string
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/OrganizationUpdateTime'
-          description: default response
+          description: A list of the Dockstore organizations for a user
       security:
       - bearer: []
       tags:
@@ -4809,12 +4844,16 @@ paths:
           type: integer
           format: int64
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
-          description: default response
+          description: A user with the specified userId
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -4840,6 +4879,10 @@ paths:
                 items:
                   $ref: '#/components/schemas/CloudInstance'
           description: OK
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -4869,6 +4912,8 @@ paths:
           description: Unauthorized
         "403":
           description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -4955,14 +5000,18 @@ paths:
           type: integer
           format: int64
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/DockstoreTool'
-          description: default response
+          description: A list of tools owned by the user
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -4979,14 +5028,18 @@ paths:
           type: integer
           format: int64
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/DockstoreTool'
-          description: default response
+          description: A list of published tools from a user
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -5013,14 +5066,20 @@ paths:
         schema:
           type: string
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/DockstoreTool'
-          description: default response
+          description: A list of tools owned by the user with the specified organization
+        "400":
+          description: Bad request
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -5044,12 +5103,16 @@ paths:
               $ref: '#/components/schemas/PrivilegeRequest'
         required: true
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
-          description: default response
+          description: Successfully updated user to admin or curator status
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -5066,14 +5129,18 @@ paths:
           type: integer
           format: int64
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Workflow'
-          description: default response
+          description: A list of services owned by the user
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -5090,14 +5157,18 @@ paths:
           type: integer
           format: int64
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Token_User'
-          description: default response
+          description: A list of tokens belonging to user specified by userId
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -5115,14 +5186,18 @@ paths:
           type: integer
           format: int64
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Workflow'
-          description: default response
+          description: A list of workflows owned by the user
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -5147,14 +5222,19 @@ paths:
         description: "This is here to appease Swagger. It requires PATCH methods to\
           \ have a body, even if it is empty. Please leave it empty."
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Workflow'
-          description: default response
+          description: Successfully added user to Dockstore workflows that they should
+            have access to
+        "400":
+          description: Bad request
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:
@@ -5171,14 +5251,18 @@ paths:
           type: integer
           format: int64
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Workflow'
-          description: default response
+          description: A list of published workflows from a user
+        "403":
+          description: Forbidden
+        "404":
+          description: User not found
       security:
       - bearer: []
       tags:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -1233,7 +1233,7 @@ paths:
     get:
       tags:
       - "tokens"
-      summary: "Add a new quay IO token."
+      summary: "Add a new Quay.io token."
       description: "This is used as part of the OAuth 2 web flow. Once a user has\
         \ approved permissions for CollaboratoryTheir browser will load the redirect\
         \ URI which should resolve here"


### PR DESCRIPTION
For #4192 

Added null checks where applicable, and added `@NotBlank` for the user endpoints that require `username` so the user can't enter a blank string in the swagger UI.

I was adding openapi `@ApiResponse` annotations for the endpoints I modified, which was a decent amount so I just decided to add annotations for all of them