### PR TITLE
Cache Docker Registry API responses if possible

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DockerRegistryAPIHelperIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/DockerRegistryAPIHelperIT.java
@@ -14,23 +14,43 @@
  *  limitations under the License.
  */
 
-package io.dockstore.webservice.helpers;
+package io.dockstore.client.cli;
 
+import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.NonConfidentialTest;
 import io.dockstore.common.Registry;
-import java.io.IOException;
-import java.net.URISyntaxException;
+import io.dockstore.webservice.DockstoreWebserviceApplication;
+import io.dockstore.webservice.DockstoreWebserviceConfiguration;
+import io.dockstore.webservice.helpers.DockerRegistryAPIHelper;
+import io.dropwizard.testing.DropwizardTestSupport;
 import java.util.Optional;
 import okhttp3.Response;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
-public class DockerRegistryAPIHelperTest {
-    
+@Category(NonConfidentialTest.class)
+public class DockerRegistryAPIHelperIT {
+
+    public static final DropwizardTestSupport<DockstoreWebserviceConfiguration> SUPPORT = new DropwizardTestSupport<>(
+            DockstoreWebserviceApplication.class, CommonTestUtilities.PUBLIC_CONFIG_PATH);
+
+
+    @Before
+    public void setUp() throws Exception {
+        SUPPORT.before();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        SUPPORT.getEnvironment().healthChecks().shutdown();
+        SUPPORT.after();
+    }
+
     /**
      * Test that the calculated digest matches the actual digest of the image.
-     * @throws URISyntaxException
-     * @throws IOException
-     * @throws InterruptedException
      */
     @Test
     public void testCalculateDockerImageDigest() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DockerRegistryAPIHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DockerRegistryAPIHelper.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2021 OICR and UCSC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.dockstore.webservice.helpers;
+
+import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
+
+import com.google.common.hash.Hashing;
+import com.google.gson.Gson;
+import io.dockstore.common.Registry;
+import io.dockstore.webservice.CacheHitListener;
+import io.dockstore.webservice.DockstoreWebserviceApplication;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.ws.rs.core.HttpHeaders;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class DockerRegistryAPIHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DockerRegistryAPIHelper.class);
+    private static final Gson GSON = new Gson();
+    private final OkHttpClient client;
+
+    public static final String DOCKER_V2_IMAGE_MANIFEST_MEDIA_TYPE = "application/vnd.docker.distribution.manifest.v2+json";
+    public static final String DOCKER_V2_IMAGE_MANIFEST_LIST_MEDIA_TYPE = "application/vnd.docker.distribution.manifest.list.v2+json";
+    public static final String OCI_IMAGE_MANIFEST_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json";
+    public static final String OCI_IMAGE_INDEX_MEDIA_TYPE = "application/vnd.oci.image.index.v1+json";
+
+    public DockerRegistryAPIHelper() {
+        // this code is duplicate from DockstoreWebserviceApplication, except this is a lot faster for unknown reasons ...
+        OkHttpClient.Builder builder = new OkHttpClient().newBuilder();
+        builder.eventListener(new CacheHitListener(DockerRegistryAPIHelper.class.getSimpleName(), "Docker Registry HTTP API V2"));
+
+        // use general cache
+        builder.cache(DockstoreWebserviceApplication.getCache(null));
+        this.client = builder.build();
+    }
+
+    /**
+     * Get an anonymous token with pull access to make Docker Registry HTTP API V2 calls.
+     * Source for token request specs: https://docs.docker.com/registry/spec/auth/token/#requesting-a-token
+     *
+     * @param registryDockerPath
+     * @param repo
+     * @return token
+     */
+    public Optional<String> getDockerToken(String registryDockerPath, String repo) {
+        String getTokenURL = String.format("https://%s/token?scope=repository:%s:pull&service=%s", registryDockerPath, repo, registryDockerPath);
+        Request request = new Request.Builder().url(getTokenURL).build();
+
+        Response tokenResponse;
+        try {
+            tokenResponse = client.newCall(request).execute();
+        } catch (IOException ex) {
+            LOG.error("Could not send token request GET {}", getTokenURL, ex);
+            return Optional.empty();
+        }
+
+        if (tokenResponse.isSuccessful()) {
+            Map<String, String> tokenMap = GSON.fromJson(tokenResponse.body().charStream(), Map.class);
+            return Optional.of(tokenMap.get("token"));
+        } else {
+            Optional<Map<String, String>> error = getDockerError(tokenResponse);
+            if (error.isPresent()) {
+                LOG.error("Token response has error code {} '{}' with message '{}'", tokenResponse.code(), error.get().get("code"), error.get().get("message"));
+            }
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Get a Docker image's manifest by calling the Docker Registry HTTP API V2 endpoint: GET /v2/[repo]/manifests/[tag_or_digest]
+     *
+     * @param token Authentication token with pull access for the image's repository
+     * @param registryDockerPath
+     * @param repo
+     * @param specifierName Value of the specifier. Either a tag or a digest
+     * @return HttpResponse
+     */
+    @SuppressWarnings("checkstyle:MagicNumber")
+    public Optional<Response> getDockerManifest(String token, String registryDockerPath, String repo, String specifierName) {
+        // Ex: https://ghcr.io/v2/<repo>/manifests/<tag_or_digest>
+        String getManifestURL = String.format("https://%s/v2/%s/manifests/%s", registryDockerPath, repo, specifierName);
+        String acceptHeader = String.join(",", DOCKER_V2_IMAGE_MANIFEST_MEDIA_TYPE, DOCKER_V2_IMAGE_MANIFEST_LIST_MEDIA_TYPE, OCI_IMAGE_MANIFEST_MEDIA_TYPE, OCI_IMAGE_INDEX_MEDIA_TYPE);
+        int tooManyRequestsCode = 429;
+
+        Request request = new Request.Builder()
+                .url(getManifestURL)
+                .addHeader(HttpHeaders.ACCEPT, acceptHeader)
+                .addHeader(HttpHeaders.AUTHORIZATION, String.join(" ", JWT_SECURITY_DEFINITION_NAME, token))
+                .build();
+
+        Response manifestResponse;
+        try {
+            // Send request and retry if rate limit exceeded. This seems to happen occasionally for Amazon ECR images
+            boolean success = false;
+            int maxRetries = 3;
+            int retries = 0;
+            do {
+                long waitTime = getWaitTimeExp(retries);
+                if (retries > 0) {
+                    LOG.info("Retrying in {} milliseconds", waitTime);
+                }
+                Thread.sleep(waitTime);
+
+                manifestResponse = client.newCall(request).execute();
+                if (manifestResponse.isSuccessful()) {
+                    success = true;
+                } else {
+                    Optional<Map<String, String>> error = getDockerError(manifestResponse);
+                    if (error.isPresent()) {
+                        LOG.error("Manifest response has error code {} '{}' with message '{}'", manifestResponse.code(), error.get().get("code"), error.get().get("message"));
+                    }
+                }
+            } while (!success && (retries++ < maxRetries) && (manifestResponse.code() == tooManyRequestsCode));
+            if (!success) {
+                LOG.error("Could not get manifest after retrying for {} times", retries);
+                return Optional.empty();
+            }
+        } catch (IOException | InterruptedException ex) {
+            LOG.error("Could not send manifest request GET {}", getManifestURL, ex);
+            return Optional.empty();
+        }
+
+        return Optional.of(manifestResponse);
+    }
+
+    /*
+     * Returns the next wait interval, in milliseconds, using an exponential
+     * backoff algorithm.
+     */
+    @SuppressWarnings("checkstyle:MagicNumber")
+    public static long getWaitTimeExp(int retryCount) {
+        if (0 == retryCount) {
+            return 0;
+        }
+
+        long waitTime = ((long) Math.pow(2, retryCount) * 100L);
+
+        return waitTime;
+    }
+
+    /**
+     * Get a blob specified by digest for a Docker image by calling the Docker Registry HTTP API V2 endpoint: GET /v2/[repo]/blobs/[digest]
+     *
+     * @param token Authentication token with pull access for the image's repository
+     * @param registryDockerPath
+     * @param repo
+     * @param digest SHA256 digest of the blob to download
+     * @return HttpResponse
+     */
+    public Optional<Response> getDockerBlob(String token, String registryDockerPath, String repo, String digest) {
+        // Ex: https://ghcr.io/v2/<repo>/blobs/<digest>
+        String getBlobURL = String.format("https://%s/v2/%s/blobs/%s", registryDockerPath, repo, digest);
+
+        Request request = new Request.Builder()
+                .url(getBlobURL)
+                .addHeader(HttpHeaders.AUTHORIZATION, String.join(" ", JWT_SECURITY_DEFINITION_NAME, token))
+                .build();
+
+        Response blobResponse;
+        try {
+            // This endpoint may issue a 307 redirect to another service to download the blob
+            blobResponse = client.newCall(request).execute();
+        } catch (IOException ex) {
+            LOG.error("Could not send blob request GET {}", getBlobURL, ex);
+            return Optional.empty();
+        }
+
+        if (blobResponse.isSuccessful()) {
+            return Optional.of(blobResponse);
+        } else {
+            Optional<Map<String, String>> error = getDockerError(blobResponse);
+            if (error.isPresent()) {
+                LOG.error("Blob response has error code {} '{}' with message '{}'", blobResponse.code(), error.get().get("code"), error.get().get("message"));
+            }
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Gets the error map of an unsuccessful Docker Registry HTTP API V2 response
+     * Failures are reported as part of 4xx responses, in a json response body (https://docs.docker.com/registry/spec/api/#errors)
+     *
+     * @param response Docker Registry HTTP API V2 response
+     * @return an error map of the response if it exists
+     */
+    public Optional<Map<String, String>> getDockerError(Response response) {
+        Map<String, List<Map<String, String>>> errorMap = GSON.fromJson(response.body().charStream(), Map.class);
+        List<Map<String, String>> errors = errorMap.get("errors");
+        if (errors != null) {
+            return Optional.of(errors.get(0));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Calculates the digest of an image by applying the SHA256 hash on the image's manifest body.
+     * Only use this for Docker V2 Schema 2 image manifests or OCI Schema 2 image manifests.
+     * Docker Schema 1 manifests require pre-processing before applying the SHA256 hash.
+     * Source for manifest calculation: https://docs.docker.com/registry/spec/api/#content-digests
+     *
+     * @param manifestResponse Docker Registry V2 Schema 2 image manifest response
+     * @return Docker image digest
+     */
+    public String calculateDockerImageDigest(Response manifestResponse) {
+        String manifestBodyString;
+        try {
+            manifestBodyString = manifestResponse.body().string();
+        } catch (IOException ex) {
+            LOG.error("Could not convert manifest body response to string", ex);
+            return "";
+        }
+
+        return Hashing.sha256().hashString(manifestBodyString, StandardCharsets.UTF_8).toString();
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DockerRegistryAPIHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DockerRegistryAPIHelper.java
@@ -20,7 +20,6 @@ import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
 
 import com.google.common.hash.Hashing;
 import com.google.gson.Gson;
-import io.dockstore.common.Registry;
 import io.dockstore.webservice.CacheHitListener;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
 import java.io.IOException;

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/DockerRegistryAPIHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/DockerRegistryAPIHelperTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 OICR and UCSC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.dockstore.webservice.helpers;
+
+import io.dockstore.common.Registry;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import okhttp3.Response;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DockerRegistryAPIHelperTest {
+    
+    /**
+     * Test that the calculated digest matches the actual digest of the image.
+     * @throws URISyntaxException
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    @Test
+    public void testCalculateDockerImageDigest() {
+        final DockerRegistryAPIHelper dockerRegistryAPIHelper = new DockerRegistryAPIHelper();
+        // GHCR image used: ghcr.io/helm/tiller@sha256:4c43eb385032945cad047d2350e4945d913b90b3ab43ee61cecb32a495c6df0f (associated tag is 'v2.17.0')
+        String repo = "helm/tiller";
+        String digest = "sha256:4c43eb385032945cad047d2350e4945d913b90b3ab43ee61cecb32a495c6df0f";
+        Optional<String> token = dockerRegistryAPIHelper.getDockerToken(Registry.GITHUB_CONTAINER_REGISTRY.getDockerPath(), repo);
+        Assert.assertTrue(token.isPresent());
+        Optional<Response> manifestResponse = dockerRegistryAPIHelper.getDockerManifest(token.get(), Registry.GITHUB_CONTAINER_REGISTRY.getDockerPath(), repo, digest);
+        Assert.assertTrue(manifestResponse.get().isSuccessful());
+        String calculatedDigest = "sha256:" + dockerRegistryAPIHelper.calculateDockerImageDigest(manifestResponse.get());
+        Assert.assertEquals(digest, calculatedDigest);
+
+        // Amazon ECR image used: public.ecr.aws/nginx/unit:1.24.0-minimal
+        repo = "nginx/unit";
+        digest = "sha256:5711186c4c24cf544c1d6ea1f64de288fc3d1f47bc506cae251a75047b15a89a";
+        token = dockerRegistryAPIHelper.getDockerToken(Registry.AMAZON_ECR.getDockerPath(), repo);
+        Assert.assertTrue(token.isPresent());
+        manifestResponse = dockerRegistryAPIHelper.getDockerManifest(token.get(), Registry.AMAZON_ECR.getDockerPath(), repo, digest);
+        Assert.assertTrue(manifestResponse.get().isSuccessful());
+        calculatedDigest = "sha256:" + dockerRegistryAPIHelper.calculateDockerImageDigest(manifestResponse.get());
+        Assert.assertEquals(digest, calculatedDigest);
+    }
+
+}

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/DockerRegistryAPIHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/DockerRegistryAPIHelperTest.java
@@ -34,26 +34,24 @@ public class DockerRegistryAPIHelperTest {
      */
     @Test
     public void testCalculateDockerImageDigest() {
-        final DockerRegistryAPIHelper dockerRegistryAPIHelper = new DockerRegistryAPIHelper();
         // GHCR image used: ghcr.io/helm/tiller@sha256:4c43eb385032945cad047d2350e4945d913b90b3ab43ee61cecb32a495c6df0f (associated tag is 'v2.17.0')
         String repo = "helm/tiller";
         String digest = "sha256:4c43eb385032945cad047d2350e4945d913b90b3ab43ee61cecb32a495c6df0f";
-        Optional<String> token = dockerRegistryAPIHelper.getDockerToken(Registry.GITHUB_CONTAINER_REGISTRY.getDockerPath(), repo);
+        Optional<String> token = DockerRegistryAPIHelper.getDockerToken(Registry.GITHUB_CONTAINER_REGISTRY.getDockerPath(), repo);
         Assert.assertTrue(token.isPresent());
-        Optional<Response> manifestResponse = dockerRegistryAPIHelper.getDockerManifest(token.get(), Registry.GITHUB_CONTAINER_REGISTRY.getDockerPath(), repo, digest);
+        Optional<Response> manifestResponse = DockerRegistryAPIHelper.getDockerManifest(token.get(), Registry.GITHUB_CONTAINER_REGISTRY.getDockerPath(), repo, digest);
         Assert.assertTrue(manifestResponse.get().isSuccessful());
-        String calculatedDigest = "sha256:" + dockerRegistryAPIHelper.calculateDockerImageDigest(manifestResponse.get());
+        String calculatedDigest = "sha256:" + DockerRegistryAPIHelper.calculateDockerImageDigest(manifestResponse.get());
         Assert.assertEquals(digest, calculatedDigest);
 
         // Amazon ECR image used: public.ecr.aws/nginx/unit:1.24.0-minimal
         repo = "nginx/unit";
         digest = "sha256:5711186c4c24cf544c1d6ea1f64de288fc3d1f47bc506cae251a75047b15a89a";
-        token = dockerRegistryAPIHelper.getDockerToken(Registry.AMAZON_ECR.getDockerPath(), repo);
+        token = DockerRegistryAPIHelper.getDockerToken(Registry.AMAZON_ECR.getDockerPath(), repo);
         Assert.assertTrue(token.isPresent());
-        manifestResponse = dockerRegistryAPIHelper.getDockerManifest(token.get(), Registry.AMAZON_ECR.getDockerPath(), repo, digest);
+        manifestResponse = DockerRegistryAPIHelper.getDockerManifest(token.get(), Registry.AMAZON_ECR.getDockerPath(), repo, digest);
         Assert.assertTrue(manifestResponse.get().isSuccessful());
-        calculatedDigest = "sha256:" + dockerRegistryAPIHelper.calculateDockerImageDigest(manifestResponse.get());
+        calculatedDigest = "sha256:" + DockerRegistryAPIHelper.calculateDockerImageDigest(manifestResponse.get());
         Assert.assertEquals(digest, calculatedDigest);
     }
-
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -15,12 +15,9 @@ import io.dockstore.webservice.languages.LanguageHandlerInterface.DockerSpecifie
 import io.dropwizard.testing.ResourceHelpers;
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpStatus;
@@ -263,38 +260,6 @@ public class CWLHandlerTest {
         Assert.assertEquals("sha256:123456789abc", handler.getSpecifierName("foo@sha256:123456789abc", DockerSpecifier.DIGEST));
         Assert.assertEquals("sha256:123456789abc", handler.getSpecifierName("ghcr.io/foo/bar/test@sha256:123456789abc", DockerSpecifier.DIGEST));
         Assert.assertEquals("sha256:123456789abc", handler.getSpecifierName("ghcr.io/foo/bar/test:1@sha256:123456789abc", DockerSpecifier.DIGEST));
-    }
-
-    /**
-     * Test that the calculated digest matches the actual digest of the image.
-     * @throws URISyntaxException
-     * @throws IOException
-     * @throws InterruptedException
-     */
-    @Test
-    public void testCalculateDockerImageDigest() throws URISyntaxException, IOException, InterruptedException {
-        final LanguageHandlerInterface handler = Mockito.mock(LanguageHandlerInterface.class, Mockito.CALLS_REAL_METHODS);
-        // GHCR image used: ghcr.io/helm/tiller@sha256:4c43eb385032945cad047d2350e4945d913b90b3ab43ee61cecb32a495c6df0f (associated tag is 'v2.17.0')
-        String repo = "helm/tiller";
-        String digest = "sha256:4c43eb385032945cad047d2350e4945d913b90b3ab43ee61cecb32a495c6df0f";
-        Optional<String> token = handler.getDockerToken(Registry.GITHUB_CONTAINER_REGISTRY, repo);
-        Assert.assertTrue(token.isPresent());
-        Optional<HttpResponse<String>> manifestResponse = handler.getDockerManifest(token.get(), Registry.GITHUB_CONTAINER_REGISTRY.getDockerPath(), repo, digest);
-        Assert.assertEquals(HttpStatus.SC_OK, manifestResponse.get().statusCode());
-        String manifestBody = manifestResponse.get().body();
-        String calculatedDigest = "sha256:" + handler.calculateDockerImageDigest(manifestBody);
-        Assert.assertEquals(digest, calculatedDigest);
-
-        // Amazon ECR image used: public.ecr.aws/nginx/unit:1.24.0-minimal
-        repo = "nginx/unit";
-        digest = "sha256:5711186c4c24cf544c1d6ea1f64de288fc3d1f47bc506cae251a75047b15a89a";
-        token = handler.getDockerToken(Registry.AMAZON_ECR, repo);
-        Assert.assertTrue(token.isPresent());
-        manifestResponse = handler.getDockerManifest(token.get(), Registry.AMAZON_ECR.getDockerPath(), repo, digest);
-        Assert.assertEquals(HttpStatus.SC_OK, manifestResponse.get().statusCode());
-        manifestBody = manifestResponse.get().body();
-        calculatedDigest = "sha256:" + handler.calculateDockerImageDigest(manifestBody);
-        Assert.assertEquals(digest, calculatedDigest);
     }
 
     @Test


### PR DESCRIPTION
For #4368 

Switched over to using the okhttp client with the general Dockstore cache.

This client is used for 3 Docker Registry endpoints:
- GET token
- GET manifest
- GET blob

From my testing, Amazon ECR does not support caching for any of these endpoints. They were all cache misses.

GitHub Container Registry does support caching for the `GET manifest` endpoint. I thought they would also support caching for the `GET blob` endpoint since the response header contains an Etag, but I only saw cache misses for it. I think this is because of how okhttp handles caching for 307 redirect responses, which is often returned by the `GET blob` endpoint. In their source code (https://github.com/square/okhttp/blob/f8fd4d08decf697013008b05ad7d2be10a648358/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheStrategy.kt#L313) it's only cached if it has the right response headers, like the `Expires` header. The GHCR response doesn't contain this, so it's not cached.