### PR TITLE
Fix .dockstore.yml authors update

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -474,11 +474,17 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     }
 
     public void setAuthors(final Set<Author> authors) {
-        this.authors = authors;
+        this.authors.clear();
+        if (authors != null) {
+            this.authors.addAll(authors);
+        }
     }
 
     public void setOrcidAuthors(final Set<OrcidAuthor> orcidAuthors) {
-        this.orcidAuthors = orcidAuthors;
+        this.getOrcidAuthors().clear();
+        if (orcidAuthors != null) {
+            this.orcidAuthors.addAll(orcidAuthors);
+        }
     }
 
     public ReferenceType getReferenceType() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -626,6 +626,8 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 existingWorkflowVersion.setToolTableJson(null);
                 existingWorkflowVersion.setReferenceType(remoteWorkflowVersion.getReferenceType());
                 existingWorkflowVersion.setValid(remoteWorkflowVersion.isValid());
+                existingWorkflowVersion.setAuthors(remoteWorkflowVersion.getAuthors());
+                existingWorkflowVersion.setOrcidAuthors(remoteWorkflowVersion.getOrcidAuthors());
                 updateDBVersionSourceFilesWithRemoteVersionSourceFiles(existingWorkflowVersion, remoteWorkflowVersion);
             } else {
                 if (checkUrlLambdaUrl != null) {


### PR DESCRIPTION
**Description**
This fixes a bug that Natalie encountered when reviewing the ticket. The authors in the table weren't being updated if there were changes to the authors in the .dockstore.yml

For the ticket's comment that the webservice isn’t returning any authors for this workflow https://dev.dockstore.net/workflows/github.com/nf-core/smrnaseq:1.0.0?tab=files, I think it just needs to be refreshed because the authors are displayed correctly when I fork the repo, add it to My Workflows, and refresh. I tried looking on prod for the same workflow, but the workflow hasn't been refreshed (last updated in 2019). 

Also found a different workflow on dev that doesn't return any authors: https://dev.dockstore.net/workflows/github.com/vgteam/vg_wdl/vg-pipeline-workingexample:master?tab=info. It does return authors on prod though https://dockstore.org/workflows/github.com/vgteam/vg_wdl/vg-pipeline-workingexample:master?tab=info because it was recently refreshed.

**Issue**
#4295 

- [x] check that you pass the basic style checks and unit tests by running `mvn clean install` 
