### PR TITLE
Feature/regex backtrack fix

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -16,10 +16,16 @@
 
 package io.dockstore.client.cli;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import static io.dockstore.webservice.core.Version.CANNOT_FREEZE_VERSIONS_WITH_NO_FILES;
+import static io.dockstore.webservice.helpers.EntryVersionHelper.CANNOT_MODIFY_FROZEN_VERSIONS_THIS_WAY;
+import static io.dockstore.webservice.resources.WorkflowResource.FROZEN_VERSION_REQUIRED;
+import static io.dockstore.webservice.resources.WorkflowResource.NO_ZENDO_USER_TOKEN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.google.common.collect.Lists;
 import io.dockstore.common.CommonTestUtilities;
@@ -29,11 +35,6 @@ import io.dockstore.common.SlowTest;
 import io.dockstore.common.SourceControl;
 import io.dockstore.common.WorkflowTest;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
-import io.dockstore.webservice.core.BioWorkflow;
-import io.dockstore.webservice.core.Tool;
-import io.dockstore.webservice.helpers.BitBucketSourceCodeRepo;
-import io.dockstore.webservice.helpers.GitHubSourceCodeRepo;
-import io.dockstore.webservice.helpers.GitLabSourceCodeRepo;
 import io.dockstore.webservice.jdbi.FileDAO;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
@@ -42,6 +43,10 @@ import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.SourceFile;
 import io.swagger.client.model.Workflow;
 import io.swagger.client.model.WorkflowVersion;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -55,17 +60,6 @@ import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
-
-import static io.dockstore.webservice.core.Version.CANNOT_FREEZE_VERSIONS_WITH_NO_FILES;
-import static io.dockstore.webservice.helpers.EntryVersionHelper.CANNOT_MODIFY_FROZEN_VERSIONS_THIS_WAY;
-import static io.dockstore.webservice.resources.WorkflowResource.FROZEN_VERSION_REQUIRED;
-import static io.dockstore.webservice.resources.WorkflowResource.NO_ZENDO_USER_TOKEN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * This test suite tests various workflow related processes.
@@ -529,154 +523,6 @@ public class GeneralWorkflowIT extends BaseIT {
         } catch (ApiException e) {
             assertTrue(e.getMessage().contains("Please ensure that the workflow path uses the file extension cwl"));
         }
-
-    }
-
-    /**
-     * Tests that parsing a GitLab URL works
-     */
-    @Test
-    public void testGitLabUrlRegexParsing() {
-        GitLabSourceCodeRepo repo = new GitLabSourceCodeRepo("fakeUser", "fakeToken");
-        final BioWorkflow entry = new BioWorkflow();
-
-        /* Test good URLs */
-        entry.setGitUrl("git@gitlab.com:dockstore/dockstore-ui.git");
-        String gitlabId = repo.getRepositoryId(entry);
-        assertEquals("gitlab ID parse check", "dockstore/dockstore-ui", gitlabId);
-
-        entry.setGitUrl("git@gitlab.com:dockstore-cow/goat.git");
-        gitlabId = repo.getRepositoryId(entry);
-        assertEquals("gitlab ID parse check", "dockstore-cow/goat", gitlabId);
-
-        entry.setGitUrl("git@gitlab.com:dockstore.dot/goat.bat.git");
-        gitlabId = repo.getRepositoryId(entry);
-        assertEquals("gitlab ID parse check", "dockstore.dot/goat.bat", gitlabId);
-
-        entry.setGitUrl("git@gitlab.com:dockstore.dot/goat.git");
-        gitlabId = repo.getRepositoryId(entry);
-        assertEquals("gitlab ID parse check", "dockstore.dot/goat", gitlabId);
-
-        /* Test bad URLs */
-        entry.setGitUrl("git@gitlab.com/dockstore/dockstore-ui.git");
-        gitlabId = repo.getRepositoryId(entry);
-        assertEquals("gitlab ID parse check", null, gitlabId);
-
-        entry.setGitUrl("git@gitlab.com:dockstore:dockstore-ui.git");
-        gitlabId = repo.getRepositoryId(entry);
-        assertEquals("gitlab ID parse check", null, gitlabId);
-
-        entry.setGitUrl("git@gitlab.com:/dockstore-ui.git");
-        gitlabId = repo.getRepositoryId(entry);
-        assertEquals("gitlab ID parse check", null, gitlabId);
-
-        entry.setGitUrl("git@gitlab.com:dockstore");
-        gitlabId = repo.getRepositoryId(entry);
-        assertEquals("gitlab ID parse check", null, gitlabId);
-
-        entry.setGitUrl("git@gitlab.com:dockstore/dockstore-ui");
-        gitlabId = repo.getRepositoryId(entry);
-        assertEquals("gitlab ID parse check", null, gitlabId);
-
-    }
-    
-    /**
-     * Tests that parsing a GitHub URL works
-     */
-    @Test
-    public void testGitHubUrlRegexParsing() {
-        GitHubSourceCodeRepo repo = new GitHubSourceCodeRepo("fakeUser", "fakeToken");
-        final Tool entry = new Tool();
-
-        /* Test good URLs */
-        entry.setGitUrl("git@github.com:dockstore/dockstore-ui.git");
-        String githubId = repo.getRepositoryId(entry);
-        assertEquals("GitHub ID parse check", "dockstore/dockstore-ui", githubId);
-
-        entry.setGitUrl("git@github.com:dockstore-cow/goat.git");
-        githubId = repo.getRepositoryId(entry);
-        assertEquals("GitHub ID parse check", "dockstore-cow/goat", githubId);
-
-        entry.setGitUrl("git@github.com:dockstore.dot/goat.bat.git");
-        githubId = repo.getRepositoryId(entry);
-        assertEquals("GitHub ID parse check", "dockstore.dot/goat.bat", githubId);
-
-        entry.setGitUrl("git@github.com:dockstore.dot/goat.git");
-        githubId = repo.getRepositoryId(entry);
-        assertEquals("GitHub ID parse check", "dockstore.dot/goat", githubId);
-
-        /* Test bad URLs */
-        entry.setGitUrl("git@github.com/dockstore/dockstore-ui.git");
-        githubId = repo.getRepositoryId(entry);
-        assertEquals("GitHub ID parse check", null, githubId);
-
-        entry.setGitUrl("git@github.com:dockstore:dockstore-ui.git");
-        githubId = repo.getRepositoryId(entry);
-        assertEquals("GitHub ID parse check", null, githubId);
-
-        entry.setGitUrl("git@github.com:/dockstore-ui.git");
-        githubId = repo.getRepositoryId(entry);
-        assertEquals("GitHub ID parse check", null, githubId);
-
-        entry.setGitUrl("git@github.com:dockstore");
-        githubId = repo.getRepositoryId(entry);
-        assertEquals("GitHub ID parse check", null, githubId);
-
-        entry.setGitUrl("git@github.com:dockstore/dockstore-ui");
-        githubId = repo.getRepositoryId(entry);
-        assertEquals("GitHub ID parse check", null, githubId);
-
-    }
-
-    /**
-     * Tests that parsing a BitBucket URL works
-     */
-    @Test
-    public void testBitBucketUrlParsing() {
-        BitBucketSourceCodeRepo repo = new BitBucketSourceCodeRepo("fakeUser", "fakeToken");
-        final BioWorkflow entry = new BioWorkflow();
-
-        /* Test good URLs */
-        entry.setGitUrl("git@bitbucket.org:dockstore/dockstore-ui.git");
-        String bitBucketId = repo.getRepositoryId(entry);
-        assertEquals("Bitbucket ID parse check", "dockstore/dockstore-ui", bitBucketId);
-
-        entry.setGitUrl("git@bitbucket.org:dockstore/dockstore-ui.git");
-        bitBucketId = repo.getRepositoryId(entry);
-        assertEquals("Bitbucket ID parse check", "dockstore/dockstore-ui", bitBucketId);
-
-        entry.setGitUrl("git@bitbucket.org:dockstore-cow/goat.git");
-        bitBucketId = repo.getRepositoryId(entry);
-        assertEquals("Bitbucket ID parse check", "dockstore-cow/goat", bitBucketId);
-
-        entry.setGitUrl("git@bitbucket.org:dockstore.dot/goat.bat.git");
-        bitBucketId = repo.getRepositoryId(entry);
-        assertEquals("Bitbucket ID parse check", "dockstore.dot/goat.bat", bitBucketId);
-
-        entry.setGitUrl("git@bitbucket.org:dockstore.dot/goat.git");
-        bitBucketId = repo.getRepositoryId(entry);
-        assertEquals("Bitbucket ID parse check", "dockstore.dot/goat", bitBucketId);
-
-        /* Test bad URLs */
-        entry.setGitUrl("git@bitbucket.org/dockstore/dockstore-ui.git");
-        bitBucketId = repo.getRepositoryId(entry);
-        assertEquals("Bitbucket ID parse check", null, bitBucketId);
-
-        entry.setGitUrl("git@bitbucket.org:dockstore:dockstore-ui.git");
-        bitBucketId = repo.getRepositoryId(entry);
-        assertEquals("Bitbucket ID parse check", null, bitBucketId);
-
-        entry.setGitUrl("git@bitbucket.org:/dockstore-ui.git");
-        bitBucketId = repo.getRepositoryId(entry);
-        assertEquals("Bitbucket ID parse check", null, bitBucketId);
-
-        entry.setGitUrl("git@bitbucket.org:dockstore");
-        bitBucketId = repo.getRepositoryId(entry);
-        assertEquals("Bitbucket ID parse check", null, bitBucketId);
-
-        entry.setGitUrl("git@bitbucket.org:dockstore/dockstore-ui");
-        bitBucketId = repo.getRepositoryId(entry);
-        assertEquals("Bitbucket ID parse check", null, bitBucketId);
 
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -16,10 +16,16 @@
 
 package io.dockstore.client.cli;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import static io.dockstore.webservice.core.Version.CANNOT_FREEZE_VERSIONS_WITH_NO_FILES;
+import static io.dockstore.webservice.helpers.EntryVersionHelper.CANNOT_MODIFY_FROZEN_VERSIONS_THIS_WAY;
+import static io.dockstore.webservice.resources.WorkflowResource.FROZEN_VERSION_REQUIRED;
+import static io.dockstore.webservice.resources.WorkflowResource.NO_ZENDO_USER_TOKEN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.google.common.collect.Lists;
 import io.dockstore.common.CommonTestUtilities;
@@ -42,6 +48,10 @@ import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.SourceFile;
 import io.swagger.client.model.Workflow;
 import io.swagger.client.model.WorkflowVersion;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -55,17 +65,6 @@ import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
-
-import static io.dockstore.webservice.core.Version.CANNOT_FREEZE_VERSIONS_WITH_NO_FILES;
-import static io.dockstore.webservice.helpers.EntryVersionHelper.CANNOT_MODIFY_FROZEN_VERSIONS_THIS_WAY;
-import static io.dockstore.webservice.resources.WorkflowResource.FROZEN_VERSION_REQUIRED;
-import static io.dockstore.webservice.resources.WorkflowResource.NO_ZENDO_USER_TOKEN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * This test suite tests various workflow related processes.

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -29,6 +29,11 @@ import io.dockstore.common.SlowTest;
 import io.dockstore.common.SourceControl;
 import io.dockstore.common.WorkflowTest;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
+import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.Tool;
+import io.dockstore.webservice.helpers.BitBucketSourceCodeRepo;
+import io.dockstore.webservice.helpers.GitHubSourceCodeRepo;
+import io.dockstore.webservice.helpers.GitLabSourceCodeRepo;
 import io.dockstore.webservice.jdbi.FileDAO;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
@@ -524,6 +529,154 @@ public class GeneralWorkflowIT extends BaseIT {
         } catch (ApiException e) {
             assertTrue(e.getMessage().contains("Please ensure that the workflow path uses the file extension cwl"));
         }
+
+    }
+
+    /**
+     * Tests that parsing a GitHub URL works
+     */
+    @Test
+    public void testGitLabUrlRegexParsing() {
+        GitLabSourceCodeRepo repo = new GitLabSourceCodeRepo("fakeUser", "fakeToken");
+        final BioWorkflow entry = new BioWorkflow();
+
+        /* Test good URLs */
+        entry.setGitUrl("git@gitlab.com:dockstore/dockstore-ui.git");
+        String gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", "dockstore/dockstore-ui", gitlabId);
+
+        entry.setGitUrl("git@gitlab.com:dockstore-cow/goat.git");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", "dockstore-cow/goat", gitlabId);
+
+        entry.setGitUrl("git@gitlab.com:dockstore.dot/goat.bat.git");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", "dockstore.dot/goat.bat", gitlabId);
+
+        entry.setGitUrl("git@gitlab.com:dockstore.dot/goat.git");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", "dockstore.dot/goat", gitlabId);
+
+        /* Test bad URLs */
+        entry.setGitUrl("git@gitlab.com/dockstore/dockstore-ui.git");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", null, gitlabId);
+
+        entry.setGitUrl("git@gitlab.com:dockstore:dockstore-ui.git");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", null, gitlabId);
+
+        entry.setGitUrl("git@gitlab.com:/dockstore-ui.git");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", null, gitlabId);
+
+        entry.setGitUrl("git@gitlab.com:dockstore");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", null, gitlabId);
+
+        entry.setGitUrl("git@gitlab.com:dockstore/dockstore-ui");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", null, gitlabId);
+
+    }
+    
+    /**
+     * Tests that parsing a GitHub URL works
+     */
+    @Test
+    public void testGitHubUrlRegexParsing() {
+        GitHubSourceCodeRepo repo = new GitHubSourceCodeRepo("fakeUser", "fakeToken");
+        final Tool entry = new Tool();
+
+        /* Test good URLs */
+        entry.setGitUrl("git@github.com:dockstore/dockstore-ui.git");
+        String githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", "dockstore/dockstore-ui", githubId);
+
+        entry.setGitUrl("git@github.com:dockstore-cow/goat.git");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", "dockstore-cow/goat", githubId);
+
+        entry.setGitUrl("git@github.com:dockstore.dot/goat.bat.git");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", "dockstore.dot/goat.bat", githubId);
+
+        entry.setGitUrl("git@github.com:dockstore.dot/goat.git");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", "dockstore.dot/goat", githubId);
+
+        /* Test bad URLs */
+        entry.setGitUrl("git@github.com/dockstore/dockstore-ui.git");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", null, githubId);
+
+        entry.setGitUrl("git@github.com:dockstore:dockstore-ui.git");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", null, githubId);
+
+        entry.setGitUrl("git@github.com:/dockstore-ui.git");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", null, githubId);
+
+        entry.setGitUrl("git@github.com:dockstore");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", null, githubId);
+
+        entry.setGitUrl("git@github.com:dockstore/dockstore-ui");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", null, githubId);
+
+    }
+
+    /**
+     * Tests that parsing a BitBucket URL works
+     */
+    @Test
+    public void testBitBucketUrlParsing() {
+        BitBucketSourceCodeRepo repo = new BitBucketSourceCodeRepo("fakeUser", "fakeToken");
+        final BioWorkflow entry = new BioWorkflow();
+
+        /* Test good URLs */
+        entry.setGitUrl("git@bitbucket.example.com:dockstore/dockstore-ui.git");
+        String bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", "bitbucket.example.com/dockstore", bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:dockstore/dockstore-ui.git");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", "bitbucket.org/dockstore", bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:dockstore-cow/goat.git");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", "bitbucket.org/dockstore-cow", bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:dockstore.dot/goat.bat.git");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", "bitbucket.org/dockstore.dot", bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:dockstore.dot/goat.git");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", "bitbucket.org/dockstore.dot", bitBucketId);
+
+        /* Test bad URLs */
+        entry.setGitUrl("git@bitbucket.org/dockstore/dockstore-ui.git");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", null, bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:dockstore:dockstore-ui.git");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", null, bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:/dockstore-ui.git");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", null, bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:dockstore");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", null, bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:dockstore/dockstore-ui");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", null, bitBucketId);
 
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -16,16 +16,10 @@
 
 package io.dockstore.client.cli;
 
-import static io.dockstore.webservice.core.Version.CANNOT_FREEZE_VERSIONS_WITH_NO_FILES;
-import static io.dockstore.webservice.helpers.EntryVersionHelper.CANNOT_MODIFY_FROZEN_VERSIONS_THIS_WAY;
-import static io.dockstore.webservice.resources.WorkflowResource.FROZEN_VERSION_REQUIRED;
-import static io.dockstore.webservice.resources.WorkflowResource.NO_ZENDO_USER_TOKEN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import com.google.common.collect.Lists;
 import io.dockstore.common.CommonTestUtilities;
@@ -48,10 +42,6 @@ import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.SourceFile;
 import io.swagger.client.model.Workflow;
 import io.swagger.client.model.WorkflowVersion;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -65,6 +55,17 @@ import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
+
+import static io.dockstore.webservice.core.Version.CANNOT_FREEZE_VERSIONS_WITH_NO_FILES;
+import static io.dockstore.webservice.helpers.EntryVersionHelper.CANNOT_MODIFY_FROZEN_VERSIONS_THIS_WAY;
+import static io.dockstore.webservice.resources.WorkflowResource.FROZEN_VERSION_REQUIRED;
+import static io.dockstore.webservice.resources.WorkflowResource.NO_ZENDO_USER_TOKEN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * This test suite tests various workflow related processes.
@@ -532,7 +533,7 @@ public class GeneralWorkflowIT extends BaseIT {
     }
 
     /**
-     * Tests that parsing a GitHub URL works
+     * Tests that parsing a GitLab URL works
      */
     @Test
     public void testGitLabUrlRegexParsing() {
@@ -636,25 +637,25 @@ public class GeneralWorkflowIT extends BaseIT {
         final BioWorkflow entry = new BioWorkflow();
 
         /* Test good URLs */
-        entry.setGitUrl("git@bitbucket.example.com:dockstore/dockstore-ui.git");
+        entry.setGitUrl("git@bitbucket.org:dockstore/dockstore-ui.git");
         String bitBucketId = repo.getRepositoryId(entry);
-        assertEquals("Bitbucket ID parse check", "bitbucket.example.com/dockstore", bitBucketId);
+        assertEquals("Bitbucket ID parse check", "dockstore/dockstore-ui", bitBucketId);
 
         entry.setGitUrl("git@bitbucket.org:dockstore/dockstore-ui.git");
         bitBucketId = repo.getRepositoryId(entry);
-        assertEquals("Bitbucket ID parse check", "bitbucket.org/dockstore", bitBucketId);
+        assertEquals("Bitbucket ID parse check", "dockstore/dockstore-ui", bitBucketId);
 
         entry.setGitUrl("git@bitbucket.org:dockstore-cow/goat.git");
         bitBucketId = repo.getRepositoryId(entry);
-        assertEquals("Bitbucket ID parse check", "bitbucket.org/dockstore-cow", bitBucketId);
+        assertEquals("Bitbucket ID parse check", "dockstore-cow/goat", bitBucketId);
 
         entry.setGitUrl("git@bitbucket.org:dockstore.dot/goat.bat.git");
         bitBucketId = repo.getRepositoryId(entry);
-        assertEquals("Bitbucket ID parse check", "bitbucket.org/dockstore.dot", bitBucketId);
+        assertEquals("Bitbucket ID parse check", "dockstore.dot/goat.bat", bitBucketId);
 
         entry.setGitUrl("git@bitbucket.org:dockstore.dot/goat.git");
         bitBucketId = repo.getRepositoryId(entry);
-        assertEquals("Bitbucket ID parse check", "bitbucket.org/dockstore.dot", bitBucketId);
+        assertEquals("Bitbucket ID parse check", "dockstore.dot/goat", bitBucketId);
 
         /* Test bad URLs */
         entry.setGitUrl("git@bitbucket.org/dockstore/dockstore-ui.git");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -343,12 +343,13 @@ public abstract class AbstractImageRegistry {
     }
 
     public static String getGitRepositoryFromGitUrl(String gitUrl) {
-        Map<String, String> repoUrlMap = parseGitUrl(gitUrl);
-        if (repoUrlMap == null) {
+        Optional<Map<String, String>> repoUrlMap = parseGitUrl(gitUrl);
+        if (repoUrlMap.isEmpty()) {
             return null;
         }
-        String username = repoUrlMap.get("Username");
-        String repository = repoUrlMap.get("Repository");
+
+        String username = repoUrlMap.get().get(SourceCodeRepoFactory.GIT_URL_USER_KEY);
+        String repository = repoUrlMap.get().get(SourceCodeRepoFactory.GIT_URL_REPOSITORY_KEY);
         return username + '/' + repository;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -16,19 +16,7 @@
 
 package io.dockstore.webservice.helpers;
 
-import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import javax.ws.rs.core.GenericType;
+import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 
 import com.google.common.base.Strings;
 import io.dockstore.common.DescriptorLanguage;
@@ -51,12 +39,22 @@ import io.swagger.bitbucket.client.model.PaginatedRepositories;
 import io.swagger.bitbucket.client.model.PaginatedTreeentries;
 import io.swagger.bitbucket.client.model.Repository;
 import io.swagger.bitbucket.client.model.Tag;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.ws.rs.core.GenericType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 
 /**
  * @author dyuen

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -356,7 +356,7 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
     public String getRepositoryId(Entry entry) {
         String repositoryId;
         String giturl = entry.getGitUrl();
-        Optional<Map<String, String>> gitMap = SourceCodeRepoFactory.parseGitUrl(giturl, Optional.of("git@bitbucket.org"));
+        Optional<Map<String, String>> gitMap = SourceCodeRepoFactory.parseGitUrl(giturl, Optional.of("bitbucket.org"));
         LOG.info(gitUsername + ": " + giturl);
         if (gitMap.isEmpty()) {
             LOG.info(gitUsername + ": Namespace and/or repository name could not be found from tool's giturl");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -362,8 +362,8 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
             LOG.info(gitUsername + ": Namespace and/or repository name could not be found from tool's giturl");
             return null;
         }
-        repositoryId = gitMap.get().get(SourceCodeRepoFactory.GIT_URL_SOURCE_KEY) + "/"
-                + gitMap.get().get(SourceCodeRepoFactory.GIT_URL_USER_KEY);
+        repositoryId = gitMap.get().get(SourceCodeRepoFactory.GIT_URL_USER_KEY) + "/"
+                + gitMap.get().get(SourceCodeRepoFactory.GIT_URL_REPOSITORY_KEY);
         return repositoryId;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -16,17 +16,7 @@
 
 package io.dockstore.webservice.helpers;
 
-import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import javax.ws.rs.core.GenericType;
+import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 
 import com.google.common.base.Strings;
 import io.dockstore.common.DescriptorLanguage;
@@ -49,12 +39,20 @@ import io.swagger.bitbucket.client.model.PaginatedRepositories;
 import io.swagger.bitbucket.client.model.PaginatedTreeentries;
 import io.swagger.bitbucket.client.model.Repository;
 import io.swagger.bitbucket.client.model.Tag;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.ws.rs.core.GenericType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 
 /**
  * @author dyuen

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -77,17 +77,17 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
     // https://sonarcloud.io/organizations/dockstore/rules?open=java%3AS5852&rule_key=java%3AS5852
     // See Prevent Catastrophic Backtracking and Possessive Quantifiers and Atomic Grouping to The Rescue
     // in https://www.regular-expressions.info/catastrophic.html
-    // So use more restrictive regex and possesive quantifiers '++' with atomic group '?>'
+    // So use more restrictive regex and possesive quantifiers '++' and atomic group
     // Can test regex at https://regex101.com/
-    // format 1 git@bitbucket.org:dockstore/dockstore-ui.git
-    private static final Pattern BITBUCKET_REGEX_PATTERN = Pattern.compile("git@([^\\s:]++):([^\\s/]++)/(?>(\\S+)\\.git$)");
+    // format git@bitbucket.org:dockstore/dockstore-ui.git
+    private static final Pattern BITBUCKET_REGEX_PATTERN = Pattern.compile("^git@([^\\s:]++):([^\\s/]++)/(?>\\S+\\.git)$");
 
 
     /**
      * @param gitUsername           username that owns the bitbucket token
      * @param bitbucketTokenContent bitbucket token
      */
-    BitBucketSourceCodeRepo(String gitUsername, String bitbucketTokenContent) {
+    public BitBucketSourceCodeRepo(String gitUsername, String bitbucketTokenContent) {
         this.gitUsername = gitUsername;
 
         apiClient = Configuration.getDefaultApiClient();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryLabelHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryLabelHelper.java
@@ -16,16 +16,15 @@
 
 package io.dockstore.webservice.helpers;
 
+import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Entry;
+import io.dockstore.webservice.core.Label;
+import io.dockstore.webservice.jdbi.LabelDAO;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-
-import io.dockstore.webservice.CustomWebApplicationException;
-import io.dockstore.webservice.core.Entry;
-import io.dockstore.webservice.core.Label;
-import io.dockstore.webservice.jdbi.LabelDAO;
 import org.apache.http.HttpStatus;
 
 /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryLabelHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryLabelHelper.java
@@ -16,15 +16,16 @@
 
 package io.dockstore.webservice.helpers;
 
-import io.dockstore.webservice.CustomWebApplicationException;
-import io.dockstore.webservice.core.Entry;
-import io.dockstore.webservice.core.Label;
-import io.dockstore.webservice.jdbi.LabelDAO;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+
+import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Entry;
+import io.dockstore.webservice.core.Label;
+import io.dockstore.webservice.jdbi.LabelDAO;
 import org.apache.http.HttpStatus;
 
 /**
@@ -45,7 +46,7 @@ public class EntryLabelHelper<T extends Entry> {
             entry.setLabels(new TreeSet<>());
         } else {
             Set<String> labelStringSet = new HashSet<>(Arrays.asList(labelStrings.toLowerCase().split("\\s*,\\s*")));
-            final String labelStringPattern = "^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$";
+            final String labelStringPattern = "^[a-zA-Z0-9]++(-[a-zA-Z0-9]++)*+$";
 
             // This matches the restriction on labels to 255 characters
             // if this is changed then the java object/mapped db schema needs to be changed

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHelper.java
@@ -25,7 +25,7 @@ public final class GitHelper {
      */
     public static Optional<String> parseGitHubReference(String gitReference) {
         // Match the github reference (ex. refs/heads/feature/foobar or refs/tags/1.0)
-        Pattern pattern = Pattern.compile("^refs/(tags|heads)/([a-zA-Z0-9]+([./_-]?[a-zA-Z0-9]+)*)$");
+        Pattern pattern = Pattern.compile("^refs/(tags|heads)/([a-zA-Z0-9]++([./_-]?[a-zA-Z0-9]+)*)$");
         Matcher matcher = pattern.matcher(gitReference);
 
         if (!matcher.find()) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -16,11 +16,23 @@
 
 package io.dockstore.webservice.helpers;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
-import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATHS;
-import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
-import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -53,23 +65,6 @@ import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowMode;
 import io.dockstore.webservice.core.WorkflowVersion;
 import io.dockstore.webservice.jdbi.TokenDAO;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import okhttp3.OkHttpClient;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -97,6 +92,12 @@ import org.kohsuke.github.extras.ImpatientHttpConnector;
 import org.kohsuke.github.extras.okhttp3.ObsoleteUrlFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATHS;
+import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
+import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 
 /**
  * @author dyuen
@@ -950,8 +951,8 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             if (gitMap.isEmpty()) {
                 return null;
             } else {
-                return gitMap.get().get(SourceCodeRepoFactory.GIT_URL_SOURCE_KEY) + "/"
-                        + gitMap.get().get(SourceCodeRepoFactory.GIT_URL_USER_KEY);
+                return gitMap.get().get(SourceCodeRepoFactory.GIT_URL_USER_KEY) + "/"
+                        + gitMap.get().get(SourceCodeRepoFactory.GIT_URL_REPOSITORY_KEY);
             }
         } else {
             return ((Workflow)entry).getOrganization() + '/' + ((Workflow)entry).getRepository();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -16,11 +16,23 @@
 
 package io.dockstore.webservice.helpers;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
-import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATHS;
-import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
-import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -53,23 +65,6 @@ import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowMode;
 import io.dockstore.webservice.core.WorkflowVersion;
 import io.dockstore.webservice.jdbi.TokenDAO;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import okhttp3.OkHttpClient;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -97,6 +92,12 @@ import org.kohsuke.github.extras.ImpatientHttpConnector;
 import org.kohsuke.github.extras.okhttp3.ObsoleteUrlFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATHS;
+import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
+import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 
 /**
  * @author dyuen
@@ -945,7 +946,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     public String getRepositoryId(Entry entry) {
         if (entry.getClass().equals(Tool.class)) {
             // Parse git url for repo
-            Optional<Map<String, String>> gitMap = SourceCodeRepoFactory.parseGitUrl(entry.getGitUrl(), Optional.of("git@github.com"));
+            Optional<Map<String, String>> gitMap = SourceCodeRepoFactory.parseGitUrl(entry.getGitUrl(), Optional.of("github.com"));
 
             if (gitMap.isEmpty()) {
                 return null;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -16,23 +16,11 @@
 
 package io.dockstore.webservice.helpers;
 
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATHS;
+import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
+import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -65,6 +53,23 @@ import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowMode;
 import io.dockstore.webservice.core.WorkflowVersion;
 import io.dockstore.webservice.jdbi.TokenDAO;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import okhttp3.OkHttpClient;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -92,12 +97,6 @@ import org.kohsuke.github.extras.ImpatientHttpConnector;
 import org.kohsuke.github.extras.okhttp3.ObsoleteUrlFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
-import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATHS;
-import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
-import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 
 /**
  * @author dyuen

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -16,23 +16,11 @@
 
 package io.dockstore.webservice.helpers;
 
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATHS;
+import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
+import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -65,6 +53,23 @@ import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowMode;
 import io.dockstore.webservice.core.WorkflowVersion;
 import io.dockstore.webservice.jdbi.TokenDAO;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import okhttp3.OkHttpClient;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -93,12 +98,6 @@ import org.kohsuke.github.extras.okhttp3.ObsoleteUrlFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
-import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATHS;
-import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
-import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
-
 /**
  * @author dyuen
  */
@@ -117,6 +116,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     // Can test regex at https://regex101.com/
     // format git@github.com:dockstore/dockstore-ui.git
     private static final Pattern GITHUB_REGEX_PATTERN = Pattern.compile("^git@github.com:([^\\s/]++)/(?>(\\S+)\\.git)$");
+
     /**
      *  @param githubTokenUsername the username for githubTokenContent
      * @param githubTokenContent authorization token

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
@@ -16,6 +16,17 @@
 
 package io.dockstore.webservice.helpers;
 
+import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
+
+import com.google.common.collect.Lists;
+import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.common.SourceControl;
+import io.dockstore.webservice.core.Entry;
+import io.dockstore.webservice.core.SourceControlOrganization;
+import io.dockstore.webservice.core.SourceFile;
+import io.dockstore.webservice.core.Version;
+import io.dockstore.webservice.core.Workflow;
+import io.dockstore.webservice.core.WorkflowVersion;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -28,16 +39,6 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import com.google.common.collect.Lists;
-import io.dockstore.common.DescriptorLanguage;
-import io.dockstore.common.SourceControl;
-import io.dockstore.webservice.core.Entry;
-import io.dockstore.webservice.core.SourceControlOrganization;
-import io.dockstore.webservice.core.SourceFile;
-import io.dockstore.webservice.core.Version;
-import io.dockstore.webservice.core.Workflow;
-import io.dockstore.webservice.core.WorkflowVersion;
 import org.gitlab.api.GitlabAPI;
 import org.gitlab.api.TokenType;
 import org.gitlab.api.models.GitlabBranch;
@@ -47,8 +48,6 @@ import org.gitlab.api.models.GitlabRepositoryTree;
 import org.gitlab.api.models.GitlabTag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 
 /**
  * @author aduncan on 05/10/16.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
@@ -16,17 +16,6 @@
 
 package io.dockstore.webservice.helpers;
 
-import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
-
-import com.google.common.collect.Lists;
-import io.dockstore.common.DescriptorLanguage;
-import io.dockstore.common.SourceControl;
-import io.dockstore.webservice.core.Entry;
-import io.dockstore.webservice.core.SourceControlOrganization;
-import io.dockstore.webservice.core.SourceFile;
-import io.dockstore.webservice.core.Version;
-import io.dockstore.webservice.core.Workflow;
-import io.dockstore.webservice.core.WorkflowVersion;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -37,6 +26,16 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import com.google.common.collect.Lists;
+import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.common.SourceControl;
+import io.dockstore.webservice.core.Entry;
+import io.dockstore.webservice.core.SourceControlOrganization;
+import io.dockstore.webservice.core.SourceFile;
+import io.dockstore.webservice.core.Version;
+import io.dockstore.webservice.core.Workflow;
+import io.dockstore.webservice.core.WorkflowVersion;
 import org.gitlab.api.GitlabAPI;
 import org.gitlab.api.TokenType;
 import org.gitlab.api.models.GitlabBranch;
@@ -46,6 +45,8 @@ import org.gitlab.api.models.GitlabRepositoryTree;
 import org.gitlab.api.models.GitlabTag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 
 /**
  * @author aduncan on 05/10/16.
@@ -229,8 +230,8 @@ public class GitLabSourceCodeRepo extends SourceCodeRepoInterface {
             return null;
         }
 
-        repositoryId = gitMap.get().get(SourceCodeRepoFactory.GIT_URL_SOURCE_KEY) + "/"
-            + gitMap.get().get(SourceCodeRepoFactory.GIT_URL_USER_KEY);
+        repositoryId = gitMap.get().get(SourceCodeRepoFactory.GIT_URL_USER_KEY) + "/"
+            + gitMap.get().get(SourceCodeRepoFactory.GIT_URL_REPOSITORY_KEY);
         return repositoryId;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
@@ -16,16 +16,7 @@
 
 package io.dockstore.webservice.helpers;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 
 import com.google.common.collect.Lists;
 import io.dockstore.common.DescriptorLanguage;
@@ -36,6 +27,16 @@ import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowVersion;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.gitlab.api.GitlabAPI;
 import org.gitlab.api.TokenType;
 import org.gitlab.api.models.GitlabBranch;
@@ -45,8 +46,6 @@ import org.gitlab.api.models.GitlabRepositoryTree;
 import org.gitlab.api.models.GitlabTag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 
 /**
  * @author aduncan on 05/10/16.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
@@ -222,7 +222,7 @@ public class GitLabSourceCodeRepo extends SourceCodeRepoInterface {
     public String getRepositoryId(Entry entry) {
         String repositoryId;
         String giturl = entry.getGitUrl();
-        Optional<Map<String, String>> gitMap = SourceCodeRepoFactory.parseGitUrl(entry.getGitUrl(), Optional.of("git@gitlab.com"));
+        Optional<Map<String, String>> gitMap = SourceCodeRepoFactory.parseGitUrl(entry.getGitUrl(), Optional.of("gitlab.com"));
         LOG.info(gitUsername + ": " + giturl);
 
         if (gitMap.isEmpty()) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
@@ -132,28 +132,28 @@ public final class SourceCodeRepoFactory {
      * Parse Git URL to retrieve source, username and repository name.
      *
      * @param url
-     * @param repositoryName fixed repository name to match in git URL
+     * @param sourceName fixed git host to match in git URL, e.g. github.com, bitbucket.org, gitlab.com
      * @return a map with keys: Source, Username, Repository
      */
-    public static Optional<Map<String, String>> parseGitUrl(String url, Optional<String> repositoryName) {
+    public static Optional<Map<String, String>> parseGitUrl(String url, Optional<String> sourceName) {
         final String logGitUrlFormatString = "{} {}";
         final String githubRepositoryRegex1 = "[^\\s:]++";
         final String githubRepositoryRegex2 = "[^\\s/]++";
 
-        String repositoryNameRegex1 = repositoryName.isPresent() ? repositoryName.get() : githubRepositoryRegex1;
-        String repositoryNameRegex2 = repositoryName.isPresent() ? repositoryName.get() : githubRepositoryRegex2;
+        String sourceNameRegex1 = sourceName.isPresent() ? sourceName.get() : githubRepositoryRegex1;
+        String sourceNameRegex2 = sourceName.isPresent() ? sourceName.get() : githubRepositoryRegex2;
         // Avoid SonarCloud warning: Using slow regular expressions is security-sensitive
         // https://sonarcloud.io/organizations/dockstore/rules?open=java%3AS5852&rule_key=java%3AS5852
         // See Prevent Catastrophic Backtracking and Possessive Quantifiers and Atomic Grouping to The Rescue
         // in https://www.regular-expressions.info/catastrophic.html
         // So use more restrictive regex and possesive quantifiers '++' with atomic group '?>'
         // Can test regex at https://regex101.com/
-        // If a caller provides repositoryName the pattern matcher will expect that exact repository name in the URL,
-        // otherwise it will match any valid repository name
+        // If a caller provides sourceName the pattern matcher will expect that exact git host name in the URL,
+        // otherwise it will match any valid git host name
         // Any valid user name will be matched
         // Any valid repository name will be matched, including names with dots, e.g. my.repo.with.dots.git
-        Pattern gitUrlRegexPattern1 = Pattern.compile("^git@(" + repositoryNameRegex1 + "):([^\\s/]++)/(?>(\\S+)\\.git)$");
-        Pattern gitUrlRegexPattern2 = Pattern.compile("^git://(" + repositoryNameRegex2 + ")/([^\\s/]++)/(?>(\\S+)\\.git)$");
+        Pattern gitUrlRegexPattern1 = Pattern.compile("^git@(" + sourceNameRegex1 + "):([^\\s/]++)/(?>(\\S+)\\.git)$");
+        Pattern gitUrlRegexPattern2 = Pattern.compile("^git://(" + sourceNameRegex2 + ")/([^\\s/]++)/(?>(\\S+)\\.git)$");
 
 
         Matcher m1 = gitUrlRegexPattern1.matcher(url);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
@@ -16,17 +16,16 @@
 
 package io.dockstore.webservice.helpers;
 
+import io.dockstore.common.SourceControl;
+import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Token;
+import io.dockstore.webservice.core.TokenType;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import io.dockstore.common.SourceControl;
-import io.dockstore.webservice.CustomWebApplicationException;
-import io.dockstore.webservice.core.Token;
-import io.dockstore.webservice.core.TokenType;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
@@ -176,9 +176,9 @@ public final class SourceCodeRepoFactory {
         String gitUsername = matcherActual.group(usernameIndex);
         String gitRepository = matcherActual.group(reponameIndex);
 
-        LOG.debug(GIT_URL_SOURCE_KEY + " " + source);
-        LOG.debug(GIT_URL_USER_KEY + " " + gitUsername);
-        LOG.debug(GIT_URL_REPOSITORY_KEY + " " + gitRepository);
+        LOG.debug("{} {}", GIT_URL_SOURCE_KEY, source);
+        LOG.debug("{} {}", GIT_URL_USER_KEY, gitUsername);
+        LOG.debug("{} {}", GIT_URL_REPOSITORY_KEY, gitRepository);
 
         Map<String, String> map = new HashMap<>();
         map.put(GIT_URL_SOURCE_KEY, source);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
@@ -38,6 +38,7 @@ public final class SourceCodeRepoFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(SourceCodeRepoFactory.class);
 
+    private static final String LOG_GIT_URL_FORMAT_STRING = "{} {}";
     private static final String GITHUB_REPOSITORY_REGEX_1 = "[^\\s:]++";
     private static final String GITHUB_REPOSITORY_REGEX_2 = "[^\\s/]++";
 
@@ -176,9 +177,9 @@ public final class SourceCodeRepoFactory {
         String gitUsername = matcherActual.group(usernameIndex);
         String gitRepository = matcherActual.group(reponameIndex);
 
-        LOG.debug("{} {}", GIT_URL_SOURCE_KEY, source);
-        LOG.debug("{} {}", GIT_URL_USER_KEY, gitUsername);
-        LOG.debug("{} {}", GIT_URL_REPOSITORY_KEY, gitRepository);
+        LOG.debug(LOG_GIT_URL_FORMAT_STRING, GIT_URL_SOURCE_KEY, source);
+        LOG.debug(LOG_GIT_URL_FORMAT_STRING, GIT_URL_USER_KEY, gitUsername);
+        LOG.debug(LOG_GIT_URL_FORMAT_STRING, GIT_URL_REPOSITORY_KEY, gitRepository);
 
         Map<String, String> map = new HashMap<>();
         map.put(GIT_URL_SOURCE_KEY, source);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
@@ -16,15 +16,16 @@
 
 package io.dockstore.webservice.helpers;
 
-import io.dockstore.common.SourceControl;
-import io.dockstore.webservice.CustomWebApplicationException;
-import io.dockstore.webservice.core.Token;
-import io.dockstore.webservice.core.TokenType;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import io.dockstore.common.SourceControl;
+import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Token;
+import io.dockstore.webservice.core.TokenType;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,9 +43,9 @@ public final class SourceCodeRepoFactory {
     // So use more restrictive regex and possesive quantifiers '++' with atomic group '?>'
     // Can test regex at https://regex101.com/
     // format 1 git@github.com:dockstore/dockstore-ui.git
-    private static final Pattern GITHUB_REGEX_PATTERN_1 = Pattern.compile("git@([^\\s:]++):([^\\s/]++)/(?>(\\S+)\\.git$)");
+    private static final Pattern GITHUB_REGEX_PATTERN_1 = Pattern.compile("^git@([^\\s:]++):([^\\s/]++)/(?>(\\S+)\\.git)$");
     // format 2 git://github.com/denis-yuen/dockstore-whalesay.git (should be avoided)
-    private static final Pattern GITHUB_REGEX_PATTERN_2 = Pattern.compile("git://([^\\s/]++)/([^\\s/]++)/(?>(\\S+)\\.git$)");
+    private static final Pattern GITHUB_REGEX_PATTERN_2 = Pattern.compile("^git://([^\\s/]++)/([^\\s/]++)/(?>(\\S+)\\.git)$");
 
     private SourceCodeRepoFactory() {
         // hide the constructor for utility classes

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
@@ -16,16 +16,15 @@
 
 package io.dockstore.webservice.helpers;
 
+import io.dockstore.common.SourceControl;
+import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Token;
+import io.dockstore.webservice.core.TokenType;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import io.dockstore.common.SourceControl;
-import io.dockstore.webservice.CustomWebApplicationException;
-import io.dockstore.webservice.core.Token;
-import io.dockstore.webservice.core.TokenType;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
@@ -37,10 +37,6 @@ public final class SourceCodeRepoFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(SourceCodeRepoFactory.class);
 
-    private static final String LOG_GIT_URL_FORMAT_STRING = "{} {}";
-    private static final String GITHUB_REPOSITORY_REGEX_1 = "[^\\s:]++";
-    private static final String GITHUB_REPOSITORY_REGEX_2 = "[^\\s/]++";
-
     private SourceCodeRepoFactory() {
         // hide the constructor for utility classes
     }
@@ -140,8 +136,12 @@ public final class SourceCodeRepoFactory {
      * @return a map with keys: Source, Username, Repository
      */
     public static Optional<Map<String, String>> parseGitUrl(String url, Optional<String> repositoryName) {
-        String repositoryNameRegex1 = repositoryName.isPresent() ? repositoryName.get() : GITHUB_REPOSITORY_REGEX_1;
-        String repositoryNameRegex2 = repositoryName.isPresent() ? repositoryName.get() : GITHUB_REPOSITORY_REGEX_2;
+        final String logGitUrlFormatString = "{} {}";
+        final String githubRepositoryRegex1 = "[^\\s:]++";
+        final String githubRepositoryRegex2 = "[^\\s/]++";
+
+        String repositoryNameRegex1 = repositoryName.isPresent() ? repositoryName.get() : githubRepositoryRegex1;
+        String repositoryNameRegex2 = repositoryName.isPresent() ? repositoryName.get() : githubRepositoryRegex2;
         // Avoid SonarCloud warning: Using slow regular expressions is security-sensitive
         // https://sonarcloud.io/organizations/dockstore/rules?open=java%3AS5852&rule_key=java%3AS5852
         // See Prevent Catastrophic Backtracking and Possessive Quantifiers and Atomic Grouping to The Rescue
@@ -176,9 +176,9 @@ public final class SourceCodeRepoFactory {
         String gitUsername = matcherActual.group(usernameIndex);
         String gitRepository = matcherActual.group(reponameIndex);
 
-        LOG.debug(LOG_GIT_URL_FORMAT_STRING, GIT_URL_SOURCE_KEY, source);
-        LOG.debug(LOG_GIT_URL_FORMAT_STRING, GIT_URL_USER_KEY, gitUsername);
-        LOG.debug(LOG_GIT_URL_FORMAT_STRING, GIT_URL_REPOSITORY_KEY, gitRepository);
+        LOG.debug(logGitUrlFormatString, GIT_URL_SOURCE_KEY, source);
+        LOG.debug(logGitUrlFormatString, GIT_URL_USER_KEY, gitUsername);
+        LOG.debug(logGitUrlFormatString, GIT_URL_REPOSITORY_KEY, gitRepository);
 
         Map<String, String> map = new HashMap<>();
         map.put(GIT_URL_SOURCE_KEY, source);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -16,35 +16,10 @@
 
 package io.dockstore.webservice.resources;
 
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ResourceContext;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
-import javax.ws.rs.core.StreamingOutput;
+import static io.dockstore.webservice.Constants.AMAZON_ECR_PRIVATE_REGISTRY_REGEX;
+import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
+import static io.dockstore.webservice.resources.ResourceConstants.OPENAPI_JWT_SECURITY_DEFINITION_NAME;
+import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_LIMIT;
 
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.base.Strings;
@@ -98,17 +73,40 @@ import io.swagger.quay.client.model.QuayRepo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ResourceContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.StreamingOutput;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.hibernate.Hibernate;
 import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static io.dockstore.webservice.Constants.AMAZON_ECR_PRIVATE_REGISTRY_REGEX;
-import static io.dockstore.webservice.Constants.JWT_SECURITY_DEFINITION_NAME;
-import static io.dockstore.webservice.resources.ResourceConstants.OPENAPI_JWT_SECURITY_DEFINITION_NAME;
-import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_LIMIT;
 
 /**
  * @author dyuen
@@ -1095,10 +1093,7 @@ public class DockerRepoResource
     private static boolean isGit(String url) {
         final Optional<Map<String, String>> stringStringGitUrlMap = SourceCodeRepoFactory
                 .parseGitUrl(url);
-        if (stringStringGitUrlMap.isEmpty()) {
-            return false;
-        }
-        return true;
+        return !stringStringGitUrlMap.isEmpty();
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -1091,9 +1091,16 @@ public class DockerRepoResource
      * @return is url of the format git@source:gitUsername/gitRepository
      */
     private static boolean isGit(String url) {
-        Pattern p = Pattern.compile("git@(\\S+):(\\S+)/(\\S+)\\.git");
-        Matcher m = p.matcher(url);
-        return m.matches();
+        final Map<String, String> stringStringGitUrlMap = SourceCodeRepoFactory
+                .parseGitUrl(url);
+        if (stringStringGitUrlMap == null) {
+            return false;
+        }
+        return true;
+
+        // Pattern p = Pattern.compile("git@(\\S+):(\\S+)/(\\S+)\\.git");
+        // Matcher m = p.matcher(url);
+        // return m.matches();
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1711,13 +1711,14 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
             // Determine gitUrl
             gitUrl = tool.getGitUrl();
-            final Optional<Map<String, String>>  stringStringGitUrlMap = SourceCodeRepoFactory
+            final Optional<Map<String, String>>  stringStringGitUrlMapOpt = SourceCodeRepoFactory
                     .parseGitUrl(gitUrl);
-            if (!stringStringGitUrlMap.isEmpty()) {
+            if (!stringStringGitUrlMapOpt.isEmpty()) {
                 SourceControlConverter converter = new SourceControlConverter();
-                sourceControl = converter.convertToEntityAttribute(stringStringGitUrlMap.get().get(SourceCodeRepoFactory.GIT_URL_SOURCE_KEY));
-                organization = stringStringGitUrlMap.get().get(SourceCodeRepoFactory.GIT_URL_USER_KEY);
-                repository = stringStringGitUrlMap.get().get(SourceCodeRepoFactory.GIT_URL_REPOSITORY_KEY);
+                final Map<String, String> stringStringGitUrlMap = stringStringGitUrlMapOpt.get();
+                sourceControl = converter.convertToEntityAttribute(stringStringGitUrlMap.get(SourceCodeRepoFactory.GIT_URL_SOURCE_KEY));
+                organization = stringStringGitUrlMap.get(SourceCodeRepoFactory.GIT_URL_USER_KEY);
+                repository = stringStringGitUrlMap.get(SourceCodeRepoFactory.GIT_URL_REPOSITORY_KEY);
             } else {
                 throw new CustomWebApplicationException("Problem parsing git url.", HttpStatus.SC_BAD_REQUEST);
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1711,27 +1711,16 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
             // Determine gitUrl
             gitUrl = tool.getGitUrl();
-            final Map<String, String> stringStringGitUrlMap = SourceCodeRepoFactory
+            final Optional<Map<String, String>>  stringStringGitUrlMap = SourceCodeRepoFactory
                     .parseGitUrl(gitUrl);
-            if (stringStringGitUrlMap != null) {
+            if (!stringStringGitUrlMap.isEmpty()) {
                 SourceControlConverter converter = new SourceControlConverter();
-                sourceControl = converter.convertToEntityAttribute(stringStringGitUrlMap.get("Source"));
-                organization = stringStringGitUrlMap.get("Username");
-                repository = stringStringGitUrlMap.get("Repository");
+                sourceControl = converter.convertToEntityAttribute(stringStringGitUrlMap.get().get(SourceCodeRepoFactory.GIT_URL_SOURCE_KEY));
+                organization = stringStringGitUrlMap.get().get(SourceCodeRepoFactory.GIT_URL_USER_KEY);
+                repository = stringStringGitUrlMap.get().get(SourceCodeRepoFactory.GIT_URL_REPOSITORY_KEY);
             } else {
                 throw new CustomWebApplicationException("Problem parsing git url.", HttpStatus.SC_BAD_REQUEST);
             }
-            // Determine source control, org, and repo
-            // Pattern p = Pattern.compile("git@(\\S+):(\\S+)/(\\S+)\\.git");
-            // Matcher m = p.matcher(tool.getGitUrl());
-            // if (m.find()) {
-            //     SourceControlConverter converter = new SourceControlConverter();
-            //     sourceControl = converter.convertToEntityAttribute(m.group(1));
-            //     organization = m.group(2);
-            //     repository = m.group(3);
-            // } else {
-            //     throw new CustomWebApplicationException("Problem parsing git url.", HttpStatus.SC_BAD_REQUEST);
-            // }
 
             // Determine publish information
             isPublished = tool.getIsPublished();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -59,6 +59,7 @@ import io.dockstore.webservice.helpers.EntryVersionHelper;
 import io.dockstore.webservice.helpers.FileFormatHelper;
 import io.dockstore.webservice.helpers.MetadataResourceHelper;
 import io.dockstore.webservice.helpers.PublicStateManager;
+import io.dockstore.webservice.helpers.SourceCodeRepoFactory;
 import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
 import io.dockstore.webservice.helpers.StateManagerMode;
 import io.dockstore.webservice.helpers.StringInputValidationHelper;
@@ -111,8 +112,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.security.RolesAllowed;
 import javax.servlet.http.HttpServletResponse;
@@ -1712,18 +1711,27 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
             // Determine gitUrl
             gitUrl = tool.getGitUrl();
-
-            // Determine source control, org, and repo
-            Pattern p = Pattern.compile("git@(\\S+):(\\S+)/(\\S+)\\.git");
-            Matcher m = p.matcher(tool.getGitUrl());
-            if (m.find()) {
+            final Map<String, String> stringStringGitUrlMap = SourceCodeRepoFactory
+                    .parseGitUrl(gitUrl);
+            if (stringStringGitUrlMap != null) {
                 SourceControlConverter converter = new SourceControlConverter();
-                sourceControl = converter.convertToEntityAttribute(m.group(1));
-                organization = m.group(2);
-                repository = m.group(3);
+                sourceControl = converter.convertToEntityAttribute(stringStringGitUrlMap.get("Source"));
+                organization = stringStringGitUrlMap.get("Username");
+                repository = stringStringGitUrlMap.get("Repository");
             } else {
                 throw new CustomWebApplicationException("Problem parsing git url.", HttpStatus.SC_BAD_REQUEST);
             }
+            // Determine source control, org, and repo
+            // Pattern p = Pattern.compile("git@(\\S+):(\\S+)/(\\S+)\\.git");
+            // Matcher m = p.matcher(tool.getGitUrl());
+            // if (m.find()) {
+            //     SourceControlConverter converter = new SourceControlConverter();
+            //     sourceControl = converter.convertToEntityAttribute(m.group(1));
+            //     organization = m.group(2);
+            //     repository = m.group(3);
+            // } else {
+            //     throw new CustomWebApplicationException("Problem parsing git url.", HttpStatus.SC_BAD_REQUEST);
+            // }
 
             // Determine publish information
             isPublished = tool.getIsPublished();

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/SourceCodeRepoFactoryTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/SourceCodeRepoFactoryTest.java
@@ -17,6 +17,7 @@
 package io.dockstore.webservice.helpers;
 
 import java.util.Map;
+import java.util.Optional;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,38 +30,53 @@ public class SourceCodeRepoFactoryTest {
     public void parseGitUrl() {
         // https://stackoverflow.com/questions/59081778/rules-for-special-characters-in-github-repository-name
         // test format 1
-        final Map<String, String> stringStringMap1 = SourceCodeRepoFactory
+        final Optional<Map<String, String>> stringStringMapOpt = SourceCodeRepoFactory
                 .parseGitUrl("git@github.com:dockstore/dockstore-ui.git");
-        Assert.assertNotNull(stringStringMap1);
-        Assert.assertEquals("github.com", stringStringMap1.get("Source"));
-        Assert.assertEquals("dockstore", stringStringMap1.get("Username"));
-        Assert.assertEquals("dockstore-ui", stringStringMap1.get("Repository"));
+        Assert.assertNotNull(stringStringMapOpt);
+        Assert.assertEquals("github.com", stringStringMapOpt.get().get(SourceCodeRepoFactory.GIT_URL_SOURCE_KEY));
+        Assert.assertEquals("dockstore", stringStringMapOpt.get().get(SourceCodeRepoFactory.GIT_URL_USER_KEY));
+        Assert.assertEquals("dockstore-ui", stringStringMapOpt.get().get(SourceCodeRepoFactory.GIT_URL_REPOSITORY_KEY));
 
-        final Map<String, String> repoMapWithPeriodAndHyphen = SourceCodeRepoFactory
-                .parseGitUrl("git@github.com:DockstoreTestUser2/wdl-1.0-work_flow.git");
+        final Optional<Map<String, String>> stringStringMap1 = SourceCodeRepoFactory
+                .parseGitUrl("git@github.com:dockstore/dockstore-ui.git", Optional.of("github.com"));
+        Assert.assertNotNull(stringStringMap1);
+        Assert.assertEquals("github.com", stringStringMap1.get().get(SourceCodeRepoFactory.GIT_URL_SOURCE_KEY));
+        Assert.assertEquals("dockstore", stringStringMap1.get().get(SourceCodeRepoFactory.GIT_URL_USER_KEY));
+        Assert.assertEquals("dockstore-ui", stringStringMap1.get().get(SourceCodeRepoFactory.GIT_URL_REPOSITORY_KEY));
+
+        final Optional<Map<String, String>> repoMapWithPeriodAndHyphen = SourceCodeRepoFactory
+                .parseGitUrl("git@github.com:DockstoreTestUser2/wdl-1.0-work_flow.git", Optional.of("github.com"));
         Assert.assertNotNull(repoMapWithPeriodAndHyphen);
-        Assert.assertEquals("github.com", repoMapWithPeriodAndHyphen.get("Source"));
-        Assert.assertEquals("DockstoreTestUser2", repoMapWithPeriodAndHyphen.get("Username"));
-        Assert.assertEquals("wdl-1.0-work_flow", repoMapWithPeriodAndHyphen.get("Repository"));
+        Assert.assertEquals("github.com", repoMapWithPeriodAndHyphen.get().get(SourceCodeRepoFactory.GIT_URL_SOURCE_KEY));
+        Assert.assertEquals("DockstoreTestUser2", repoMapWithPeriodAndHyphen.get().get(SourceCodeRepoFactory.GIT_URL_USER_KEY));
+        Assert.assertEquals("wdl-1.0-work_flow", repoMapWithPeriodAndHyphen.get().get(SourceCodeRepoFactory.GIT_URL_REPOSITORY_KEY));
 
         // test format 2
-        final Map<String, String> stringStringMap2 = SourceCodeRepoFactory
+        final Optional<Map<String, String>> stringStringMap2 = SourceCodeRepoFactory
                 .parseGitUrl("git://github.com/denis-yuen/dockstore-whalesay.git");
         Assert.assertNotNull(stringStringMap2);
-        Assert.assertEquals("github.com", stringStringMap2.get("Source"));
-        Assert.assertEquals("denis-yuen", stringStringMap2.get("Username"));
-        Assert.assertEquals("dockstore-whalesay", stringStringMap2.get("Repository"));
+        Assert.assertEquals("github.com", stringStringMap2.get().get(SourceCodeRepoFactory.GIT_URL_SOURCE_KEY));
+        Assert.assertEquals("denis-yuen", stringStringMap2.get().get(SourceCodeRepoFactory.GIT_URL_USER_KEY));
+        Assert.assertEquals("dockstore-whalesay", stringStringMap2.get().get(SourceCodeRepoFactory.GIT_URL_REPOSITORY_KEY));
 
-        final Map<String, String> repoMapWithPeriodAndHyphen2 = SourceCodeRepoFactory
+        final Optional<Map<String, String>> repoMapWithPeriodAndHyphen2 = SourceCodeRepoFactory
                 .parseGitUrl("git://github.com/DockstoreTestUser2/wdl-1.0-work_flow.git");
         Assert.assertNotNull(repoMapWithPeriodAndHyphen2);
-        Assert.assertEquals("github.com", repoMapWithPeriodAndHyphen2.get("Source"));
-        Assert.assertEquals("DockstoreTestUser2", repoMapWithPeriodAndHyphen2.get("Username"));
-        Assert.assertEquals("wdl-1.0-work_flow", repoMapWithPeriodAndHyphen2.get("Repository"));
+        Assert.assertEquals("github.com", repoMapWithPeriodAndHyphen2.get().get(SourceCodeRepoFactory.GIT_URL_SOURCE_KEY));
+        Assert.assertEquals("DockstoreTestUser2", repoMapWithPeriodAndHyphen2.get().get(SourceCodeRepoFactory.GIT_URL_USER_KEY));
+        Assert.assertEquals("wdl-1.0-work_flow", repoMapWithPeriodAndHyphen2.get().get(SourceCodeRepoFactory.GIT_URL_REPOSITORY_KEY));
 
         // test garbage
-        final Map<String, String> stringStringMap3 = SourceCodeRepoFactory.parseGitUrl("mostly harmless");
-        Assert.assertNull("should be null", stringStringMap3);
+        Optional<Map<String, String>> stringStringMap3 = SourceCodeRepoFactory.parseGitUrl("mostly harmless");
+        Assert.assertTrue(stringStringMap3.isEmpty());
+
+        stringStringMap3 = SourceCodeRepoFactory.parseGitUrl("mostly harmless", Optional.of("github.com"));
+        Assert.assertTrue(stringStringMap3.isEmpty());
+
+        final Optional<Map<String, String>> stringStringMapBadOpt = SourceCodeRepoFactory
+                .parseGitUrl("git@github.com:dockstore/dockstore-ui.git", Optional.of("bad source"));
+        Assert.assertTrue(stringStringMapBadOpt.isEmpty());
+
     }
 
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/SourceCodeRepoFactoryTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/SourceCodeRepoFactoryTest.java
@@ -18,8 +18,13 @@ package io.dockstore.webservice.helpers;
 
 import java.util.Map;
 import java.util.Optional;
+
+import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.Tool;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author dyuen
@@ -79,4 +84,151 @@ public class SourceCodeRepoFactoryTest {
 
     }
 
+    /**
+     * Tests that parsing a GitLab URL works
+     */
+    @Test
+    public void testGitLabUrlRegexParsing() {
+        GitLabSourceCodeRepo repo = new GitLabSourceCodeRepo("fakeUser", "fakeToken");
+        final BioWorkflow entry = new BioWorkflow();
+
+        /* Test good URLs */
+        entry.setGitUrl("git@gitlab.com:dockstore/dockstore-ui.git");
+        String gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", "dockstore/dockstore-ui", gitlabId);
+
+        entry.setGitUrl("git@gitlab.com:dockstore-cow/goat.git");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", "dockstore-cow/goat", gitlabId);
+
+        entry.setGitUrl("git@gitlab.com:dockstore.dot/goat.bat.git");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", "dockstore.dot/goat.bat", gitlabId);
+
+        entry.setGitUrl("git@gitlab.com:dockstore.dot/goat.git");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", "dockstore.dot/goat", gitlabId);
+
+        /* Test bad URLs */
+        entry.setGitUrl("git@gitlab.com/dockstore/dockstore-ui.git");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", null, gitlabId);
+
+        entry.setGitUrl("git@gitlab.com:dockstore:dockstore-ui.git");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", null, gitlabId);
+
+        entry.setGitUrl("git@gitlab.com:/dockstore-ui.git");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", null, gitlabId);
+
+        entry.setGitUrl("git@gitlab.com:dockstore");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", null, gitlabId);
+
+        entry.setGitUrl("git@gitlab.com:dockstore/dockstore-ui");
+        gitlabId = repo.getRepositoryId(entry);
+        assertEquals("gitlab ID parse check", null, gitlabId);
+
+    }
+
+    /**
+     * Tests that parsing a GitHub URL works
+     */
+    @Test
+    public void testGitHubUrlRegexParsing() {
+        GitHubSourceCodeRepo repo = new GitHubSourceCodeRepo("fakeUser", "fakeToken");
+        final Tool entry = new Tool();
+
+        /* Test good URLs */
+        entry.setGitUrl("git@github.com:dockstore/dockstore-ui.git");
+        String githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", "dockstore/dockstore-ui", githubId);
+
+        entry.setGitUrl("git@github.com:dockstore-cow/goat.git");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", "dockstore-cow/goat", githubId);
+
+        entry.setGitUrl("git@github.com:dockstore.dot/goat.bat.git");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", "dockstore.dot/goat.bat", githubId);
+
+        entry.setGitUrl("git@github.com:dockstore.dot/goat.git");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", "dockstore.dot/goat", githubId);
+
+        /* Test bad URLs */
+        entry.setGitUrl("git@github.com/dockstore/dockstore-ui.git");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", null, githubId);
+
+        entry.setGitUrl("git@github.com:dockstore:dockstore-ui.git");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", null, githubId);
+
+        entry.setGitUrl("git@github.com:/dockstore-ui.git");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", null, githubId);
+
+        entry.setGitUrl("git@github.com:dockstore");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", null, githubId);
+
+        entry.setGitUrl("git@github.com:dockstore/dockstore-ui");
+        githubId = repo.getRepositoryId(entry);
+        assertEquals("GitHub ID parse check", null, githubId);
+
+    }
+
+    /**
+     * Tests that parsing a BitBucket URL works
+     */
+    @Test
+    public void testBitBucketUrlParsing() {
+        BitBucketSourceCodeRepo repo = new BitBucketSourceCodeRepo("fakeUser", "fakeToken");
+        final BioWorkflow entry = new BioWorkflow();
+
+        /* Test good URLs */
+        entry.setGitUrl("git@bitbucket.org:dockstore/dockstore-ui.git");
+        String bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", "dockstore/dockstore-ui", bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:dockstore/dockstore-ui.git");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", "dockstore/dockstore-ui", bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:dockstore-cow/goat.git");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", "dockstore-cow/goat", bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:dockstore.dot/goat.bat.git");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", "dockstore.dot/goat.bat", bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:dockstore.dot/goat.git");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", "dockstore.dot/goat", bitBucketId);
+
+        /* Test bad URLs */
+        entry.setGitUrl("git@bitbucket.org/dockstore/dockstore-ui.git");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", null, bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:dockstore:dockstore-ui.git");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", null, bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:/dockstore-ui.git");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", null, bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:dockstore");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", null, bitBucketId);
+
+        entry.setGitUrl("git@bitbucket.org:dockstore/dockstore-ui");
+        bitBucketId = repo.getRepositoryId(entry);
+        assertEquals("Bitbucket ID parse check", null, bitBucketId);
+
+    }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/SourceCodeRepoFactoryTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/SourceCodeRepoFactoryTest.java
@@ -16,15 +16,14 @@
 
 package io.dockstore.webservice.helpers;
 
-import java.util.Map;
-import java.util.Optional;
+import static org.junit.Assert.assertEquals;
 
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Tool;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.Assert;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author dyuen


### PR DESCRIPTION
**Description**
A description of the PR, should include a decent explanation as to why this change was needed and a decent explanation as to what this change does
Fixes the SonarCloud issues around [regexes vulnerable to backtracking](https://www.regular-expressions.info/catastrophic.html) which can result in extremely long runtime, using possessive quantifiers and atomic grouping.
In addition parsing of some git URLs using the vulnerable regular expressions highlighted by SonarCloud was consolidated into one method.

**Issue**
[SEAB-2821](https://ucsc-cgl.atlassian.net/browse/SEAB-2821)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
