### PR TITLE
4407/collection display name bug fix

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -577,7 +577,18 @@ public class OrganizationIT extends BaseIT {
         // Create another collection with a different name but same display name
         stubCollection.setName("testcollection3");
         thrown.expect(ApiException.class);
-        organisationsApiUser2.createCollection(organisation.getId(), stubCollection);
+        try {
+            organisationsApiUser2.createCollection(organisation.getId(), stubCollection);
+            fail("Should not be able to create a collection with the same display name as an already existing collection in the same organization.");
+        } catch (ApiException ex) {
+            assertTrue(ex.getMessage().contains("A collection already exists with the display name"));
+        }
+
+        // Another organization should be able to use the same name and display name as another org.
+        organisation.setName("org2");
+        organisation.setDisplayName("Org 2");
+        organisation = organisationsApiUser2.createOrganization(organisation);
+        organisationsApiUser2.createCollection(organisation.getId(), collectionTwo);
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -52,13 +52,14 @@ import org.hibernate.annotations.UpdateTimestamp;
 @ApiModel("Collection")
 @Schema(name = "Collection", description = "Collection in an organization, collects entries")
 @Entity
-@Table(name = "collection")
+@Table(name = "collection", uniqueConstraints = @UniqueConstraint(name = "unique_collection_display_name", columnNames = {"organizationid", "displayname"}))
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.Collection.getByAlias", query = "SELECT e from Collection e JOIN e.aliases a WHERE KEY(a) IN :alias"),
         @NamedQuery(name = "io.dockstore.webservice.core.Collection.findAllByOrg", query = "SELECT col FROM Collection col WHERE organizationid = :organizationId"),
         @NamedQuery(name = "io.dockstore.webservice.core.Collection.deleteByOrgId", query = "DELETE Collection c WHERE c.organization.id = :organizationId"),
         @NamedQuery(name = "io.dockstore.webservice.core.Collection.findAllByOrgId", query = "SELECT c from Collection c WHERE c.organization.id = :organizationId"),
         @NamedQuery(name = "io.dockstore.webservice.core.Collection.findByNameAndOrg", query = "SELECT col FROM Collection col WHERE lower(col.name) = lower(:name) AND organizationid = :organizationId"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Collection.findByDisplayNameAndOrg", query = "SELECT col FROM Collection col WHERE lower(col.displayName) = lower(:displayName) AND organizationid = :organizationId"),
         @NamedQuery(name = "io.dockstore.webservice.core.Collection.findEntryVersionsByCollectionId", query = "SELECT entries FROM Collection c JOIN c.entries entries WHERE entries.id = :entryVersionId"),
 })
 
@@ -89,7 +90,7 @@ public class Collection implements Serializable, Aliasable {
     @Schema(description = "Description of the collection")
     private String description;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     @Pattern(regexp = "[\\w ,_\\-&()']*")
     @Size(min = 3, max = 50)
     @ApiModelProperty(value = "Display name for a collection (Ex. Recommended Alignment Algorithms). Not used for links.", position = 3)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -36,7 +36,6 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
-import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.Pattern;
@@ -52,7 +51,6 @@ import org.hibernate.annotations.UpdateTimestamp;
 @ApiModel("Collection")
 @Schema(name = "Collection", description = "Collection in an organization, collects entries")
 @Entity
-@Table(name = "collection", uniqueConstraints = @UniqueConstraint(name = "unique_collection_display_name", columnNames = {"organizationid", "displayname"}))
 @NamedQueries({
         @NamedQuery(name = "io.dockstore.webservice.core.Collection.getByAlias", query = "SELECT e from Collection e JOIN e.aliases a WHERE KEY(a) IN :alias"),
         @NamedQuery(name = "io.dockstore.webservice.core.Collection.findAllByOrg", query = "SELECT col FROM Collection col WHERE organizationid = :organizationId"),

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/CollectionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/CollectionDAO.java
@@ -43,6 +43,13 @@ public class CollectionDAO extends AbstractDAO<Collection> {
         return uniqueResult(query);
     }
 
+    public Collection findByDisplayNameAndOrg(String displayName, long organizationId) {
+        Query query = namedTypedQuery("io.dockstore.webservice.core.Collection.findByDisplayNameAndOrg")
+            .setParameter("displayName", displayName)
+            .setParameter("organizationId", organizationId);
+        return uniqueResult(query);
+    }
+
     public void deleteCollectionsByOrgId(long organizationId) {
         Query query = namedQuery("io.dockstore.webservice.core.Collection.deleteByOrgId")
                 .setParameter("organizationId", organizationId);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -477,6 +477,13 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
             throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
         }
 
+        matchingCollection = collectionDAO.findByDisplayNameAndOrg(collection.getDisplayName(), organizationId);
+        if (matchingCollection != null) {
+            String msg = "A collection already exists with the display name '" + collection.getDisplayName() + "' in the specified organization.";
+            LOG.info(msg);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+        }
+
         // Get the organization
         Organization organization = organizationDAO.findById(organizationId);
 

--- a/dockstore-webservice/src/main/resources/import.sql
+++ b/dockstore-webservice/src/main/resources/import.sql
@@ -54,3 +54,5 @@ CREATE UNIQUE INDEX one_sign_in_method_by_profile ON user_profile USING btree (o
 ALTER TABLE token DROP CONSTRAINT one_token_link_per_identify;
 CREATE UNIQUE INDEX one_token_link_per_identify ON token USING btree (onlineprofileid, tokensource) WHERE onlineprofileid IS NOT NULL;
 CREATE UNIQUE INDEX one_token_link_per_identify2 ON token USING btree (username, tokensource) WHERE onlineprofileid IS NULL;
+
+create unique index collection_displayname_index on collection (LOWER(displayname), organizationid);

--- a/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
@@ -96,4 +96,8 @@
             alter table sourcefile enable row level security;
         </sql>
     </changeSet>
+    <changeSet author="natalieperez (generated)" id="unique_collection_display_names_per_org">
+        <addUniqueConstraint columnNames="organizationid, displayname" constraintName="unique_collection_display_name" tableName="collection"/>
+        <dropUniqueConstraint constraintName="uk_collDisplayName" tableName="collection"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
@@ -97,7 +97,11 @@
         </sql>
     </changeSet>
     <changeSet author="natalieperez (generated)" id="unique_collection_display_names_per_org">
-        <addUniqueConstraint columnNames="organizationid, displayname" constraintName="unique_collection_display_name" tableName="collection"/>
+<!--        <addUniqueConstraint columnNames="organizationid, displayname" constraintName="unique_collection_display_name" tableName="collection"/>-->
+<!--        <dropUniqueConstraint constraintName="uk_collDisplayName" tableName="collection"/>-->
         <dropUniqueConstraint constraintName="uk_collDisplayName" tableName="collection"/>
+        <sql dbms="postgresql">
+            create unique index collection_displayname_index on collection (LOWER(displayname), organizationid);
+        </sql>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
@@ -97,8 +97,6 @@
         </sql>
     </changeSet>
     <changeSet author="natalieperez (generated)" id="unique_collection_display_names_per_org">
-<!--        <addUniqueConstraint columnNames="organizationid, displayname" constraintName="unique_collection_display_name" tableName="collection"/>-->
-<!--        <dropUniqueConstraint constraintName="uk_collDisplayName" tableName="collection"/>-->
         <dropUniqueConstraint constraintName="uk_collDisplayName" tableName="collection"/>
         <sql dbms="postgresql">
             create unique index collection_displayname_index on collection (LOWER(displayname), organizationid);


### PR DESCRIPTION
#4407
Return better error message if org tries to create collection with same display name
Allow orgs to reuse a collection's display name if it's used in another organization's collection.