### PR TITLE
Change default tag name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,7 @@
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.3</version>
                     <configuration>
+                        <tagNameFormat>@{project.version}</tagNameFormat>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <releaseProfiles>skipForRelease</releaseProfiles>
                     </configuration>


### PR DESCRIPTION
**Description**
Change the default scm tag name to match our release process. Saves us an extra step. See https://maven.apache.org/maven-release/maven-release-plugin/prepare-mojo.html#tagNameFormat

before:
```
What is the release version for "dockstore"? (io.dockstore:dockstore) 1.11.10: :
What is SCM release tag or label for "dockstore"? (io.dockstore:dockstore) dockstore-1.11.10: :
What is the new development version for "dockstore"? (io.dockstore:dockstore) 1.11.11-SNAPSHOT: :
```

after:
```
What is the release version for "dockstore"? (io.dockstore:dockstore) 1.11.10: :
What is SCM release tag or label for "dockstore"? (io.dockstore:dockstore) 1.11.10: :
What is the new development version for "dockstore"? (io.dockstore:dockstore) 1.11.11-SNAPSHOT: :
```

**Issue**
Adhoc issue while doing SEAB-3635 . 
