### PR TITLE
Feature/dock 1548/cwl import and include

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -106,7 +106,7 @@ public class ToolsWorkflowTestIT extends BaseIT {
         int countNode = countToolInJSON(strings);
 
         Assert.assertTrue("JSON should not be blank", strings.size() > 0);
-        Assert.assertEquals("JSON should have two tools with docker images, has " + countNode, 2, countNode);
+        Assert.assertEquals("JSON should have three tools with docker images, has " + countNode, 3, countNode);
         Assert.assertFalse("tool should not have untar since it has no docker image", strings.get(0).contains("untar"));
         Assert.assertTrue("tool should have compile as id", strings.get(0).contains("compile"));
         Assert.assertTrue("compile docker and link should not be blank" + strings.get(0), strings.get(0).contains(

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -100,7 +100,7 @@ public class ToolsWorkflowTestIT extends BaseIT {
         // Repo: test_workflow_cwl
         // Branch: master
         // Test: normal cwl workflow DAG
-        // Return: JSON string with two tools, in grep-and-count.cwl and arguments.cwl
+        // Return: JSON string with three tools, in arguments.cwl, grep.cwl, and wc.cwl
 
         final List<String> strings = getJSON("DockstoreTestUser2/test_workflow_cwl", "/1st-workflow.cwl", "cwl", "master");
         int countNode = countToolInJSON(strings);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ToolsWorkflowTestIT.java
@@ -110,12 +110,11 @@ public class ToolsWorkflowTestIT extends BaseIT {
         Assert.assertFalse("tool should not have untar since it has no docker image", strings.get(0).contains("untar"));
         Assert.assertTrue("tool should have compile as id", strings.get(0).contains("compile"));
         Assert.assertTrue("compile docker and link should not be blank" + strings.get(0), strings.get(0).contains(
-            "\"id\":\"compile\"," + "\"file\":\"arguments.cwl\"," + "\"docker\":\"java:7\","
-                + "\"link\":\"https://hub.docker.com/_/java\""));
-        Assert.assertTrue("compile docker and link should not be blank" + strings.get(0), strings.get(0).contains(
-                "\"id\":\"wrkflow\"," + "\"file\":\"grep-and-count.cwl\"," + "\"docker\":\"java:7\","
-                        + "\"link\":\"https://hub.docker.com/_/java\""));
-
+            "\"id\":\"compile\"," + "\"file\":\"arguments.cwl\"," + "\"docker\":\"java:7\",\"link\":\"https://hub.docker.com/_/java\""));
+        Assert.assertTrue("workflow.wc docker and link should not be blank" + strings.get(0), strings.get(0).contains(
+            "\"id\":\"wrkflow.wc\"," + "\"file\":\"wc.cwl\"," + "\"docker\":\"java:7\",\"link\":\"https://hub.docker.com/_/java\""));
+        Assert.assertTrue("workflow.grep docker and link should not be blank" + strings.get(0), strings.get(0).contains(
+            "\"id\":\"wrkflow.grep\"," + "\"file\":\"grep.cwl\"," + "\"docker\":\"java:7\",\"link\":\"https://hub.docker.com/_/java\""));
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -388,6 +388,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 String secondaryFile = null;
                 Object run = workflowStep.getRun();
                 String runAsJson = gson.toJson(gson.toJsonTree(run));
+                LOG.error("runAsJson " + runAsJson);
 
                 if (run instanceof String) {
                     secondaryFile = (String)run;
@@ -989,28 +990,33 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
             return obj;
         }
     
-        // TODO make case insensitive 
         private String findValue(Collection<String> keys, Map<String, Object> map) {
-            for (String key: keys) {
-                Object value = map.get(key);
-                if (value != null) {
-                    if (value instanceof String) {
-                        return (String)value;
-                    } else {
-                        error("value must be a string");
-                    }
-                }
+            String key = findKey(keys, map);
+            if (key == null) {
+                return null;
             }
+            Object value = map.get(key);
+            if (value instanceof String) {
+                return (String)value;
+            }
+            error("value must be a string");
             return null;
         }
    
-        // TODO make case insensitive 
         private void removeKey(Collection<String> keys, Map<String, Object> map) {
-            for (String key: keys) {
-                if (map.remove(key) != null) {
-                    return;
+            String key = findKey(keys, map);
+            if (key != null) {
+                map.remove(key);
+            }
+        }
+
+        private String findKey(Collection<String> keys, Map<String, Object> map) {
+            for (String mapKey: map.keySet()) {
+                if (keys.contains(mapKey.toLowerCase())) {
+                    return (mapKey);
                 }
             }
+            return null;
         }
     
         private void applyMixin(Map<String, Object> to, Map<String, Object> mixin) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -662,7 +662,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
             List<Object> stepValues;
             if (steps instanceof JSONObject) {
                 JSONObject stepsObject = (JSONObject)steps;
-                stepValues = stepsObject.keySet().stream().map(k -> stepsObject.get(k)).collect(Collectors.toList());
+                stepValues = stepsObject.keySet().stream().map(stepsObject::get).collect(Collectors.toList());
             } else if (steps instanceof JSONArray) {
                 stepValues = ((JSONArray)steps).toList();
             } else {
@@ -1073,7 +1073,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
         }
 
         private void applyMixin(Map<String, Object> to, Map<String, Object> mixin) {
-            mixin.forEach((k, v) -> to.putIfAbsent(k, v));
+            mixin.forEach(to::putIfAbsent);
         }
 
         private Object parse(String yaml) {
@@ -1082,11 +1082,13 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
         }
 
         private String resolvePath(String childPath, String parentPath) {
-            if (childPath.startsWith("http://") || childPath.startsWith("https://") || childPath.startsWith("file://")) {
+            if (childPath.startsWith("http://") || childPath.startsWith("https://")) {
                 return null;
             }
             if (childPath.startsWith("file:")) {
-                childPath = childPath.substring("file:".length());
+                // the path in a file url is always absolute
+                // see https://datatracker.ietf.org/doc/html/rfc8089
+                childPath = childPath.replaceFirst("^file:/*+", "/");
             }
             return LanguageHandlerHelper.convertRelativePathToAbsolutePath(parentPath, childPath);
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -957,7 +957,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 Map map = (Map<String, Object>)obj;
 
                 if (isEntry(map)) {
-                    idToPath.put(addIdIfAbsent(map), stripLeadingSlash(currentPath));
+                    idToPath.put(setUniqueIdIfAbsent(map), stripLeadingSlash(currentPath));
                 }
 
                 String importPath = findString(IMPORT_KEYS, map);
@@ -1021,8 +1021,11 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
             return Objects.equals(c, "CommandLineTool") || Objects.equals(c, "ExpressionTool") || Objects.equals(c, "Workflow");
         }
 
-        private String addIdIfAbsent(Map<String, Object> map) {
-            map.putIfAbsent("id", java.util.UUID.randomUUID().toString());
+        private String setUniqueIdIfAbsent(Map<String, Object> map) {
+            String currentId = (String)map.get("id");
+            if (currentId == null || idToPath.containsKey(currentId)) {
+                map.put("id", java.util.UUID.randomUUID().toString());
+            }
             return (String)map.get("id");
         }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -300,7 +300,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 throw new CustomWebApplicationException("malformed cwl", HttpStatus.SC_UNPROCESSABLE_ENTITY);
             }
             mapping = (Map<String, Object>)preprocessed;
- 
+
             // verify cwl version is correctly specified
             final Object cwlVersion = mapping.get("cwlVersion");
             if (cwlVersion != null) {
@@ -419,12 +419,11 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
 
             if (depth == 0) {
                 ArrayList<String> stepDependencies = new ArrayList<>();
-    
+
                 // Iterate over source and get the dependencies
                 if (workflowStep.getIn() != null) {
                     for (WorkflowStepInput workflowStepInput : workflowStep.getIn()) {
                         Object sources = workflowStepInput.getSource();
-    
                         processDependencies(nodePrefix, stepDependencies, sources);
                     }
                     if (stepDependencies.size() > 0) {
@@ -450,7 +449,6 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
             LOG.error("runAsJson " + runAsJson);
 
             String toolPath = null;
-         
 
             if (isTool(runAsJson, yaml)) {
                 CommandLineTool clTool = gson.fromJson(runAsJson, CommandLineTool.class);
@@ -940,7 +938,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 map.put("run", loadFileAndPreprocess(resolvePath(runPath, currentPath), depth));
             }
         }
-    
+
         private void preprocessListValues(List<Object> list, String currentPath, int depth) {
             list.replaceAll(v -> preprocess(v, currentPath, depth));
         }
@@ -953,37 +951,36 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
             map.putIfAbsent("id", java.util.UUID.randomUUID().toString());
             return (String)map.get("id"); // TODO fix?
         }
-   
-        // TODO add current file path 
+
         public Object preprocess(Object obj, String currentPath, int depth) {
-  
+
             LOG.error("PREPROCESS " + currentPath + " " + depth + ": " + obj);
- 
+
             if (depth > maxDepth) {
                 error("maximum file depth exceeded");
                 return obj;
             }
- 
+
             if (obj instanceof Map) {
-    
+
                 Map map = (Map<String, Object>)obj;
 
                 if (isTool(map)) {
                     idToPath.put(addId(map), currentPath);
                 }
-    
+
                 String importPath = findValue(IMPORT_KEYS, map);
                 if (importPath != null) {
                     LOG.error("import " + importPath + " " + currentPath);
                     return loadFileAndPreprocess(resolvePath(importPath, currentPath), depth);
                 }
-    
+
                 String includePath = findValue(INCLUDE_KEYS, map);
                 if (includePath != null) {
                     LOG.error("include " + includePath + " " + currentPath);
                     return loadFile(resolvePath(includePath, currentPath));
                 }
-    
+
                 String mixinPath = findValue(MIXIN_KEYS, map);
                 if (mixinPath != null) {
                     Object mixin = loadFileAndPreprocess(resolvePath(mixinPath, currentPath), depth);
@@ -994,18 +991,18 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                         error("a mixin must be a map");
                     }
                 }
-    
+
                 preprocessMapValues(map, currentPath, depth);
-    
+
             } else if (obj instanceof List) {
-    
+
                 preprocessListValues((List<Object>)obj, currentPath, depth);
-    
+
             }
-    
+
             return obj;
         }
-    
+
         private String findValue(Collection<String> keys, Map<String, Object> map) {
             String key = findKey(keys, map);
             if (key == null) {
@@ -1018,7 +1015,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
             error("value must be a string");
             return null;
         }
-   
+
         private void removeKey(Collection<String> keys, Map<String, Object> map) {
             String key = findKey(keys, map);
             if (key != null) {
@@ -1034,13 +1031,13 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
             }
             return null;
         }
-    
+
         private void applyMixin(Map<String, Object> to, Map<String, Object> mixin) {
             mixin.forEach((k, v) -> {
                 to.putIfAbsent(k, v);
             });
         }
-    
+
         private Object parse(String yaml) {
             new Yaml(new SafeConstructor()).load(yaml);
             return new Yaml().load(yaml);
@@ -1062,7 +1059,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
             error("file not found: " + loadPath);
             return "";
         }
-    
+
         private Object loadFileAndPreprocess(String loadPath, int depth) {
             return preprocess(parse(loadFile(loadPath)), loadPath, depth + 1);
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1346,7 +1346,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                         SourceFile mainDescriptor = getMainDescriptorFile(existingTag);
                         if (mainDescriptor != null) {
                             // Store tool table json
-                            toolsJSONTable = lInterface.getContent(w.getWorkflowPath(), mainDescriptor.getContent(),
+                            toolsJSONTable = lInterface.getContent(existingTag.getWorkflowPath(), mainDescriptor.getContent(),
                                     extractDescriptorAndSecondaryFiles(existingTag), LanguageHandlerInterface.Type.TOOLS, toolDAO);
                             toolsJSONTable.ifPresent(existingTag::setToolTableJson);
                         }
@@ -1364,7 +1364,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                     if (existingTag.getDagJson() == null) {
                         SourceFile mainDescriptor = getMainDescriptorFile(existingTag);
                         if (mainDescriptor != null) {
-                            String dagJson = lInterface.getCleanDAG(w.getWorkflowPath(), mainDescriptor.getContent(),
+                            String dagJson = lInterface.getCleanDAG(existingTag.getWorkflowPath(), mainDescriptor.getContent(),
                                     extractDescriptorAndSecondaryFiles(existingTag), LanguageHandlerInterface.Type.DAG, toolDAO);
                             existingTag.setDagJson(dagJson);
                         }

--- a/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
@@ -248,4 +248,10 @@
             alter table version_metadata add constraint check_valid_doi check (doiurl like '10._%/_%' or doiurl is null);
         </sql>
     </changeSet>
+    <changeSet author="svonworl" id="clearCwlToolTableJson">
+        <!-- DOCK-1548 improves CWL parsing, so clear the tool table json from all CWL workflow versions so that it will be recalculated. -->
+        <sql dbms="postgresql">
+            update workflowversion set tooltablejson = null where workflowpath like '%.cwl';
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerPreprocessorTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerPreprocessorTest.java
@@ -1,0 +1,111 @@
+package io.dockstore.webservice.languages;
+
+import static io.dockstore.webservice.languages.CWLHandler.Preprocessor;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.SourceFile;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+/**
+ * Tests CWLHandler.Preprocessor
+ */
+public class CWLHandlerPreprocessorTest {
+   
+    private SourceFile file(String absolutePath, String content) {
+        SourceFile sourceFile = mock(SourceFile.class);
+        when(sourceFile.getAbsolutePath()).thenReturn(absolutePath);
+        when(sourceFile.getContent()).thenReturn(content);
+        return sourceFile;
+    }
+
+    private Set<SourceFile> set(SourceFile... sourceFiles) {
+        return new HashSet<>(Arrays.asList(sourceFiles));
+    }
+
+    private Object parse(String yaml) {
+        new Yaml(new SafeConstructor()).load(yaml);
+        return new Yaml().load(yaml);
+    }
+
+    @Test
+    public void testImport() {
+        final String imported = "test: value";
+        Preprocessor pre = new Preprocessor(set(file("/b", imported)));
+        Object result = pre.preprocess(parse("$import: b"), "/a", 0);
+        Assert.assertEquals(parse(imported), result);
+    }
+
+    @Test
+    public void testInclude() {
+        final String included = "abcde";
+        Preprocessor pre = new Preprocessor(set(file("/b", included)));
+        Object result = pre.preprocess(parse("$import: b"), "/a", 0);
+        Assert.assertEquals(included, result);
+    }
+
+    @Test
+    public void testMixin() {
+        Preprocessor pre = new Preprocessor(set(file("/b", "a: x\nb: y")));
+        Object result = pre.preprocess(parse("a: z\n$mixin: b"), "/a", 0);
+        Assert.assertEquals(parse("a: z\nb: y"), result);
+    }
+
+    @Test
+    public void testRun() {
+        final String runContent = "something: torun";
+        Preprocessor pre = new Preprocessor(set(file("/b", runContent)));
+        Object result = pre.preprocess(parse("run: b"), "/a", 0);
+        Assert.assertEquals(parse("run:\n  " + runContent), result);
+    }
+
+    @Test
+    public void testMissingFile() {
+        Preprocessor pre = new Preprocessor(set());
+        Assert.assertEquals(Collections.emptyMap(), pre.preprocess(parse("$import: b"), "/a", 0));
+        Assert.assertEquals("", pre.preprocess(parse("$include: b"), "/a", 0));
+        Assert.assertEquals(parse("a: x"), pre.preprocess(parse("a: x\n$mixin: b"), "/a", 0));
+    }
+
+    @Test
+    public void testMultilevelImports() {
+        final String imported = "levels: two";
+        Preprocessor pre = new Preprocessor(set(file("/b", "$import: c"), file("/c", imported)));
+        Object result = pre.preprocess(parse("$import: b"), "/a", 0);
+        Assert.assertEquals(parse(imported), result);
+    }
+
+    @Test
+    public void testHttpUrlImport() {
+        Assert.assertEquals(Collections.emptyMap(), new Preprocessor(set()).preprocess(parse("$import: http://www.foo.com/bar"), "/a", 0));
+        Assert.assertEquals(Collections.emptyMap(), new Preprocessor(set()).preprocess(parse("$import: https://www.foo.com/bar"), "/a", 0));
+    }
+
+    @Test
+    public void testFileUrlImport() {
+        final String imported = "some: thing";
+        Preprocessor pre = new Preprocessor(set(file("/b", imported)));
+        Object result = pre.preprocess(parse("$import: file://b"), "/a", 0);
+        Assert.assertEquals(parse(imported), result);
+    }
+
+    @Test
+    public void testMaxDepth() {
+    }
+
+    @Test
+    public void testMaxCharCount() {
+    }
+
+    @Test
+    public void testMaxFileCount() {
+    }
+}

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerPreprocessorTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerPreprocessorTest.java
@@ -19,7 +19,7 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
  * Tests CWLHandler.Preprocessor
  */
 public class CWLHandlerPreprocessorTest {
-   
+
     private SourceFile file(String absolutePath, String content) {
         SourceFile sourceFile = mock(SourceFile.class);
         when(sourceFile.getAbsolutePath()).thenReturn(absolutePath);
@@ -37,8 +37,12 @@ public class CWLHandlerPreprocessorTest {
     }
 
     private Object preprocess(String content, Set<SourceFile> files) {
+        return preprocess(content, files, "/a");
+    }
+
+    private Object preprocess(String content, Set<SourceFile> files, String rootPath) {
         Preprocessor pre = new Preprocessor(files);
-        return pre.preprocess(parse(content), "/a", 0);
+        return pre.preprocess(parse(content), rootPath, 0);
     }
 
     @Test
@@ -76,6 +80,18 @@ public class CWLHandlerPreprocessorTest {
     public void testMultilevelImports() {
         final String imported = "levels: two";
         Assert.assertEquals(parse(imported), preprocess("$import: b", set(file("/b", "$import: c"), file("/c", imported))));
+    }
+
+    @Test
+    public void testRelativeImport() {
+        final String imported = "some: content";
+        Assert.assertEquals(parse(imported), preprocess("$import: subsub/b", set(file("/sub/subsub/b", imported)), "/sub/a"));
+    }
+
+    @Test
+    public void testAbsoluteImport() {
+        final String imported = "some: content";
+        Assert.assertEquals(parse(imported), preprocess("$import: /b", set(file("/b", imported)), "/sub/a"));
     }
 
     @Test

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -316,24 +316,4 @@ public class CWLHandlerTest {
             assertThat(e.getErrorMessage()).contains(CWLHandler.CWL_PARSE_SECONDARY_ERROR);
         }
     }
-
-    @Test
-    public void testImport() {
-        // TODO relative and absolute
-    }
-
-    @Test
-    public void testInclude() {
-        // TODO relative and absolute
-    }
-
-    @Test
-    public void testMixin() {
-        // TODO relative and absolute
-    }
-
-    @Test
-    public void testImportsIntoSubdirectories() {
-        // TODO relative and absolute
-    }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -316,4 +316,24 @@ public class CWLHandlerTest {
             assertThat(e.getErrorMessage()).contains(CWLHandler.CWL_PARSE_SECONDARY_ERROR);
         }
     }
+
+    @Test
+    public void testImport() {
+        // TODO relative and absolute
+    }
+
+    @Test
+    public void testInclude() {
+        // TODO relative and absolute
+    }
+
+    @Test
+    public void testMixin() {
+        // TODO relative and absolute
+    }
+
+    @Test
+    public void testImportsIntoSubdirectories() {
+        // TODO relative and absolute
+    }
 }


### PR DESCRIPTION
**Description**
This draft PR implements changes to the webserver CWL parsing logic to handle all $include/$import/$mixin directives correctly and to properly identify tools in CWLs that have a file structure more than two levels deep.

The solution within is very rough, and not intended to be the final product.  I would like high-level feedback on the overall solution.  Specifically, I'm looking for answers to the following questions:
* Is it appropriate to fully expand the CWL and parse it, recursively if necessary?
* If the workflow is incomplete, meaning a file that the workflow includes does not exist, is it ok to display an informative error message and no tools, rather than partial results?  The implemented behavior is the former.

Please don't examine for low-level correctness: bugs need to be fixed, debugging cruft needs to be removed, tests need to be written, code needs to be primped, include cycles need to be detected, etc.

I've been testing by manually registering the following repo, which is a fork of the repo noted in the ticket:
https://github.com/svonworl/multi-step-cwl

The solution is two-pronged.  First, I implemented a preprocessor that expands $include/$import/$mixin and "run: <file>" directives, which solves the first part of the problem when parsing the CWL from the above repo, wherein the existing code fails because it does not understand the "{$import" in the "label" field.  Then, I changed CWLHandler.getContent() to examine the proprocessed/expanded CWL and recursively descend through workflows and their subworkflows to find the tools within.  As Walt mentions in the ticket, the existing code "only goes one subworkflow level down".  

The preprocessing step is prescribed by the CWL spec:
https://www.commonwl.org/v1.2/Workflow.html#Document_preprocessing
My solution currently supports $mixin, which was in a previous version of the spec, but has since been dropped.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-1548