### PR TITLE
Fix regression tests on release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ workflows:
                 - /^release.*$/
           requires:
             - build
+          context: sonarcloud
 jobs:
   regression-integration-tests:
     executor: machine_integration_test_exec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,33 +50,33 @@ workflows:
     jobs:
       - build:
           <<: *common_filters
-#      - unit_test:
-#          <<: *common_filters
-#          requires:
-#            - build
-#          context:
-#            - sonarcloud
-#            - aws
-#      - workflow-integration-tests:
-#          <<: *common_filters
-#          requires:
-#            - build
-#          context: sonarcloud
-#      - language-parsing-tests:
-#          <<: *common_filters
-#          requires:
-#            - build
-#          context: sonarcloud
-#      - tool-integration-tests:
-#          <<: *common_filters
-#          requires:
-#            - build
-#          context: sonarcloud
-#      - integration-tests:
-#          <<: *common_filters
-#          requires:
-#            - build
-#          context: sonarcloud
+      - unit_test:
+          <<: *common_filters
+          requires:
+            - build
+          context:
+            - sonarcloud
+            - aws
+      - workflow-integration-tests:
+          <<: *common_filters
+          requires:
+            - build
+          context: sonarcloud
+      - language-parsing-tests:
+          <<: *common_filters
+          requires:
+            - build
+          context: sonarcloud
+      - tool-integration-tests:
+          <<: *common_filters
+          requires:
+            - build
+          context: sonarcloud
+      - integration-tests:
+          <<: *common_filters
+          requires:
+            - build
+          context: sonarcloud
       - regression-integration-tests:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,10 @@ jobs:
       - setup_machine
       - setup_test
       - setup_postgres_docker
+      - install-pip
+      - run:
+          name: install pip dependencies
+          command: scripts/install-tests.sh
       - setup_integration_test
       - save_test_results
   integration-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,33 +50,33 @@ workflows:
     jobs:
       - build:
           <<: *common_filters
-      - unit_test:
-          <<: *common_filters
-          requires:
-            - build
-          context:
-            - sonarcloud
-            - aws
-      - workflow-integration-tests:
-          <<: *common_filters
-          requires:
-            - build
-          context: sonarcloud
-      - language-parsing-tests:
-          <<: *common_filters
-          requires:
-            - build
-          context: sonarcloud
-      - tool-integration-tests:
-          <<: *common_filters
-          requires:
-            - build
-          context: sonarcloud
-      - integration-tests:
-          <<: *common_filters
-          requires:
-            - build
-          context: sonarcloud
+#      - unit_test:
+#          <<: *common_filters
+#          requires:
+#            - build
+#          context:
+#            - sonarcloud
+#            - aws
+#      - workflow-integration-tests:
+#          <<: *common_filters
+#          requires:
+#            - build
+#          context: sonarcloud
+#      - language-parsing-tests:
+#          <<: *common_filters
+#          requires:
+#            - build
+#          context: sonarcloud
+#      - tool-integration-tests:
+#          <<: *common_filters
+#          requires:
+#            - build
+#          context: sonarcloud
+#      - integration-tests:
+#          <<: *common_filters
+#          requires:
+#            - build
+#          context: sonarcloud
       - regression-integration-tests:
           filters:
             branches:

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ClientRegressionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ClientRegressionIT.java
@@ -89,14 +89,14 @@ public class ClientRegressionIT extends BaseIT {
 
     @Test
     public void testListEntriesOld() throws IOException, ApiException {
-        String[] commandArray = new String[] { "--config", TestUtility.getConfigFileLocation(true), "tool", "list" };
+        String[] commandArray = new String[] { "--config", TestUtility.getConfigFileLocation(true), "tool", "list", "--script" };
         ImmutablePair<String, String> stringStringImmutablePair = runOldDockstoreClient(dockstore, commandArray);
         checkToolList(stringStringImmutablePair.getLeft());
     }
 
     @Test
     public void testDebugModeListEntriesOld() throws IOException, ApiException {
-        String[] commandArray = new String[] { "--debug", "--config", TestUtility.getConfigFileLocation(true), "tool", "list" };
+        String[] commandArray = new String[] { "--debug", "--config", TestUtility.getConfigFileLocation(true), "tool", "list", "--script" };
         ImmutablePair<String, String> stringStringImmutablePair = runOldDockstoreClient(dockstore, commandArray);
         checkToolList(stringStringImmutablePair.getLeft());
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -351,7 +351,7 @@ public final class CommonTestUtilities {
     public static void checkToolList(String log) {
         Assert.assertTrue(log.contains("NAME"));
         Assert.assertTrue(log.contains("DESCRIPTION"));
-        Assert.assertTrue(log.contains("Git Repo"));
+        Assert.assertTrue(log.toLowerCase().contains("git repo"));
     }
 
     public static void restartElasticsearch() throws Exception {


### PR DESCRIPTION
**Description**
I don't think regression tests have ever worked on CircleCI. I'm a little confused at the history, but there are no release/1.10 nor release 1.11 builds in CircleCI. In any case, the 3 fixes:

1. Install pip dependencies so tests running CWL tool will pass
2. Add the `--script` option to tests that were failing; without it, the command would fail saying a newer version is available.
3. We changed "Git Repo" to "GIT REPO" in the newer web service, so do a case-insensitive compare.

**Issue**
None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
