### PR TITLE
Add admin topic migration endpoint

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -97,7 +97,8 @@ import org.hibernate.annotations.UpdateTimestamp;
         @NamedQuery(name = "Entry.getCollectionToolsWithVersions", query = "SELECT new io.dockstore.webservice.core.CollectionEntry(t.id, t.dbUpdateDate, 'tool', t.registry, t.namespace, t.name, t.toolname, v.name, v.versionMetadata.verified) from Version v, Tool t, Collection col join col.entries as e where v.id = e.version.id and col.id = :collectionId and t.id = e.entry.id and t.isPublished = true"),
         @NamedQuery(name = "io.dockstore.webservice.core.Entry.findLabelByEntryId", query = "SELECT e.labels FROM Entry e WHERE e.id = :entryId"),
         @NamedQuery(name = "Entry.findToolsDescriptorTypes", query = "SELECT t.descriptorType FROM Tool t WHERE t.id = :entryId"),
-        @NamedQuery(name = "Entry.findWorkflowsDescriptorTypes", query = "SELECT w.descriptorType FROM Workflow w WHERE w.id = :entryId")
+        @NamedQuery(name = "Entry.findWorkflowsDescriptorTypes", query = "SELECT w.descriptorType FROM Workflow w WHERE w.id = :entryId"),
+        @NamedQuery(name = "Entry.findAllGitHubGenericEntries", query = "SELECT e FROM Entry e WHERE e.gitUrl LIKE '%github.com%'")
 })
 // TODO: Replace this with JPA when possible
 @NamedNativeQueries({
@@ -262,7 +263,7 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     @JsonIgnore
     private List<Category> categories = new ArrayList<>();
 
-    @Column()
+    @Column(columnDefinition = "text")
     @Schema(description = "Short description of the entry")
     private String topic;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -66,6 +66,7 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Transient;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.CreationTimestamp;
@@ -98,7 +99,7 @@ import org.hibernate.annotations.UpdateTimestamp;
         @NamedQuery(name = "io.dockstore.webservice.core.Entry.findLabelByEntryId", query = "SELECT e.labels FROM Entry e WHERE e.id = :entryId"),
         @NamedQuery(name = "Entry.findToolsDescriptorTypes", query = "SELECT t.descriptorType FROM Tool t WHERE t.id = :entryId"),
         @NamedQuery(name = "Entry.findWorkflowsDescriptorTypes", query = "SELECT w.descriptorType FROM Workflow w WHERE w.id = :entryId"),
-        @NamedQuery(name = "Entry.findAllGitHubGenericEntriesWithNoTopic", query = "SELECT e FROM Entry e WHERE e.gitUrl LIKE 'git@github.com%' AND e.topic IS NULL")
+        @NamedQuery(name = "Entry.findAllGitHubEntriesWithNoTopic", query = "SELECT e FROM Entry e WHERE e.gitUrl LIKE 'git@github.com%' AND e.topic IS NULL")
 })
 // TODO: Replace this with JPA when possible
 @NamedNativeQueries({
@@ -696,6 +697,6 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     }
 
     public void setTopic(String topic) {
-        this.topic = topic;
+        this.topic = StringUtils.abbreviate(topic, 150);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -98,7 +98,7 @@ import org.hibernate.annotations.UpdateTimestamp;
         @NamedQuery(name = "io.dockstore.webservice.core.Entry.findLabelByEntryId", query = "SELECT e.labels FROM Entry e WHERE e.id = :entryId"),
         @NamedQuery(name = "Entry.findToolsDescriptorTypes", query = "SELECT t.descriptorType FROM Tool t WHERE t.id = :entryId"),
         @NamedQuery(name = "Entry.findWorkflowsDescriptorTypes", query = "SELECT w.descriptorType FROM Workflow w WHERE w.id = :entryId"),
-        @NamedQuery(name = "Entry.findAllGitHubGenericEntries", query = "SELECT e FROM Entry e WHERE e.gitUrl LIKE '%github.com%'")
+        @NamedQuery(name = "Entry.findAllGitHubGenericEntriesWithNoTopic", query = "SELECT e FROM Entry e WHERE e.gitUrl LIKE 'git@github.com%' AND e.topic IS NULL")
 })
 // TODO: Replace this with JPA when possible
 @NamedNativeQueries({
@@ -263,7 +263,7 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     @JsonIgnore
     private List<Category> categories = new ArrayList<>();
 
-    @Column(columnDefinition = "text")
+    @Column()
     @Schema(description = "Short description of the entry")
     private String topic;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -105,7 +105,6 @@ import org.slf4j.LoggerFactory;
 public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
     public static final String OUT_OF_GIT_HUB_RATE_LIMIT = "Out of GitHub rate limit";
-    public static final int MAX_TOPIC_LENGTH = 150;
     private static final Logger LOG = LoggerFactory.getLogger(GitHubSourceCodeRepo.class);
     private final GitHub github;
     private String githubTokenUsername;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -139,7 +139,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     public String getTopic(String repositoryId) {
         try {
             GHRepository repository = github.getRepository(repositoryId);
-            return repository.getDescription();
+            return repository.getDescription(); // Could be null if the repository doesn't have a description
         } catch (IOException e) {
             LOG.error(String.format("Could not get topic from: %s", repositoryId, e));
             return null;
@@ -1112,6 +1112,21 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             LOG.info(msg, ex);
             throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
         }
+    }
+
+    // DO NOT USE THIS FUNCTION ELSEWHERE.
+    // This function is only for gathering topics for existing workflows and tools and only needs to be run once.
+    public void syncTopic(Entry entry) {
+        String repositoryId = getRepositoryId(entry);
+        GHRepository repository;
+        try {
+            repository = github.getRepository(repositoryId);
+        } catch (IOException e) {
+            String errorMessage = String.format("Could not get topic from: %s", repositoryId);
+            LOG.info(errorMessage, e);
+            throw new CustomWebApplicationException(errorMessage, HttpStatus.SC_NOT_FOUND);
+        }
+        entry.setTopic(repository.getDescription()); // Could be null if the repo doesn't have a description
     }
 
     public User.Profile getProfile(final User user, final GHUser ghUser) throws IOException {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -303,8 +303,8 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
         return Arrays.asList(this.currentSession().getNamedQuery("Entry.findWorkflowsDescriptorTypes").setParameter("entryId", entryId).getSingleResult().toString());
     }
 
-    public List<Entry> findAllGitHubGenericEntriesWithNoTopic() {
-        return list(this.currentSession().getNamedQuery("Entry.findAllGitHubGenericEntriesWithNoTopic"));
+    public List<Entry> findAllGitHubEntriesWithNoTopic() {
+        return list(this.currentSession().getNamedQuery("Entry.findAllGitHubEntriesWithNoTopic"));
     }
 
     private void processQuery(String filter, String sortCol, String sortOrder, CriteriaBuilder cb, CriteriaQuery query, Root<T> entry) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -303,8 +303,8 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
         return Arrays.asList(this.currentSession().getNamedQuery("Entry.findWorkflowsDescriptorTypes").setParameter("entryId", entryId).getSingleResult().toString());
     }
 
-    public List<Entry> findAllGitHubGenericEntries() {
-        return list(this.currentSession().getNamedQuery("Entry.findAllGitHubGenericEntries"));
+    public List<Entry> findAllGitHubGenericEntriesWithNoTopic() {
+        return list(this.currentSession().getNamedQuery("Entry.findAllGitHubGenericEntriesWithNoTopic"));
     }
 
     private void processQuery(String filter, String sortCol, String sortOrder, CriteriaBuilder cb, CriteriaQuery query, Root<T> entry) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -303,6 +303,10 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
         return Arrays.asList(this.currentSession().getNamedQuery("Entry.findWorkflowsDescriptorTypes").setParameter("entryId", entryId).getSingleResult().toString());
     }
 
+    public List<Entry> findAllGitHubGenericEntries() {
+        return list(this.currentSession().getNamedQuery("Entry.findAllGitHubGenericEntries"));
+    }
+
     private void processQuery(String filter, String sortCol, String sortOrder, CriteriaBuilder cb, CriteriaQuery query, Root<T> entry) {
         List<Predicate> predicates = new ArrayList<>();
         if (!Strings.isNullOrEmpty(filter)) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -443,18 +443,16 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
     @Path("/updateEntryToGetTopics")
     @Deprecated
     @Operation(operationId = "updateEntryToGetTopics", description = "Attempt to get the topic of all entries that use GitHub as the source control.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
-    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Get a list of entries we were unable to get the topic for.", content = @Content(
-            mediaType = "application/json",
-            array = @ArraySchema(schema = @Schema(implementation = Entry.class))))
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Get the number of entries that failed to have their topics retrieved from GitHub.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Integer.class)))
     @ApiOperation(value = "See OpenApi for details", hidden = true)
-    public List<Entry> updateEntryToGetTopics(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user) {
-        List<Entry> githubEntries = toolDAO.findAllGitHubGenericEntriesWithNoTopic();
-
+    public int updateEntryToGetTopics(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user) {
+        List<Entry> githubEntries = toolDAO.findAllGitHubEntriesWithNoTopic();
         // Use the GitHub token of the admin making this call
         Token t = tokenDAO.findGithubByUserId(user.getId()).get(0);
         GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(t);
-        List<Entry> entriesNotUpdatedWithTopic = gitHubSourceCodeRepo.syncTopics(githubEntries);
-        return entriesNotUpdatedWithTopic;
+        int numOfEntriesNotUpdatedWithTopic = gitHubSourceCodeRepo.syncTopics(githubEntries);
+        return numOfEntriesNotUpdatedWithTopic;
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -460,16 +460,15 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
             }
 
             // Find a user that has a GitHub token
-            Optional<User> gitHubUser = entry.getUsers().stream().filter(entryUser -> !tokenDAO.findGithubByUserId(((User)entryUser).getId()).isEmpty()).findFirst();
+            Optional<List<Token>> gitHubUserToken = entry.getUsers().stream().map(entryUser -> tokenDAO.findGithubByUserId(((User)entryUser).getId())).filter(gitHubTokenList -> !((List<Token>)gitHubTokenList).isEmpty()).findFirst();
             // Keep track of entries without a user with a GitHub token, so we can try to update it later with the admin's GitHub token
-            if (gitHubUser.isEmpty()) {
+            if (gitHubUserToken.isEmpty()) {
                 entriesNotUpdatedWithUserToken.add(entry);
                 continue;
             }
 
             try {
-                Token gitHubUserToken = tokenDAO.findGithubByUserId(gitHubUser.get().getId()).get(0);
-                GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(gitHubUserToken);
+                GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(gitHubUserToken.get().get(0));
                 gitHubSourceCodeRepo.syncTopic(entry);
             } catch (Exception ex) {
                 entriesNotUpdatedWithTopic.add(entry);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -21,6 +21,7 @@ import static io.dockstore.webservice.resources.ResourceConstants.OPENAPI_JWT_SE
 
 import com.codahale.metrics.annotation.Timed;
 import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.common.EntryType;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.core.BioWorkflow;
@@ -457,6 +458,9 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
         GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(t);
 
         for (Entry entry : githubEntries) {
+            if (entry.getEntryType() == EntryType.SERVICE) {
+                continue;
+            }
             try {
                 gitHubSourceCodeRepo.syncTopic(entry);
             } catch (Exception ex) {

--- a/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
@@ -241,10 +241,4 @@
             <column name="topic" type="varchar(255 BYTE)"/>
         </addColumn>
     </changeSet>
-    <changeSet author="ktran (generated)" id="changeTopicToText">
-        <modifyDataType columnName="topic" newDataType="clob" tableName="apptool"/>
-        <modifyDataType columnName="topic" newDataType="clob" tableName="service"/>
-        <modifyDataType columnName="topic" newDataType="clob" tableName="tool"/>
-        <modifyDataType columnName="topic" newDataType="clob" tableName="workflow"/>
-    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
@@ -241,4 +241,10 @@
             <column name="topic" type="varchar(255 BYTE)"/>
         </addColumn>
     </changeSet>
+    <changeSet author="ktran (generated)" id="changeTopicToText">
+        <modifyDataType columnName="topic" newDataType="clob" tableName="apptool"/>
+        <modifyDataType columnName="topic" newDataType="clob" tableName="service"/>
+        <modifyDataType columnName="topic" newDataType="clob" tableName="tool"/>
+        <modifyDataType columnName="topic" newDataType="clob" tableName="workflow"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -2172,10 +2172,10 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Entry'
-          description: Get a list of entries we were unable to get the topic for.
+                type: integer
+                format: int32
+          description: Get the number of entries that failed to have their topics
+            retrieved from GitHub.
       security:
       - bearer: []
       tags:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -2161,6 +2161,25 @@ paths:
       - bearer: []
       tags:
       - curation
+  /entries/updateEntryToGetTopics:
+    get:
+      deprecated: true
+      description: Attempt to get the topic of all entries that use GitHub as the
+        source control.
+      operationId: updateEntryToGetTopics
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Entry'
+          description: Get a list of entries we were unable to get the topic for.
+      security:
+      - bearer: []
+      tags:
+      - entries
   /entries/{entryId}/exportToOrcid:
     post:
       description: Export entry to ORCID. DOI is required


### PR DESCRIPTION
**Description**
This adds an admin topic migration endpoint which only needs to be run once. This only gets the topics of entries using GitHub as the source control provider. Topics are truncated to 150 characters (including ellipses).

- The endpoint took about 10 minutes to run locally. After running, 342 out of 4481 entries failed to have their topics updated.
- Using the admin GitHub token was much faster than using the users' tokens and it allowed for a cleaner implementation. Using the users' token for this implementation took 34 minutes (vs the 10 mins using the admin's token). I tried to optimize it with the users' tokens but I could only get it down to around 20 mins and it was kind of ugly so I reverted back to using the admin's token. 
- Running the endpoint locally called 3114 rate-limited requests. The rate limit per hour is 5000. There is caching going on, so we save some calls because of that.
  - Worst case, we could run it twice?
  - We could skip services (reduces the number of rate-limited requests to 2944)

**Issue**
[SEAB-3658](https://ucsc-cgl.atlassian.net/browse/SEAB-3658)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
