### PR TITLE
Restrict us to Java 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ executors:
     resource_class: medium+
   machine_integration_test_exec:
     machine: # run the steps with Ubuntu VM
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:202104-01
     environment:
       PGHOST: 127.0.0.1
     resource_class: medium

--- a/pom.xml
+++ b/pom.xml
@@ -458,7 +458,7 @@
                                     <version>3.5.4</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>11</version>
+                                    <version>[11.0.10,12.0)</version>
                                 </requireJavaVersion>
                                 <banDuplicatePomDependencyVersions />
                                 <bannedDependencies>


### PR DESCRIPTION
ran into issue during deploy meeting
Using Java 12 breaks the UI2 PR to test the webservice but older versions of Java 11 break something else as well
https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html

Should revisit later when https://ucsc-cgl.atlassian.net/browse/DOCK-1436
