### PR TITLE
take us up through expected auto RDS updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
         environment:
           JAVA_TOOL_OPTIONS: -Xmx512m # Nothing to do with surefire plugin, it has its own JVM. The two of these plus ES (1.3 GB) must add up to a bit less than 6GB.
           PGHOST: 127.0.0.1
-      - image: circleci/postgres:11.9
+      - image: circleci/postgres:11.12
         command: postgres -c max_connections=200
         environment:
           POSTGRES_USER: postgres
@@ -216,7 +216,7 @@ jobs:
       - image: cimg/openjdk:11.0.10
         environment:
           PGHOST: 127.0.0.1
-      - image: circleci/postgres:11.9
+      - image: circleci/postgres:11.12
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
         environment:
           JAVA_TOOL_OPTIONS: -Xmx512m # Nothing to do with surefire plugin, it has its own JVM. The two of these plus ES (1.3 GB) must add up to a bit less than 6GB.
           PGHOST: 127.0.0.1
-      - image: circleci/postgres:11.10
+      - image: circleci/postgres:11.9
         command: postgres -c max_connections=200
         environment:
           POSTGRES_USER: postgres
@@ -216,7 +216,7 @@ jobs:
       - image: cimg/openjdk:11.0.10
         environment:
           PGHOST: 127.0.0.1
-      - image: circleci/postgres:11.8
+      - image: circleci/postgres:11.9
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
         environment:
           JAVA_TOOL_OPTIONS: -Xmx512m # Nothing to do with surefire plugin, it has its own JVM. The two of these plus ES (1.3 GB) must add up to a bit less than 6GB.
           PGHOST: 127.0.0.1
-      - image: circleci/postgres:13.3
+      - image: circleci/postgres:11.12
         command: postgres -c max_connections=200
         environment:
           POSTGRES_USER: postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
         environment:
           JAVA_TOOL_OPTIONS: -Xmx512m # Nothing to do with surefire plugin, it has its own JVM. The two of these plus ES (1.3 GB) must add up to a bit less than 6GB.
           PGHOST: 127.0.0.1
-      - image: circleci/postgres:11.12
+      - image: circleci/postgres:11.10
         command: postgres -c max_connections=200
         environment:
           POSTGRES_USER: postgres

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -315,7 +315,7 @@ Lists of 358 third-party dependencies.
      (EPL 2.0) (GPL2 w/ CPE) OSGi resource locator (org.glassfish.hk2:osgi-resource-locator:1.0.3 - https://projects.eclipse.org/projects/ee4j/osgi-resource-locator)
      (MIT) parser (org.typelevel:jawn-parser_2.12:1.0.0 - http://github.com/typelevel/jawn)
      (The Apache Software License, Version 2.0) PF4J (org.pf4j:pf4j:3.2.0 - http://nexus.sonatype.org/oss-repository-hosting.html/pf4j-parent/pf4j)
-     (BSD-2-Clause) PostgreSQL JDBC Driver (org.postgresql:postgresql:42.2.19 - https://jdbc.postgresql.org)
+     (BSD-2-Clause) PostgreSQL JDBC Driver (org.postgresql:postgresql:42.2.23 - https://jdbc.postgresql.org)
      (The Apache Software License, Version 2.0) PowerMock (org.powermock:powermock-api-easymock:2.0.4 - http://www.powermock.org)
      (MIT) pprint_2.12 (com.lihaoyi:pprint_2.12:0.6.0 - https://github.com/lihaoyi/PPrint)
      (The Apache Software License, Version 2.0) rank-eval (org.elasticsearch.plugin:rank-eval-client:7.10.2 - https://github.com/elastic/elasticsearch)

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -315,7 +315,7 @@ Lists of 358 third-party dependencies.
      (EPL 2.0) (GPL2 w/ CPE) OSGi resource locator (org.glassfish.hk2:osgi-resource-locator:1.0.3 - https://projects.eclipse.org/projects/ee4j/osgi-resource-locator)
      (MIT) parser (org.typelevel:jawn-parser_2.12:1.0.0 - http://github.com/typelevel/jawn)
      (The Apache Software License, Version 2.0) PF4J (org.pf4j:pf4j:3.2.0 - http://nexus.sonatype.org/oss-repository-hosting.html/pf4j-parent/pf4j)
-     (BSD-2-Clause) PostgreSQL JDBC Driver (org.postgresql:postgresql:42.2.21 - https://jdbc.postgresql.org)
+     (BSD-2-Clause) PostgreSQL JDBC Driver (org.postgresql:postgresql:42.2.19 - https://jdbc.postgresql.org)
      (The Apache Software License, Version 2.0) PowerMock (org.powermock:powermock-api-easymock:2.0.4 - http://www.powermock.org)
      (MIT) pprint_2.12 (com.lihaoyi:pprint_2.12:0.6.0 - https://github.com/lihaoyi/PPrint)
      (The Apache Software License, Version 2.0) rank-eval (org.elasticsearch.plugin:rank-eval-client:7.10.2 - https://github.com/elastic/elasticsearch)

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -56,7 +56,7 @@ POM as their parent.
         <logback.version>1.2.3</logback.version>
         <aws.version>2.16.103</aws.version>
         <powermock.version>2.0.4</powermock.version>
-        <postgresql.version>42.2.19</postgresql.version>
+        <postgresql.version>42.2.23</postgresql.version>
         <mockito.version>2.28.2</mockito.version>
         <cwlavro.version>2.0.4.6</cwlavro.version>
         <okhttp.version>4.7.0</okhttp.version>

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -56,7 +56,7 @@ POM as their parent.
         <logback.version>1.2.3</logback.version>
         <aws.version>2.16.103</aws.version>
         <powermock.version>2.0.4</powermock.version>
-        <postgresql.version>42.2.21</postgresql.version>
+        <postgresql.version>42.2.19</postgresql.version>
         <mockito.version>2.28.2</mockito.version>
         <cwlavro.version>2.0.4.6</cwlavro.version>
         <okhttp.version>4.7.0</okhttp.version>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     # networks:
       # - elastic
   postgres_db:
-    image: postgres:11.9
+    image: postgres:11.12
     container_name: postgres1
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     # networks:
       # - elastic
   postgres_db:
-    image: postgres:11.12
+    image: postgres:11.10
     container_name: postgres1
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     # networks:
       # - elastic
   postgres_db:
-    image: postgres:11.10
+    image: postgres:11.9
     container_name: postgres1
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     # networks:
       # - elastic
   postgres_db:
-    image: postgres:13.3
+    image: postgres:11.12
     container_name: postgres1
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust

--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.21</version>
+      <version>42.2.19</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.19</version>
+      <version>42.2.23</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -448,7 +448,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.21</version>
+      <version>42.2.19</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -448,7 +448,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.19</version>
+      <version>42.2.23</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <swagger-annotations-version>1.6.0</swagger-annotations-version>
         <openapi-annotations-version>2.1.7</openapi-annotations-version>
         <!-- Used for liquibase maven plugin. Somehow use version from bom-internal instead -->
-        <postgresql.version>42.2.19</postgresql.version>
+        <postgresql.version>42.2.23</postgresql.version>
         <swagger-ui.version>3.25.0</swagger-ui.version>
         <maven-surefire.version>3.0.0-M5</maven-surefire.version>
         <maven-failsafe.version>2.21.0</maven-failsafe.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <swagger-annotations-version>1.6.0</swagger-annotations-version>
         <openapi-annotations-version>2.1.7</openapi-annotations-version>
         <!-- Used for liquibase maven plugin. Somehow use version from bom-internal instead -->
-        <postgresql.version>42.2.21</postgresql.version>
+        <postgresql.version>42.2.19</postgresql.version>
         <swagger-ui.version>3.25.0</swagger-ui.version>
         <maven-surefire.version>3.0.0-M5</maven-surefire.version>
         <maven-failsafe.version>2.21.0</maven-failsafe.version>


### PR DESCRIPTION
this is newer than what aws rds is running (11.10) , companion to https://github.com/dockstore/dockstore/pull/4388

this maintains performance as seen with 11.8 and with JDBC 42.2.19 but this is with JDBC 42.2.23 

Note that "Auto minor version upgrade" is on and will automatically take us to 11.12 at some point anyway

https://github.com/pgjdbc/pgjdbc/issues/2180 explains the pain we ran into with JDBC 42.2.21 but doesn't explain the full problem with postgres 12/13

background benchmarking at https://app.slack.com/archives/CEGMXHBHT/p1628280502020200
