### PR TITLE
Create validate_openapi.yaml

### DIFF
--- a/.github/workflows/validate_openapi.yaml
+++ b/.github/workflows/validate_openapi.yaml
@@ -1,0 +1,15 @@
+on: [push]
+
+
+jobs:
+  test_swagger_editor_validator_remote:
+    runs-on: ubuntu-latest
+    name: Swagger Editor Validator Remote
+
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Validate OpenAPI definition
+        uses: char0n/swagger-editor-validate@v1.2.1
+        with:
+          definition-file: dockstore-webservice/src/main/resources/openapi3/openapi.yaml

--- a/dockstore-webservice/src/main/resources/openapi-templates/api.mustache
+++ b/dockstore-webservice/src/main/resources/openapi-templates/api.mustache
@@ -66,7 +66,7 @@ import javax.validation.constraints.*;
 {{>generatedAnnotation}}
 {{#operations}}
 @SecuritySchemes({ @SecurityScheme(type = SecuritySchemeType.HTTP, name = "BEARER", scheme = "bearer") })
-  public class {{classname}}  {
+public class {{classname}}  {
    private final {{classname}}Service delegate;
 
    public {{classname}}(@Context ServletConfig servletContext) {

--- a/dockstore-webservice/src/main/resources/openapi-templates/api.mustache
+++ b/dockstore-webservice/src/main/resources/openapi-templates/api.mustache
@@ -21,6 +21,9 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.security.SecuritySchemes;
 import io.swagger.v3.oas.annotations.tags.Tag;
 {{/useOas2}}
 
@@ -62,7 +65,8 @@ import javax.validation.constraints.*;
 @Tag(name = "GA4GHV20", description = ResourceConstants.GA4GHV20)
 {{>generatedAnnotation}}
 {{#operations}}
-public class {{classname}}  {
+@SecuritySchemes({ @SecurityScheme(type = SecuritySchemeType.HTTP, name = "BEARER", scheme = "bearer") })
+  public class {{classname}}  {
    private final {{classname}}Service delegate;
 
    public {{classname}}(@Context ServletConfig servletContext) {

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -9623,6 +9623,9 @@ components:
         tagName:
           type: string
   securitySchemes:
+    BEARER:
+      scheme: bearer
+      type: http
     bearer:
       scheme: bearer
       type: http

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -8795,8 +8795,8 @@ definitions:
       sourceControl:
         type: "string"
         position: 17
-        description: "This is a specific source control provider like github or bitbucket\
-          \ or n/a?, required: GA4GH"
+        description: "This is a specific source control provider like github, bitbucket,\
+          \ gitlab, etc."
       descriptorType:
         type: "string"
         position: 18


### PR DESCRIPTION
**Description**
Curious about  https://swagger.io/blog/api-design/validate-openapi-definitions-swagger-editor/ 
Came up as a result of a GA4GH discussion on standard API building blocks
Fixed a validation error which I guess can't hurt

**Issue**
Based on https://github.com/ga4gh/tool-registry-service-schemas/pull/212

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
