### PR TITLE
Rollback transaction on error

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -586,6 +586,7 @@ public class WebhookIT extends BaseIT {
         List<LambdaEvent> events = usersApi.getUserGitHubEvents("0", 10);
         assertEquals("There should be 3 successful events", 3, events.stream().filter(LambdaEvent::isSuccess).count());
 
+        final int versionCountBeforeInvalidDockstoreYml = getFoobar1Workflow(client).getWorkflowVersions().size();
         // Push branch with invalid dockstore.yml
         try {
             client.handleGitHubRelease(workflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/invalidDockstoreYml", installationId);
@@ -594,6 +595,7 @@ public class WebhookIT extends BaseIT {
             List<LambdaEvent> failEvents = usersApi.getUserGitHubEvents("0", 10);
             assertEquals("There should be 1 unsuccessful event", 1,
                     failEvents.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count());
+            assertEquals("Number of versions should be the same", versionCountBeforeInvalidDockstoreYml, getFoobar1Workflow(client).getWorkflowVersions().size());
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -61,6 +61,7 @@ import io.swagger.annotations.Api;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 import org.kohsuke.github.GHRateLimit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -345,7 +346,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             String errorMessage = ex instanceof CustomWebApplicationException ? ((CustomWebApplicationException)ex).getErrorMessage() : ex.getMessage();
             String msg = "User " + username + ": Error handling push event for repository " + repository + " and reference " + gitReference + "\n" + errorMessage;
             LOG.info(msg, ex);
-            sessionFactory.getCurrentSession().clear();
+            rollbackAndBeginNewTransaction();
             LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, username, LambdaEvent.LambdaEventType.PUSH);
             lambdaEvent.setSuccess(false);
             lambdaEvent.setMessage(errorMessage);
@@ -357,7 +358,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             gitHubSourceCodeRepo.reportOnGitHubRelease(startRateLimit, endRateLimit, repository, username, gitReference, isSuccessful);
             String msg = "User " + username + ": Unhandled error while handling push event for repository " + repository + " and reference " + gitReference + "\n" + ex.getMessage();
             LOG.error(msg, ex);
-            sessionFactory.getCurrentSession().clear();
+            rollbackAndBeginNewTransaction();
             LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, username, LambdaEvent.LambdaEventType.PUSH);
             lambdaEvent.setSuccess(false);
             lambdaEvent.setMessage(ex.getMessage());
@@ -365,6 +366,23 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             sessionFactory.getCurrentSession().getTransaction().commit();
             throw new CustomWebApplicationException(msg, LAMBDA_FAILURE);
         }
+    }
+
+    /**
+     * Rollback current DB transaction then start a new one so we can record a lambda event.
+     * https://github.com/dockstore/dockstore/issues/4434
+     */
+    private void rollbackAndBeginNewTransaction() {
+        final Transaction transaction = sessionFactory.getCurrentSession().getTransaction();
+        final boolean isActive = transaction.isActive();
+        final boolean canRollback = transaction.getStatus().canRollback();
+        if (isActive && canRollback) {
+            transaction.rollback();
+        } else {
+            // I don't think this should ever happen
+            LOG.error("Transaction is not active or cannot be rolled back. Active: {0}; Can rollback: {1}", isActive, canRollback);
+        }
+        sessionFactory.getCurrentSession().beginTransaction();
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -380,7 +380,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             transaction.rollback();
         } else {
             // I don't think this should ever happen
-            LOG.error("Transaction is not active or cannot be rolled back. Active: {0}; Can rollback: {1}", isActive, canRollback);
+            LOG.error("Transaction is not active or cannot be rolled back. Active: {}; Can rollback: {}", isActive, canRollback);
         }
         sessionFactory.getCurrentSession().beginTransaction();
     }


### PR DESCRIPTION
#4434 has the details.

I tested this manually and it works.

I cannot think of an easy way to do automated testing for this, especially with the #4433 fix (that PR fixes the bug that reveals this problem). Open to ideas.

We would need an exception to be thrown after the workflow version has been created. Maybe some fancy stuff with mocks, but even that would be tricky because the integration tests are run client-side, and the error needs to come on the server.

