### PR TITLE
Don't require openssl 1.1 for decrypt/encrypt

### DIFF
--- a/encrypt.sh
+++ b/encrypt.sh
@@ -12,7 +12,7 @@ set -o xtrace
 
 tar cvf secrets.tar dockstore-integration-testing/src/test/resources/dstesting_pcks8.pem dockstore-integration-testing/src/test/resources/config_file.txt dockstore-integration-testing/src/test/resources/config_file2.txt dockstore-webservice/src/main/resources/migrations.test.confidential2.xml dockstore-integration-testing/src/test/resources/secretDockstoreTest.yml dockstore-webservice/src/main/resources/migrations.test.confidential1.xml dockstore-webservice/src/main/resources/migrations.test.confidential1_1.5.0.xml dockstore-webservice/src/main/resources/migrations.test.confidential2_1.5.0.xml
 
-openssl aes-256-cbc -e -in secrets.tar -out circle_ci_test_data.zip.enc -k "$CIRCLE_CI_KEY_2" -iv "$CIRCLE_CI_IV_2"
+openssl aes-256-cbc -md sha256 -e -in secrets.tar -out circle_ci_test_data.zip.enc -k "$CIRCLE_CI_KEY_2" -iv "$CIRCLE_CI_IV_2"
 
 rm secrets.tar
 

--- a/scripts/decrypt.sh
+++ b/scripts/decrypt.sh
@@ -12,7 +12,7 @@ set -o xtrace
 : "$CIRCLE_CI_KEY_2"
 : "$CIRCLE_CI_IV_2"
 
-openssl aes-256-cbc -d -in circle_ci_test_data.zip.enc -k "$CIRCLE_CI_KEY_2" -iv "$CIRCLE_CI_IV_2" -out secrets.tar
+openssl aes-256-cbc -md sha256 -d -in circle_ci_test_data.zip.enc -k "$CIRCLE_CI_KEY_2" -iv "$CIRCLE_CI_IV_2" -out secrets.tar
 tar xvf secrets.tar
 sudo mkdir -p /usr/local/ci
 sudo cp dockstore-integration-testing/src/test/resources/dstesting_pcks8.pem /usr/local/ci/dstesting_pcks8.pem


### PR DESCRIPTION
With this, I can encrypt/descrypt with both openssl 1.1 and LibreSSL 2.6.5

Change discovered by @svonworl.