### PR TITLE
Wildcard python destruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:11.0.10-jdk
 
 # wipe them out, all of them, to reduce CVEs
-RUN apt-get purge -y python3 python3-minimal python3.9 python3.9-minimal libpython3.9-minimal && apt-get -y autoremove
+RUN apt-get purge -y *python*  && apt-get -y autoremove
 
 # Update the APT cache
 # prepare for Java download


### PR DESCRIPTION
**Description**
Simpler version of https://github.com/dockstore/dockstore/pull/4519
Should destroy all versions of python and associated libraries even if they change version (!) between openjdk images
Puts off our impending maven upgrade

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-3467

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] check that you pass the basic style checks and unit tests by running `mvn clean install` 
