### PR TITLE
Fixed organization update to fail gracefully when no name specified

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -478,6 +478,33 @@ public class OrganizationIT extends BaseIT {
         organisationsApiUser2.createOrganization(organisation);
     }
 
+    @Test
+    public void testUpdateOrgNoName() {
+        // create admin user
+        final io.dockstore.openapi.client.ApiClient webClientOpenApiUser = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        io.dockstore.openapi.client.api.OrganizationsApi organizationsApiAdmin = new io.dockstore.openapi.client.api.OrganizationsApi(webClientOpenApiUser);
+
+        // create organization
+        io.dockstore.openapi.client.model.Organization organization = openApiStubOrgObject();
+        organization = organizationsApiAdmin.createOrganization(organization);
+
+        // attempt to update organization with valid name
+        io.dockstore.openapi.client.model.Organization newOrganization = new io.dockstore.openapi.client.model.Organization();
+        newOrganization.setDisplayName(organization.getDisplayName());
+        newOrganization.setName(organization.getName());
+        organizationsApiAdmin.updateOrganization(newOrganization, organization.getId());
+
+        // attempt to update organization with no name
+        newOrganization = new io.dockstore.openapi.client.model.Organization();
+        newOrganization.setDisplayName(organization.getDisplayName());
+        try {
+            organizationsApiAdmin.updateOrganization(newOrganization, organization.getId());
+            fail("Organization successfully updated with no name specified");
+        } catch (io.dockstore.openapi.client.ApiException ex) {
+            assertEquals(HttpStatus.SC_BAD_REQUEST, ex.getCode());
+        }
+    }
+
     /**
      * This tests that you cannot add an organization with a duplicate display name
      */

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
@@ -568,6 +568,13 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
             }
         }
 
+        // Check that new name was specified
+        if (organization.getName() == null) {
+            String msg = "An organization name must be specified.";
+            LOG.info(msg);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+        }
+
         // Check if new name is valid
         if (!Objects.equals(oldOrganization.getName(), organization.getName())) {
             Organization duplicateName = organizationDAO.findByName(organization.getName());


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/DOCK-1900
https://github.com/dockstore/dockstore/issues/4442

Pretty straightforward fix, added null organization name check and integration test.
