### PR TITLE
Handle checksums for null content

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -20,6 +20,7 @@ import static io.dockstore.common.DescriptorLanguage.CWL;
 import static io.openapi.api.impl.ToolsApiServiceImpl.DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
@@ -1326,6 +1327,17 @@ public class WorkflowIT extends BaseIT {
         // Test TRS conversion
         io.dockstore.openapi.client.model.FileWrapper fileWrapper = ga4Ghv20Api.toolsIdVersionsVersionIdTypeDescriptorGet(DescriptorLanguage.CWL.toString(), "#workflow/github.com/dockstore-testing/hello_world", "1.0.1");
         verifyTRSSourcefileConversion(fileWrapper);
+
+        testingPostgres.runUpdateStatement("update sourcefile set content = null");
+        // Make sure the above worked
+        final Long nullContentCount = testingPostgres.runSelectStatement(
+            "select count(*) from sourcefile where content is null", Long.class);
+        assertNotEquals(0, nullContentCount.longValue());
+
+        // Test that null content has a checksum
+        final Long nullSha256Count = testingPostgres.runSelectStatement(
+            "select count(*) from sourcefile where sha256 is null", Long.class);
+        assertEquals(0, nullSha256Count.longValue());
 
     }
 

--- a/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.12.0.xml
@@ -375,4 +375,16 @@
             update workflowversion set tooltablejson = null where workflowpath like '%.cwl';
         </sql>
     </changeSet>
+    <changeSet id="checksumsForNullContent" author="coverbeck">
+        <sql dbms="postgresql">
+            alter table sourcefile disable row level security;
+        </sql>
+        <dropColumn tableName="sourcefile" columnName="sha256"></dropColumn>
+        <sql dbms="postgresql">
+            alter table sourcefile add column sha256 text generated always as (digest(coalesce(content, ''), 'sha256')) stored;
+        </sql>
+        <sql dbms="postgresql">
+            alter table sourcefile enable row level security;
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
#3826

The PG digest function returns null for null content. Use
coalesce to treat nulls as empty strings. See
https://github.com/dockstore/dockstore/issues/3826#issuecomment-926675030

**Description**
A description of the PR, should include a decent explanation as to why this change was needed and a decent explanation as to what this change does

**Issue**
A link to a github issue or SEAB- ticket (using that as a prefix)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
