### PR TITLE
Fix nextflow 500 errors

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -509,7 +509,7 @@ public class WorkflowIT extends BaseIT {
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
 
         // Test getting the tool table and dag for a nextflow workflow that has a nextflow.config and main.nf
-        Workflow workflow = manualRegisterAndPublish(workflowApi, "kathy-t/hello-nextflow-workflow", "", "nfl", SourceControl.GITHUB, "/nextflow.config", false);
+        Workflow workflow = manualRegisterAndPublish(workflowApi, "DockstoreTestUser2/hello-nextflow-workflow", "", "nfl", SourceControl.GITHUB, "/nextflow.config", false);
         WorkflowVersion masterVersion = workflow.getWorkflowVersions().stream().filter(wv -> wv.getName().equals("master")).findFirst().get();
         String masterToolJsonFromApi = workflowApi.getTableToolContent(workflow.getId(), masterVersion.getId());
         String masterToolJson = testingPostgres.runSelectStatement(String.format("select tooltablejson from workflowversion where id = '%s'", masterVersion.getId()), String.class);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -370,6 +370,8 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
     private List<String> getInputDependencyList(GroovySourceAST processAST) {
         GroovySourceAST inputAST = getFirstAstWithKeyword(processAST, "input", true);
         if (inputAST != null) {
+            // Stops from parsing outside the input AST
+            inputAST.setNextSibling(null);
             return getListOfIO(inputAST);
         } else {
             return new ArrayList<>();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -525,73 +525,77 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
     private Map<String, List<String>> getCallsToDependencies(String mainDescriptor) {
         //TODO: create proper dependency arrays, for now just list processes sequentially
         Map<String, List<String>> map = new HashMap<>();
-        try {
-            List<GroovySourceAST> processList = getGroovySourceASTList(mainDescriptor, "process");
-            Map<String, List<String>> processNameToInputChannels = new HashMap<>();
-            Map<String, List<String>> processNameToOutputChannels = new HashMap<>();
+        if (mainDescriptor != null) {
+            try {
+                List<GroovySourceAST> processList = getGroovySourceASTList(mainDescriptor, "process");
+                Map<String, List<String>> processNameToInputChannels = new HashMap<>();
+                Map<String, List<String>> processNameToOutputChannels = new HashMap<>();
 
-            processList.forEach((GroovySourceAST processAST) -> {
-                String processName = getProcessValue(processAST);
+                processList.forEach((GroovySourceAST processAST) -> {
+                    String processName = getProcessValue(processAST);
+                    if (processName != null) {
+                        // Get a list of all channels that the process depends on
+                        List<String> inputs = getInputDependencyList(processAST);
+                        processNameToInputChannels.put(processName, inputs);
 
-                // Get a list of all channels that the process depends on
-                List<String> inputs = getInputDependencyList(processAST);
-                processNameToInputChannels.put(processName, inputs);
-
-                // Get a list of all channels that the process writes to
-                List<String> outputs = getOutputDependencyList(processAST);
-                processNameToOutputChannels.put(processName, outputs);
-            });
-
-            // Create a map of process name to dependent processes
-            processNameToInputChannels.keySet().forEach((String processName) -> {
-                List<String> dependencies = new ArrayList<>();
-                processNameToInputChannels.get(processName).forEach((String channelRead) -> {
-                    processNameToOutputChannels.keySet().forEach((String dependentProcessName) -> {
-                        Optional<String> temp = processNameToOutputChannels.get(dependentProcessName).stream()
-                            .filter(channelWrite -> Objects.equals(channelRead, channelWrite)).findFirst();
-
-                        if (temp.isPresent()) {
-                            dependencies.add(dependentProcessName);
-                        }
-                    });
+                        // Get a list of all channels that the process writes to
+                        List<String> outputs = getOutputDependencyList(processAST);
+                        processNameToOutputChannels.put(processName, outputs);
+                    }
                 });
-                map.put(processName, dependencies);
-            });
-        } catch (IOException | TokenStreamException | RecognitionException e) {
-            LOG.warn("could not parse", e);
+
+                // Create a map of process name to dependent processes
+                processNameToInputChannels.keySet().forEach((String processName) -> {
+                    List<String> dependencies = new ArrayList<>();
+                    processNameToInputChannels.get(processName).forEach((String channelRead) -> {
+                        processNameToOutputChannels.keySet().forEach((String dependentProcessName) -> {
+                            Optional<String> temp = processNameToOutputChannels.get(dependentProcessName).stream().filter(channelWrite -> Objects.equals(channelRead, channelWrite)).findFirst();
+
+                            if (temp.isPresent()) {
+                                dependencies.add(dependentProcessName);
+                            }
+                        });
+                    });
+                    map.put(processName, dependencies);
+                });
+            } catch (IOException | TokenStreamException | RecognitionException e) {
+                LOG.warn("could not parse", e);
+            }
         }
         return map;
     }
 
     protected Map<String, DockerParameter> getCallsToDockerMap(String mainDescriptor, String defaultContainer) {
         Map<String, DockerParameter> map = new HashMap<>();
-        try {
-            List<GroovySourceAST> processList = getGroovySourceASTList(mainDescriptor, "process");
+        if (mainDescriptor != null) {
+            try {
+                List<GroovySourceAST> processList = getGroovySourceASTList(mainDescriptor, "process");
 
-            for (GroovySourceAST processAST : processList) {
-                String processName = getProcessValue(processAST);
-                if (processName == null) {
-                    continue;
-                }
-                GroovySourceAST containerAST = getFirstAstWithKeyword(processAST, "container", false);
-                String containerName;
-                if (containerAST != null) {
-                    containerName = containerAST.getNextSibling().getFirstChild().getText();
-                } else {
-                    containerName = defaultContainer;
-                }
-
-                if (containerName != null) {
-                    if (containerName.startsWith("$")) { // Parameterized container name
-                        map.put(processName, new DockerParameter(containerName, DockerImageReference.DYNAMIC));
-                    } else {
-                        map.put(processName, new DockerParameter(containerName, DockerImageReference.LITERAL));
+                for (GroovySourceAST processAST : processList) {
+                    String processName = getProcessValue(processAST);
+                    if (processName == null) {
+                        continue;
                     }
-                    LOG.debug("found container: " + containerName + " in process " + processName);
+                    GroovySourceAST containerAST = getFirstAstWithKeyword(processAST, "container", false);
+                    String containerName;
+                    if (containerAST != null) {
+                        containerName = containerAST.getNextSibling().getFirstChild().getText();
+                    } else {
+                        containerName = defaultContainer;
+                    }
+
+                    if (containerName != null) {
+                        if (containerName.startsWith("$")) { // Parameterized container name
+                            map.put(processName, new DockerParameter(containerName, DockerImageReference.DYNAMIC));
+                        } else {
+                            map.put(processName, new DockerParameter(containerName, DockerImageReference.LITERAL));
+                        }
+                        LOG.debug("found container: " + containerName + " in process " + processName);
+                    }
                 }
+            } catch (IOException | TokenStreamException | RecognitionException e) {
+                LOG.warn("could not parse", e);
             }
-        } catch (IOException | TokenStreamException | RecognitionException e) {
-            LOG.warn("could not parse", e);
         }
         return map;
     }


### PR DESCRIPTION
**Description**
The ticket talks about two 500 responses (one from Richard's description in the ticket and one by Charles' comment). The 500s are because of null pointer exceptions caused by different reasons. 

The first 500 (Richard's description) is because the main script for the nextflow workflow is `GoodbyeWorld.nf`, but the workflow's `nextflow.config` doesn't specify this using the `mainScript` key so the webservice fails to find the main script. When we try to get the main script in `getContent` and call other methods on it, a null pointer exception is thrown. This PR adds null checks to those methods.

The second 500 (Charles' comment) is because when we're parsing the input dependencies, we also parse outside of the input block which sometimes caused null pointer exceptions depending on how the nextflow script is ordered. This PR prevents us from parsing outside of the input block.

**Issue**
#3928 

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
