### PR TITLE
Feature/dock 1580/fix 500 invalid org

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -2056,4 +2056,23 @@ public class OrganizationIT extends BaseIT {
         assertEquals(io.dockstore.openapi.client.model.Organization.StatusEnum.APPROVED, organization.getStatus());
         assertEquals("testname", organization.getName());
     }
+
+    /**
+     * Test an admin user accessing a nonexistent organization.
+     */
+    @Test
+    public void testAdminViewNonexistentOrganization() {
+        // Setup admin
+        final ApiClient webClientAdminUser = getWebClient(ADMIN_USERNAME, testingPostgres);
+        final OrganizationsApi organizationsApiAdmin = new OrganizationsApi(webClientAdminUser);
+        final Long nonexistentID = 11111111111111111L; // very unlikely an org is assigned this ID
+
+        // Access non-existent organization - this should fail
+        try {
+            organizationsApiAdmin.getOrganizationById(nonexistentID);
+            fail("An admin accessing a nonexistent organization should throw an exception");
+        } catch (io.dockstore.openapi.client.ApiException ex) {
+            assertEquals(HttpStatus.SC_NOT_FOUND, ex.getCode());
+        }
+    }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -2062,12 +2062,13 @@ public class OrganizationIT extends BaseIT {
      */
     @Test
     public void testAdminViewNonexistentOrganization() {
+
         // Setup admin
-        final ApiClient webClientAdminUser = getWebClient(ADMIN_USERNAME, testingPostgres);
-        final OrganizationsApi organizationsApiAdmin = new OrganizationsApi(webClientAdminUser);
+        final io.dockstore.openapi.client.ApiClient webClientAdminUser = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        final io.dockstore.openapi.client.api.OrganizationsApi organizationsApiAdmin = new io.dockstore.openapi.client.api.OrganizationsApi(webClientAdminUser);
         final Long nonexistentID = 11111111111111111L; // very unlikely an org is assigned this ID
 
-        // Access non-existent organization - this should fail
+        // Access non-existent organization - this should fail with a 404
         try {
             organizationsApiAdmin.getOrganizationById(nonexistentID);
             fail("An admin accessing a nonexistent organization should throw an exception");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -198,7 +198,7 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
             // User is given, check if the collections organization is either approved or the user has access
             // Admins and curators should be able to see collections from unapproved organizations
             Organization organization = organizationDAO.findByName(organizationName);
-            if (organization == null || !OrganizationResource.doesOrganizationExistToUser(organization.getId(), user.get().getId(), organizationDAO)) {
+            if (organization == null || !OrganizationResource.doesOrganizationExistToUser(organization.getId(), user.get().getId(), organizationDAO, userDAO)) {
                 String msg = "Organization " + Utilities.cleanForLogging(organizationName) + " not found.";
                 LOG.info(msg);
                 throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
@@ -414,7 +414,7 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
             Organization organization = organizationDAO.findApprovedById(organizationId);
             throwExceptionForNullOrganization(organization);
         } else {
-            boolean doesOrgExist = OrganizationResource.doesOrganizationExistToUser(organizationId, user.get().getId(), organizationDAO);
+            boolean doesOrgExist = OrganizationResource.doesOrganizationExistToUser(organizationId, user.get().getId(), organizationDAO, userDAO);
             if (!doesOrgExist) {
                 String msg = "Organization not found.";
                 LOG.info(msg);
@@ -618,7 +618,7 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
             throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
         }
 
-        return OrganizationResource.doesOrganizationExistToUser(collection.getOrganization().getId(), userId, organizationDAO);
+        return OrganizationResource.doesOrganizationExistToUser(collection.getOrganization().getId(), userId, organizationDAO, userDAO);
     }
 
     /**

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/OrganizationResourceTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/OrganizationResourceTest.java
@@ -1,0 +1,151 @@
+package io.dockstore.webservice.resources;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import io.dockstore.webservice.core.Organization;
+import io.dockstore.webservice.core.OrganizationUser;
+import io.dockstore.webservice.core.User;
+import io.dockstore.webservice.jdbi.OrganizationDAO;
+import io.dockstore.webservice.jdbi.UserDAO;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class OrganizationResourceTest {
+
+    private User normalUser;
+    private User adminUser;
+    private User curatorUser;
+    private User memberUser;
+
+    private Organization approvedOrganization;
+    private Organization pendingOrganization;
+    private Organization rejectedOrganization;
+
+    private Map<Long, User> idToUser;
+    private Map<Long, Organization> idToOrganization;
+    
+    private UserDAO userDAO;
+    private OrganizationDAO organizationDAO;
+
+    private User mockUser(Long id, boolean isAdmin, boolean isCurator) {
+        User user = Mockito.mock(User.class);
+
+        when(user.getId()).thenReturn(id);
+        when(user.getIsAdmin()).thenReturn(isAdmin);
+        when(user.isCurator()).thenReturn(isCurator);
+
+        idToUser.put(user.getId(), user);
+
+        return (user);
+    }
+
+    private Organization mockOrganization(Long id, Organization.ApplicationState state, User member) {
+        Organization organization = Mockito.mock(Organization.class);
+
+        when(organization.getId()).thenReturn(id);
+        when(organization.getStatus()).thenReturn(state);
+
+        Set<OrganizationUser> organizationUsers = new HashSet<>();
+        organizationUsers.add(mockOrganizationUser(organization, member));
+        when(organization.getUsers()).thenReturn(organizationUsers);
+            
+        idToOrganization.put(organization.getId(), organization);
+
+        return (organization);
+    }
+
+    private OrganizationUser mockOrganizationUser(Organization organization, User user) {
+        OrganizationUser organizationUser = Mockito.mock(OrganizationUser.class);
+        OrganizationUser.OrganizationUserId id = new OrganizationUser.OrganizationUserId(user.getId(), organization.getId());
+        when(organizationUser.getId()).thenReturn(id);
+        when(organizationUser.getUser()).thenReturn(user);
+        when(organizationUser.isAccepted()).thenReturn(true);
+        when(organizationUser.getRole()).thenReturn(OrganizationUser.Role.MEMBER);
+
+        return (organizationUser);
+    }
+
+    private UserDAO mockUserDAO() {
+        UserDAO mockedUserDAO = Mockito.mock(UserDAO.class);
+        when(mockedUserDAO.findById(anyLong())).thenAnswer(invocation -> {
+            return (idToUser.get(invocation.getArgument(0)));
+        });
+        return (mockedUserDAO);
+    }
+
+    private OrganizationDAO mockOrganizationDAO() {
+        OrganizationDAO mockedOrganizationDAO = Mockito.mock(OrganizationDAO.class);
+        when(mockedOrganizationDAO.findById(anyLong())).thenAnswer(invocation -> {
+            return (idToOrganization.get(invocation.getArgument(0)));
+        });
+        return (mockedOrganizationDAO);
+    }
+
+    @Before
+    public void init() {
+        idToUser = new HashMap<>();
+
+        normalUser = mockUser(1L, false, false);
+        adminUser = mockUser(2L, true, false);
+        curatorUser = mockUser(3L, false, true);
+        memberUser = mockUser(4L, false, false);
+
+        idToOrganization = new HashMap<>();
+
+        approvedOrganization = mockOrganization(10L,
+            Organization.ApplicationState.APPROVED, memberUser);
+        pendingOrganization = mockOrganization(11L,
+            Organization.ApplicationState.PENDING, memberUser);
+        rejectedOrganization = mockOrganization(12L,
+            Organization.ApplicationState.REJECTED, memberUser);
+
+        userDAO = mockUserDAO();
+        organizationDAO = mockOrganizationDAO();
+    }
+
+    private void checkExists(Long organizationId, Long userId, boolean shouldExist) {
+        boolean exists = OrganizationResource.doesOrganizationExistToUser(
+            organizationId, userId, organizationDAO, userDAO);
+        Assert.assertEquals(shouldExist, exists);
+    }
+
+    @Test
+    public void doesOrganizationExistToUserTest() {
+        final Long bogusUserID = -1L;
+        final Long bogusOrganizationID = -1L;
+
+        // To avoid duplicating the logic we're testing, we explicitly
+        // specify each of the test conditions and expected results below.
+
+        checkExists(approvedOrganization.getId(), normalUser.getId(), true);
+        checkExists(approvedOrganization.getId(), adminUser.getId(), true);
+        checkExists(approvedOrganization.getId(), curatorUser.getId(), true);
+        checkExists(approvedOrganization.getId(), memberUser.getId(), true);
+        checkExists(approvedOrganization.getId(), bogusUserID, true);
+
+        checkExists(pendingOrganization.getId(), normalUser.getId(), false);
+        checkExists(pendingOrganization.getId(), adminUser.getId(), true);
+        checkExists(pendingOrganization.getId(), curatorUser.getId(), true);
+        checkExists(pendingOrganization.getId(), memberUser.getId(), true);
+        checkExists(pendingOrganization.getId(), bogusUserID, false);
+
+        checkExists(rejectedOrganization.getId(), normalUser.getId(), false);
+        checkExists(rejectedOrganization.getId(), adminUser.getId(), true);
+        checkExists(rejectedOrganization.getId(), curatorUser.getId(), true);
+        checkExists(rejectedOrganization.getId(), memberUser.getId(), true);
+        checkExists(rejectedOrganization.getId(), bogusUserID, false);
+
+        checkExists(bogusOrganizationID, normalUser.getId(), false);
+        checkExists(bogusOrganizationID, adminUser.getId(), false);
+        checkExists(bogusOrganizationID, curatorUser.getId(), false);
+        checkExists(bogusOrganizationID, memberUser.getId(), false);
+        checkExists(bogusOrganizationID, bogusUserID, false);
+    }
+}

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/OrganizationResourceTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/OrganizationResourceTest.java
@@ -91,13 +91,12 @@ public class OrganizationResourceTest {
     @Before
     public void init() {
         idToUser = new HashMap<>();
+        idToOrganization = new HashMap<>();
 
         normalUser = mockUser(1L, false, false);
         adminUser = mockUser(2L, true, false);
         curatorUser = mockUser(3L, false, true);
         memberUser = mockUser(4L, false, false);
-
-        idToOrganization = new HashMap<>();
 
         approvedOrganization = mockOrganization(10L,
             Organization.ApplicationState.APPROVED, memberUser);
@@ -116,6 +115,9 @@ public class OrganizationResourceTest {
         Assert.assertEquals(shouldExist, exists);
     }
 
+    /**
+     * Test that {@link OrganizationResource#doesOrganizationExistToUser} implements the correct organization visibility policy.
+     */
     @Test
     public void doesOrganizationExistToUserTest() {
         final Long bogusUserID = -1L;


### PR DESCRIPTION
Issue https://ucsc-cgl.atlassian.net/browse/DOCK-1580

This change fixes a 500 error when an admin user tries to retrieve a nonexistent organization by ID, returning the proper 404 instead.

There was a choice between a quick fix, which would have only addressed this particular failure case, and a more comprehensive fix to a deeper static method OrganizationResource.doesOrganizationExistToUser() that is used to determine organization-to-user visibility throughout OrganizationResource and CollectionResource.  I went for the latter deep fix, which may address a family of related bugs (some of which are already patched?), generally involving admins/curators not being able to perform various operations on pending or rejected orgs.

Included is an integration test of the specific failure case, and a new unit test class OrganizationResourceTest, which includes a single test of the organization-to-user visibility policy as implemented by the method OrganizationResource.doesOrganizationExistToUser().

The unit test is also an experiment: to see how deep into the object hierarchy I could mock.  Somewhat deep, but there are some simple architectural changes that would make it easy to go farther, like passing a DAOFactory into the *Resource constructors, which would allow the *Resource objects to be easily mocked.  That way, you could mock the entire data representation, it would be crazy.





