### PR TITLE
migrate to cimg namespace 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
         environment:
           JAVA_TOOL_OPTIONS: -Xmx512m # Nothing to do with surefire plugin, it has its own JVM. The two of these plus ES (1.3 GB) must add up to a bit less than 6GB.
           PGHOST: 127.0.0.1
-      - image: circleci/postgres:13.3
+      - image: cimg/postgres:13.3
         command: postgres -c max_connections=200 -c jit=off
         environment:
           POSTGRES_USER: postgres


### PR DESCRIPTION
**Description**
Attempt to update, but definitely running into https://github.com/CircleCI-Public/cimg-postgres/issues/11

> ERROR [2021-11-02 19:35:33,528] liquibase.changelog.ChangeSet: Change Set migrations.1.12.0.xml::calculatedChecksums::coverbeck failed.  Error: ERROR: could not open extension control file "/usr/lib/postgresql/13/share/extension/pgcrypto.control": No such file or directory [Failed SQL: (0) create extension if not exists pgcrypto]
liquibase.exception.MigrationFailedException: Migration failed for change set migrations.1.12.0.xml::calculatedChecksums::coverbeck:
     Reason: liquibase.exception.DatabaseException: ERROR: could not open extension control file "/usr/lib/postgresql/13/share/extension/pgcrypto.control": No such file or directory [Failed SQL: (0) create extension if not exists pgcrypto]

Update: this has been fixed, CircleCI has updated their postgres images


**Issue**
https://github.com/dockstore/dockstore/issues/4555

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
