### PR TITLE
Feature/4673 maybe/wrong index

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -108,7 +108,7 @@ public class ElasticListener implements StateListenerInterface {
         }
         try {
             RestHighLevelClient client = ElasticSearchHelper.restHighLevelClient();
-            String entryType = entry instanceof Tool ? TOOLS_INDEX : WORKFLOWS_INDEX;
+            String entryType = entry instanceof Tool || entry instanceof AppTool ? TOOLS_INDEX : WORKFLOWS_INDEX;
             DocWriteResponse post;
             switch (command) {
             case PUBLISH:


### PR DESCRIPTION
**Description**
I'm not entirely sure what was happening when the original issue was created. At the time, sometimes kathy's tool would load and other times it wouldn't when clicking on it from the ES search results. I couldn't reproduce this locally but the issue was still appearing in dev (loading a blank page). I asked Kathy if the tool was still published in dev, but it wasn't. Once it was republished, it seemed to be accessible. I did notice though that the index was not being updated correctly when github apptools were published/unpublished.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2038

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ ] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
