### PR TITLE
Return sha-256 for source file checksums

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,7 @@ commands:
           command: |
             psql -c "create user dockstore with password 'dockstore' createdb;" -U postgres
             psql -c 'create database webservice_test with owner = dockstore;' -U postgres
+            psql -c 'create database webservice_test_proposed with owner = dockstore;' -U postgres
   setup_postgres_docker:
     steps:
       - run:
@@ -367,6 +368,7 @@ commands:
           command: |
             docker exec -it -u postgres postgres1 psql -c "create user dockstore with password 'dockstore' createdb;"
             docker exec -it -u postgres postgres1 psql -c "create database webservice_test with owner = dockstore;"
+            docker exec -it -u postgres postgres1 psql -c "create database webservice_test_proposed with owner = dockstore;"
   old_python: # Need Python 3.6 for old Dockstore 1.7 requirements.txt
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,6 +216,12 @@ jobs:
       - image: cimg/openjdk:11.0.10
         environment:
           PGHOST: 127.0.0.1
+      - image: circleci/postgres:11.12
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_PASSWORD: postgres
     steps: # a collection of executable commands
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ jobs:
       - image: cimg/openjdk:11.0.10
         environment:
           PGHOST: 127.0.0.1
-      - image: circleci/postgres:11.12
+      - image: circleci/postgres:13.3
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: postgres
@@ -363,7 +363,7 @@ commands:
   setup_postgres_docker:
     steps:
       - run:
-          name: setup postgres docker
+          name: setup postgres
           command: |
             docker exec -it -u postgres postgres1 psql -c "create user dockstore with password 'dockstore' createdb;"
             docker exec -it -u postgres postgres1 psql -c "create database webservice_test with owner = dockstore;"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,12 +216,6 @@ jobs:
       - image: cimg/openjdk:11.0.10
         environment:
           PGHOST: 127.0.0.1
-      - image: circleci/postgres:11.12
-        environment:
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_PASSWORD: postgres
     steps: # a collection of executable commands
       - checkout
       - restore_cache:
@@ -363,7 +357,7 @@ commands:
   setup_postgres_docker:
     steps:
       - run:
-          name: setup postgres
+          name: setup postgres docker
           command: |
             docker exec -it -u postgres postgres1 psql -c "create user dockstore with password 'dockstore' createdb;"
             docker exec -it -u postgres postgres1 psql -c "create database webservice_test with owner = dockstore;"

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -411,7 +411,7 @@ public class GeneralIT extends BaseIT {
         verifyTRSSourceFileConversion(fileWrappers);
     }
 
-    public void verifySourcefileChecksumsSaved(final List<Tag> tags) {
+    private void verifySourcefileChecksumsSaved(final List<Tag> tags) {
         assertTrue(tags.size() > 0);
         tags.stream().forEach(tag -> {
             List<io.dockstore.webservice.core.SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(tag.getId());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -16,8 +16,10 @@
 
 package io.dockstore.client.cli;
 
+import static io.dockstore.webservice.core.SourceFile.SHA_TYPE;
 import static io.dockstore.webservice.core.Version.CANNOT_FREEZE_VERSIONS_WITH_NO_FILES;
 import static io.dockstore.webservice.helpers.EntryVersionHelper.CANNOT_MODIFY_FROZEN_VERSIONS_THIS_WAY;
+import static io.openapi.api.impl.ToolsApiServiceImpl.DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -90,8 +92,6 @@ import org.kohsuke.github.RateLimitHandler;
 @Category({ ConfidentialTest.class, ToolTest.class })
 public class GeneralIT extends BaseIT {
     public static final String DOCKSTORE_TOOL_IMPORTS = "dockstore-tool-imports";
-
-    private static final String DESCRIPTOR_FILE_SHA_TYPE_FOR_TRS = "sha1";
 
     private static final String DOCKERHUB_TOOL_PATH = "registry.hub.docker.com/testPath/testUpdatePath/test5";
 
@@ -397,7 +397,7 @@ public class GeneralIT extends BaseIT {
         tool = toolApi.refresh(tool.getId());
 
         List<Tag> tags = tool.getWorkflowVersions();
-        verifySourcefileChecksumsSaved(tags);
+        verifySourcefileChecksums(tags);
 
         PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         toolApi.publish(tool.getId(), publishRequest);
@@ -411,7 +411,7 @@ public class GeneralIT extends BaseIT {
         verifyTRSSourceFileConversion(fileWrappers);
     }
 
-    private void verifySourcefileChecksumsSaved(final List<Tag> tags) {
+    private void verifySourcefileChecksums(final List<Tag> tags) {
         assertTrue(tags.size() > 0);
         tags.stream().forEach(tag -> {
             List<io.dockstore.webservice.core.SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(tag.getId());
@@ -420,7 +420,7 @@ public class GeneralIT extends BaseIT {
                 assertTrue(sourceFile.getChecksums().size() > 0);
                 sourceFile.getChecksums().stream().forEach(checksum -> {
                     assertFalse(checksum.getChecksum().isEmpty());
-                    assertFalse(checksum.getType().isEmpty());
+                    assertEquals(SHA_TYPE, checksum.getType());
                 });
             });
         });
@@ -594,13 +594,13 @@ public class GeneralIT extends BaseIT {
         assertTrue(tool.getDescriptorType().get(0) != tool.getDescriptorType().get(1));
     }
 
-    public void verifyTRSSourceFileConversion(final List<FileWrapper> fileWrappers) {
+    private void verifyTRSSourceFileConversion(final List<FileWrapper> fileWrappers) {
         assertTrue(fileWrappers.size() > 0);
         fileWrappers.stream().forEach(fileWrapper -> {
             assertTrue(fileWrapper.getChecksum().size() > 0);
             fileWrapper.getChecksum().stream().forEach(checksum -> {
                 assertFalse(checksum.getChecksum().isEmpty());
-                assertEquals(DESCRIPTOR_FILE_SHA_TYPE_FOR_TRS, checksum.getType());
+                assertEquals(DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS, checksum.getType());
             });
         });
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -17,6 +17,7 @@
 package io.dockstore.client.cli;
 
 import static io.dockstore.common.DescriptorLanguage.CWL;
+import static io.openapi.api.impl.ToolsApiServiceImpl.DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -139,7 +140,6 @@ public class WorkflowIT extends BaseIT {
     private static final String DOCKSTORE_TEST_USER2_MORE_IMPORT_STRUCTURE =
         SourceControl.GITHUB.toString() + "/DockstoreTestUser2/workflow-seq-import";
     private static final String GATK_SV_TAG = "dockstore-test";
-    private static final String DESCRIPTOR_FILE_SHA_TYPE_FOR_TRS = "sha1";
     private static final String DOCKER_IMAGE_SHA_TYPE_FOR_TRS = "sha-256";
 
     @Rule
@@ -1278,7 +1278,7 @@ public class WorkflowIT extends BaseIT {
         assertEquals(1, fileWrapper.getChecksum().size());
         fileWrapper.getChecksum().stream().forEach(checksum -> {
             assertFalse(checksum.getChecksum().isEmpty());
-            assertEquals(DESCRIPTOR_FILE_SHA_TYPE_FOR_TRS, checksum.getType());
+            assertEquals(DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS, checksum.getType());
         });
     }
 
@@ -1288,7 +1288,7 @@ public class WorkflowIT extends BaseIT {
             assertFalse("Source File should have a checksum", sourceFile.getChecksums().isEmpty());
             assertTrue(sourceFile.getChecksums().size() >= 1);
             sourceFile.getChecksums().stream().forEach(checksum -> {
-                assertFalse(checksum.getType().isEmpty());
+                assertEquals(io.dockstore.webservice.core.SourceFile.SHA_TYPE, checksum.getType());
                 assertFalse(checksum.getChecksum().isEmpty());
             });
         });

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -73,7 +73,7 @@ import org.slf4j.LoggerFactory;
 public class SourceFile implements Comparable<SourceFile> {
 
     public static final EnumSet<DescriptorLanguage.FileType> TEST_FILE_TYPES = EnumSet.of(DescriptorLanguage.FileType.CWL_TEST_JSON, DescriptorLanguage.FileType.WDL_TEST_JSON, DescriptorLanguage.FileType.NEXTFLOW_TEST_PARAMS);
-    private static final String SHA_TYPE_FOR_SOURCEFILES = "SHA-1";
+    public static final String SHA_TYPE = "SHA-256";
 
     private static final Logger LOG = LoggerFactory.getLogger(SourceFile.class);
 
@@ -109,9 +109,6 @@ public class SourceFile implements Comparable<SourceFile> {
 
     @Formula("digest(content, 'sha256')")
     private String sha256;
-
-    @Formula("digest(content, 'sha1')")
-    private String sha1;
 
     // database timestamps
     @Column(updatable = false)
@@ -181,8 +178,8 @@ public class SourceFile implements Comparable<SourceFile> {
     public List<Checksum> getChecksums() {
         // I wanted to memoize this, but, Hibernate beans aren't thread-safe; this should be fast; it's unlikely to be called several times per instance (I think)
         List<Checksum> checksums = new ArrayList<Checksum>();
-        if (StringUtils.isNotBlank(sha1)) {
-            checksums.add(new Checksum(SHA_TYPE_FOR_SOURCEFILES, removeEncodingFromDigest(sha1)));
+        if (StringUtils.isNotBlank(sha256)) {
+            checksums.add(new Checksum(SHA_TYPE, removeEncodingFromDigest(sha256)));
         }
         return checksums;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.persistence.Column;
-import javax.persistence.Convert;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
@@ -51,8 +50,10 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,6 +73,7 @@ import org.slf4j.LoggerFactory;
 public class SourceFile implements Comparable<SourceFile> {
 
     public static final EnumSet<DescriptorLanguage.FileType> TEST_FILE_TYPES = EnumSet.of(DescriptorLanguage.FileType.CWL_TEST_JSON, DescriptorLanguage.FileType.WDL_TEST_JSON, DescriptorLanguage.FileType.NEXTFLOW_TEST_PARAMS);
+    private static final String SHA_TYPE_FOR_SOURCEFILES = "SHA-1";
 
     private static final Logger LOG = LoggerFactory.getLogger(SourceFile.class);
 
@@ -105,10 +107,11 @@ public class SourceFile implements Comparable<SourceFile> {
     @ApiModelProperty(value = "When true, this version cannot be affected by refreshes to the content or updates to its metadata", position = 5)
     private boolean frozen = false;
 
-    @Column(columnDefinition = "varchar")
-    @Convert(converter = ChecksumConverter.class)
-    @ApiModelProperty(value = "The checksum(s) of the sourcefile's content", position = 6)
-    private List<Checksum> checksums = new ArrayList<>();
+    @Formula("digest(content, 'sha256')")
+    private String sha256;
+
+    @Formula("digest(content, 'sha1')")
+    private String sha1;
 
     // database timestamps
     @Column(updatable = false)
@@ -174,12 +177,14 @@ public class SourceFile implements Comparable<SourceFile> {
         return Paths.get(absolutePath).normalize().toString();
     }
 
+    @ApiModelProperty(value = "The checksum(s) of the sourcefile's content", position = 6)
     public List<Checksum> getChecksums() {
+        // I wanted to memoize this, but, Hibernate beans aren't thread-safe; this should be fast; it's unlikely to be called several times per instance (I think)
+        List<Checksum> checksums = new ArrayList<Checksum>();
+        if (StringUtils.isNotBlank(sha1)) {
+            checksums.add(new Checksum(SHA_TYPE_FOR_SOURCEFILES, removeEncodingFromDigest(sha1)));
+        }
         return checksums;
-    }
-
-    public void setChecksums(final List<Checksum> checksums) {
-        this.checksums = checksums;
     }
 
     public void setAbsolutePath(String absolutePath) {
@@ -223,6 +228,20 @@ public class SourceFile implements Comparable<SourceFile> {
 
     public void setFrozen(boolean frozen) {
         this.frozen = frozen;
+    }
+
+    /**
+     * An example digest from PG is \x24ea9b890cc4fe30b061f3c585c8988fccb95157 -- remove the \x
+     *
+     * Not sure we should do this, but it is backwards compatible with how we've been doing digests.
+     * @param sha
+     * @return
+     */
+    private String removeEncodingFromDigest(String sha) {
+        if (sha.startsWith("\\x")) {
+            return sha.substring(2);
+        }
+        return sha;
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -695,17 +695,6 @@ public abstract class AbstractImageRegistry {
             for (SourceFile newFile : newFiles) {
                 if (Objects.equals(oldFile.getAbsolutePath(), newFile.getAbsolutePath())) {
                     oldFile.setContent(newFile.getContent());
-
-                    Optional<String> sha = FileFormatHelper.calcSHA1(oldFile.getContent());
-                    if (sha.isPresent()) {
-                        checksums.add(new Checksum(SHA_TYPE_FOR_SOURCEFILES, sha.get()));
-                        if (oldFile.getChecksums() == null) {
-                            oldFile.setChecksums(checksums);
-                        } else {
-                            oldFile.getChecksums().clear();
-                            oldFile.getChecksums().addAll(checksums);
-                        }
-                    }
                     newFiles.remove(newFile);
                     found = true;
                     break;
@@ -721,10 +710,6 @@ public abstract class AbstractImageRegistry {
         for (SourceFile newFile : newFiles) {
             long id = fileDAO.create(newFile);
             SourceFile file = fileDAO.findById(id);
-            Optional<String> sha = FileFormatHelper.calcSHA1(file.getContent());
-            if (sha.isPresent()) {
-                file.getChecksums().add(new Checksum(SHA_TYPE_FOR_SOURCEFILES, sha.get()));
-            }
             tag.addSourceFile(file);
         }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/FileFormatHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/FileFormatHelper.java
@@ -7,16 +7,11 @@ import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.jdbi.FileFormatDAO;
 import io.dockstore.webservice.languages.CWLHandler;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-import javax.xml.bind.DatatypeConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,22 +96,5 @@ public final class FileFormatHelper {
             }
         });
         return fileFormatsFromDB;
-    }
-
-    public static Optional<String> calcSHA1(String content) {
-        if (content != null) {
-            try {
-                MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
-                final byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
-                messageDigest.update(bytes, 0, bytes.length);
-                String sha1 = DatatypeConverter.printHexBinary(messageDigest.digest()).toLowerCase();
-                return Optional.of(sha1);
-            } catch (UnsupportedOperationException | NoSuchAlgorithmException ex) {
-                LOG.error("Unable to calculate SHA-1", ex);
-            }
-        } else {
-            LOG.error("File descriptor content is null");
-        }
-        return Optional.empty();
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -22,7 +22,6 @@ import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.core.AppTool;
 import io.dockstore.webservice.core.Author;
 import io.dockstore.webservice.core.BioWorkflow;
-import io.dockstore.webservice.core.Checksum;
 import io.dockstore.webservice.core.LambdaEvent;
 import io.dockstore.webservice.core.OrcidAuthor;
 import io.dockstore.webservice.core.Service;
@@ -58,7 +57,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -88,7 +86,6 @@ import org.slf4j.LoggerFactory;
 @Api("workflows")
 public abstract class AbstractWorkflowResource<T extends Workflow> implements SourceControlResourceInterface, AuthenticatedResourceInterface {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractWorkflowResource.class);
-    private static final String SHA_TYPE_FOR_SOURCEFILES = "SHA-1";
 
     protected final HttpClient client;
     protected final TokenDAO tokenDAO;
@@ -212,27 +209,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             String fileKey = file.getType().toString() + file.getAbsolutePath();
             SourceFile existingFile = existingFileMap.get(fileKey);
             if (existingFileMap.containsKey(fileKey)) {
-                List<Checksum> checksums = new ArrayList<>();
-                Optional<String> sha = FileFormatHelper.calcSHA1(file.getContent());
-                if (sha.isPresent()) {
-                    checksums.add(new Checksum(SHA_TYPE_FOR_SOURCEFILES, sha.get()));
-                    if (existingFile.getChecksums() == null) {
-                        existingFile.setChecksums(checksums);
-                    } else {
-                        existingFile.getChecksums().clear();
-                        existingFileMap.get(fileKey).getChecksums().addAll(checksums);
-
-                    }
-                }
                 existingFile.setContent(file.getContent());
             } else {
                 final long fileID = fileDAO.create(file);
                 final SourceFile fileFromDB = fileDAO.findById(fileID);
-
-                Optional<String> sha = FileFormatHelper.calcSHA1(file.getContent());
-                if (sha.isPresent()) {
-                    fileFromDB.getChecksums().add(new Checksum(SHA_TYPE_FOR_SOURCEFILES, sha.get()));
-                }
                 existingVersion.getSourceFiles().add(fileFromDB);
             }
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -38,7 +38,6 @@ import io.dockstore.webservice.api.PublishRequest;
 import io.dockstore.webservice.api.StarRequest;
 import io.dockstore.webservice.core.AppTool;
 import io.dockstore.webservice.core.BioWorkflow;
-import io.dockstore.webservice.core.Checksum;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Image;
 import io.dockstore.webservice.core.LambdaEvent;
@@ -1336,21 +1335,6 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
                         Set<Image> images = lInterface.getImagesFromRegistry(toolsJSONTable.get());
                         existingTag.getImages().addAll(images);
-                    }
-
-                    // Grab checksum for file descriptors if not already available.
-                    for (SourceFile sourceFile : existingTag.getSourceFiles()) {
-                        Optional<String> sha = FileFormatHelper.calcSHA1(sourceFile.getContent());
-                        if (sha.isPresent()) {
-                            List<Checksum> checksums = new ArrayList<>();
-                            checksums.add(new Checksum(SHA_TYPE_FOR_SOURCEFILES, sha.get()));
-                            if (sourceFile.getChecksums() == null) {
-                                sourceFile.setChecksums(checksums);
-                            } else if (sourceFile.getChecksums().isEmpty()) {
-                                sourceFile.getChecksums().addAll(checksums);
-                            }
-                        }
-
                     }
 
                     // store dag

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -88,11 +88,14 @@ import org.slf4j.LoggerFactory;
 
 public class ToolsApiServiceImpl extends ToolsApiService implements AuthenticatedResourceInterface {
     public static final Response BAD_DECODE_RESPONSE = Response.status(getExtendedStatus(Status.BAD_REQUEST, "Could not decode version")).build();
+
+    // Algorithms should come from: https://github.com/ga4gh-discovery/ga4gh-checksum/blob/master/hash-alg.csv
+    public static final String DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS = "sha-256";
+
     private static final String GITHUB_PREFIX = "git@github.com:";
     private static final String BITBUCKET_PREFIX = "git@bitbucket.org:";
     private static final int SEGMENTS_IN_ID = 3;
     private static final int DEFAULT_PAGE_SIZE = 1000;
-    private static final String DESCRIPTOR_FILE_SHA_TYPE_FOR_TRS = "sha1";
     private static final Logger LOG = LoggerFactory.getLogger(ToolsApiServiceImpl.class);
 
     private static ToolDAO toolDAO = null;
@@ -626,7 +629,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         if (sourceFile.getChecksums() != null && !sourceFile.getChecksums().isEmpty()) {
             sourceFile.getChecksums().stream().forEach(checksum -> {
                 Checksum trsChecksum = new Checksum();
-                trsChecksum.setType(DESCRIPTOR_FILE_SHA_TYPE_FOR_TRS);
+                trsChecksum.setType(DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS);
                 trsChecksum.setChecksum(checksum.getChecksum());
                 trsChecksums.add(trsChecksum);
             });

--- a/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
@@ -83,4 +83,14 @@
             <column name="publicaccessibletestparameterfile" type="bool"/>
         </addColumn>
     </changeSet>
+    <changeSet id="calculatedChecksums" author="coverbeck">
+        <sql dbms="postgresql">
+            alter table sourcefile disable row level security;
+        </sql>
+        <dropColumn tableName="sourcefile" columnName="checksums"></dropColumn>
+        <sql dbms="postgresql">
+            alter table sourcefile enable row level security;
+            create extension if not exists pgcrypto;
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/propose_migration.sh
+++ b/propose_migration.sh
@@ -9,15 +9,15 @@ set -o xtrace
 if [ "${CIRCLECI-false}" = "true" ]; then
     dropdb -U postgres webservice_test || true
     dropdb -U postgres webservice_test_proposed || true
-    createdb -U postgres webservice_test || true
-    createdb -U postgres webservice_test_proposed || true
+    createdb -U postgres webservice_test -O dockstore || true
+    createdb -U postgres webservice_test_proposed -O dockstore || true
     rm dockstore-webservice/target/detected-migrations.xml || true
 else
     ## uncomment/comment this section if database is running locally on postgres
     sudo -i -u postgres dropdb webservice_test || true # comment this line if you want to diff with an already loaded db dump
     sudo -i -u postgres dropdb webservice_test_proposed || true
-    sudo -i -u postgres createdb webservice_test || true # comment this line if you want to diff with an already loaded db dump
-    sudo -i -u postgres createdb webservice_test_proposed || true
+    sudo -i -u postgres createdb webservice_test -O dockstore || true # comment this line if you want to diff with an already loaded db dump
+    sudo -i -u postgres createdb webservice_test_proposed -O dockstore || true
     rm dockstore-webservice/target/detected-migrations.xml || true
     ## uncomment/comment this section if running on docker
 #    docker exec -it -u postgres -e PGPASSWORD=dockstore postgres1 dropdb webservice_test || true


### PR DESCRIPTION

https://ucsc-cgl.atlassian.net/browse/SEAB-2824

Using Hibernate's `@Formula` (calculated field) to generate. Need to create `pgcrypto` extension in Postgres.

Dropped sha1 entirely, but it's easy enough to add back if we want.

Upgraded unit tests to use 13.3 to match integration tests. And also because the DB owner in PG 11 doesn't have permission to create pgcrypto extension in 11.

### Advantages
* We now serve up SHAs for all our source files. We had been adding SHAs for source files as we added/updated versions (about half our source files currently have SHAs last I looked), and so some had them, and some didn't.
* Pushes the calculation to the DB
* Allows us to drop the checksum column from the DB.

### Disadvantages
* Pushes the calculation to the DB. In theory it could affect query performance. My experiments were inconclusive. I tried fetching 5,000 source files in one PSQL query, with and without the digest, and both queries would fluctuate within a very wide range (5 -14 seconds). For smaller numbers of sourcefiles, a more probable query, e.g., 100-1000, times are almost identical. Confusingly, the query without the digest sometimes takes (a little) longer. There's probably caching I'm unaware of.
* We've avoided adding Hibernate-specific features, now we've got one.