### PR TITLE
Feature/4540/get commit

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -542,7 +542,8 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         } else {
             // I'm not sure when this would happen.
             LOG.error("Unsupported GitHub reference object. Unable to find commit ID for type: " + ref.getObject().getType());
-            throw new CustomWebApplicationException("Unsupported branch/tag/release. Unable to find commit ID.", HttpStatus.SC_BAD_REQUEST);
+            // This is probably wrong, but we should mimic the behaviour from before since this is a hotfix.
+            sha = ref.getObject().getSha();
         }
         return sha;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1009,7 +1009,10 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
             for (GHRef ref : refs) {
                 String reference = StringUtils.removePattern(ref.getRef(), "refs/.+?/");
-                return getCommitSHA(ref, repo, reference);
+                if (reference.equals(version.getReference())) {
+                    return getCommitSHA(ref, repo, reference);
+                }
+
             }
         } catch (IOException e) {
             LOG.error(gitUsername + ": IOException on getCommitId " + e.getMessage(), e);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -529,6 +529,9 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         }
     }
 
+    // When a user creates an annotated tag, the object type will be a tag. Otherwise, it's probably of type commit?
+    // The documentation doesn't list the possibilities https://github-api.kohsuke.org/apidocs/org/kohsuke/github/GHRef.GHObject.html#getType(),
+    // but I'll assume it mirrors the 4 Git types: blobs, trees, commits, and tags.
     private String getCommitSHA(GHRef ref, GHRepository repository, String refName) throws IOException {
         String sha = null;
         if ("commit".equals(ref.getObject().getType())) {
@@ -1006,9 +1009,6 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
             for (GHRef ref : refs) {
                 String reference = StringUtils.removePattern(ref.getRef(), "refs/.+?/");
-                // When a user creates an annotated tag, the object type will be a tag. Otherwise, it's probably of type commit?
-                // The documentation doesn't list the possibilities https://github-api.kohsuke.org/apidocs/org/kohsuke/github/GHRef.GHObject.html#getType(),
-                // but I'll assume it mirrors the 4 Git types: blobs, trees, commits, and tags.
                 return getCommitSHA(ref, repo, reference);
             }
         } catch (IOException e) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -530,15 +530,18 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     }
 
     private String getCommitSHA(GHRef ref, GHRepository repository, String refName) throws IOException {
-        String sha = ref.getObject().getSha();
-        if (ref.getObject().getType().equals("tag")) {
+        String sha = null;
+        if ("commit".equals(ref.getObject().getType())) {
+            sha = ref.getObject().getSha();
+        } else if (ref.getObject().getType().equals("tag")) {
             GHTagObject tagObject = repository.getTagObject(sha);
             sha = tagObject.getObject().getSha();
         } else if (ref.getObject().getType().equals("branch")) {
             GHBranch branch = repository.getBranch(refName);
             sha = branch.getSHA1();
         } else {
-            // I'm not sure when this would ever happen.
+            // I'm not sure when this would happen.
+            LOG.error("Unsupported GitHub reference object. Unable to find commit ID for type: " + ref.getObject().getType());
             throw new CustomWebApplicationException("Unsupported branch/tag/release. Unable to find commit ID.", HttpStatus.SC_BAD_REQUEST);
         }
         return sha;

--- a/dockstore-webservice/src/test/java/core/CWLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/CWLParseTest.java
@@ -28,7 +28,6 @@ import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.languages.LanguageHandlerFactory;
 import io.dockstore.webservice.languages.LanguageHandlerInterface;
 import io.dropwizard.testing.ResourceHelpers;
-
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Rule;


### PR DESCRIPTION
**Description**
The object type will be of type tag if the user created an annotated tag instead of a lightweight one, so this checks for that.

**Issue**
#4540

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
