### PR TITLE
Add warning for unknown .dockstore.yml properties

### DIFF
--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -88,6 +88,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.9</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>30.1.1-jre</version>

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -82,6 +82,10 @@
             <artifactId>commons-exec</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
@@ -1,12 +1,20 @@
 package io.dockstore.common.yaml;
 
 import io.dockstore.common.DescriptorLanguageSubclass;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -18,6 +26,7 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
@@ -39,6 +48,11 @@ public final class DockstoreYamlHelper {
                 validate(dockstoreYaml10);
                 return dockstoreYaml10;
             }
+
+            @Override
+            public void validateDockstoreYamlProperties(final String content) throws DockstoreYamlException {
+                return; // Don't validate properties for 1.0
+            }
         },
         ONE_ONE("1.1") {
             @Override
@@ -47,6 +61,11 @@ public final class DockstoreYamlHelper {
                 validate(dockstoreYaml11);
                 return dockstoreYaml11;
             }
+
+            @Override
+            public void validateDockstoreYamlProperties(final String content) throws DockstoreYamlException {
+                findUnknownProperty(DockstoreYaml11.class, content);
+            }
         },
         ONE_TWO("1.2") {
             @Override
@@ -54,6 +73,11 @@ public final class DockstoreYamlHelper {
                 final DockstoreYaml12 dockstoreYaml12 = readDockstoreYaml12(content);
                 validate(dockstoreYaml12);
                 return dockstoreYaml12;
+            }
+
+            @Override
+            public void validateDockstoreYamlProperties(final String content) throws DockstoreYamlException {
+                findUnknownProperty(DockstoreYaml12.class, content);
             }
         };
 
@@ -64,6 +88,8 @@ public final class DockstoreYamlHelper {
         }
 
         public abstract DockstoreYaml readAndValidateDockstoreYaml(String content) throws DockstoreYamlException;
+
+        public abstract void validateDockstoreYamlProperties(String content) throws DockstoreYamlException;
 
         public static Optional<Version> findVersion(final String versionString) {
             return Stream.of(values()).filter(v -> v.version.equals(versionString)).findFirst();
@@ -112,7 +138,7 @@ public final class DockstoreYamlHelper {
             }
 
         });
-        return readContent(content, constructor);
+        return readContent(content, constructor, true);
     }
 
     static DockstoreYaml readDockstoreYaml(final String content) throws DockstoreYamlException {
@@ -165,17 +191,17 @@ public final class DockstoreYamlHelper {
 
 
     private static DockstoreYaml11 readDockstoreYaml11(final String content) throws DockstoreYamlException {
-        return readContent(content, new Constructor(DockstoreYaml11.class));
+        return readContent(content, new Constructor(DockstoreYaml11.class), true);
     }
 
     private static DockstoreYaml12 readDockstoreYaml12(final String content) throws DockstoreYamlException {
-        return readContent(content, new Constructor(DockstoreYaml12.class));
+        return readContent(content, new Constructor(DockstoreYaml12.class), true);
     }
 
-    private static <T> T readContent(final String content, final Constructor constructor) throws DockstoreYamlException {
+    private static <T> T readContent(final String content, final Constructor constructor, final boolean skipUnknownProperties) throws DockstoreYamlException {
         try {
             Representer representer = new Representer();
-            representer.getPropertyUtils().setSkipMissingProperties(true);
+            representer.getPropertyUtils().setSkipMissingProperties(skipUnknownProperties);
             final Yaml yaml = new Yaml(constructor, representer);
             return yaml.load(content);
         } catch (Exception e) {
@@ -184,6 +210,152 @@ public final class DockstoreYamlHelper {
             errorMsg += exceptionMsg;
             LOG.error(errorMsg, e);
             throw new DockstoreYamlException(errorMsg);
+        }
+    }
+
+    /**
+     * Validates the .dockstore.yml properties. An exception is ONLY thrown if there's an unknown property.
+     * An initial reading of the content (using a method like readAsDockstoreYaml12, for example) should be performed prior to calling this method to catch other validation errors.
+     * @param content .dockstore.yml content
+     * @throws DockstoreYamlException Exception is thrown only if an unknown property is found in the content.
+     */
+    public static void validateDockstoreYamlProperties(final String content) throws DockstoreYamlException {
+        final Optional<Version> maybeVersion = findValidVersion(content);
+        if (maybeVersion.isPresent()) {
+            maybeVersion.get().validateDockstoreYamlProperties(content);
+        }
+    }
+
+    /**
+     * Finds an unknown property in the .dockstore.yml if it exists and tries to find a suggestion.
+     * An exception is ONLY thrown if there's an unknown property. Will not throw for other yaml validation errors.
+     * @param dockstoreYamlClass DockstoreYaml class. Allowed values: DockstoreYaml12.class, DockstoreYaml11.class
+     * @param content .dockstore.yml content
+     * @throws DockstoreYamlException Exception is thrown only if an unknown property is found in the content
+     */
+    private static void findUnknownProperty(final Class<? extends DockstoreYaml> dockstoreYamlClass, final String content) throws DockstoreYamlException {
+        try {
+            readContent(content, new Constructor(dockstoreYamlClass), false);
+        } catch (DockstoreYamlException ex) {
+            String exceptionMessage = ex.getMessage();
+            final Matcher matcher = WRONG_KEY_PATTERN.matcher(exceptionMessage);
+
+            if (matcher.find()) {
+                String unknownProperty = matcher.group(1);
+                String suggestedProperty = getSuggestedDockstoreYamlProperty(dockstoreYamlClass, unknownProperty);
+                String errorMessage = String.format("Unknown property: '%s'.", unknownProperty);
+                if (!suggestedProperty.isEmpty()) {
+                    errorMessage += String.format(" Did you mean: '%s'?", suggestedProperty);
+                }
+                throw new DockstoreYamlException(errorMessage);
+            }
+        }
+    }
+
+    /**
+     * Finds a valid .dockstore.yml property that is the closest to the unknown property according to its Levenshtein distance.
+     * @param dockstoreYamlClass The DockstoreYaml class. Allowed values: DockstoreYaml12.class, Dockstore11.class
+     * @param unknownProperty The unknown property to find a suggestion for.
+     * @return A suggested property.
+     */
+    public static String getSuggestedDockstoreYamlProperty(Class<? extends DockstoreYaml> dockstoreYamlClass, String unknownProperty) {
+        Set<String> validProperties = getDockstoreYamlProperties(dockstoreYamlClass);
+        LevenshteinDistance levenshteinDistance = new LevenshteinDistance();
+        int shortestDistance = Integer.MAX_VALUE;
+        String shortestDistanceProperty = "";
+
+        if (validProperties.contains(unknownProperty) || unknownProperty.isEmpty()) {
+            return unknownProperty;
+        }
+
+        for (String validProperty : validProperties) {
+            int distance = levenshteinDistance.apply(unknownProperty, validProperty);
+            if (distance < shortestDistance) {
+                shortestDistance = distance;
+                shortestDistanceProperty = validProperty;
+            }
+        }
+
+        // Return the property if the number of changes needed to be made is less than the length of the unknown property.
+        // This is to prevent suggestions that don't make sense.
+        if (shortestDistance < unknownProperty.length()) {
+            return shortestDistanceProperty;
+        } else {
+            return "";
+        }
+    }
+
+    /**
+     * Gets all the properties of a .dockstore.yml as a list of strings.
+     * The convention that makes this work is that all the property fields in the DockstoreYaml classes are private.
+     * Uses bread-first search to find all the classes.
+     * @param dockstoreYamlClass The DockstoreYaml class. Allowed values: DockstoreYaml12.class, DockstoreYaml11.class
+     * @return A set of properties belonging to the .dockstore.yml version
+     */
+    public static Set<String> getDockstoreYamlProperties(Class<? extends DockstoreYaml> dockstoreYamlClass) {
+        Set<String> properties = new HashSet<>();
+        Queue<Class> dockstoreYmlPropertiesQueue = new ArrayDeque<>(); // A queue to process the property classes
+        List<Class> discoveredClasses = new ArrayList<>();
+        final String dockstoreYamlPackageName = dockstoreYamlClass.getPackageName();
+
+        discoveredClasses.add(dockstoreYamlClass);
+        dockstoreYmlPropertiesQueue.add(dockstoreYamlClass); // Add the high level class to the queue
+
+        while (!dockstoreYmlPropertiesQueue.isEmpty()) {
+            Class propertyClass = dockstoreYmlPropertiesQueue.poll(); // Get a class in the queue to process
+            Field[] declaredFields = propertyClass.getDeclaredFields(); // Get all the fields declared in the class
+
+            // Go through each field and determine if the field needs to be parsed further for properties
+            for (Field field : declaredFields) {
+                if (Modifier.isPublic(field.getModifiers())) {
+                    continue; // By our own convention, public fields are not part of the .dockstore.yml properties
+                }
+
+                // The field name is a .dockstore.yml property
+                properties.add(field.getName());
+
+                // Determine the class of the field
+                Class fieldClass = field.getType();
+                Type fieldGenericType = field.getGenericType(); // This is the field's generic type, if it has one. If it doesn't, this is just the field's class
+                if  (fieldGenericType instanceof ParameterizedType) {
+                    // Example: List<YamlWorkflow> is a parameterized type. We want to get the class YamlWorkflow
+                    Type[] parameterizedTypes = ((ParameterizedType) fieldGenericType).getActualTypeArguments();
+                    // There can be more than one parameterized type if it's something like Map<String, String>
+                    for (Type type: parameterizedTypes) {
+                        String className = type.getTypeName();
+                        try {
+                            fieldClass = Class.forName(className);
+                        } catch (ClassNotFoundException ex) {
+                            LOG.error("Could not get the class object for {}", className, ex);
+                            continue;
+                        }
+                        addNewPropertyClassToQueue(dockstoreYamlPackageName, fieldClass, discoveredClasses, dockstoreYmlPropertiesQueue);
+                    }
+                } else {
+                    addNewPropertyClassToQueue(dockstoreYamlPackageName, fieldClass, discoveredClasses, dockstoreYmlPropertiesQueue);
+                }
+            }
+        }
+
+        return properties;
+    }
+
+    /**
+     * Adds a class to the queue if it belongs in the io.dockstore.common.yaml package and it hasn't been processed yet.
+     * Also checks if the class has a super class and adds that to the queue if it's valid.
+     * @param dockstoreYamlPackageName The package name of the DockstoreYaml class
+     * @param propertyClass The class to add to the queue if it's valid
+     * @param discoveredClasses List of classes that have been discovered and processed
+     * @param classQueue Queue of classes waiting to be processed
+     */
+    private static void addNewPropertyClassToQueue(String dockstoreYamlPackageName, Class propertyClass, List<Class> discoveredClasses, Queue classQueue) {
+        // Check if the class is in the io.dockstore.common.yaml package to prevent classes like String from being added to the queue
+        if (propertyClass.getPackageName().equals(dockstoreYamlPackageName) && !discoveredClasses.contains(propertyClass)) {
+            discoveredClasses.add(propertyClass);
+            classQueue.add(propertyClass);
+
+            // Check if the superclass is a valid .dockstore.yml class. Ex: Service12's superclass is AbstractYamlService
+            addNewPropertyClassToQueue(dockstoreYamlPackageName, propertyClass.getSuperclass(), discoveredClasses, classQueue);
         }
     }
 

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
@@ -30,12 +30,12 @@ public class YamlWorkflow {
      * Allow GALAXY, but continue to support GXFORMAT2, and keep it
      * as GXFORMAT2 in the object for other classes already relying on that
      */
-    private static final String NEW_GALAXY_SUBCLASS = "GALAXY";
+    public static final String NEW_GALAXY_SUBCLASS = "GALAXY";
 
     private String name;
-    @NotNull
+    @NotNull(message = "Missing property \"subclass\"")
     private String subclass;
-    @NotNull
+    @NotNull(message = "Missing property \"primaryDescriptorPath\"")
     private String primaryDescriptorPath;
 
     /**

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -361,24 +361,26 @@ public class DockstoreYamlTest {
     @Test
     public void testGetDockstoreYamlProperties() {
         Set<String> properties = DockstoreYamlHelper.getDockstoreYamlProperties(DockstoreYaml12.class);
-        assertEquals("There should be 33 unique properties in a version 1.2 .dockstore.yml", 33, properties.size());
+        assertEquals("Should have the correct number of unique properties for a version 1.2 .dockstore.yml", 33, properties.size());
 
         properties = DockstoreYamlHelper.getDockstoreYamlProperties(DockstoreYaml11.class);
-        assertEquals("There should be 29 unique properties in a version 1.1 .dockstore.yml", 29, properties.size());
+        assertEquals("Should have the correct number of unique properties for a version 1.1 .dockstore.yml", 29, properties.size());
     }
 
     @Test
     public void testValidateDockstoreYamlProperties() {
         try {
             DockstoreYamlHelper.validateDockstoreYamlProperties(DOCKSTORE12_YAML.replace("publish", "published"));
+            fail("Should not pass property validation because there's an unknown property");
         } catch (DockstoreYamlHelper.DockstoreYamlException ex) {
-            assertEquals("Unknown property: 'published'. Did you mean: 'publish'?", ex.getMessage());
+            assertTrue(ex.getMessage().contains(DockstoreYamlHelper.UNKNOWN_PROPERTY));
         }
 
         try {
             DockstoreYamlHelper.validateDockstoreYamlProperties(DOCKSTORE11_YAML.replace("description", "descriptions"));
+            fail("Should not pass property validation because there's an unknown property");
         } catch (DockstoreYamlHelper.DockstoreYamlException ex) {
-            assertEquals("Unknown property: 'descriptions'. Did you mean: 'description'?", ex.getMessage());
+            assertTrue(ex.getMessage().contains(DockstoreYamlHelper.UNKNOWN_PROPERTY));
         }
     }
 }

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -30,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -330,4 +331,48 @@ public class DockstoreYamlTest {
         assertFalse(DockstoreYamlHelper.filterGitReference(Path.of("refs/tags/["), filters));
     }
 
+
+    @Test
+    public void testGetSuggestedDockstoreYamlProperty() {
+        Class dockstoreYamlClass = DockstoreYaml12.class;
+
+        String suggestedProperty = DockstoreYamlHelper.getSuggestedDockstoreYamlProperty(dockstoreYamlClass, "z");
+        assertEquals("Shouldn't suggest a property if there's too many changes that needs to be done", "", suggestedProperty);
+
+        suggestedProperty = DockstoreYamlHelper.getSuggestedDockstoreYamlProperty(dockstoreYamlClass, "workflows");
+        assertEquals("Should return the same property back if it's already a valid property", "workflows", suggestedProperty);
+
+        suggestedProperty = DockstoreYamlHelper.getSuggestedDockstoreYamlProperty(dockstoreYamlClass, "affilliation");
+        assertEquals("affiliation", suggestedProperty);
+
+        suggestedProperty = DockstoreYamlHelper.getSuggestedDockstoreYamlProperty(dockstoreYamlClass, "filter");
+        assertEquals("filters", suggestedProperty);
+
+        suggestedProperty = DockstoreYamlHelper.getSuggestedDockstoreYamlProperty(dockstoreYamlClass, "apptool");
+        assertEquals("tools", suggestedProperty);
+
+        suggestedProperty = DockstoreYamlHelper.getSuggestedDockstoreYamlProperty(dockstoreYamlClass, "e-mail");
+        assertEquals("email", suggestedProperty);
+
+        suggestedProperty = DockstoreYamlHelper.getSuggestedDockstoreYamlProperty(dockstoreYamlClass, "testParameterFilets");
+        assertEquals("testParameterFiles", suggestedProperty);
+    }
+
+    @Test
+    public void testGetDockstoreYamlProperties() {
+        Set<String> properties = DockstoreYamlHelper.getDockstoreYamlProperties(DockstoreYaml12.class);
+        assertEquals("There should be 33 unique properties in a version 1.2 .dockstore.yml", 33, properties.size());
+
+        properties = DockstoreYamlHelper.getDockstoreYamlProperties(DockstoreYaml11.class);
+        assertEquals("There should be 29 unique properties in a version 1.1 .dockstore.yml", 29, properties.size());
+    }
+
+    @Test
+    public void testValidateDockstoreYamlProperties() {
+        try {
+            DockstoreYamlHelper.validateDockstoreYamlProperties(DOCKSTORE12_YAML.replace("publish", "published"));
+        } catch (DockstoreYamlHelper.DockstoreYamlException ex) {
+            assertEquals("Unknown property: 'published'. Did you mean: 'publish'?", ex.getMessage());
+        }
+    }
 }

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -374,5 +374,11 @@ public class DockstoreYamlTest {
         } catch (DockstoreYamlHelper.DockstoreYamlException ex) {
             assertEquals("Unknown property: 'published'. Did you mean: 'publish'?", ex.getMessage());
         }
+
+        try {
+            DockstoreYamlHelper.validateDockstoreYamlProperties(DOCKSTORE11_YAML.replace("description", "descriptions"));
+        } catch (DockstoreYamlHelper.DockstoreYamlException ex) {
+            assertEquals("Unknown property: 'descriptions'. Did you mean: 'description'?", ex.getMessage());
+        }
     }
 }


### PR DESCRIPTION
**Description**

- This PR handles unknown .dockstore.yml properties by suggesting a valid property (if a suggestion makes sense). It only catches one unknown property at a time.
- The unknown properties validation works separately from the validation that is done when reading the .dockstore.yml into a DockstoreYaml object. It assumes that the .dockstore.yml is read into an object first to catch any major validation errors like no workflows/services/tools or missing mandatory property.
- The property validation message really only throws if it's a unknown optional property since missing mandatory properties will throw a validation error before it can be validated.
- I searched through the DockstoreYaml fields to collect all the valid property names so that it could be used for suggestions. The convention that made this worked is that all private fields in DockstoreYaml classes are properties in the .dockstore.yml.

![image](https://user-images.githubusercontent.com/25287123/141836617-30c7bbe9-5fa9-4ae8-a67d-fe3350746d9d.png)


**Issue**
#4161 

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
