### PR TITLE
Feature/seab 3669/remove garbage from version metadata table

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
@@ -200,7 +200,7 @@ public class EntryResourceIT extends BaseIT {
 
         // Give the workflow version a DOI url
         testingPostgres.runUpdateStatement(String.format("update version_metadata set doistatus='%s' where id=%s", Version.DOIStatus.CREATED.name(), workflowVersionId));
-        testingPostgres.runUpdateStatement(String.format("update version_metadata set doiurl='dummyurl' where id=%s", workflowVersionId));
+        testingPostgres.runUpdateStatement(String.format("update version_metadata set doiurl='10.foo/bar' where id=%s", workflowVersionId));
 
         // Hoverfly is not used as a class rule here because for some reason it's trying to intercept GitHub in both spy and simulation mode
         try (Hoverfly hoverfly = new Hoverfly(HoverflyMode.SIMULATE)) {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -100,6 +100,8 @@ public class GeneralIT extends BaseIT {
 
     private static final String QUAY_TOOL_PATH = "quay.io/dockstoretestuser2/dockstore-tool-imports/test5";
 
+    private static final String DUMMY_DOI = "10.foo/bar";
+
     @Rule
     public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
 
@@ -1235,10 +1237,10 @@ public class GeneralIT extends BaseIT {
         // but should be able to change doi stuff
         master.setFrozen(true);
         master.setDoiStatus(Tag.DoiStatusEnum.REQUESTED);
-        master.setDoiURL("foo");
+        master.setDoiURL(DUMMY_DOI);
         tags = tagsApi.updateTags(refresh.getId(), Lists.newArrayList(master));
         master = tags.stream().filter(t -> t.getName().equals("1.0")).findFirst().get();
-        assertEquals("foo", master.getDoiURL());
+        assertEquals(DUMMY_DOI, master.getDoiURL());
         assertEquals(Tag.DoiStatusEnum.REQUESTED, master.getDoiStatus());
 
         // try modifying sourcefiles

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -68,6 +68,8 @@ import org.junit.experimental.categories.Category;
 @Category({ ConfidentialTest.class, WorkflowTest.class })
 public class GeneralWorkflowIT extends BaseIT {
 
+    private static final String DUMMY_DOI = "10.foo/bar";
+
     @Rule
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
 
@@ -678,10 +680,10 @@ public class GeneralWorkflowIT extends BaseIT {
         // but should be able to change doi stuff
         master.setFrozen(true);
         master.setDoiStatus(WorkflowVersion.DoiStatusEnum.REQUESTED);
-        master.setDoiURL("foo");
+        master.setDoiURL(DUMMY_DOI);
         workflowVersions = workflowsApi.updateWorkflowVersion(workflowBeforeFreezing.getId(), Lists.newArrayList(master));
         master = workflowVersions.stream().filter(v -> v.getName().equals("master")).findFirst().get();
-        assertEquals("foo", master.getDoiURL());
+        assertEquals(DUMMY_DOI, master.getDoiURL());
         assertEquals(WorkflowVersion.DoiStatusEnum.REQUESTED, master.getDoiStatus());
 
         // refresh should skip over the frozen version
@@ -762,12 +764,12 @@ public class GeneralWorkflowIT extends BaseIT {
             workflowBeforeFreezing.getWorkflowVersions().stream().filter(v -> v.getName().equals(versionToSnapshot)).findFirst().get();
         version.setFrozen(true);
         version.setDoiStatus(WorkflowVersion.DoiStatusEnum.REQUESTED);
-        version.setDoiURL("foo");
+        version.setDoiURL(DUMMY_DOI);
         assertFalse("Double check that this version is in fact invalid", version.isValid());
         List<WorkflowVersion> workflowVersions = workflowsApi
             .updateWorkflowVersion(workflowBeforeFreezing.getId(), Lists.newArrayList(version));
         version = workflowVersions.stream().filter(v -> v.getName().equals(versionToSnapshot)).findFirst().get();
-        assertEquals("foo", version.getDoiURL());
+        assertEquals(DUMMY_DOI, version.getDoiURL());
         assertEquals(WorkflowVersion.DoiStatusEnum.REQUESTED, version.getDoiStatus());
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
@@ -37,6 +37,7 @@ import javax.persistence.MapsId;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
+import javax.validation.constraints.Pattern;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -59,6 +60,7 @@ public class VersionMetadata {
     protected String verifiedSource;
 
     @Column()
+    @Pattern(regexp = "10\\..+/.+")
     protected String doiURL;
 
     @Column()

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
@@ -60,7 +60,7 @@ public class VersionMetadata {
     protected String verifiedSource;
 
     @Column()
-    @Pattern(regexp = "10\\..+/.+")
+    @Pattern(regexp = "10\\.[^/]++/.++")
     protected String doiURL;
 
     @Column()

--- a/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
@@ -241,7 +241,7 @@
             <column name="topic" type="varchar(255 BYTE)"/>
         </addColumn>
     </changeSet>
-    <changeSet author="svonworl" id="removeGarbageFromVersionMetadata">
+    <changeSet author="svonworl" id="cleanAndConstrainVersionMetadataDoi">
         <!-- A few 'string' string literal values somehow snuck into version_metadata.doiurl. Null any value that's not a valid DOI and set a constraint so it doesn't happen again -->
         <sql dbms="postgresql">
             update version_metadata set doiurl = null where doiurl not like '10._%/_%';

--- a/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
@@ -241,4 +241,10 @@
             <column name="topic" type="varchar(255 BYTE)"/>
         </addColumn>
     </changeSet>
+    <changeSet author="svonworl" id="removeGarbageFromVersionMetadata">
+        <!-- clean up some 'string' string literals that somehow snuck into version_metadata -->
+        <sql dbms="postgresql">
+            update version_metadata set doiurl = null where doiurl = 'string';
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
@@ -242,7 +242,7 @@
         </addColumn>
     </changeSet>
     <changeSet author="svonworl" id="removeGarbageFromVersionMetadata">
-        <!-- clean up some 'string' string literals that somehow snuck into version_metadata -->
+        <!-- null some 'string' string literals that somehow snuck into version_metadata.doiurl -->
         <sql dbms="postgresql">
             update version_metadata set doiurl = null where doiurl = 'string';
         </sql>

--- a/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
@@ -242,9 +242,10 @@
         </addColumn>
     </changeSet>
     <changeSet author="svonworl" id="removeGarbageFromVersionMetadata">
-        <!-- null some 'string' string literals that somehow snuck into version_metadata.doiurl -->
+        <!-- A few 'string' string literal values somehow snuck into version_metadata.doiurl. Null any value that's not a valid DOI and set a constraint so it doesn't happen again -->
         <sql dbms="postgresql">
-            update version_metadata set doiurl = null where doiurl = 'string';
+            update version_metadata set doiurl = null where doiurl not like '10._%/_%';
+            alter table version_metadata add constraint check_valid_doi check (doiurl like '10._%/_%' or doiurl is null);
         </sql>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**Description**
Somehow, some 'string' string literals crept into the version_metadata.doiurl column.  This PR:
1. modifies the db migrations to null all non-DOIs in the version_metadata.doiurl column.
2. adds a Pattern annotation to the VersionMetadata.doiUrl property enforce valid DOIs.
3. per Denis' suggestion, sets a db constraint so invalid DOIs can't reenter the db, and we can detect it if they try.

I inspected the source, and a local source of the 'string's was not apparent.  Possibly, they came from Zenodo.

I've tested this locally by migrating the db on the command line, and it functions properly...

However, any direct update of database records is inherently dangerous.  Ideally, we would have a test to ensure that all valid DOIs that were in the db beforehand are still there after the migrations.  But, I don't think the infra to support that exists right now, and there's probably more important things to work on.
 
**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-3669

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
