### PR TITLE
reindex entries of deleted category in Elasticsearch

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -603,6 +603,11 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
         // Soft delete the collection
         collection.setDeleted(true);
 
+        // If the collection was a Category, reindex the entries.
+        if (collection instanceof Category) {
+            reindexEntries(collection);
+        }
+
         // Create the delete collection event.
         Event.Builder eventBuild = new Event.Builder()
                 .withOrganization(organization)


### PR DESCRIPTION
**Description**
When I merged the "categories" feature with the "collection deletion" feature, I forgot to insert the code that would reindex the entries, in the case that the deleted collection was a category.  The upshot: information about a deleted category would linger upon the category's entries in Elasticsearch.  This PR is the fix.

**Issue**
#4184