### PR TITLE
Bump gson to 2.8.9

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -157,7 +157,7 @@ Lists of 356 third-party dependencies.
      (The Apache Software License, Version 2.0) Google OAuth Client Library for Java (com.google.oauth-client:google-oauth-client:1.31.4 - https://github.com/googleapis/google-oauth-java-client/google-oauth-client)
      (The Apache Software License, Version 2.0) Google OAuth2 API v2-rev151-1.25.0 (com.google.apis:google-api-services-oauth2:v2-rev151-1.25.0 - http://nexus.sonatype.org/oss-repository-hosting.html/google-api-services-oauth2)
      (The Apache Software License, Version 2.0) Graph Core (org.scala-graph:graph-core_2.12:1.13.1 - http://scala-graph.org)
-     (Apache 2.0) Gson (com.google.code.gson:gson:2.8.8 - https://github.com/google/gson/gson)
+     (Apache-2.0) Gson (com.google.code.gson:gson:2.8.9 - https://github.com/google/gson/gson)
      (The Apache Software License, Version 2.0) GSON extensions to the Google HTTP Client Library for Java. (com.google.http-client:google-http-client-gson:1.38.1 - https://github.com/googleapis/google-http-java-client/google-http-client-gson)
      (The Apache Software License, Version 2.0) Guava InternalFutureFailureAccess and InternalFutures (com.google.guava:failureaccess:1.0.1 - https://github.com/google/guava/failureaccess)
      (The Apache Software License, Version 2.0) Guava ListenableFuture only (com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava - https://github.com/google/guava/listenablefuture)

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -589,7 +589,7 @@ POM as their parent.
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.8.8</version>
+                <version>2.8.9</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.8</version>
+      <version>2.8.9</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-event-consumer/generated/src/main/resources/pom.xml
+++ b/dockstore-event-consumer/generated/src/main/resources/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.8</version>
+      <version>2.8.9</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -504,7 +504,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.8</version>
+      <version>2.8.9</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
**Description**
gson deserialization vulnerability.

**Introduced through**: com.google.code.gson:gson@2.8.6, io.cwl:cwlavro-generated@2.0.4.4 and others
**Fixed in**: com.google.code.gson:gson@2.8.9

cwlavro partner PR: https://github.com/dockstore/cwlavro/pull/28

**Issue**
Snyk warning ticket: https://ucsc-cgl.atlassian.net/browse/SEAB-3713

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [X] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
