### PR TITLE
Prevent duplicate paths between apptools and workflows

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 356 third-party dependencies.
+Lists of 355 third-party dependencies.
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.12:2.5.31 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.12:2.5.31 - https://akka.io/)
      (Apache License, Version 2.0) akka-slf4j (com.typesafe.akka:akka-slf4j_2.12:2.5.31 - https://akka.io/)
@@ -281,7 +281,6 @@ Lists of 356 third-party dependencies.
      (Apache License 2.0) Metrics Integration with JMX (io.dropwizard.metrics:metrics-jmx:4.1.25 - https://metrics.dropwizard.io/metrics-jmx)
      (Apache License 2.0) Metrics Utility Servlets (io.dropwizard.metrics:metrics-servlets:4.1.25 - https://metrics.dropwizard.io/metrics-servlets)
      (Apache 2) metrics-scala (nl.grons:metrics-scala_2.12:4.0.0 - https://github.com/erikvanoosten/metrics-scala)
-     (WDL License https://github.com/openwdl/wdl/blob/master/LICENSE) metrics-statsd-common (com.readytalk:metrics-statsd-common:4.2.0 - no url defined)
      (The Apache Software License, Version 2.0) metrics3-statsd (com.readytalk:metrics3-statsd:4.2.0 - no url defined)
      (Prior BSD License) MiG Base64 (com.brsanthu:migbase64:2.2 - http://sourceforge.net/projects/migbase64/)
      (Eclipse Distribution License - v 1.0) MIME streaming extension (org.jvnet.mimepull:mimepull:1.9.13 - https://github.com/eclipse-ee4j/metro-mimepull)

--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -256,6 +256,10 @@
           <artifactId>guava</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>com.readytalk</groupId>
+          <artifactId>metrics-statsd-common</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>eu.timepit</groupId>
           <artifactId>refined_2.12</artifactId>
         </exclusion>

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -223,6 +223,10 @@
                     <artifactId>guava</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.readytalk</groupId>
+                    <artifactId>metrics-statsd-common</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>eu.timepit</groupId>
                     <artifactId>refined_2.12</artifactId>
                 </exclusion>

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -848,71 +848,71 @@ public class WebhookIT extends BaseIT {
     }
 
     // .dockstore.yml in test repo needs to change to add a 'name' field to one of them. Should also include another branch that doesn't keep the name field
-        @Test
-        public void testTools() throws Exception {
-            CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
-            final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
-            final io.dockstore.openapi.client.ApiClient openApiClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
-            io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(openApiClient);
-            WorkflowsApi client = new WorkflowsApi(webClient);
+    @Test
+    public void testTools() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+        final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        final io.dockstore.openapi.client.ApiClient openApiClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(openApiClient);
+        WorkflowsApi client = new WorkflowsApi(webClient);
 
-            client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/feature/seab-3734/addNameField", installationId);
-            Workflow appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepoToolPath, APPTOOL, "versions");
-            Workflow workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions");
+        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/feature/seab-3734/addNameField", installationId);
+        Workflow appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepoToolPath, APPTOOL, "versions");
+        Workflow workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions");
 
-            assertNotNull(workflow);
-            assertNotNull(appTool);
+        assertNotNull(workflow);
+        assertNotNull(appTool);
 
-            assertEquals(1, appTool.getWorkflowVersions().size());
-            assertEquals(1, workflow.getWorkflowVersions().size());
+        assertEquals(1, appTool.getWorkflowVersions().size());
+        assertEquals(1, workflow.getWorkflowVersions().size());
 
-            Long userId = usersApi.getUser().getId();
-            List<io.dockstore.openapi.client.model.Workflow> usersAppTools = usersApi.userAppTools(userId);
-            assertEquals(1, usersAppTools.size());
+        Long userId = usersApi.getUser().getId();
+        List<io.dockstore.openapi.client.model.Workflow> usersAppTools = usersApi.userAppTools(userId);
+        assertEquals(1, usersAppTools.size());
 
-            client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/invalid-workflow", installationId);
-            appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepoToolPath, APPTOOL, "versions,validations");
-            workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions,validations");
-            assertEquals(2, appTool.getWorkflowVersions().size());
-            assertEquals(2, workflow.getWorkflowVersions().size());
+        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/invalid-workflow", installationId);
+        appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepoToolPath, APPTOOL, "versions,validations");
+        workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions,validations");
+        assertEquals(2, appTool.getWorkflowVersions().size());
+        assertEquals(2, workflow.getWorkflowVersions().size());
 
-            WorkflowVersion invalidVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> !workflowVersion.isValid()).findFirst().get();
-            invalidVersion.getValidations();
-            Validation workflowValidation = invalidVersion.getValidations().stream().filter(validation -> validation.getType().equals(Validation.TypeEnum.DOCKSTORE_CWL)).findFirst().get();
-            assertFalse(workflowValidation.isValid());
-            assertTrue(workflowValidation.getMessage().contains("Did you mean to register a tool"));
-            appTool.getWorkflowVersions().stream().forEach(workflowVersion -> {
-                if (!workflowVersion.isValid()) {
-                    fail("Tool should be valid for both versions");
-                }
-            });
+        WorkflowVersion invalidVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> !workflowVersion.isValid()).findFirst().get();
+        invalidVersion.getValidations();
+        Validation workflowValidation = invalidVersion.getValidations().stream().filter(validation -> validation.getType().equals(Validation.TypeEnum.DOCKSTORE_CWL)).findFirst().get();
+        assertFalse(workflowValidation.isValid());
+        assertTrue(workflowValidation.getMessage().contains("Did you mean to register a tool"));
+        appTool.getWorkflowVersions().stream().forEach(workflowVersion -> {
+            if (!workflowVersion.isValid()) {
+                fail("Tool should be valid for both versions");
+            }
+        });
 
-            client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/invalidTool", installationId);
-            appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepoToolPath, APPTOOL, "versions,validations");
-            workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions,validations");
-            assertEquals(3, appTool.getWorkflowVersions().size());
-            assertEquals(3, workflow.getWorkflowVersions().size());
+        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/invalidTool", installationId);
+        appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepoToolPath, APPTOOL, "versions,validations");
+        workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions,validations");
+        assertEquals(3, appTool.getWorkflowVersions().size());
+        assertEquals(3, workflow.getWorkflowVersions().size());
 
-            invalidVersion = appTool.getWorkflowVersions().stream().filter(workflowVersion -> !workflowVersion.isValid()).findFirst().get();
-            Validation toolValidation = invalidVersion.getValidations().stream().filter(validation -> validation.getType().equals(Validation.TypeEnum.DOCKSTORE_CWL)).findFirst().get();
-            assertFalse(toolValidation.isValid());
-            assertTrue(toolValidation.getMessage().contains("Did you mean to register a workflow"));
+        invalidVersion = appTool.getWorkflowVersions().stream().filter(workflowVersion -> !workflowVersion.isValid()).findFirst().get();
+        Validation toolValidation = invalidVersion.getValidations().stream().filter(validation -> validation.getType().equals(Validation.TypeEnum.DOCKSTORE_CWL)).findFirst().get();
+        assertFalse(toolValidation.isValid());
+        assertTrue(toolValidation.getMessage().contains("Did you mean to register a workflow"));
 
-            testingPostgres.runUpdateStatement("update apptool set ispublished = 't' where id = " + appTool.getId());
-            testingPostgres.runUpdateStatement("update workflow set ispublished = 't' where id = " + workflow.getId());
+        testingPostgres.runUpdateStatement("update apptool set ispublished = 't' where id = " + appTool.getId());
+        testingPostgres.runUpdateStatement("update workflow set ispublished = 't' where id = " + workflow.getId());
 
-            Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openApiClient);
-            final List<io.dockstore.openapi.client.model.Tool> tools = ga4Ghv20Api.toolsGet(null, null, null, null, null, null, null, null, null, null, null, null, null);
-            assertEquals(2, tools.size());
+        Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openApiClient);
+        final List<io.dockstore.openapi.client.model.Tool> tools = ga4Ghv20Api.toolsGet(null, null, null, null, null, null, null, null, null, null, null, null, null);
+        assertEquals(2, tools.size());
 
-            final io.dockstore.openapi.client.model.Tool tool = ga4Ghv20Api.toolsIdGet("github.com/DockstoreTestUser2/test-workflows-and-tools");
-            assertNotNull(tool);
-            assertEquals("CommandLineTool", tool.getToolclass().getDescription());
+        final io.dockstore.openapi.client.model.Tool tool = ga4Ghv20Api.toolsIdGet("github.com/DockstoreTestUser2/test-workflows-and-tools");
+        assertNotNull(tool);
+        assertEquals("CommandLineTool", tool.getToolclass().getDescription());
 
-            final Tool trsWorkflow = ga4Ghv20Api.toolsIdGet(ToolsImplCommon.WORKFLOW_PREFIX + "/github.com/DockstoreTestUser2/test-workflows-and-tools");
-            assertNotNull(trsWorkflow);
-            assertEquals("Workflow", trsWorkflow.getToolclass().getDescription());
-        }
+        final Tool trsWorkflow = ga4Ghv20Api.toolsIdGet(ToolsImplCommon.WORKFLOW_PREFIX + "/github.com/DockstoreTestUser2/test-workflows-and-tools");
+        assertNotNull(trsWorkflow);
+        assertEquals("Workflow", trsWorkflow.getToolclass().getDescription());
+    }
 
     @Test
     public void testDuplicatePathsAcrossTables() throws Exception {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -905,7 +905,7 @@ public class WebhookIT extends BaseIT {
         final List<io.dockstore.openapi.client.model.Tool> tools = ga4Ghv20Api.toolsGet(null, null, null, null, null, null, null, null, null, null, null, null, null);
         assertEquals(2, tools.size());
 
-        final io.dockstore.openapi.client.model.Tool tool = ga4Ghv20Api.toolsIdGet("github.com/DockstoreTestUser2/test-workflows-and-tools");
+        final io.dockstore.openapi.client.model.Tool tool = ga4Ghv20Api.toolsIdGet("github.com/DockstoreTestUser2/test-workflows-and-tools/md5sum");
         assertNotNull(tool);
         assertEquals("CommandLineTool", tool.getToolclass().getDescription());
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -35,10 +35,13 @@ import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
+import io.dockstore.openapi.client.api.Ga4Ghv20Api;
 import io.dockstore.openapi.client.api.LambdaEventsApi;
+import io.dockstore.openapi.client.model.Tool;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.jdbi.FileDAO;
+import io.swagger.api.impl.ToolsImplCommon;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.UsersApi;
@@ -89,6 +92,7 @@ public class WebhookIT extends BaseIT {
     private final String githubFiltersRepo = "DockstoreTestUser2/dockstoreyml-github-filters-test";
     private final String installationId = "1179416";
     private final String toolAndWorkflowRepo = "DockstoreTestUser2/test-workflows-and-tools";
+    private final String toolAndWorkflowRepoToolPath = "DockstoreTestUser2/test-workflows-and-tools/md5sum";
     private final String authorsRepo = "DockstoreTestUser2/test-authors";
     private FileDAO fileDAO;
 
@@ -844,71 +848,71 @@ public class WebhookIT extends BaseIT {
     }
 
     // .dockstore.yml in test repo needs to change to add a 'name' field to one of them. Should also include another branch that doesn't keep the name field
-    //    @Test
-    //    public void testTools() throws Exception {
-    //        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
-    //        final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
-    //        final io.dockstore.openapi.client.ApiClient openApiClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
-    //        io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(openApiClient);
-    //        WorkflowsApi client = new WorkflowsApi(webClient);
-    //
-    //        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/main", installationId);
-    //        Workflow appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, APPTOOL, "versions");
-    //        Workflow workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions");
-    //
-    //        assertNotNull(workflow);
-    //        assertNotNull(appTool);
-    //
-    //        assertEquals(1, appTool.getWorkflowVersions().size());
-    //        assertEquals(1, workflow.getWorkflowVersions().size());
-    //
-    //        Long userId = usersApi.getUser().getId();
-    //        List<io.dockstore.openapi.client.model.Workflow> usersAppTools = usersApi.userAppTools(userId);
-    //        assertEquals(1, usersAppTools.size());
-    //
-    //        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/invalid-workflow", installationId);
-    //        appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, APPTOOL, "versions,validations");
-    //        workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions,validations");
-    //        assertEquals(2, appTool.getWorkflowVersions().size());
-    //        assertEquals(2, workflow.getWorkflowVersions().size());
-    //
-    //        WorkflowVersion invalidVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> !workflowVersion.isValid()).findFirst().get();
-    //        invalidVersion.getValidations();
-    //        Validation workflowValidation = invalidVersion.getValidations().stream().filter(validation -> validation.getType().equals(Validation.TypeEnum.DOCKSTORE_CWL)).findFirst().get();
-    //        assertFalse(workflowValidation.isValid());
-    //        assertTrue(workflowValidation.getMessage().contains("Did you mean to register a tool"));
-    //        appTool.getWorkflowVersions().stream().forEach(workflowVersion -> {
-    //            if (!workflowVersion.isValid()) {
-    //                fail("Tool should be valid for both versions");
-    //            }
-    //        });
-    //
-    //        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/invalidTool", installationId);
-    //        appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, APPTOOL, "versions,validations");
-    //        workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions,validations");
-    //        assertEquals(3, appTool.getWorkflowVersions().size());
-    //        assertEquals(3, workflow.getWorkflowVersions().size());
-    //
-    //        invalidVersion = appTool.getWorkflowVersions().stream().filter(workflowVersion -> !workflowVersion.isValid()).findFirst().get();
-    //        Validation toolValidation = invalidVersion.getValidations().stream().filter(validation -> validation.getType().equals(Validation.TypeEnum.DOCKSTORE_CWL)).findFirst().get();
-    //        assertFalse(toolValidation.isValid());
-    //        assertTrue(toolValidation.getMessage().contains("Did you mean to register a workflow"));
-    //
-    //        testingPostgres.runUpdateStatement("update apptool set ispublished = 't' where id = " + appTool.getId());
-    //        testingPostgres.runUpdateStatement("update workflow set ispublished = 't' where id = " + workflow.getId());
-    //
-    //        Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openApiClient);
-    //        final List<Tool> tools = ga4Ghv20Api.toolsGet(null, null, null, null, null, null, null, null, null, null, null, null, null);
-    //        assertEquals(2, tools.size());
-    //
-    //        final Tool tool = ga4Ghv20Api.toolsIdGet("github.com/DockstoreTestUser2/test-workflows-and-tools");
-    //        assertNotNull(tool);
-    //        assertEquals("CommandLineTool", tool.getToolclass().getDescription());
-    //
-    //        final Tool trsWorkflow = ga4Ghv20Api.toolsIdGet(ToolsImplCommon.WORKFLOW_PREFIX + "/github.com/DockstoreTestUser2/test-workflows-and-tools");
-    //        assertNotNull(trsWorkflow);
-    //        assertEquals("Workflow", trsWorkflow.getToolclass().getDescription());
-    //    }
+        @Test
+        public void testTools() throws Exception {
+            CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+            final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+            final io.dockstore.openapi.client.ApiClient openApiClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+            io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(openApiClient);
+            WorkflowsApi client = new WorkflowsApi(webClient);
+
+            client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/feature/seab-3734/addNameField", installationId);
+            Workflow appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepoToolPath, APPTOOL, "versions");
+            Workflow workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions");
+
+            assertNotNull(workflow);
+            assertNotNull(appTool);
+
+            assertEquals(1, appTool.getWorkflowVersions().size());
+            assertEquals(1, workflow.getWorkflowVersions().size());
+
+            Long userId = usersApi.getUser().getId();
+            List<io.dockstore.openapi.client.model.Workflow> usersAppTools = usersApi.userAppTools(userId);
+            assertEquals(1, usersAppTools.size());
+
+            client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/invalid-workflow", installationId);
+            appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepoToolPath, APPTOOL, "versions,validations");
+            workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions,validations");
+            assertEquals(2, appTool.getWorkflowVersions().size());
+            assertEquals(2, workflow.getWorkflowVersions().size());
+
+            WorkflowVersion invalidVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> !workflowVersion.isValid()).findFirst().get();
+            invalidVersion.getValidations();
+            Validation workflowValidation = invalidVersion.getValidations().stream().filter(validation -> validation.getType().equals(Validation.TypeEnum.DOCKSTORE_CWL)).findFirst().get();
+            assertFalse(workflowValidation.isValid());
+            assertTrue(workflowValidation.getMessage().contains("Did you mean to register a tool"));
+            appTool.getWorkflowVersions().stream().forEach(workflowVersion -> {
+                if (!workflowVersion.isValid()) {
+                    fail("Tool should be valid for both versions");
+                }
+            });
+
+            client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/invalidTool", installationId);
+            appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepoToolPath, APPTOOL, "versions,validations");
+            workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions,validations");
+            assertEquals(3, appTool.getWorkflowVersions().size());
+            assertEquals(3, workflow.getWorkflowVersions().size());
+
+            invalidVersion = appTool.getWorkflowVersions().stream().filter(workflowVersion -> !workflowVersion.isValid()).findFirst().get();
+            Validation toolValidation = invalidVersion.getValidations().stream().filter(validation -> validation.getType().equals(Validation.TypeEnum.DOCKSTORE_CWL)).findFirst().get();
+            assertFalse(toolValidation.isValid());
+            assertTrue(toolValidation.getMessage().contains("Did you mean to register a workflow"));
+
+            testingPostgres.runUpdateStatement("update apptool set ispublished = 't' where id = " + appTool.getId());
+            testingPostgres.runUpdateStatement("update workflow set ispublished = 't' where id = " + workflow.getId());
+
+            Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openApiClient);
+            final List<io.dockstore.openapi.client.model.Tool> tools = ga4Ghv20Api.toolsGet(null, null, null, null, null, null, null, null, null, null, null, null, null);
+            assertEquals(2, tools.size());
+
+            final io.dockstore.openapi.client.model.Tool tool = ga4Ghv20Api.toolsIdGet("github.com/DockstoreTestUser2/test-workflows-and-tools");
+            assertNotNull(tool);
+            assertEquals("CommandLineTool", tool.getToolclass().getDescription());
+
+            final Tool trsWorkflow = ga4Ghv20Api.toolsIdGet(ToolsImplCommon.WORKFLOW_PREFIX + "/github.com/DockstoreTestUser2/test-workflows-and-tools");
+            assertNotNull(trsWorkflow);
+            assertEquals("Workflow", trsWorkflow.getToolclass().getDescription());
+        }
 
     @Test
     public void testDuplicatePathsAcrossTables() throws Exception {
@@ -918,7 +922,7 @@ public class WebhookIT extends BaseIT {
         WorkflowsApi client = new WorkflowsApi(webClient);
 
         try {
-            client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/main", installationId);
+            client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/duplicate-paths", installationId);
             fail("Should not be able to create a workflow and apptool with the same path.");
         } catch (ApiException ex) {
             assertTrue(ex.getMessage().contains("with the same path already exists."));

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -941,5 +941,8 @@ public class WebhookIT extends BaseIT {
         } catch (Exception ex) {
             assertTrue(ex.getMessage().contains("duplicate key value violates"));
         }
+
+        // Should be able to have service with duplicate name
+        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/addService", installationId);
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -856,7 +856,7 @@ public class WebhookIT extends BaseIT {
         io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(openApiClient);
         WorkflowsApi client = new WorkflowsApi(webClient);
 
-        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/feature/seab-3734/addNameField", installationId);
+        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/main", installationId);
         Workflow appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepoToolPath, APPTOOL, "versions");
         Workflow workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions");
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -35,13 +35,10 @@ import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
-import io.dockstore.openapi.client.api.Ga4Ghv20Api;
 import io.dockstore.openapi.client.api.LambdaEventsApi;
-import io.dockstore.openapi.client.model.Tool;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.jdbi.FileDAO;
-import io.swagger.api.impl.ToolsImplCommon;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.UsersApi;
@@ -846,69 +843,99 @@ public class WebhookIT extends BaseIT {
         }
     }
 
+    // .dockstore.yml in test repo needs to change to add a 'name' field to one of them. Should also include another branch that doesn't keep the name field
+    //    @Test
+    //    public void testTools() throws Exception {
+    //        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+    //        final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+    //        final io.dockstore.openapi.client.ApiClient openApiClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+    //        io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(openApiClient);
+    //        WorkflowsApi client = new WorkflowsApi(webClient);
+    //
+    //        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/main", installationId);
+    //        Workflow appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, APPTOOL, "versions");
+    //        Workflow workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions");
+    //
+    //        assertNotNull(workflow);
+    //        assertNotNull(appTool);
+    //
+    //        assertEquals(1, appTool.getWorkflowVersions().size());
+    //        assertEquals(1, workflow.getWorkflowVersions().size());
+    //
+    //        Long userId = usersApi.getUser().getId();
+    //        List<io.dockstore.openapi.client.model.Workflow> usersAppTools = usersApi.userAppTools(userId);
+    //        assertEquals(1, usersAppTools.size());
+    //
+    //        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/invalid-workflow", installationId);
+    //        appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, APPTOOL, "versions,validations");
+    //        workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions,validations");
+    //        assertEquals(2, appTool.getWorkflowVersions().size());
+    //        assertEquals(2, workflow.getWorkflowVersions().size());
+    //
+    //        WorkflowVersion invalidVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> !workflowVersion.isValid()).findFirst().get();
+    //        invalidVersion.getValidations();
+    //        Validation workflowValidation = invalidVersion.getValidations().stream().filter(validation -> validation.getType().equals(Validation.TypeEnum.DOCKSTORE_CWL)).findFirst().get();
+    //        assertFalse(workflowValidation.isValid());
+    //        assertTrue(workflowValidation.getMessage().contains("Did you mean to register a tool"));
+    //        appTool.getWorkflowVersions().stream().forEach(workflowVersion -> {
+    //            if (!workflowVersion.isValid()) {
+    //                fail("Tool should be valid for both versions");
+    //            }
+    //        });
+    //
+    //        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/invalidTool", installationId);
+    //        appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, APPTOOL, "versions,validations");
+    //        workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions,validations");
+    //        assertEquals(3, appTool.getWorkflowVersions().size());
+    //        assertEquals(3, workflow.getWorkflowVersions().size());
+    //
+    //        invalidVersion = appTool.getWorkflowVersions().stream().filter(workflowVersion -> !workflowVersion.isValid()).findFirst().get();
+    //        Validation toolValidation = invalidVersion.getValidations().stream().filter(validation -> validation.getType().equals(Validation.TypeEnum.DOCKSTORE_CWL)).findFirst().get();
+    //        assertFalse(toolValidation.isValid());
+    //        assertTrue(toolValidation.getMessage().contains("Did you mean to register a workflow"));
+    //
+    //        testingPostgres.runUpdateStatement("update apptool set ispublished = 't' where id = " + appTool.getId());
+    //        testingPostgres.runUpdateStatement("update workflow set ispublished = 't' where id = " + workflow.getId());
+    //
+    //        Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openApiClient);
+    //        final List<Tool> tools = ga4Ghv20Api.toolsGet(null, null, null, null, null, null, null, null, null, null, null, null, null);
+    //        assertEquals(2, tools.size());
+    //
+    //        final Tool tool = ga4Ghv20Api.toolsIdGet("github.com/DockstoreTestUser2/test-workflows-and-tools");
+    //        assertNotNull(tool);
+    //        assertEquals("CommandLineTool", tool.getToolclass().getDescription());
+    //
+    //        final Tool trsWorkflow = ga4Ghv20Api.toolsIdGet(ToolsImplCommon.WORKFLOW_PREFIX + "/github.com/DockstoreTestUser2/test-workflows-and-tools");
+    //        assertNotNull(trsWorkflow);
+    //        assertEquals("Workflow", trsWorkflow.getToolclass().getDescription());
+    //    }
+
     @Test
-    public void testTools() throws Exception {
+    public void testDuplicatePathsAcrossTables() throws Exception {
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
         final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
         final io.dockstore.openapi.client.ApiClient openApiClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
-        io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(openApiClient);
         WorkflowsApi client = new WorkflowsApi(webClient);
 
-        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/main", installationId);
-        Workflow appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, APPTOOL, "versions");
-        Workflow workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions");
+        try {
+            client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/main", installationId);
+            fail("Should not be able to create a workflow and apptool with the same path.");
+        } catch (ApiException ex) {
+            assertTrue(ex.getMessage().contains("with the same path already exists."));
+        }
 
-        assertNotNull(workflow);
-        assertNotNull(appTool);
+        // Check that the database trigger created an entry in fullworkflowpath table
+        long pathCount = testingPostgres.runSelectStatement("select count(*) from fullworkflowpath", long.class);
+        assertEquals(0, pathCount);
+        client.handleGitHubRelease(githubFiltersRepo, BasicIT.USER_2_USERNAME, "refs/tags/1.0", installationId);
+        pathCount = testingPostgres.runSelectStatement("select count(*) from fullworkflowpath", long.class);
+        assertTrue(pathCount >= 3);
 
-        assertEquals(1, appTool.getWorkflowVersions().size());
-        assertEquals(1, workflow.getWorkflowVersions().size());
-
-        Long userId = usersApi.getUser().getId();
-        List<io.dockstore.openapi.client.model.Workflow> usersAppTools = usersApi.userAppTools(userId);
-        assertEquals(1, usersAppTools.size());
-
-        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/invalid-workflow", installationId);
-        appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, APPTOOL, "versions,validations");
-        workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions,validations");
-        assertEquals(2, appTool.getWorkflowVersions().size());
-        assertEquals(2, workflow.getWorkflowVersions().size());
-
-        WorkflowVersion invalidVersion = workflow.getWorkflowVersions().stream().filter(workflowVersion -> !workflowVersion.isValid()).findFirst().get();
-        invalidVersion.getValidations();
-        Validation workflowValidation = invalidVersion.getValidations().stream().filter(validation -> validation.getType().equals(Validation.TypeEnum.DOCKSTORE_CWL)).findFirst().get();
-        assertFalse(workflowValidation.isValid());
-        assertTrue(workflowValidation.getMessage().contains("Did you mean to register a tool"));
-        appTool.getWorkflowVersions().stream().forEach(workflowVersion -> {
-            if (!workflowVersion.isValid()) {
-                fail("Tool should be valid for both versions");
-            }
-        });
-
-        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/invalidTool", installationId);
-        appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, APPTOOL, "versions,validations");
-        workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions,validations");
-        assertEquals(3, appTool.getWorkflowVersions().size());
-        assertEquals(3, workflow.getWorkflowVersions().size());
-
-        invalidVersion = appTool.getWorkflowVersions().stream().filter(workflowVersion -> !workflowVersion.isValid()).findFirst().get();
-        Validation toolValidation = invalidVersion.getValidations().stream().filter(validation -> validation.getType().equals(Validation.TypeEnum.DOCKSTORE_CWL)).findFirst().get();
-        assertFalse(toolValidation.isValid());
-        assertTrue(toolValidation.getMessage().contains("Did you mean to register a workflow"));
-
-        testingPostgres.runUpdateStatement("update apptool set ispublished = 't' where id = " + appTool.getId());
-        testingPostgres.runUpdateStatement("update workflow set ispublished = 't' where id = " + workflow.getId());
-
-        Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openApiClient);
-        final List<Tool> tools = ga4Ghv20Api.toolsGet(null, null, null, null, null, null, null, null, null, null, null, null, null);
-        assertEquals(2, tools.size());
-
-        final Tool tool = ga4Ghv20Api.toolsIdGet("github.com/DockstoreTestUser2/test-workflows-and-tools");
-        assertNotNull(tool);
-        assertEquals("CommandLineTool", tool.getToolclass().getDescription());
-
-        final Tool trsWorkflow = ga4Ghv20Api.toolsIdGet(ToolsImplCommon.WORKFLOW_PREFIX + "/github.com/DockstoreTestUser2/test-workflows-and-tools");
-        assertNotNull(trsWorkflow);
-        assertEquals("Workflow", trsWorkflow.getToolclass().getDescription());
+        try {
+            testingPostgres.runUpdateStatement("INSERT INTO fullworkflowpath(id, organization, repository, sourcecontrol, workflowname) VALUES (1010, 'DockstoreTestUser2', 'dockstoreyml-github-filters-test', 'github.com', 'filternone')");
+            fail("Database should prevent duplicate paths between tables");
+        } catch (Exception ex) {
+            assertTrue(ex.getMessage().contains("duplicate key value violates"));
+        }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -192,7 +192,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             Tag.class, Label.class, SourceFile.class, Workflow.class, CollectionOrganization.class, WorkflowVersion.class, FileFormat.class,
             Organization.class, Notification.class, OrganizationUser.class, Event.class, Collection.class, Validation.class, BioWorkflow.class, Service.class, VersionMetadata.class, Image.class, Checksum.class, LambdaEvent.class,
             ParsedInformation.class, EntryVersion.class, DeletedUsername.class, CloudInstance.class, Author.class, OrcidAuthor.class,
-            AppTool.class, Category.class) {
+            AppTool.class, Category.class, FullWorkflowPath.class) {
         @Override
         public DataSourceFactory getDataSourceFactory(DockstoreWebserviceConfiguration configuration) {
             return configuration.getDataSourceFactory();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/FullWorkflowPath.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/FullWorkflowPath.java
@@ -23,8 +23,6 @@ import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
@@ -41,9 +39,8 @@ import javax.persistence.Table;
 public class FullWorkflowPath implements Serializable {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", unique = true, nullable = false)
-    @ApiModelProperty(value = "Implementation specific ID for the full workflow path in this web service")
+    @ApiModelProperty(value = "Implementation specific ID for the full workflow path in this web service.")
     private long id;
 
     @Column(columnDefinition = "text")
@@ -59,7 +56,7 @@ public class FullWorkflowPath implements Serializable {
     private String repository;
 
     @Column(nullable = false, columnDefinition = "text")
-    @ApiModelProperty(value = "This is a specific source control provider like github or bitbucket or n/a?, required: GA4GH", required = true, dataType = "string")
+    @ApiModelProperty(value = "This is a specific source control provider like github, bitbucket, gitlab, etc.", required = true, dataType = "string")
     @Convert(converter = SourceControlConverter.class)
     private SourceControl sourceControl;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/FullWorkflowPath.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/FullWorkflowPath.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dockstore.webservice;
+
+import io.dockstore.common.SourceControl;
+import io.dockstore.webservice.core.SourceControlConverter;
+import io.swagger.annotations.ApiModelProperty;
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * Workflow is broken into three different subclasses: BioWorkflow, Service, and AppTool. All three are in separate tables in our database and there is a unique
+ * constraint within each table to prevent duplicate names. However, we want names to be unique across workflows and apptools, so this is being added to keep track
+ * of the full path names within a single table and have the constraint be enforced at the database level.
+ *
+ * @author Natalie
+ */
+
+@Entity
+@Table(name = "fullworkflowpath")
+public class FullWorkflowPath implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", unique = true, nullable = false)
+    @ApiModelProperty(value = "Implementation specific ID for the full workflow path in this web service")
+    private long id;
+
+    @Column(columnDefinition = "text")
+    @ApiModelProperty(value = "This is the name of the workflow, not needed when only one workflow in a repo")
+    private String workflowName;
+
+    @Column(nullable = false)
+    @ApiModelProperty(value = "This is a git organization for the workflow", required = true)
+    private String organization;
+
+    @Column(nullable = false)
+    @ApiModelProperty(value = "This is a git repository name", required = true)
+    private String repository;
+
+    @Column(nullable = false, columnDefinition = "text")
+    @ApiModelProperty(value = "This is a specific source control provider like github or bitbucket or n/a?, required: GA4GH", required = true, dataType = "string")
+    @Convert(converter = SourceControlConverter.class)
+    private SourceControl sourceControl;
+
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -113,7 +113,7 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
     private String repository;
 
     @Column(nullable = false, columnDefinition = "text")
-    @ApiModelProperty(value = "This is a specific source control provider like github or bitbucket or n/a?, required: GA4GH", required = true, position = 17, dataType = "string")
+    @ApiModelProperty(value = "This is a specific source control provider like github, bitbucket, gitlab, etc.", required = true, position = 17, dataType = "string")
     @Convert(converter = SourceControlConverter.class)
     private SourceControl sourceControl;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -20,6 +20,7 @@ import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.AppTool;
+import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.SourceControlConverter;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
@@ -182,16 +183,15 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
      * If creating an apptool, check the workflow table and vice versa.
      *
      * @param path
-     * @param clazz
-     * @param <T>
+     * @param clazz the table you want to check for a duplicate for
      * @return
      */
     public <T extends Workflow> void checkForDuplicateAcrossTables(String path, Class<T> clazz) {
         final List<Workflow> workflows = findByPath(path, false);
-        final List<T> filteredWorkflows = workflows.stream()
-            .filter(workflow -> workflow.getClass().equals(clazz))
-            .map(clazz::cast)
+        final List<Workflow> filteredWorkflows = workflows.stream()
+            .filter(workflow -> workflow.getClass() != Service.class)
             .collect(Collectors.toList());
+
         if (filteredWorkflows.size() > 0) {
             String workflowType;
             if (clazz == AppTool.class) {
@@ -199,7 +199,7 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
             } else {
                 workflowType = "workflow";
             }
-            throw new CustomWebApplicationException("A " + workflowType + " with the same path already exists. Add the 'name' field to the new or already existing entry.", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            throw new CustomWebApplicationException("A " + workflowType + " with the same path already exists. Add the 'name' field to the entry you are currently trying to register to give it a unique path.", HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -19,6 +19,7 @@ package io.dockstore.webservice.jdbi;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
 import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.AppTool;
 import io.dockstore.webservice.core.SourceControlConverter;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
@@ -152,7 +153,7 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
     }
 
     /**
-     * Finds a BioWorkflow or Service matching the given path.
+     * Finds a BioWorkflow, Apptool, or Service matching the given path.
      *
      * Initial implementation currently calls findByPath and filters the result; would ideally do it as a query with
      * no filtering instead.
@@ -174,6 +175,32 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
             throw new CustomWebApplicationException("Entries with the same path exist", HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
         return filteredWorkflows.size() == 1 ? Optional.of(filteredWorkflows.get(0)) : Optional.empty();
+    }
+
+    /**
+     * Find if a path already exists in the BioWorkflow or Apptool table since we do not want duplicate names between them.
+     * If creating an apptool, check the workflow table and vice versa.
+     *
+     * @param path
+     * @param clazz
+     * @param <T>
+     * @return
+     */
+    public <T extends Workflow> void checkForDuplicateAcrossTables(String path, Class<T> clazz) {
+        final List<Workflow> workflows = findByPath(path, false);
+        final List<T> filteredWorkflows = workflows.stream()
+            .filter(workflow -> workflow.getClass().equals(clazz))
+            .map(clazz::cast)
+            .collect(Collectors.toList());
+        if (filteredWorkflows.size() > 0) {
+            String workflowType;
+            if (clazz == AppTool.class) {
+                workflowType = "tool";
+            } else {
+                workflowType = "workflow";
+            }
+            throw new CustomWebApplicationException("A " + workflowType + " with the same path already exists. Add the 'name' field to the new or already existing entry.", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        }
     }
 
     @SuppressWarnings({"checkstyle:ParameterNumber"})

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -461,7 +461,6 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @param user User that triggered action
      * @param dockstoreYml
      */
-    //
     private void createBioWorkflowsAndVersionsFromDockstoreYml(List<YamlWorkflow> yamlWorkflows, String repository, String gitReference, String installationId, User user,
             final SourceFile dockstoreYml, boolean isOneStepWorkflow) {
         GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createGitHubAppRepo(gitHubAppSetup(installationId));
@@ -551,7 +550,6 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @param gitHubSourceCodeRepo Source Code Repo
      * @return New or updated workflow
      */
-    //
     private Workflow createOrGetWorkflow(Class workflowType, String repository, User user, String workflowName, String subclass, GitHubSourceCodeRepo gitHubSourceCodeRepo) {
         // Check for existing workflow
         String dockstoreWorkflowPath = "github.com/" + repository + (workflowName != null && !workflowName.isEmpty() ? "/" + workflowName : "");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -461,6 +461,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @param user User that triggered action
      * @param dockstoreYml
      */
+    //
     private void createBioWorkflowsAndVersionsFromDockstoreYml(List<YamlWorkflow> yamlWorkflows, String repository, String gitReference, String installationId, User user,
             final SourceFile dockstoreYml, boolean isOneStepWorkflow) {
         GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createGitHubAppRepo(gitHubAppSetup(installationId));
@@ -550,6 +551,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @param gitHubSourceCodeRepo Source Code Repo
      * @return New or updated workflow
      */
+    //
     private Workflow createOrGetWorkflow(Class workflowType, String repository, User user, String workflowName, String subclass, GitHubSourceCodeRepo gitHubSourceCodeRepo) {
         // Check for existing workflow
         String dockstoreWorkflowPath = "github.com/" + repository + (workflowName != null && !workflowName.isEmpty() ? "/" + workflowName : "");
@@ -566,10 +568,12 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             StringInputValidationHelper.checkEntryName(workflowType, workflowName);
 
             if (workflowType == BioWorkflow.class) {
+                workflowDAO.checkForDuplicateAcrossTables(dockstoreWorkflowPath, AppTool.class);
                 workflowToUpdate = gitHubSourceCodeRepo.initializeWorkflowFromGitHub(repository, subclass, workflowName);
             } else if (workflowType == Service.class) {
                 workflowToUpdate = gitHubSourceCodeRepo.initializeServiceFromGitHub(repository, subclass);
             } else if (workflowType == AppTool.class) {
+                workflowDAO.checkForDuplicateAcrossTables(dockstoreWorkflowPath, BioWorkflow.class);
                 workflowToUpdate = gitHubSourceCodeRepo.initializeOneStepWorkflowFromGitHub(repository, subclass, workflowName);
             } else {
                 throw new CustomWebApplicationException(workflowType.getCanonicalName()  + " is not a valid workflow type. Currently only workflows, tools, and services are supported by GitHub Apps.", LAMBDA_FAILURE);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1950,6 +1950,9 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         if (duplicate.isPresent()) {
             throw new CustomWebApplicationException("A workflow with the same path and name already exists.", HttpStatus.SC_BAD_REQUEST);
         }
+
+        // Check that there isn't a duplicate in the Apptool table.
+        workflowDAO.checkForDuplicateAcrossTables(workflow.getWorkflowPath(), AppTool.class);
         final long workflowID = workflowDAO.create(workflow);
         final Workflow workflowFromDB = workflowDAO.findById(workflowID);
         workflowFromDB.getUsers().add(user);

--- a/dockstore-webservice/src/main/resources/import.sql
+++ b/dockstore-webservice/src/main/resources/import.sql
@@ -21,11 +21,13 @@ COMMENT ON COLUMN workflowversion.dbcreatedate IS 'Remote: When workflow was ref
 COMMENT ON COLUMN workflowversion.dbupdatedate IS 'Remote: When workflow was refreshed for the first time or last time version was edited under action column in versions tab. Hosted: time version created or last time version was edited under actions column in versions tab. Basically anytime db entry modified';
 -- postgres partial indexes seem unsupported https://stackoverflow.com/questions/12025844/how-to-annotate-unique-constraint-with-where-clause-in-jpa
 CREATE UNIQUE INDEX full_workflow_name ON workflow USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
+CREATE UNIQUE INDEX full_workflow_name_masterlist ON fullworkflowpath USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
 CREATE UNIQUE INDEX full_tool_name ON tool USING btree (registry, namespace, name, toolname) WHERE toolname IS NOT NULL;
-CREATE UNIQUE INDEX full_apptool_name ON apptool USING btree (sourcecontrol, organization, repository, workflowname) WHERE toolname IS NOT NULL;
+CREATE UNIQUE INDEX full_apptool_name ON apptool USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
 CREATE UNIQUE INDEX partial_workflow_name ON workflow USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
+CREATE UNIQUE INDEX partial_workflow_name_masterlist ON fullworkflowpath USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
 CREATE UNIQUE INDEX partial_tool_name ON tool USING btree (registry, namespace, name) WHERE toolname IS NULL;
-CREATE UNIQUE INDEX partial_apptool_name ON apptool USING btree (sourcecontrol, organization, repository) WHERE toolname IS NULL;
+CREATE UNIQUE INDEX partial_apptool_name ON apptool USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
 CREATE UNIQUE INDEX full_service_name ON service USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
 CREATE UNIQUE INDEX partial_service_name ON service USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
 CREATE UNIQUE INDEX partial_cloud_instance ON cloud_instance USING btree (url) WHERE user_id IS NULL;

--- a/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
@@ -248,4 +248,57 @@
             alter table version_metadata add constraint check_valid_doi check (doiurl like '10._%/_%' or doiurl is null);
         </sql>
     </changeSet>
+    <changeSet id="add_path_constraint_to_apptool" author="natalieperez">
+        <sql dbms="postgresql">
+            CREATE UNIQUE INDEX if not exists full_apptool_name ON apptool USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
+            CREATE UNIQUE INDEX if not exists partial_apptool_name ON apptool USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
+        </sql>
+    </changeSet>
+    <changeSet author="natalieperez (generated)" id="1641836305491-1">
+        <createTable tableName="fullworkflowpath">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="fullworkflowpath_pkey"/>
+            </column>
+            <column name="organization" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="repository" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sourcecontrol" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="workflowname" type="TEXT"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="add_constraint_on_masterlist" author="natalieperez">
+        <sql dbms="postgresql">
+            CREATE UNIQUE INDEX full_workflow_name_masterlist ON fullworkflowpath USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
+            CREATE UNIQUE INDEX partial_workflow_name_masterlist ON fullworkflowpath USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
+        </sql>
+        <sql dbms="postgresql">
+            CREATE OR REPLACE FUNCTION workflow_path_insert_trigger_fnc()
+            RETURNS trigger AS
+            '
+            BEGIN
+            INSERT INTO fullworkflowpath(id, organization, repository, sourcecontrol, workflowname)
+            VALUES (NEW.id, NEW.organization, NEW.repository, NEW.sourcecontrol, NEW.workflowname);
+            RETURN NEW;
+            END;
+            '
+            LANGUAGE 'plpgsql';
+
+            CREATE TRIGGER workflow_path_trigger
+            AFTER INSERT
+            ON workflow
+            FOR EACH ROW
+            EXECUTE PROCEDURE workflow_path_insert_trigger_fnc();
+
+            CREATE TRIGGER apptool_path_trigger
+            AFTER INSERT
+            ON apptool
+            FOR EACH ROW
+            EXECUTE PROCEDURE workflow_path_insert_trigger_fnc();
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
@@ -248,13 +248,11 @@
             alter table version_metadata add constraint check_valid_doi check (doiurl like '10._%/_%' or doiurl is null);
         </sql>
     </changeSet>
-    <changeSet id="add_path_constraint_to_apptool" author="natalieperez">
+    <changeSet id="add_constraints_triggers_for_apptools" author="natalieperez">
         <sql dbms="postgresql">
             CREATE UNIQUE INDEX if not exists full_apptool_name ON apptool USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
             CREATE UNIQUE INDEX if not exists partial_apptool_name ON apptool USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
         </sql>
-    </changeSet>
-    <changeSet author="natalieperez (generated)" id="1641836305491-1">
         <createTable tableName="fullworkflowpath">
             <column autoIncrement="true" name="id" type="BIGINT">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="fullworkflowpath_pkey"/>
@@ -270,13 +268,10 @@
             </column>
             <column name="workflowname" type="TEXT"/>
         </createTable>
-    </changeSet>
-    <changeSet id="add_constraint_on_masterlist" author="natalieperez">
         <sql dbms="postgresql">
             CREATE UNIQUE INDEX full_workflow_name_masterlist ON fullworkflowpath USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
             CREATE UNIQUE INDEX partial_workflow_name_masterlist ON fullworkflowpath USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
-        </sql>
-        <sql dbms="postgresql">
+
             CREATE OR REPLACE FUNCTION workflow_path_insert_trigger_fnc()
             RETURNS trigger AS
             '
@@ -299,6 +294,29 @@
             ON apptool
             FOR EACH ROW
             EXECUTE PROCEDURE workflow_path_insert_trigger_fnc();
+
+            CREATE OR REPLACE FUNCTION workflow_path_deletion_trigger_fnc()
+            RETURNS trigger AS
+            '
+            BEGIN
+            DELETE FROM fullworkflowpath
+            WHERE OLD.id = fullworkflowpath.id;
+            RETURN NEW;
+            END;
+            '
+            LANGUAGE 'plpgsql';
+
+            CREATE TRIGGER workflow_path_deletion_trigger
+            AFTER DELETE
+            ON workflow
+            FOR EACH ROW
+            EXECUTE PROCEDURE workflow_path_deletion_trigger_fnc();
+
+            CREATE TRIGGER apptool_path_deletion_trigger
+            AFTER DELETE
+            ON apptool
+            FOR EACH ROW
+            EXECUTE PROCEDURE workflow_path_deletion_trigger_fnc();
         </sql>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**Description**
Don't allow there to be duplicate paths between apptools and workflows. This PR creates a master list of all workflow/apptool paths in a new table called `fullworkflowpath` and there is a new trigger that will insert a new row into this table every time a row is inserted into the either the `workflow` or `apptool` tables. Will do something similar to deletions as well

Also fixes the original constraint on apptools because that's been wrong this whole time.

Will wait for some feedback before merging the following to fix the broken webhookIT test
Changing test repo: 
https://github.com/DockstoreTestUser2/test-workflows-and-tools/pull/1
https://github.com/DockstoreTestUser2/test-workflows-and-tools/pull/2
https://github.com/DockstoreTestUser2/test-workflows-and-tools/pull/3
New branch https://github.com/DockstoreTestUser2/test-workflows-and-tools/tree/duplicate-paths

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-3734

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ ] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
