### PR TITLE
Feature/seab 3472/jdbc statements

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -616,9 +616,6 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             WorkflowVersion updatedWorkflowVersion;
             // Update existing source files, add new source files, remove deleted sourcefiles, clear json for dag and tool table
             if (existingWorkflowVersion != null) {
-                if (Objects.equals(existingWorkflowVersion.getCommitID(), remoteWorkflowVersion.getCommitID())) {
-                    return;
-                }
                 // Copy over workflow version level information
                 existingWorkflowVersion.setWorkflowPath(remoteWorkflowVersion.getWorkflowPath());
                 existingWorkflowVersion.setLastModified(remoteWorkflowVersion.getLastModified());


### PR DESCRIPTION
**Description**
Attempted to only update the version if the commit id is different, but that seems to fail many tests. The only change right now is to avoid a single workflowVersionDAO.getWorkflowVersionByWorkflowIdAndVersionName per workflow in the .dockstore.yml which is kind of underwhelming in performance gain. Will likely need to modify the JDBC alerts to something higher.

JDBC statements using testGithubDirDockstoreYml with an additional handleGitHubRelease call:
Before: 3 + 92 + 3 + 8 + 3 + 65
After: 3 + 83 + 3 + 8 + 3 +59

Need to look further into it but the addition of only updating the version if commit id changed only results in the number of statements being decreased by 1/4 which is odd because that should be the bulk of the statements.

**Issue**
SEAB-3472
