### PR TITLE
Allow private and public Amazon ECR tools to be registered

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/Registry.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/Registry.java
@@ -28,12 +28,13 @@ public enum Registry {
     QUAY_IO("quay.io", "Quay.io", "https://quay.io/repository/", false, false),
     DOCKER_HUB("registry.hub.docker.com", "Docker Hub", "https://hub.docker.com/", false, false),
     GITLAB("registry.gitlab.com", "GitLab", "https://gitlab.com/", false, false),
-    AMAZON_ECR("public.ecr.aws", "Amazon ECR", null, true, false),
+    AMAZON_ECR("public.ecr.aws", "Amazon ECR", null, false, true),
     SEVEN_BRIDGES(null, "Seven Bridges", null, true, true),
     GITHUB_CONTAINER_REGISTRY("ghcr.io", "GitHub Container Registry", "https://ghcr.io/", false, false);
 
     /**
-     * this name is what is actually used in commands like docker pull
+     * this name is what is actually used in commands like docker pull.
+     * this name contains the public docker path for registries that have both a public facing site and private custom docker paths (like Amazon ECR)
      */
     private final String dockerPath;
 
@@ -55,7 +56,7 @@ public enum Registry {
     private final boolean privateOnly;
 
     /**
-     * if set to true, then the registry has no public facing site and is only available through an authorized docker pull (the docker registry path is not set)
+     * if set to true, then the registry has custom docker paths that are only available through an authorized docker pull.
      * if set to false, then the registry has a public facing site which can be linked to
      */
     private final boolean customDockerPath;

--- a/dockstore-common/src/main/java/io/dockstore/common/Registry.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/Registry.java
@@ -28,13 +28,13 @@ public enum Registry {
     QUAY_IO("quay.io", "Quay.io", "https://quay.io/repository/", false, false),
     DOCKER_HUB("registry.hub.docker.com", "Docker Hub", "https://hub.docker.com/", false, false),
     GITLAB("registry.gitlab.com", "GitLab", "https://gitlab.com/", false, false),
-    AMAZON_ECR("public.ecr.aws", "Amazon ECR", null, false, true),
+    AMAZON_ECR("public.ecr.aws", "Amazon ECR", "https://gallery.ecr.aws/", false, true),
     SEVEN_BRIDGES(null, "Seven Bridges", null, true, true),
     GITHUB_CONTAINER_REGISTRY("ghcr.io", "GitHub Container Registry", "https://ghcr.io/", false, false);
 
     /**
-     * this name is what is actually used in commands like docker pull.
-     * this name contains the public docker path for registries that have both a public facing site and private custom docker paths (like Amazon ECR)
+     * This name is what is actually used in commands like docker pull.
+     * For registries that have both a public facing site and private custom docker paths (ex: Amazon ECR), this name contains the public docker path
      */
     private final String dockerPath;
 
@@ -56,8 +56,9 @@ public enum Registry {
     private final boolean privateOnly;
 
     /**
-     * if set to true, then the registry has custom docker paths that are only available through an authorized docker pull.
-     * if set to false, then the registry has a public facing site which can be linked to
+     * If set to true, then the registry has custom docker paths that are only available through an authorized docker pull.
+     * - Note: even if this is set to true, the registry may still have a public facing site and a public docker registry path (ex: Amazon ECR).
+     * If set to false, then the registry has a public facing site which can be linked to
      */
     private final boolean customDockerPath;
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -1494,6 +1494,21 @@ public class WorkflowIT extends BaseIT {
     }
 
     @Test
+    public void testAmazonECRHostedToolCreation() {
+        final io.dockstore.openapi.client.ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        io.dockstore.openapi.client.api.HostedApi hostedApi = new io.dockstore.openapi.client.api.HostedApi(webClient);
+        io.dockstore.openapi.client.api.ContainersApi containersApi = new io.dockstore.openapi.client.api.ContainersApi(webClient);
+
+        // Create a hosted Amazon ECR tool using a private repository
+        io.dockstore.openapi.client.model.DockstoreTool tool = hostedApi.createHostedTool("test.dkr.ecr.us-east-1.amazonaws.com", "foo", io.openapi.model.DescriptorType.CWL.toString(), "namespace", "bar");
+        assertNotNull(containersApi.getContainer(tool.getId(), ""));
+
+        // Create a hosted Amazon ECR tool using a public repository
+        tool = hostedApi.createHostedTool("public.ecr.aws", "foo", io.openapi.model.DescriptorType.CWL.toString(), "namespace", "bar");
+        assertNotNull(containersApi.getContainer(tool.getId(), ""));
+    }
+
+    @Test
     public void testDuplicateAmazonECRHostedToolCreation() {
         final io.dockstore.openapi.client.ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         io.dockstore.openapi.client.api.HostedApi hostedApi = new io.dockstore.openapi.client.api.HostedApi(webClient);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/Constants.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/Constants.java
@@ -29,6 +29,7 @@ public final class Constants {
     public static final String DOCKSTORE_YML_PATH = "/.dockstore.yml";
     public static final List<String> DOCKSTORE_YML_PATHS = List.of(DOCKSTORE_YML_PATH, "/.github/.dockstore.yml");
     public static final String SKIP_COMMIT_ID = "skip";
+    public static final String AMAZON_ECR_PRIVATE_REGISTRY_REGEX = "^[a-zA-Z0-9]+\\.dkr\\.ecr\\.[a-zA-Z0-9-]+\\.amazonaws\\.com";
 
     private Constants() {
         // not called

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -28,6 +28,7 @@ import io.dockstore.webservice.helpers.EntryStarredSerializer;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -566,21 +567,21 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     }
 
     /**
-     * Given a path (A/B/C/D), splits it into parts and returns it
+     * Given a path (A/B/C/D), splits it into parts and returns it.
+     * Need to indicate whether the path has an entry name in order to determine the repo name if there are more than 3 components in the path
      *
      * @param path
-     * @return An array of fields used to identify an entry
+     * @param hasEntryName boolean indicating whether the path has an entry name
+     * @return An array of fields used to identify components of an entry's path
      */
-    public static String[] splitPath(String path) {
-        // Used for accessing index of path
+    public static String[] splitPath(String path, boolean hasEntryName) {
+        // Registry and org indices are deterministic: always the first and second components of the path, respectively
         final int registryIndex = 0;
         final int orgIndex = 1;
-        final int repoIndex = 2;
-        final int entryNameIndex = 3;
+        final int repoIndexStart = 2; // Repo and entry name indices are not deterministic because repo name can have slashes
 
-        // Lengths of paths
-        final int pathNoNameLength = 3;
-        final int pathWithNameLength = 4;
+        // Path must at least have 3 components, i.e. <registry>/<org>/<repo>
+        final int minPathLength = 3;
 
         // Used for storing values at path locations
         String registry;
@@ -590,15 +591,29 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
 
         // Split path by slash
         String[] splitPath = path.split("/");
+        final int lastIndex = splitPath.length - 1;
 
         // Only split if it is the correct length
-        if (splitPath.length == pathNoNameLength || splitPath.length == pathWithNameLength) {
-            // Get remaining positions
+        if (splitPath.length >= minPathLength) {
             registry = splitPath[registryIndex];
             org = splitPath[orgIndex];
-            repo = splitPath[repoIndex];
-            if (splitPath.length == pathWithNameLength) {
-                entryName = splitPath[entryNameIndex];
+
+            if (splitPath.length == minPathLength) { // <registry>/<org>/<repo>
+                repo = splitPath[repoIndexStart];
+            } else {
+                String[] repoNameComponents;
+                if (hasEntryName) {
+                    // Assume that the last component is the entry name: <registry>/<org>/<repo>/<entry-name>
+                    entryName = splitPath[lastIndex];
+
+                    // The repo name is the components between org and entry-name
+                    // Note: repo name may contain slashes, ex: <registry>/<org>/<repo-part-1>/<repo-part-2>/<entry-name>
+                    repoNameComponents = Arrays.copyOfRange(splitPath, repoIndexStart, lastIndex);
+                } else {
+                    // Assume that everything after the registry and org is part of the repository name: <registry>/<org>/<repo-part-1>/<repo-part-2>
+                    repoNameComponents = Arrays.copyOfRange(splitPath, repoIndexStart, lastIndex + 1);
+                }
+                repo = String.join("/", repoNameComponents);
             }
 
             // Return an array of the form [A,B,C,D]

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -16,6 +16,8 @@
 
 package io.dockstore.webservice.core;
 
+import static io.dockstore.webservice.Constants.AMAZON_ECR_PRIVATE_REGISTRY_REGEX;
+
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -382,7 +384,7 @@ public class Tool extends Entry<Tool, Tag> {
         }
 
         // Deal with registries with custom registry paths
-        if (this.registry.matches("^[a-zA-Z0-9]+\\.dkr\\.ecr\\.[a-zA-Z0-9._/-]+\\.amazonaws\\.com")) {
+        if (this.registry.matches(AMAZON_ECR_PRIVATE_REGISTRY_REGEX)) {
             return Registry.AMAZON_ECR;
         } else if (this.registry.matches("^([a-zA-Z0-9]+-)?images\\.sbgenomics\\.com")) {
             return Registry.SEVEN_BRIDGES;
@@ -399,8 +401,8 @@ public class Tool extends Entry<Tool, Tag> {
             this.setRegistry(registryThing.getDockerPath());
             break;
         case AMAZON_ECR:
-            if (!this.registry.matches("^[a-zA-Z0-9]+\\.dkr\\.ecr\\.[a-zA-Z0-9._/-]+\\.amazonaws\\.com")) {
-                // set registry to public Amazon ECR docker path if it's not a private Amazon ECR registry
+            if (!this.registry.matches(AMAZON_ECR_PRIVATE_REGISTRY_REGEX)) {
+                // Set registry to public Amazon ECR docker path if it's not a private Amazon ECR registry
                 this.setRegistry(registryThing.getDockerPath());
             }
             break;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -382,7 +382,7 @@ public class Tool extends Entry<Tool, Tag> {
         }
 
         // Deal with registries with custom registry paths
-        if (this.registry.matches("^[a-zA-Z0-9]+\\.dkr\\.ecr\\.[a-zA-Z0-9]+\\.amazonaws\\.com")) {
+        if (this.registry.matches("^[a-zA-Z0-9]+\\.dkr\\.ecr\\.[a-zA-Z0-9._/-]+\\.amazonaws\\.com")) {
             return Registry.AMAZON_ECR;
         } else if (this.registry.matches("^([a-zA-Z0-9]+-)?images\\.sbgenomics\\.com")) {
             return Registry.SEVEN_BRIDGES;
@@ -398,8 +398,13 @@ public class Tool extends Entry<Tool, Tag> {
         case DOCKER_HUB:
             this.setRegistry(registryThing.getDockerPath());
             break;
-        case SEVEN_BRIDGES:
         case AMAZON_ECR:
+            if (!this.registry.matches("^[a-zA-Z0-9]+\\.dkr\\.ecr\\.[a-zA-Z0-9._/-]+\\.amazonaws\\.com")) {
+                // set registry to public Amazon ECR docker path if it's not a private Amazon ECR registry
+                this.setRegistry(registryThing.getDockerPath());
+            }
+            break;
+        case SEVEN_BRIDGES:
             break;
         default:
             break;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -62,7 +62,7 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
      * @return A list of workflows with the given path
      */
     public List<Workflow> findAllByPath(String path, boolean findPublished) {
-        String[] splitPath = Workflow.splitPath(path);
+        String[] splitPath = Workflow.splitPath(path, false);
 
         // Not a valid path
         if (splitPath == null) {
@@ -104,7 +104,7 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
      * @return Workflow matching the path
      */
     public List<Workflow> findByPath(String path, boolean findPublished) {
-        String[] splitPath = Workflow.splitPath(path);
+        String[] splitPath = Workflow.splitPath(path, true);
 
         // Not a valid path
         if (splitPath == null) {
@@ -229,7 +229,7 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
         Root<Workflow> entry = q.from(Workflow.class);
 
         for (String path : paths) {
-            String[] splitPath = Workflow.splitPath(path);
+            String[] splitPath = Workflow.splitPath(path, true);
 
             if (splitPath == null) {
                 continue;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -83,6 +83,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -322,10 +323,11 @@ public class DockerRepoResource
     @Timed
     @UnitOfWork
     @Path("/{containerId}")
+    @Consumes(MediaType.APPLICATION_JSON)
     @Operation(operationId = "updateContainer", description = "Update the tool with the given tool.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Update the tool with the given tool.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class,
-        notes = "Updates default descriptor paths, default Docker paths, default test parameter paths, git url,"
+        notes = "Updates default descriptor paths, default Dockerfile paths, default test parameter paths, git url,"
                 + " and default version. Also updates tool maintainer email, and private access for manual tools.")
     public Tool updateContainer(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,
         @ApiParam(value = "Tool to modify.", required = true) @PathParam("containerId") Long containerId,
@@ -764,8 +766,8 @@ public class DockerRepoResource
     @Timed
     @UnitOfWork(readOnly = true)
     @Path("/path/{repository}/published")
-    @Operation(operationId = "getPublishedContainerByPath", description = "Get a list of published tools by path.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
-    @ApiOperation(value = "Get a list of published tools by path.", notes = "NO authentication", response = Tool.class)
+    @Operation(operationId = "getPublishedContainerByPath", description = "Get a list of published tools by path. Do not include tool name.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
+    @ApiOperation(value = "Get a list of published tools by path.", notes = "NO authentication", response = Tool.class, responseContainer = "List")
     public List<Tool> getPublishedContainerByPath(
         @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
         List<Tool> tools = toolDAO.findAllByPath(path, true);
@@ -778,7 +780,7 @@ public class DockerRepoResource
     @Timed
     @UnitOfWork(readOnly = true)
     @Path("/path/{repository}")
-    @Operation(operationId = "getContainerByPath", description = "Get a list of tools by path.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
+    @Operation(operationId = "getContainerByPath", description = "Get a list of tools by path. Do not include tool name.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Get a list of tools by path.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Does not require tool name.", response = Tool.class, responseContainer = "List")
     public List<Tool> getContainerByPath(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -354,6 +354,18 @@ public class DockerRepoResource
             throw new CustomWebApplicationException("A published, private tool must have either an tool author email or tool maintainer email set up.", HttpStatus.SC_BAD_REQUEST);
         }
 
+        if (registry == Registry.AMAZON_ECR) {
+            // Public Amazon ECR tool (public.ecr.aws docker path) can't be set to private
+            if (tool.getRegistry().equals(Registry.AMAZON_ECR.getDockerPath()) && tool.isPrivateAccess()) {
+                throw new CustomWebApplicationException("The Amazon ECR tool has a public docker path and cannot be set to private.", HttpStatus.SC_BAD_REQUEST);
+            }
+
+            // Private Amazon ECR tool with custom docker path can't be set to public
+            if (!tool.getRegistry().equals(Registry.AMAZON_ECR.getDockerPath()) && !tool.isPrivateAccess()) {
+                throw new CustomWebApplicationException("The Amazon ECR tool has a custom docker path and cannot be set to public.", HttpStatus.SC_BAD_REQUEST);
+            }
+        }
+
         updateInfo(foundTool, tool);
 
         Tool result = toolDAO.findById(containerId);
@@ -543,6 +555,19 @@ public class DockerRepoResource
         if (tool.isPrivateAccess() && Strings.isNullOrEmpty(tool.getToolMaintainerEmail())) {
             throw new CustomWebApplicationException("Tool maintainer email is required for private tools.", HttpStatus.SC_BAD_REQUEST);
         }
+
+        if (registry == Registry.AMAZON_ECR) {
+            // Public Amazon ECR tool (public.ecr.aws docker path) can't be set to private
+            if (tool.getRegistry().equals(Registry.AMAZON_ECR.getDockerPath()) && tool.isPrivateAccess()) {
+                throw new CustomWebApplicationException("The Amazon ECR tool has a public docker path and cannot be set to private.", HttpStatus.SC_BAD_REQUEST);
+            }
+
+            // Private Amazon ECR tool with custom docker path can't be set to public
+            if (!tool.getRegistry().equals(Registry.AMAZON_ECR.getDockerPath()) && !tool.isPrivateAccess()) {
+                throw new CustomWebApplicationException("The Amazon ECR tool has a custom docker path and cannot be set to public.", HttpStatus.SC_BAD_REQUEST);
+            }
+        }
+
         // populate user in tool
         tool.addUser(user);
         // create dependent Tags before creating tool

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
@@ -43,6 +43,9 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.Authorization;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import java.util.Date;
 import java.util.HashMap;
@@ -94,6 +97,7 @@ public class HostedToolResource extends AbstractHostedEntryResource<Tool, Tag, T
 
     @Override
     @Operation(operationId = "createHostedTool", description = "Create a hosted tool.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully created a hosted tool.", content = @Content(schema = @Schema(implementation = Tool.class)))
     @ApiOperation(nickname = "createHostedTool", value = "Create a hosted tool.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class)
     public Tool createHosted(User user, String registry, String name, DescriptorLanguage descriptorType, String namespace, String entryName) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
@@ -15,6 +15,7 @@
  */
 package io.dockstore.webservice.resources;
 
+import static io.dockstore.webservice.Constants.AMAZON_ECR_PRIVATE_REGISTRY_REGEX;
 import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
 import static io.dockstore.webservice.resources.ResourceConstants.OPENAPI_JWT_SECURITY_DEFINITION_NAME;
 
@@ -246,7 +247,7 @@ public class HostedToolResource extends AbstractHostedEntryResource<Tool, Tag, T
             if (Objects.equals(registry.toLowerCase(), registryObject.getDockerPath())) {
                 return registry;
             } else if (Objects.equals(registryObject.name(), Registry.AMAZON_ECR.name())) {
-                if (registry.matches("^[a-zA-Z0-9]+\\.dkr\\.ecr\\.[a-zA-Z0-9]+\\.amazonaws\\.com")) {
+                if (registry.matches(AMAZON_ECR_PRIVATE_REGISTRY_REGEX)) {
                     return registry;
                 }
             } else if (Objects.equals(registryObject.name(), Registry.SEVEN_BRIDGES.name())) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
@@ -115,6 +115,7 @@ public class HostedWorkflowResource extends AbstractHostedEntryResource<Workflow
 
     @Override
     @Operation(operationId = "createHostedWorkflow", description = "Create a hosted workflow.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully created a hosted workflow.", content = @Content(schema = @Schema(implementation = Workflow.class)))
     @ApiOperation(nickname = "createHostedWorkflow", value = "Create a hosted workflow.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class)
     public Workflow createHosted(User user, String registry, String name, DescriptorLanguage descriptorType, String namespace, String entryName) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1015,7 +1015,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @Timed
     @UnitOfWork(readOnly = true)
     @Path("/path/{repository}")
-    @Operation(operationId = "getAllWorkflowByPath", description = "Get a list of workflows by path.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
+    @Operation(operationId = "getAllWorkflowByPath", description = "Get a list of workflows by path. Do not include workflow name.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(nickname = "getAllWorkflowByPath", value = "Get a list of workflows by path.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, notes = "Does not require workflow name.", response = Workflow.class, responseContainer = "List")
     public List<Workflow> getAllWorkflowByPath(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -935,8 +935,8 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
-          description: Successfully created hosted entry
+                $ref: '#/components/schemas/DockstoreTool'
+          description: Successfully created a hosted tool.
       security:
       - bearer: []
       tags:
@@ -1096,7 +1096,7 @@ paths:
       - containertags
   /containers/path/{repository}:
     get:
-      description: Get a list of tools by path.
+      description: Get a list of tools by path. Do not include tool name.
       operationId: getContainerByPath
       parameters:
       - in: path
@@ -1119,7 +1119,7 @@ paths:
       - containers
   /containers/path/{repository}/published:
     get:
-      description: Get a list of published tools by path.
+      description: Get a list of published tools by path. Do not include tool name.
       operationId: getPublishedContainerByPath
       parameters:
       - in: path
@@ -1324,7 +1324,7 @@ paths:
           format: int64
       requestBody:
         content:
-          '*/*':
+          application/json:
             schema:
               $ref: '#/components/schemas/DockstoreTool'
       responses:
@@ -5448,8 +5448,8 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Entry'
-          description: Successfully created hosted entry
+                $ref: '#/components/schemas/Workflow'
+          description: Successfully created a hosted workflow.
       security:
       - bearer: []
       tags:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -5846,7 +5846,7 @@ paths:
       - workflows
   /workflows/path/{repository}:
     get:
-      description: Get a list of workflows by path.
+      description: Get a list of workflows by path. Do not include workflow name.
       operationId: getAllWorkflowByPath
       parameters:
       - in: path

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -1575,7 +1575,9 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/DockstoreTool"
+            type: "array"
+            items:
+              $ref: "#/definitions/DockstoreTool"
   /containers/published:
     get:
       tags:
@@ -1760,10 +1762,12 @@ paths:
       tags:
       - "containers"
       summary: "Update the tool with the given tool."
-      description: "Updates default descriptor paths, default Docker paths, default\
+      description: "Updates default descriptor paths, default Dockerfile paths, default\
         \ test parameter paths, git url, and default version. Also updates tool maintainer\
         \ email, and private access for manual tools."
       operationId: "updateContainer"
+      consumes:
+      - "application/json"
       produces:
       - "application/json"
       parameters:


### PR DESCRIPTION
For #4331. This is only the webservice PR for the ticket. Will also have a PR for the UI once this is merged.

This allows private and public Amazon ECR tools to be manually registered. Harvesting checksums for Amazon ECR tools is split out to another ticket #4409.

Amazon ECR is the only registry that we have that is not a private only registry, but has custom docker paths for its private repositories. I changed the descriptions of these fields in the `Registry` class to reflect this idea that having a custom docker path does not necessarily mean that it's a private only registry.

Changed how we were splitting the paths because Amazon ECR (and GitHub Container Registry) allows repository names with slashes, thus the indices for the path components are not all necessarily deterministic anymore. 

The existence of slashes in repository names also made it possible for tools to have the same tool paths without necessarily have the same repository and tool name, so had to do an additional check in the DB when looking for duplicate tool paths.
- Example of two tools with the same tool path `public.ecr.aws/x5g7o3i3/appropriate/curl`:
  - Existing tool has registry = `public.ecr.aws`, namespace = `x5g7o3i3`, name = `appropriate/curl`, toolname = `NULL`
  - New tool has registry = `public.ecr.aws`, namespace = `x5g7o3i3`, name = `appropriate`, toolname = `curl`

I added a lot of tests because I was worried my changes to splitting the path components might have affected searching for workflow paths. Might add some more tests if I think of any edge cases.

