### PR TITLE
DOCK-1919: Correctly store DOI URL in ORCID

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
@@ -113,13 +113,14 @@ public final class ORCIDHelper {
     }
 
     public static String doiToUrl(String doi) {
-        // If the DOI appears well-formed, return the corresponding doi.org proxy URL.
-        // https://www.doi.org/doi_handbook/2_Numbering.html
+        // If the DOI appears well-formed, return the corresponding doi.org proxy URL:
         // https://www.doi.org/factsheets/DOIProxy.html
+        // A well-formed DOI starts with "10." and contains a slash:
+        // https://www.doi.org/doi_handbook/2_Numbering.html#2.2
         if (doi != null && doi.startsWith("10.") && doi.contains("/")) {
             return "https://doi.org/" + doi;
         }
-        // Otherwise, it might be a URL already, empty, or null.  Return as-is.
+        // If the argument isn't a well-formed DOI, it might be a URL already, or empty.  Return as-is.
         return doi;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
@@ -75,15 +75,15 @@ public final class ORCIDHelper {
         externalID.setType("doi");
         if (optionalVersion.isPresent()) {
             Version v = optionalVersion.get();
-            Url url = new Url(v.getDoiURL());
-            externalID.setUrl(url);
-            externalID.setValue(v.getDoiURL());
+            String doi = v.getDoiURL(); // getDoiURL returns a DOI, not a URL
+            externalID.setUrl(new Url(doiToUrl(doi)));
+            externalID.setValue(doi);
             title.setContent(e.getEntryPath() + ":" + v.getName());
             work.setShortDescription(StringUtils.abbreviate(v.getDescription(), descriptionLength));
         } else {
-            Url url = new Url(e.getConceptDoi());
-            externalID.setUrl(url);
-            externalID.setValue(e.getConceptDoi());
+            String doi = e.getConceptDoi();
+            externalID.setUrl(new Url(doiToUrl(doi)));
+            externalID.setValue(doi);
             title.setContent(e.getEntryPath());
             work.setShortDescription(StringUtils.abbreviate(e.getDescription(), descriptionLength));
         }
@@ -110,6 +110,17 @@ public final class ORCIDHelper {
         lastModifiedDate.setValue(calendar);
         work.setLastModifiedDate(lastModifiedDate);
         return transformWork(work);
+    }
+
+    public static String doiToUrl(String doi) {
+        // If the DOI appears well-formed, return the corresponding doi.org proxy URL.
+        // https://www.doi.org/doi_handbook/2_Numbering.html
+        // https://www.doi.org/factsheets/DOIProxy.html
+        if (doi != null && doi.startsWith("10.") && doi.contains("/")) {
+            return "https://doi.org/" + doi;
+        }
+        // Otherwise, it might be a URL already, empty, or null.  Return as-is.
+        return doi;
     }
 
     public static HttpResponse<String> postWorkString(String baseURL, String id, String workString, String token)

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ORCIDHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ORCIDHelperTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 OICR and UCSC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.dockstore.webservice.helpers;
+
+import io.dockstore.webservice.helpers.ORCIDHelper;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ORCIDHelperTest {
+
+    @Test
+    public void testDoiToUrl() throws IOException {
+
+        // Valid DOIs should be converted to a URL that references the doi.org proxy.
+        // A valid DOI starts with "10." and contains a slash.
+        for (String doi: Arrays.asList("10.5281/zenodo.5541915", "10.foo/bar")) {
+            assertEquals("https://doi.org/" + doi, ORCIDHelper.doiToUrl(doi));
+        }
+
+        // Invalid DOIs, including DOI URLs, should be returned as-is.
+        for (String nonDoi: Arrays.asList("https://doi.org/10.5281/zenodo.5541915", "10.1234", "", null)) {
+            assertEquals(nonDoi, ORCIDHelper.doiToUrl(nonDoi));
+        }
+    }
+}

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ORCIDHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ORCIDHelperTest.java
@@ -16,24 +16,24 @@
 
 package io.dockstore.webservice.helpers;
 
-import io.dockstore.webservice.helpers.ORCIDHelper;
+import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class ORCIDHelperTest {
 
     @Test
-    public void testDoiToUrl() throws IOException {
+    public void testDoiToUrl() {
 
         // Valid DOIs should be converted to a URL that references the doi.org proxy.
         // A valid DOI starts with "10." and contains a slash.
-        for (String doi: Arrays.asList("10.5281/zenodo.5541915", "10.foo/bar")) {
-            assertEquals("https://doi.org/" + doi, ORCIDHelper.doiToUrl(doi));
+        for (String doi: Arrays.asList("10.5281/zenodo.5541915", "10.3.14159/foobar")) {
+            Assert.assertEquals("https://doi.org/" + doi, ORCIDHelper.doiToUrl(doi));
         }
 
         // Invalid DOIs, including DOI URLs, should be returned as-is.
-        for (String nonDoi: Arrays.asList("https://doi.org/10.5281/zenodo.5541915", "10.1234", "", null)) {
-            assertEquals(nonDoi, ORCIDHelper.doiToUrl(nonDoi));
+        for (String nonDoi: Arrays.asList("https://doi.org/10.5281/zenodo.5541915", "12.13.14/potato", "")) {
+            Assert.assertEquals(nonDoi, ORCIDHelper.doiToUrl(nonDoi));
         }
     }
 }


### PR DESCRIPTION
**Description**
Corrects the webservice so that the DOI URL which is pushed to ORCID is well-formed.  It is quite difficult to write an integration test for this PR, but I did user test it, and it works. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-1919
#4478 

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
