### PR TITLE
Validate name in .dockstore.yml

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
@@ -18,7 +18,6 @@ package io.dockstore.client.cli;
 
 import static io.dockstore.common.DescriptorLanguage.CWL;
 import static io.dockstore.common.DescriptorLanguage.WDL;
-import static io.dockstore.webservice.resources.AuthenticatedResourceInterface.ENTRY_NAME_LENGTH_LIMIT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -695,41 +694,6 @@ public class CRUDClientIT extends BaseIT {
             fail("Should not be able to register a hosted tool with a tool name containing special characters that are not underscores or hyphens.");
         } catch (io.dockstore.openapi.client.ApiException ex) {
             assertTrue(ex.getMessage().contains(invalidEntryNameMessage));
-        }
-
-        try {
-            hostedApi.createHostedTool(Registry.QUAY_IO.getDockerPath().toLowerCase(), "awesomeTool", CWL.getShortName(), "coolNamespace", "-foo-");
-            fail("Should not be able to register a hosted tool with a tool name that has external hyphens.");
-        } catch (io.dockstore.openapi.client.ApiException ex) {
-            assertTrue(ex.getMessage().contains(invalidEntryNameMessage));
-        }
-
-        try {
-            hostedApi.createHostedTool(Registry.QUAY_IO.getDockerPath().toLowerCase(), "awesomeTool", CWL.getShortName(), "coolNamespace", "_foo_");
-            fail("Should not be able to register a hosted tool with a tool name that has external underscores.");
-        } catch (io.dockstore.openapi.client.ApiException ex) {
-            assertTrue(ex.getMessage().contains(invalidEntryNameMessage));
-        }
-
-        try {
-            String longToolName = "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-"
-                    + "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmn"; // 257 characters
-            hostedApi.createHostedTool(Registry.QUAY_IO.getDockerPath().toLowerCase(), "awesomeTool", CWL.getShortName(), "coolNamespace", longToolName);
-            fail("Should not be able to register a hosted tool with a tool name that exceeds " + ENTRY_NAME_LENGTH_LIMIT + " characters.");
-        } catch (io.dockstore.openapi.client.ApiException ex) {
-            assertTrue(ex.getMessage().contains(invalidEntryNameMessage));
-        }
-
-        try {
-            hostedApi.createHostedTool(Registry.QUAY_IO.getDockerPath().toLowerCase(), "awesomeTool", CWL.getShortName(), "coolNamespace", "foo");
-        } catch (io.dockstore.openapi.client.ApiException ex) {
-            fail("Should be able to register a hosted tool with a tool name containing only alphanumeric characters.");
-        }
-
-        try {
-            hostedApi.createHostedTool(Registry.QUAY_IO.getDockerPath().toLowerCase(), "awesomeTool", CWL.getShortName(), "coolNamespace", "foo-bar_1");
-        } catch (io.dockstore.openapi.client.ApiException ex) {
-            fail("Should be able to register a hosted tool with a tool name containing alphanumeric characters, internal hyphens, and internal underscores.");
         }
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
@@ -687,13 +687,12 @@ public class CRUDClientIT extends BaseIT {
     public void testHostedToolNameValidation() {
         final io.dockstore.openapi.client.ApiClient webClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
         io.dockstore.openapi.client.api.HostedApi hostedApi = new io.dockstore.openapi.client.api.HostedApi(webClient);
-        final String invalidEntryNameMessage = "Invalid entry name";
 
         try {
             hostedApi.createHostedTool(Registry.QUAY_IO.getDockerPath().toLowerCase(), "awesomeTool", CWL.getShortName(), "coolNamespace", "<foo!>/<$bar>");
             fail("Should not be able to register a hosted tool with a tool name containing special characters that are not underscores or hyphens.");
         } catch (io.dockstore.openapi.client.ApiException ex) {
-            assertTrue(ex.getMessage().contains(invalidEntryNameMessage));
+            assertTrue(ex.getMessage().contains("Invalid tool name"));
         }
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -1407,7 +1407,6 @@ public class GeneralIT extends BaseIT {
     public void testManualToolNameValidation() {
         final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
         ContainersApi containersApi = new ContainersApi(webClient);
-        String invalidEntryNameMessage = "Invalid entry name";
         DockstoreTool tool = createManualTool();
 
         try {
@@ -1415,7 +1414,7 @@ public class GeneralIT extends BaseIT {
             containersApi.registerManual(tool);
             fail("Should not be able to register a tool with a tool name containing special characters that are not underscores and hyphens.");
         } catch (ApiException ex) {
-            assertTrue(ex.getMessage().contains(invalidEntryNameMessage));
+            assertTrue(ex.getMessage().contains("Invalid tool name"));
         }
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -19,7 +19,6 @@ package io.dockstore.client.cli;
 import static io.dockstore.webservice.core.SourceFile.SHA_TYPE;
 import static io.dockstore.webservice.core.Version.CANNOT_FREEZE_VERSIONS_WITH_NO_FILES;
 import static io.dockstore.webservice.helpers.EntryVersionHelper.CANNOT_MODIFY_FROZEN_VERSIONS_THIS_WAY;
-import static io.dockstore.webservice.resources.AuthenticatedResourceInterface.ENTRY_NAME_LENGTH_LIMIT;
 import static io.openapi.api.impl.ToolsApiServiceImpl.DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1417,46 +1416,6 @@ public class GeneralIT extends BaseIT {
             fail("Should not be able to register a tool with a tool name containing special characters that are not underscores and hyphens.");
         } catch (ApiException ex) {
             assertTrue(ex.getMessage().contains(invalidEntryNameMessage));
-        }
-
-        try {
-            tool.setToolname("-foo-");
-            containersApi.registerManual(tool);
-            fail("Should not be able to register a tool with a tool name that has external hyphens.");
-        } catch (ApiException ex) {
-            assertTrue(ex.getMessage().contains(invalidEntryNameMessage));
-        }
-
-        try {
-            tool.setToolname("_foo_");
-            containersApi.registerManual(tool);
-            fail("Should not be able to register a tool with a tool name that has external underscores.");
-        } catch (ApiException ex) {
-            assertTrue(ex.getMessage().contains(invalidEntryNameMessage));
-        }
-
-        try {
-            String longToolName = "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-"
-                    + "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmn"; // 257 characters
-            tool.setToolname(longToolName);
-            containersApi.registerManual(tool);
-            fail("Should not be able to register a tool with a tool name that exceeds " + ENTRY_NAME_LENGTH_LIMIT + " characters.");
-        } catch (ApiException ex) {
-            assertTrue(ex.getMessage().contains(invalidEntryNameMessage));
-        }
-
-        try {
-            tool.setToolname("foo");
-            containersApi.registerManual(tool);
-        } catch (ApiException ex) {
-            fail("Should be able to register a tool with a tool name containing only alphanumeric characters.");
-        }
-
-        try {
-            tool.setToolname("foo-bar_1");
-            containersApi.registerManual(tool);
-        } catch (ApiException ex) {
-            fail("Should be able to register a tool with a tool name containing alphanumeric characters, internal hyphens, and internal underscores.");
         }
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -1807,13 +1807,12 @@ public class WorkflowIT extends BaseIT {
     public void testManualWorkflowNameValidation() {
         final io.dockstore.openapi.client.ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         io.dockstore.openapi.client.api.WorkflowsApi workflowsApi = new io.dockstore.openapi.client.api.WorkflowsApi(webClient);
-        String invalidEntryNameMessage = "Invalid entry name";
 
         try {
             workflowsApi.manualRegister("github", DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "/Dockstore.wdl", "!@#$/%^&*<foo><bar>", "wdl", "/test.json");
             fail("Should not be able to register a workflow with a workflow name containing special characters that are not underscores and hyphens.");
         } catch (io.dockstore.openapi.client.ApiException ex) {
-            assertTrue(ex.getMessage().contains(invalidEntryNameMessage));
+            assertTrue(ex.getMessage().contains("Invalid workflow name"));
         }
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -17,7 +17,6 @@
 package io.dockstore.client.cli;
 
 import static io.dockstore.common.DescriptorLanguage.CWL;
-import static io.dockstore.webservice.resources.AuthenticatedResourceInterface.ENTRY_NAME_LENGTH_LIMIT;
 import static io.openapi.api.impl.ToolsApiServiceImpl.DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1815,41 +1814,6 @@ public class WorkflowIT extends BaseIT {
             fail("Should not be able to register a workflow with a workflow name containing special characters that are not underscores and hyphens.");
         } catch (io.dockstore.openapi.client.ApiException ex) {
             assertTrue(ex.getMessage().contains(invalidEntryNameMessage));
-        }
-
-        try {
-            workflowsApi.manualRegister("github", DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "/Dockstore.wdl", "-foo-", "wdl", "/test.json");
-            fail("Should not be able to register a workflow with a workflow name that has external hyphens.");
-        } catch (io.dockstore.openapi.client.ApiException ex) {
-            assertTrue(ex.getMessage().contains(invalidEntryNameMessage));
-        }
-
-        try {
-            workflowsApi.manualRegister("github", DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "/Dockstore.wdl", "_foo_", "wdl", "/test.json");
-            fail("Should not be able to register a workflow with a workflow name that has external underscores.");
-        } catch (io.dockstore.openapi.client.ApiException ex) {
-            assertTrue(ex.getMessage().contains(invalidEntryNameMessage));
-        }
-
-        try {
-            String longWorkflowName = "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-"
-                    + "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmn"; // 257 characters
-            workflowsApi.manualRegister("github", DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "/Dockstore.wdl", longWorkflowName, "wdl", "/test.json");
-            fail("Should not be able to register a workflow with a workflow name that exceeds " + ENTRY_NAME_LENGTH_LIMIT + " characters.");
-        } catch (io.dockstore.openapi.client.ApiException ex) {
-            assertTrue(ex.getMessage().contains(invalidEntryNameMessage));
-        }
-
-        try {
-            workflowsApi.manualRegister("github", "dockstore-testing/hello-wdl-workflow", "/Dockstore.wdl", "foo", "wdl", "/test.json");
-        } catch (io.dockstore.openapi.client.ApiException ex) {
-            fail("Should be able to register a workflow with a workflow name containing only alphanumeric characters.");
-        }
-
-        try {
-            workflowsApi.manualRegister("github", "dockstore-testing/hello-wdl-workflow", "/Dockstore.wdl", "foo-bar_1", "wdl", "/test.json");
-        } catch (io.dockstore.openapi.client.ApiException ex) {
-            fail("Should be able to register a workflow with a workflow name containing alphanumeric characters, internal hyphens, and internal underscores.");
         }
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -806,7 +806,7 @@ public class WebhookIT extends BaseIT {
      * @throws Exception
      */
     @Test
-    public void testDockstoreYmlInvalidName() throws Exception {
+    public void testDockstoreYmlInvalidWorkflowName() throws Exception {
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
         final io.dockstore.openapi.client.ApiClient webClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
         io.dockstore.openapi.client.api.WorkflowsApi workflowsApi = new io.dockstore.openapi.client.api.WorkflowsApi(webClient);
@@ -819,6 +819,7 @@ public class WebhookIT extends BaseIT {
             List<io.dockstore.openapi.client.model.LambdaEvent> failEvents = usersApi.getUserGitHubEvents("0", 10);
             assertEquals("There should be 1 unsuccessful event", 1,
                     failEvents.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count());
+            assertTrue(failEvents.get(0).getMessage().contains("Invalid workflow name"));
         }
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -801,6 +801,27 @@ public class WebhookIT extends BaseIT {
         assertEquals(0, version.getOrcidAuthors().size());
     }
 
+    /**
+     * Tests that the GitHub release process doesn't work for workflows with invalid names
+     * @throws Exception
+     */
+    @Test
+    public void testDockstoreYmlInvalidName() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+        final io.dockstore.openapi.client.ApiClient webClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        io.dockstore.openapi.client.api.WorkflowsApi workflowsApi = new io.dockstore.openapi.client.api.WorkflowsApi(webClient);
+        io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(webClient);
+
+        try {
+            workflowsApi.handleGitHubRelease("refs/heads/invalidWorkflowName", installationId, workflowRepo, BasicIT.USER_2_USERNAME);
+        } catch (io.dockstore.openapi.client.ApiException ex) {
+            assertEquals("Should not be able to add a workflow with an invalid name", LAMBDA_ERROR, ex.getCode());
+            List<io.dockstore.openapi.client.model.LambdaEvent> failEvents = usersApi.getUserGitHubEvents("0", 10);
+            assertEquals("There should be 1 unsuccessful event", 1,
+                    failEvents.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count());
+        }
+    }
+
     @Test
     public void testTools() throws Exception {
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/languages/GalaxyPluginIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/languages/GalaxyPluginIT.java
@@ -203,8 +203,8 @@ public class GalaxyPluginIT {
     public void testTestParameterPaths() {
         final ApiClient webClient = getWebClient(true, BaseIT.USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
-        workflowApi.handleGitHubRelease(galaxyWorkflowRepo, BaseIT.USER_2_USERNAME, "refs/tags/dockstore/3851", installationId);
-        Workflow workflow = workflowApi.getWorkflowByPath("github.com/" + galaxyWorkflowRepo + "/COVID-19 variation analysis on Illumina metagenomic data", BaseIT.BIOWORKFLOW, "versions");
+        workflowApi.handleGitHubRelease(galaxyWorkflowRepo, BaseIT.USER_2_USERNAME, "refs/heads/validTestParameterFiles", installationId);
+        Workflow workflow = workflowApi.getWorkflowByPath("github.com/" + galaxyWorkflowRepo + "/COVID-19-variation-analysis-on-Illumina-metagenomic-data", BaseIT.BIOWORKFLOW, "versions");
         WorkflowVersion version = workflow.getWorkflowVersions().get(0);
         List<SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(version.getId());
         assertTrue("Test file should have the expected path",

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/StringInputValidationHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/StringInputValidationHelper.java
@@ -1,0 +1,26 @@
+package io.dockstore.webservice.helpers;
+
+import io.dockstore.webservice.CustomWebApplicationException;
+import java.util.regex.Pattern;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class StringInputValidationHelper {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StringInputValidationHelper.class);
+
+    public static final Pattern ENTRY_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*+"); // Used to validate tool and workflow names
+    public static final int ENTRY_NAME_LENGTH_LIMIT = 256;
+
+    private StringInputValidationHelper() {
+
+    }
+
+    public static void checkEntryName(String name) {
+        if (name != null && !name.isEmpty() && (!ENTRY_NAME_PATTERN.matcher(name).matches() || name.length() > ENTRY_NAME_LENGTH_LIMIT)) {
+            throw new CustomWebApplicationException(String.format(
+                    "Invalid entry name: '%s'. Entry name may not exceed %s characters and may only consist of alphanumeric characters, internal underscores, and internal hyphens.",
+                    name, ENTRY_NAME_LENGTH_LIMIT), HttpStatus.SC_BAD_REQUEST);
+        }
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/StringInputValidationHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/StringInputValidationHelper.java
@@ -1,13 +1,17 @@
 package io.dockstore.webservice.helpers;
 
 import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.AppTool;
+import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.Service;
+import io.dockstore.webservice.core.Tool;
 import java.util.regex.Pattern;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class StringInputValidationHelper {
-    private static final Logger LOGGER = LoggerFactory.getLogger(StringInputValidationHelper.class);
+    private static final Logger LOG = LoggerFactory.getLogger(StringInputValidationHelper.class);
 
     public static final Pattern ENTRY_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*+"); // Used to validate tool and workflow names
     public static final int ENTRY_NAME_LENGTH_LIMIT = 256;
@@ -16,11 +20,29 @@ public final class StringInputValidationHelper {
 
     }
 
-    public static void checkEntryName(String name) {
+    /**
+     * Checks that the entry name is valid
+     * @param entryType Valid types: Tool.class, AppTool.class, BioWorkflow.class, or Service.class.
+     * @param name Name to validate
+     */
+    public static void checkEntryName(Class entryType, String name) {
         if (name != null && !name.isEmpty() && (!ENTRY_NAME_PATTERN.matcher(name).matches() || name.length() > ENTRY_NAME_LENGTH_LIMIT)) {
+            String entryTypeString;
+
+            if (entryType.equals(Tool.class) || entryType.equals(AppTool.class)) {
+                entryTypeString = "tool";
+            } else if (entryType.equals(BioWorkflow.class)) {
+                entryTypeString = "workflow";
+            } else if (entryType.equals(Service.class)) {
+                entryTypeString = "service";
+            } else {
+                LOG.error("{} is not a valid entry type for name validation", entryType.getCanonicalName());
+                throw new CustomWebApplicationException(entryType.getCanonicalName() + " is not a valid entry type", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            }
+
             throw new CustomWebApplicationException(String.format(
-                    "Invalid entry name: '%s'. Entry name may not exceed %s characters and may only consist of alphanumeric characters, internal underscores, and internal hyphens.",
-                    name, ENTRY_NAME_LENGTH_LIMIT), HttpStatus.SC_BAD_REQUEST);
+                    "Invalid %s name: '%s'. The %s name may not exceed %s characters and may only consist of alphanumeric characters, internal underscores, and internal hyphens.",
+                    entryTypeString, name, entryTypeString, ENTRY_NAME_LENGTH_LIMIT), HttpStatus.SC_BAD_REQUEST);
         }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/StringInputValidationHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/StringInputValidationHelper.java
@@ -3,6 +3,7 @@ package io.dockstore.webservice.helpers;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.AppTool;
 import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.Tool;
 import java.util.regex.Pattern;
@@ -25,7 +26,7 @@ public final class StringInputValidationHelper {
      * @param entryType Valid types: Tool.class, AppTool.class, BioWorkflow.class, or Service.class.
      * @param name Name to validate
      */
-    public static void checkEntryName(Class entryType, String name) {
+    public static void checkEntryName(Class<? extends Entry> entryType, String name) {
         if (name != null && !name.isEmpty() && (!ENTRY_NAME_PATTERN.matcher(name).matches() || name.length() > ENTRY_NAME_LENGTH_LIMIT)) {
             String entryTypeString;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -372,6 +372,12 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
     protected abstract String checkRegistry(String registry);
 
     /**
+     * Check that the entry name is valid
+     * @param entryName
+     */
+    protected abstract void checkEntryName(String entryName);
+
+    /**
      * Create new version of a workflow or tag of a tool
      * @param entry the parent for the new version
      * @return the new version

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -44,6 +44,7 @@ import io.dockstore.webservice.helpers.PublicStateManager;
 import io.dockstore.webservice.helpers.SourceCodeRepoFactory;
 import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
 import io.dockstore.webservice.helpers.StateManagerMode;
+import io.dockstore.webservice.helpers.StringInputValidationHelper;
 import io.dockstore.webservice.jdbi.EventDAO;
 import io.dockstore.webservice.jdbi.FileDAO;
 import io.dockstore.webservice.jdbi.FileFormatDAO;
@@ -541,7 +542,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
 
     /**
      * Create or retrieve workflow or service based on Dockstore.yml
-     * @param workflowType Either BioWorkflow.class or Service.class
+     * @param workflowType Either BioWorkflow.class, Service.class or AppTool.class
      * @param repository Repository path (ex. dockstore/dockstore-ui2)
      * @param user User that triggered action
      * @param workflowName User that triggered action
@@ -550,6 +551,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @return New or updated workflow
      */
     private Workflow createOrGetWorkflow(Class workflowType, String repository, User user, String workflowName, String subclass, GitHubSourceCodeRepo gitHubSourceCodeRepo) {
+        // Validate workflowName before checking for existing workflows because if workflowName contains slashes (which are invalid),
+        // we may find a workflow that matches the workflow path but has a different values for the components that make up the path.
+        StringInputValidationHelper.checkEntryName(workflowName);
+
         // Check for existing workflow
         String dockstoreWorkflowPath = "github.com/" + repository + (workflowName != null && !workflowName.isEmpty() ? "/" + workflowName : "");
         Optional<Workflow> workflow = workflowDAO.findByPath(dockstoreWorkflowPath, false, workflowType);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -553,7 +553,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     private Workflow createOrGetWorkflow(Class workflowType, String repository, User user, String workflowName, String subclass, GitHubSourceCodeRepo gitHubSourceCodeRepo) {
         // Validate workflowName before checking for existing workflows because if workflowName contains slashes (which are invalid),
         // we may find a workflow that matches the workflow path but has a different values for the components that make up the path.
-        StringInputValidationHelper.checkEntryName(workflowName);
+        StringInputValidationHelper.checkEntryName(workflowType, workflowName);
 
         // Check for existing workflow
         String dockstoreWorkflowPath = "github.com/" + repository + (workflowName != null && !workflowName.isEmpty() ? "/" + workflowName : "");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -551,10 +551,6 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @return New or updated workflow
      */
     private Workflow createOrGetWorkflow(Class workflowType, String repository, User user, String workflowName, String subclass, GitHubSourceCodeRepo gitHubSourceCodeRepo) {
-        // Validate workflowName before checking for existing workflows because if workflowName contains slashes (which are invalid),
-        // we may find a workflow that matches the workflow path but has a different values for the components that make up the path.
-        StringInputValidationHelper.checkEntryName(workflowType, workflowName);
-
         // Check for existing workflow
         String dockstoreWorkflowPath = "github.com/" + repository + (workflowName != null && !workflowName.isEmpty() ? "/" + workflowName : "");
         Optional<Workflow> workflow = workflowDAO.findByPath(dockstoreWorkflowPath, false, workflowType);
@@ -566,6 +562,8 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             if (user == null) {
                 throw new CustomWebApplicationException("User does not have an account on Dockstore.", LAMBDA_FAILURE);
             }
+
+            StringInputValidationHelper.checkEntryName(workflowType, workflowName);
 
             if (workflowType == BioWorkflow.class) {
                 workflowToUpdate = gitHubSourceCodeRepo.initializeWorkflowFromGitHub(repository, subclass, workflowName);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
@@ -24,7 +24,6 @@ import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.User;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Pattern;
 import javax.ws.rs.container.ContainerRequestContext;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
@@ -36,8 +35,6 @@ import org.slf4j.LoggerFactory;
 public interface AuthenticatedResourceInterface {
 
     Logger LOG = LoggerFactory.getLogger(AuthenticatedResourceInterface.class);
-    Pattern ENTRY_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*+"); // Used to validate tool and workflow names
-    int ENTRY_NAME_LENGTH_LIMIT = 256;
 
     /**
      * Check if admin or if container belongs to user
@@ -275,14 +272,6 @@ public interface AuthenticatedResourceInterface {
             });
         } catch (Exception e) {
             LOG.debug("encountered a user agent that we could not parse, meh", e);
-        }
-    }
-
-    default void checkEntryName(String name) {
-        if (name != null && !name.isEmpty() && (!ENTRY_NAME_PATTERN.matcher(name).matches() || name.length() > ENTRY_NAME_LENGTH_LIMIT)) {
-            throw new CustomWebApplicationException("Invalid entry name. Entry name may not exceed " + ENTRY_NAME_LENGTH_LIMIT
-                    + " characters and may only consist of alphanumeric characters, internal underscores, and internal hyphens.",
-                    HttpStatus.SC_BAD_REQUEST);
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -51,6 +51,7 @@ import io.dockstore.webservice.helpers.QuayImageRegistry;
 import io.dockstore.webservice.helpers.SourceCodeRepoFactory;
 import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
 import io.dockstore.webservice.helpers.StateManagerMode;
+import io.dockstore.webservice.helpers.StringInputValidationHelper;
 import io.dockstore.webservice.jdbi.EventDAO;
 import io.dockstore.webservice.jdbi.FileDAO;
 import io.dockstore.webservice.jdbi.FileFormatDAO;
@@ -536,7 +537,7 @@ public class DockerRepoResource
         }
 
         // Check if the tool has a valid tool name
-        checkEntryName(toolParam.getToolname());
+        StringInputValidationHelper.checkEntryName(toolParam.getToolname());
 
         final Set<Tag> workflowVersionsFromParam = Sets.newHashSet(toolParam.getWorkflowVersions());
         toolParam.setWorkflowVersions(Sets.newHashSet());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -537,7 +537,7 @@ public class DockerRepoResource
         }
 
         // Check if the tool has a valid tool name
-        StringInputValidationHelper.checkEntryName(toolParam.getToolname());
+        StringInputValidationHelper.checkEntryName(toolParam.getClass(), toolParam.getToolname());
 
         final Set<Tag> workflowVersionsFromParam = Sets.newHashSet(toolParam.getWorkflowVersions());
         toolParam.setWorkflowVersions(Sets.newHashSet());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
@@ -267,6 +267,6 @@ public class HostedToolResource extends AbstractHostedEntryResource<Tool, Tag, T
 
     @Override
     protected void checkEntryName(String entryName) {
-        StringInputValidationHelper.checkEntryName(entryName);
+        StringInputValidationHelper.checkEntryName(Tool.class, entryName);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
@@ -35,6 +35,7 @@ import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.helpers.EntryVersionHelper;
 import io.dockstore.webservice.helpers.PublicStateManager;
 import io.dockstore.webservice.helpers.StateManagerMode;
+import io.dockstore.webservice.helpers.StringInputValidationHelper;
 import io.dockstore.webservice.jdbi.TagDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import io.dockstore.webservice.languages.LanguageHandlerFactory;
@@ -262,5 +263,10 @@ public class HostedToolResource extends AbstractHostedEntryResource<Tool, Tag, T
         }
 
         throw new CustomWebApplicationException(registry + " is not a valid registry type", HttpStatus.SC_BAD_REQUEST);
+    }
+
+    @Override
+    protected void checkEntryName(String entryName) {
+        StringInputValidationHelper.checkEntryName(entryName);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
@@ -302,6 +302,6 @@ public class HostedWorkflowResource extends AbstractHostedEntryResource<Workflow
 
     @Override
     public void checkEntryName(String name) {
-        return; // Don't need to check anything because hosted workflows don't have entry names
+        return; // Don't need to validate entry name because hosted workflows don't have entry names
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -61,6 +61,7 @@ import io.dockstore.webservice.helpers.MetadataResourceHelper;
 import io.dockstore.webservice.helpers.PublicStateManager;
 import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
 import io.dockstore.webservice.helpers.StateManagerMode;
+import io.dockstore.webservice.helpers.StringInputValidationHelper;
 import io.dockstore.webservice.helpers.URIHelper;
 import io.dockstore.webservice.helpers.ZenodoHelper;
 import io.dockstore.webservice.jdbi.BioWorkflowDAO;
@@ -1257,7 +1258,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         }
 
         // Validate the workflow name
-        checkEntryName(workflowName);
+        StringInputValidationHelper.checkEntryName(workflowName);
 
         String registryURLPrefix = sourceControlEnum.get().toString();
         String gitURL = "git@" + registryURLPrefix + ":" + workflowPath + ".git";

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1258,7 +1258,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         }
 
         // Validate the workflow name
-        StringInputValidationHelper.checkEntryName(workflowName);
+        StringInputValidationHelper.checkEntryName(BioWorkflow.class, workflowName);
 
         String registryURLPrefix = sourceControlEnum.get().toString();
         String gitURL = "git@" + registryURLPrefix + ":" + workflowPath + ".git";

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/StringInputValidationHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/StringInputValidationHelperTest.java
@@ -15,21 +15,28 @@ public class StringInputValidationHelperTest {
 
         try {
             StringInputValidationHelper.checkEntryName("!@#$/%^&*<foo><bar>");
-            fail("Should not be able to register a workflow with a workflow name containing special characters that are not underscores and hyphens.");
+            fail("Entry name with special characters that are not underscores and hyphens should fail validation.");
+        } catch (CustomWebApplicationException ex) {
+            assertTrue(ex.getErrorMessage().contains(invalidEntryNameMessage));
+        }
+
+        try {
+            StringInputValidationHelper.checkEntryName("foo bar");
+            fail("Entry name with spaces should fail validation.");
         } catch (CustomWebApplicationException ex) {
             assertTrue(ex.getErrorMessage().contains(invalidEntryNameMessage));
         }
 
         try {
             StringInputValidationHelper.checkEntryName("-foo-");
-            fail("Should not be able to register a workflow with a workflow name that has external hyphens.");
+            fail("Entry name with external hyphens should fail validation.");
         } catch (CustomWebApplicationException ex) {
             assertTrue(ex.getErrorMessage().contains(invalidEntryNameMessage));
         }
 
         try {
             StringInputValidationHelper.checkEntryName("_foo_");
-            fail("Should not be able to register a workflow with a workflow name that has external underscores.");
+            fail("Entry name with external underscores should fail validation.");
         } catch (CustomWebApplicationException ex) {
             assertTrue(ex.getErrorMessage().contains(invalidEntryNameMessage));
         }
@@ -38,7 +45,7 @@ public class StringInputValidationHelperTest {
             String longWorkflowName = "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-"
                     + "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmn"; // 257 characters
             StringInputValidationHelper.checkEntryName(longWorkflowName);
-            fail("Should not be able to register a workflow with a workflow name that exceeds " + ENTRY_NAME_LENGTH_LIMIT + " characters.");
+            fail("Entry name that exceeds " + ENTRY_NAME_LENGTH_LIMIT + " characters should fail validation.");
         } catch (CustomWebApplicationException ex) {
             assertTrue(ex.getErrorMessage().contains(invalidEntryNameMessage));
         }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/StringInputValidationHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/StringInputValidationHelperTest.java
@@ -1,0 +1,58 @@
+package io.dockstore.webservice.helpers;
+
+import static io.dockstore.webservice.helpers.StringInputValidationHelper.ENTRY_NAME_LENGTH_LIMIT;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.dockstore.webservice.CustomWebApplicationException;
+import org.junit.Test;
+
+public class StringInputValidationHelperTest {
+
+    @Test
+    public void testCheckEntryName() {
+        String invalidEntryNameMessage = "Invalid entry name";
+
+        try {
+            StringInputValidationHelper.checkEntryName("!@#$/%^&*<foo><bar>");
+            fail("Should not be able to register a workflow with a workflow name containing special characters that are not underscores and hyphens.");
+        } catch (CustomWebApplicationException ex) {
+            assertTrue(ex.getErrorMessage().contains(invalidEntryNameMessage));
+        }
+
+        try {
+            StringInputValidationHelper.checkEntryName("-foo-");
+            fail("Should not be able to register a workflow with a workflow name that has external hyphens.");
+        } catch (CustomWebApplicationException ex) {
+            assertTrue(ex.getErrorMessage().contains(invalidEntryNameMessage));
+        }
+
+        try {
+            StringInputValidationHelper.checkEntryName("_foo_");
+            fail("Should not be able to register a workflow with a workflow name that has external underscores.");
+        } catch (CustomWebApplicationException ex) {
+            assertTrue(ex.getErrorMessage().contains(invalidEntryNameMessage));
+        }
+
+        try {
+            String longWorkflowName = "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-"
+                    + "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmn"; // 257 characters
+            StringInputValidationHelper.checkEntryName(longWorkflowName);
+            fail("Should not be able to register a workflow with a workflow name that exceeds " + ENTRY_NAME_LENGTH_LIMIT + " characters.");
+        } catch (CustomWebApplicationException ex) {
+            assertTrue(ex.getErrorMessage().contains(invalidEntryNameMessage));
+        }
+
+        try {
+            StringInputValidationHelper.checkEntryName("foo");
+        } catch (CustomWebApplicationException ex) {
+            fail("Name with only alphanumeric characters should pass validation");
+        }
+
+        try {
+            StringInputValidationHelper.checkEntryName("foo-bar_1");
+        } catch (CustomWebApplicationException ex) {
+            fail("Name with alphanumeric characters, internal hyphens and internal underscores should pass validation");
+        }
+    }
+}

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/StringInputValidationHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/StringInputValidationHelperTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.fail;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.AppTool;
 import io.dockstore.webservice.core.BioWorkflow;
-import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.Tool;
 import org.junit.Test;

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/StringInputValidationHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/StringInputValidationHelperTest.java
@@ -5,59 +5,62 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.AppTool;
+import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.Entry;
+import io.dockstore.webservice.core.Service;
+import io.dockstore.webservice.core.Tool;
 import org.junit.Test;
 
 public class StringInputValidationHelperTest {
 
     @Test
     public void testCheckEntryName() {
-        String invalidEntryNameMessage = "Invalid entry name";
-
         try {
-            StringInputValidationHelper.checkEntryName("!@#$/%^&*<foo><bar>");
+            StringInputValidationHelper.checkEntryName(Tool.class, "!@#$/%^&*<foo><bar>");
             fail("Entry name with special characters that are not underscores and hyphens should fail validation.");
         } catch (CustomWebApplicationException ex) {
-            assertTrue(ex.getErrorMessage().contains(invalidEntryNameMessage));
+            assertTrue(ex.getErrorMessage().contains("Invalid tool name"));
         }
 
         try {
-            StringInputValidationHelper.checkEntryName("foo bar");
+            StringInputValidationHelper.checkEntryName(AppTool.class, "foo bar");
             fail("Entry name with spaces should fail validation.");
         } catch (CustomWebApplicationException ex) {
-            assertTrue(ex.getErrorMessage().contains(invalidEntryNameMessage));
+            assertTrue(ex.getErrorMessage().contains("Invalid tool name"));
         }
 
         try {
-            StringInputValidationHelper.checkEntryName("-foo-");
+            StringInputValidationHelper.checkEntryName(BioWorkflow.class, "-foo-");
             fail("Entry name with external hyphens should fail validation.");
         } catch (CustomWebApplicationException ex) {
-            assertTrue(ex.getErrorMessage().contains(invalidEntryNameMessage));
+            assertTrue(ex.getErrorMessage().contains("Invalid workflow name"));
         }
 
         try {
-            StringInputValidationHelper.checkEntryName("_foo_");
+            StringInputValidationHelper.checkEntryName(Service.class, "_foo_");
             fail("Entry name with external underscores should fail validation.");
         } catch (CustomWebApplicationException ex) {
-            assertTrue(ex.getErrorMessage().contains(invalidEntryNameMessage));
+            assertTrue(ex.getErrorMessage().contains("Invalid service name"));
         }
 
         try {
             String longWorkflowName = "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-"
                     + "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmn"; // 257 characters
-            StringInputValidationHelper.checkEntryName(longWorkflowName);
+            StringInputValidationHelper.checkEntryName(BioWorkflow.class, longWorkflowName);
             fail("Entry name that exceeds " + ENTRY_NAME_LENGTH_LIMIT + " characters should fail validation.");
         } catch (CustomWebApplicationException ex) {
-            assertTrue(ex.getErrorMessage().contains(invalidEntryNameMessage));
+            assertTrue(ex.getErrorMessage().contains("Invalid workflow name"));
         }
 
         try {
-            StringInputValidationHelper.checkEntryName("foo");
+            StringInputValidationHelper.checkEntryName(BioWorkflow.class, "foo");
         } catch (CustomWebApplicationException ex) {
             fail("Name with only alphanumeric characters should pass validation");
         }
 
         try {
-            StringInputValidationHelper.checkEntryName("foo-bar_1");
+            StringInputValidationHelper.checkEntryName(BioWorkflow.class, "foo-bar_1");
         } catch (CustomWebApplicationException ex) {
             fail("Name with alphanumeric characters, internal hyphens and internal underscores should pass validation");
         }


### PR DESCRIPTION
**Description**
This PR validates the workflow name in the .dockstore.yml using the same validation that's in the front-end. If the name is invalid, the GitHub release fails and you can view the error message in the GitHub App logs:

![Screenshot 2021-10-28 at 08-54-24 Dockstore My Workflows](https://user-images.githubusercontent.com/25287123/139262892-b96a1ac9-2620-47bb-9cda-d2f0dc5dfc5b.png)

I also refactored `checkEntryName` into a helper class for string input validation so future string input validation methods that are usable in several places can be put here as well. 

There are a handful of existing GitHub app workflows that have names containing spaces which is invalid with the validation used in this PR. This is a [published workflow](https://dockstore.org/workflows/github.com/arvados/bh20-seq-resource/Pangenome%20Generator:master?tab=info) on prod with a workflow name containing spaces ([corresponding .dockstore.yml](https://github.com/pubseq/bh20-seq-resource/blob/aa1b7e5f507148149f0d65f9bfe86fe9daffbcc8/.dockstore.yml#L3)). With these workflows, any subsequent pushes to these repos would result in a failure. If they fix the workflow name, it would create a new workflow since the workflow path is technically different. 

**Issue**
[SEAB-1866](https://ucsc-cgl.atlassian.net/browse/SEAB-1866)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
