### PR TITLE
Update trs limit

### DIFF
--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -106,12 +106,12 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient-osgi</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpcore-osgi</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -140,20 +140,20 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.typelevel</groupId>
           <artifactId>cats-effect_2.12</artifactId>
+          <groupId>org.typelevel</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.typelevel</groupId>
           <artifactId>cats-core_2.12</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.typelevel</groupId>
-          <artifactId>alleycats-core_2.12</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>eu.timepit</groupId>
+          <artifactId>alleycats-core_2.12</artifactId>
+          <groupId>org.typelevel</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>refined_2.12</artifactId>
+          <groupId>eu.timepit</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -164,28 +164,28 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.typelevel</groupId>
           <artifactId>cats-effect_2.12</artifactId>
+          <groupId>org.typelevel</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.typelevel</groupId>
           <artifactId>cats-core_2.12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.typelevel</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>alleycats-core_2.12</artifactId>
+          <groupId>org.typelevel</groupId>
         </exclusion>
         <exclusion>
-          <groupId>eu.timepit</groupId>
           <artifactId>refined_2.12</artifactId>
+          <groupId>eu.timepit</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.commons</groupId>
           <artifactId>commons-text</artifactId>
+          <groupId>org.apache.commons</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -196,28 +196,28 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.typelevel</groupId>
           <artifactId>cats-effect_2.12</artifactId>
+          <groupId>org.typelevel</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.typelevel</groupId>
           <artifactId>cats-core_2.12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.typelevel</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>alleycats-core_2.12</artifactId>
+          <groupId>org.typelevel</groupId>
         </exclusion>
         <exclusion>
-          <groupId>eu.timepit</groupId>
           <artifactId>refined_2.12</artifactId>
+          <groupId>eu.timepit</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.commons</groupId>
           <artifactId>commons-text</artifactId>
+          <groupId>org.apache.commons</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -228,8 +228,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.typelevel</groupId>
           <artifactId>cats-effect_2.12</artifactId>
+          <groupId>org.typelevel</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -246,32 +246,32 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
         </exclusion>
         <exclusion>
-          <groupId>eu.timepit</groupId>
           <artifactId>refined_2.12</artifactId>
+          <groupId>eu.timepit</groupId>
         </exclusion>
         <exclusion>
-          <groupId>io.circe</groupId>
           <artifactId>circe-core_2.12</artifactId>
+          <groupId>io.circe</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.typelevel</groupId>
           <artifactId>cats-core_2.12</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.typelevel</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>alleycats-core_2.12</artifactId>
+          <groupId>org.typelevel</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.google.cloud</groupId>
           <artifactId>google-cloud-resourcemanager</artifactId>
+          <groupId>com.google.cloud</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.google.cloud</groupId>
           <artifactId>google-cloud-monitoring</artifactId>
+          <groupId>com.google.cloud</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -282,8 +282,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>eu.timepit</groupId>
           <artifactId>refined_2.12</artifactId>
+          <groupId>eu.timepit</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -294,8 +294,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>eu.timepit</groupId>
           <artifactId>refined_2.12</artifactId>
+          <groupId>eu.timepit</groupId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -64,8 +64,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.liquibase</groupId>
           <artifactId>liquibase-core</artifactId>
+          <groupId>org.liquibase</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -76,8 +76,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.liquibase</groupId>
           <artifactId>liquibase-core</artifactId>
+          <groupId>org.liquibase</groupId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -16,14 +16,16 @@
 
 package io.dockstore.client.cli;
 
-import static io.dockstore.webservice.core.Version.CANNOT_FREEZE_VERSIONS_WITH_NO_FILES;
-import static io.dockstore.webservice.helpers.EntryVersionHelper.CANNOT_MODIFY_FROZEN_VERSIONS_THIS_WAY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import javax.ws.rs.core.Response;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,15 +57,6 @@ import io.swagger.client.model.PublishRequest;
 import io.swagger.client.model.SourceFile;
 import io.swagger.client.model.Tag;
 import io.swagger.client.model.Workflow;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.SortedSet;
-import java.util.TreeSet;
-import javax.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -81,6 +74,15 @@ import org.kohsuke.github.AbuseLimitHandler;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.RateLimitHandler;
+
+import static io.dockstore.webservice.core.Version.CANNOT_FREEZE_VERSIONS_WITH_NO_FILES;
+import static io.dockstore.webservice.helpers.EntryVersionHelper.CANNOT_MODIFY_FROZEN_VERSIONS_THIS_WAY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Extra confidential integration tests, don't rely on the type of repository used (Github, Dockerhub, Quay.io, Bitbucket)

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -15,12 +15,14 @@
  */
 package io.dockstore.webservice;
 
-import java.util.List;
-import java.util.Map;
-
-import javax.ws.rs.client.Client;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
+import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
+import static junit.framework.TestCase.assertNotSame;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import io.dockstore.client.cli.BaseIT;
 import io.dockstore.client.cli.BasicIT;
@@ -47,6 +49,11 @@ import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.StarRequest;
 import io.swagger.client.model.Tool;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -54,6 +61,7 @@ import org.hibernate.Transaction;
 import org.hibernate.context.internal.ManagedSessionContext;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
@@ -61,15 +69,6 @@ import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
-
-import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
-import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
-import static junit.framework.TestCase.assertNotSame;
-import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * @author dyuen
@@ -134,6 +133,7 @@ public class ServiceIT extends BaseIT {
     }
 
     @Test
+    @Ignore("https://github.com/dockstore/dockstore/pull/4720")
     public void testTRSOutputOfService() {
         new CreateContent().invoke();
         final ApiClient webClient = getWebClient(true, false);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -15,14 +15,12 @@
  */
 package io.dockstore.webservice;
 
-import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
-import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
-import static junit.framework.TestCase.assertNotSame;
-import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
 
 import io.dockstore.client.cli.BaseIT;
 import io.dockstore.client.cli.BasicIT;
@@ -49,11 +47,6 @@ import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.StarRequest;
 import io.swagger.client.model.Tool;
-import java.util.List;
-import java.util.Map;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -69,6 +62,15 @@ import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
+import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
+import static junit.framework.TestCase.assertNotSame;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author dyuen

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -118,68 +118,68 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>
+          <groupId>com.google.code.findbugs</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson.jaxrs</groupId>
           <artifactId>jackson-jaxrs-json-provider</artifactId>
+          <groupId>com.fasterxml.jackson.jaxrs</groupId>
         </exclusion>
         <exclusion>
-          <groupId>joda-time</groupId>
           <artifactId>joda-time</artifactId>
+          <groupId>joda-time</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson.datatype</groupId>
           <artifactId>jackson-datatype-joda</artifactId>
+          <groupId>com.fasterxml.jackson.datatype</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson.module</groupId>
           <artifactId>jackson-module-jaxb-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.module</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.scala-lang</groupId>
           <artifactId>scala-library</artifactId>
+          <groupId>org.scala-lang</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.commons</groupId>
           <artifactId>commons-lang3</artifactId>
+          <groupId>org.apache.commons</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>jackson-core</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson.dataformat</groupId>
           <artifactId>jackson-dataformat-yaml</artifactId>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.glassfish.jersey.containers</groupId>
           <artifactId>jersey-container-servlet-core</artifactId>
+          <groupId>org.glassfish.jersey.containers</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.glassfish.jersey.core</groupId>
           <artifactId>jersey-common</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.glassfish.jersey.core</groupId>
-          <artifactId>jersey-server</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.glassfish.hk2.external</groupId>
+          <artifactId>jersey-server</artifactId>
+          <groupId>org.glassfish.jersey.core</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>javax.inject</artifactId>
+          <groupId>org.glassfish.hk2.external</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -196,72 +196,72 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>javax.ws.rs</groupId>
           <artifactId>jsr311-api</artifactId>
+          <groupId>javax.ws.rs</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>
+          <groupId>com.google.code.findbugs</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson.jaxrs</groupId>
           <artifactId>jackson-jaxrs-json-provider</artifactId>
+          <groupId>com.fasterxml.jackson.jaxrs</groupId>
         </exclusion>
         <exclusion>
-          <groupId>joda-time</groupId>
           <artifactId>joda-time</artifactId>
+          <groupId>joda-time</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson.datatype</groupId>
           <artifactId>jackson-datatype-joda</artifactId>
+          <groupId>com.fasterxml.jackson.datatype</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson.module</groupId>
           <artifactId>jackson-module-jaxb-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.module</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.scala-lang</groupId>
           <artifactId>scala-library</artifactId>
+          <groupId>org.scala-lang</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.commons</groupId>
           <artifactId>commons-lang3</artifactId>
+          <groupId>org.apache.commons</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>jackson-core</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson.dataformat</groupId>
           <artifactId>jackson-dataformat-yaml</artifactId>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.glassfish.jersey.containers</groupId>
           <artifactId>jersey-container-servlet-core</artifactId>
+          <groupId>org.glassfish.jersey.containers</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.glassfish.jersey.core</groupId>
           <artifactId>jersey-common</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.glassfish.jersey.core</groupId>
-          <artifactId>jersey-server</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.glassfish.hk2.external</groupId>
+          <artifactId>jersey-server</artifactId>
+          <groupId>org.glassfish.jersey.core</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>javax.inject</artifactId>
+          <groupId>org.glassfish.hk2.external</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -296,20 +296,20 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>ch.qos.logback</groupId>
           <artifactId>logback-classic</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>ch.qos.logback</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>logback-core</artifactId>
+          <groupId>ch.qos.logback</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.commons</groupId>
           <artifactId>commons-text</artifactId>
+          <groupId>org.apache.commons</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -320,20 +320,20 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.javassist</groupId>
           <artifactId>javassist</artifactId>
+          <groupId>org.javassist</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.hibernate</groupId>
           <artifactId>hibernate-core</artifactId>
+          <groupId>org.hibernate</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.h2database</groupId>
           <artifactId>h2</artifactId>
+          <groupId>com.h2database</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.poi</groupId>
           <artifactId>poi</artifactId>
+          <groupId>org.apache.poi</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -350,8 +350,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.javassist</groupId>
           <artifactId>javassist</artifactId>
+          <groupId>org.javassist</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -362,8 +362,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.javassist</groupId>
           <artifactId>javassist</artifactId>
+          <groupId>org.javassist</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -404,8 +404,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.javassist</groupId>
           <artifactId>javassist</artifactId>
+          <groupId>org.javassist</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -512,8 +512,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>ch.qos.logback</groupId>
           <artifactId>logback-classic</artifactId>
+          <groupId>ch.qos.logback</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -548,8 +548,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
+          <groupId>commons-codec</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -560,8 +560,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>javax.xml.bind</groupId>
           <artifactId>jaxb-api</artifactId>
+          <groupId>javax.xml.bind</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -572,8 +572,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>javax.xml.bind</groupId>
           <artifactId>jaxb-api</artifactId>
+          <groupId>javax.xml.bind</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -596,8 +596,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.squareup.okhttp3</groupId>
           <artifactId>okhttp-urlconnection</artifactId>
+          <groupId>com.squareup.okhttp3</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -614,8 +614,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -632,8 +632,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -650,8 +650,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -668,12 +668,12 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient-osgi</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpcore-osgi</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -684,8 +684,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -714,8 +714,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpcore-osgi</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -726,104 +726,104 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.tdunning</groupId>
           <artifactId>t-digest</artifactId>
+          <groupId>com.tdunning</groupId>
         </exclusion>
         <exclusion>
-          <groupId>joda-time</groupId>
           <artifactId>joda-time</artifactId>
+          <groupId>joda-time</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-core</artifactId>
+          <groupId>org.apache.logging.log4j</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-analyzers-common</artifactId>
+          <groupId>org.apache.lucene</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-backward-codecs</artifactId>
+          <groupId>org.apache.lucene</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-grouping</artifactId>
+          <groupId>org.apache.lucene</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-highlighter</artifactId>
+          <groupId>org.apache.lucene</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-join</artifactId>
+          <groupId>org.apache.lucene</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-memory</artifactId>
+          <groupId>org.apache.lucene</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-misc</artifactId>
+          <groupId>org.apache.lucene</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-queries</artifactId>
+          <groupId>org.apache.lucene</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-queryparser</artifactId>
+          <groupId>org.apache.lucene</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-sandbox</artifactId>
+          <groupId>org.apache.lucene</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-spatial-extras</artifactId>
+          <groupId>org.apache.lucene</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-spatial3d</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.apache.lucene</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>lucene-suggest</artifactId>
+          <groupId>org.apache.lucene</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.elasticsearch</groupId>
           <artifactId>elasticsearch-core</artifactId>
+          <groupId>org.elasticsearch</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.elasticsearch</groupId>
           <artifactId>elasticsearch-secure-sm</artifactId>
+          <groupId>org.elasticsearch</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.elasticsearch</groupId>
           <artifactId>elasticsearch-x-content</artifactId>
+          <groupId>org.elasticsearch</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.elasticsearch</groupId>
           <artifactId>elasticsearch-geo</artifactId>
+          <groupId>org.elasticsearch</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.elasticsearch</groupId>
           <artifactId>elasticsearch-cli</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.elasticsearch</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>jna</artifactId>
+          <groupId>org.elasticsearch</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.hdrhistogram</groupId>
           <artifactId>HdrHistogram</artifactId>
+          <groupId>org.hdrhistogram</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.locationtech.jts</groupId>
           <artifactId>jts-core</artifactId>
+          <groupId>org.locationtech.jts</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.locationtech.spatial4j</groupId>
           <artifactId>spatial4j</artifactId>
+          <groupId>org.locationtech.spatial4j</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -834,16 +834,16 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
+          <groupId>commons-codec</groupId>
         </exclusion>
         <exclusion>
-          <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
+          <groupId>commons-logging</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -854,20 +854,20 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.elasticsearch.client</groupId>
           <artifactId>elasticsearch-rest-client</artifactId>
+          <groupId>org.elasticsearch.client</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.elasticsearch.plugin</groupId>
           <artifactId>mapper-extras-client</artifactId>
+          <groupId>org.elasticsearch.plugin</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.elasticsearch.plugin</groupId>
           <artifactId>parent-join-client</artifactId>
+          <groupId>org.elasticsearch.plugin</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.elasticsearch.plugin</groupId>
           <artifactId>aggs-matrix-stats-client</artifactId>
+          <groupId>org.elasticsearch.plugin</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -878,28 +878,28 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-core</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson.dataformat</groupId>
           <artifactId>jackson-dataformat-smile</artifactId>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson.dataformat</groupId>
           <artifactId>jackson-dataformat-yaml</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.fasterxml.jackson.dataformat</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>jackson-dataformat-cbor</artifactId>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.elasticsearch</groupId>
           <artifactId>elasticsearch-core</artifactId>
+          <groupId>org.elasticsearch</groupId>
         </exclusion>
         <exclusion>
-          <groupId>org.yaml</groupId>
           <artifactId>snakeyaml</artifactId>
+          <groupId>org.yaml</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -916,8 +916,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+          <groupId>com.google.guava</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1000,24 +1000,24 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.commons</groupId>
           <artifactId>commons-lang3</artifactId>
+          <groupId>org.apache.commons</groupId>
         </exclusion>
         <exclusion>
-          <groupId>commons-lang</groupId>
           <artifactId>commons-lang</artifactId>
+          <groupId>commons-lang</groupId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson.jaxrs</groupId>
           <artifactId>jackson-jaxrs-json-provider</artifactId>
+          <groupId>com.fasterxml.jackson.jaxrs</groupId>
         </exclusion>
         <exclusion>
-          <groupId>io.swagger</groupId>
           <artifactId>swagger-jersey-jaxrs</artifactId>
+          <groupId>io.swagger</groupId>
         </exclusion>
         <exclusion>
-          <groupId>commons-io</groupId>
           <artifactId>commons-io</artifactId>
+          <groupId>commons-io</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1052,8 +1052,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>javax.xml.bind</groupId>
           <artifactId>jaxb-api</artifactId>
+          <groupId>javax.xml.bind</groupId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -75,6 +75,7 @@ import io.dockstore.webservice.helpers.PersistenceExceptionMapper;
 import io.dockstore.webservice.helpers.PublicStateManager;
 import io.dockstore.webservice.helpers.TransactionExceptionMapper;
 import io.dockstore.webservice.helpers.statelisteners.TRSListener;
+import io.dockstore.webservice.jdbi.BioWorkflowDAO;
 import io.dockstore.webservice.jdbi.DeletedUsernameDAO;
 import io.dockstore.webservice.jdbi.EventDAO;
 import io.dockstore.webservice.jdbi.FileDAO;
@@ -335,6 +336,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         final TagDAO tagDAO = new TagDAO(hibernate.getSessionFactory());
         final EventDAO eventDAO = new EventDAO(hibernate.getSessionFactory());
         final VersionDAO versionDAO = new VersionDAO(hibernate.getSessionFactory());
+        final BioWorkflowDAO bioWorkflowDAO = new BioWorkflowDAO(hibernate.getSessionFactory());
 
         LOG.info("Cache directory for OkHttp is: " + cache.directory().getAbsolutePath());
         LOG.info("This is our custom logger saying that we're about to load authenticators");
@@ -395,6 +397,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         // attach the container dao statically to avoid too much modification of generated code
         ToolsApiServiceImpl.setToolDAO(toolDAO);
         ToolsApiServiceImpl.setWorkflowDAO(workflowDAO);
+        ToolsApiServiceImpl.setBioWorkflowDAO(bioWorkflowDAO);
         ToolsApiServiceImpl.setFileDAO(fileDAO);
         ToolsApiServiceImpl.setConfig(configuration);
         ToolsApiServiceImpl.setTrsListener(trsListener);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -93,7 +93,7 @@ import org.hibernate.annotations.Check;
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.findByUserRegistryNamespace", query = "SELECT t from Tool t WHERE t.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId) AND t.registry = :registry AND t.namespace = :namespace"),
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.findByUserRegistryNamespaceRepository", query = "SELECT t from Tool t WHERE t.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId) AND t.registry = :registry AND t.namespace = :namespace AND t.name = :repository"),
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.getEntriesByUserId", query = "SELECT t FROM Tool t WHERE t.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)"),
-        @NamedQuery(name = "io.dockstore.webservice.core.Tool.getPublishedNamespaces", query = "SELECT lower(namespace) FROM Tool c WHERE c.isPublished = true"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Tool.getPublishedNamespaces", query = "SELECT distinct lower(namespace) FROM Tool c WHERE c.isPublished = true"),
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.getPublishedEntriesByUserId", query = "SELECT t FROM Tool t WHERE t.isPublished = true AND t.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)")
 })
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -93,6 +93,7 @@ import org.hibernate.annotations.Check;
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.findByUserRegistryNamespace", query = "SELECT t from Tool t WHERE t.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId) AND t.registry = :registry AND t.namespace = :namespace"),
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.findByUserRegistryNamespaceRepository", query = "SELECT t from Tool t WHERE t.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId) AND t.registry = :registry AND t.namespace = :namespace AND t.name = :repository"),
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.getEntriesByUserId", query = "SELECT t FROM Tool t WHERE t.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Tool.getPublishedNamespaces", query = "SELECT lower(namespace) FROM Tool c WHERE c.isPublished = true"),
         @NamedQuery(name = "io.dockstore.webservice.core.Tool.getPublishedEntriesByUserId", query = "SELECT t FROM Tool t WHERE t.isPublished = true AND t.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)")
 })
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -83,7 +83,8 @@ import org.hibernate.annotations.Check;
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findByOrganizationWithoutUser", query = "SELECT c FROM Workflow c WHERE lower(c.organization) = lower(:organization) AND c.sourceControl = :sourceControl AND :user not in elements(c.users)"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findWorkflowByWorkflowVersionId", query = "SELECT c FROM Workflow c, Version v WHERE v.id = :workflowVersionId AND c.id = v.parent"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.getEntriesByUserId", query = "SELECT w FROM Workflow w WHERE w.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)"),
-        @NamedQuery(name = "io.dockstore.webservice.core.Workflow.getPublishedEntriesByUserId", query = "SELECT w FROM Workflow w WHERE w.isPublished = true AND w.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)")
+        @NamedQuery(name = "io.dockstore.webservice.core.Workflow.getPublishedOrganizations", query = "SELECT lower(organization) FROM Workflow w WHERE w.isPublished = true"),
+    @NamedQuery(name = "io.dockstore.webservice.core.Workflow.getPublishedEntriesByUserId", query = "SELECT w FROM Workflow w WHERE w.isPublished = true AND w.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)")
 })
 
 @Check(constraints = " ((ischecker IS TRUE) or (ischecker IS FALSE and workflowname NOT LIKE '\\_%'))")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -83,7 +83,7 @@ import org.hibernate.annotations.Check;
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findByOrganizationWithoutUser", query = "SELECT c FROM Workflow c WHERE lower(c.organization) = lower(:organization) AND c.sourceControl = :sourceControl AND :user not in elements(c.users)"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.findWorkflowByWorkflowVersionId", query = "SELECT c FROM Workflow c, Version v WHERE v.id = :workflowVersionId AND c.id = v.parent"),
         @NamedQuery(name = "io.dockstore.webservice.core.Workflow.getEntriesByUserId", query = "SELECT w FROM Workflow w WHERE w.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)"),
-        @NamedQuery(name = "io.dockstore.webservice.core.Workflow.getPublishedOrganizations", query = "SELECT lower(organization) FROM Workflow w WHERE w.isPublished = true"),
+        @NamedQuery(name = "io.dockstore.webservice.core.Workflow.getPublishedOrganizations", query = "SELECT distinct lower(organization) FROM Workflow w WHERE w.isPublished = true"),
     @NamedQuery(name = "io.dockstore.webservice.core.Workflow.getPublishedEntriesByUserId", query = "SELECT w FROM Workflow w WHERE w.isPublished = true AND w.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)")
 })
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -16,11 +16,23 @@
 
 package io.dockstore.webservice.helpers;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
-import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATHS;
-import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
-import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -51,23 +63,6 @@ import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowMode;
 import io.dockstore.webservice.core.WorkflowVersion;
 import io.dockstore.webservice.jdbi.TokenDAO;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import okhttp3.OkHttpClient;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -94,6 +89,12 @@ import org.kohsuke.github.extras.ImpatientHttpConnector;
 import org.kohsuke.github.extras.okhttp3.ObsoleteUrlFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATHS;
+import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
+import static io.dockstore.webservice.Constants.SKIP_COMMIT_ID;
 
 /**
  * @author dyuen

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/BioWorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/BioWorkflowDAO.java
@@ -16,13 +16,16 @@
 package io.dockstore.webservice.jdbi;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.SourceControlConverter;
 import io.dockstore.webservice.core.database.MyWorkflows;
 import io.dockstore.webservice.core.database.RSSWorkflowPath;
 import io.dockstore.webservice.core.database.WorkflowPath;
@@ -39,6 +42,36 @@ public class BioWorkflowDAO extends EntryDAO<BioWorkflow> {
         super(factory);
     }
 
+    @Override
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
+    protected Root<BioWorkflow> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker,
+        CriteriaBuilder cb, CriteriaQuery<?> q) {
+
+        final SourceControlConverter converter = new SourceControlConverter();
+        final Root<BioWorkflow> entryRoot = q.from(BioWorkflow.class);
+
+        Predicate predicate = cb.isTrue(entryRoot.get("isPublished"));
+        predicate = andLike(cb, predicate, entryRoot.get("organization"), Optional.ofNullable(organization));
+        predicate = andLike(cb, predicate, entryRoot.get("repository"), Optional.ofNullable(name));
+        predicate = andLike(cb, predicate, entryRoot.get("workflowName"), Optional.ofNullable(toolname));
+        predicate = andLike(cb, predicate, entryRoot.get("description"), Optional.ofNullable(description));
+        predicate = andLike(cb, predicate, entryRoot.get("author"), Optional.ofNullable(author));
+
+        if (descriptorLanguage != null) {
+            predicate = cb.and(predicate, cb.equal(entryRoot.get("descriptorType"), descriptorLanguage));
+        }
+        if (registry != null) {
+            predicate = cb.and(predicate, cb.equal(entryRoot.get("sourceControl"), converter.convertToEntityAttribute(registry)));
+        }
+
+        if (checker != null) {
+            predicate = cb.and(predicate, cb.isTrue(entryRoot.get("isChecker")));
+        }
+
+        q.where(predicate);
+        return entryRoot;
+    }
+
     public List<WorkflowPath> findAllPublishedPaths() {
         return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.BioWorkflow.findAllPublishedPaths"));
     }
@@ -50,12 +83,5 @@ public class BioWorkflowDAO extends EntryDAO<BioWorkflow> {
 
     public List<MyWorkflows> findUserBioWorkflows(long userId) {
         return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.BioWorkflow.findUserBioWorkflows").setParameter("userId", userId));
-    }
-
-    @Override
-    @SuppressWarnings({"checkstyle:ParameterNumber"})
-    protected Root<BioWorkflow> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker,
-        CriteriaBuilder cb, CriteriaQuery<?> q) {
-        throw new UnsupportedOperationException("only supported for tools and workflows directly for now");
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/BioWorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/BioWorkflowDAO.java
@@ -17,6 +17,11 @@ package io.dockstore.webservice.jdbi;
 
 import java.util.List;
 
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.database.MyWorkflows;
 import io.dockstore.webservice.core.database.RSSWorkflowPath;
@@ -45,5 +50,12 @@ public class BioWorkflowDAO extends EntryDAO<BioWorkflow> {
 
     public List<MyWorkflows> findUserBioWorkflows(long userId) {
         return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.BioWorkflow.findUserBioWorkflows").setParameter("userId", userId));
+    }
+
+    @Override
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
+    protected Root<BioWorkflow> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker,
+        CriteriaBuilder cb, CriteriaQuery<?> q) {
+        throw new UnsupportedOperationException("only supported for tools and workflows directly for now");
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -215,6 +215,7 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
         return typedQuery.getResultList();
     }
 
+    @Deprecated
     public List<T> findAllPublished() {
         return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core." + typeOfT.getSimpleName() + ".findAllPublished"));
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -225,6 +225,18 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
         return ((BigInteger)namedQuery("Entry.hostedWorkflowCount").setParameter("userid", userid).getSingleResult()).longValueExact();
     }
 
+    // TODO: these methods should be merged with the proprietary version in EntryDAO, but should be a major version refactoring.
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
+    public long countAllPublished(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker) {
+        final CriteriaBuilder cb = currentSession().getCriteriaBuilder();
+        final CriteriaQuery<Long> q = cb.createQuery(Long.class);
+
+        Root<T> entryRoot = generatePredicate(descriptorLanguage, registry, organization, name, toolname, description, author, checker, cb, q);
+
+        q.select(cb.count(entryRoot));
+        return currentSession().createQuery(q).getSingleResult();
+    }
+
     public long countAllPublished(Optional<String> filter) {
         if (filter.isEmpty()) {
             return countAllPublished();
@@ -239,18 +251,6 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
 
     private long countAllPublished() {
         return (long)this.currentSession().getNamedQuery("io.dockstore.webservice.core." + typeOfT.getSimpleName() + ".countAllPublished").getSingleResult();
-    }
-
-    // TODO: this should be merged with the proprietary version in EntryDAO, but should be a major version refactoring
-    @SuppressWarnings({"checkstyle:ParameterNumber"})
-    public long countAllPublished(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker) {
-        final CriteriaBuilder cb = currentSession().getCriteriaBuilder();
-        final CriteriaQuery<Long> q = cb.createQuery(Long.class);
-
-        Root<T> entryRoot = generatePredicate(descriptorLanguage, registry, organization, name, toolname, description, author, checker, cb, q);
-
-        q.select(cb.count(entryRoot));
-        return currentSession().createQuery(q).getSingleResult();
     }
 
     public List<Label> getLabelByEntryId(long entryId) {
@@ -316,7 +316,6 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
     private String wildcardLike(String value) {
         return '%' + value + '%';
     }
-
 
     @SuppressWarnings({"checkstyle:ParameterNumber"})
     public List<T> filterTrsToolsGet(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -34,6 +34,7 @@ import javax.persistence.criteria.Root;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
+import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.core.CollectionEntry;
 import io.dockstore.webservice.core.CollectionOrganization;
 import io.dockstore.webservice.core.Entry;
@@ -240,6 +241,18 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
         return (long)this.currentSession().getNamedQuery("io.dockstore.webservice.core." + typeOfT.getSimpleName() + ".countAllPublished").getSingleResult();
     }
 
+    // TODO: this should be merged with the proprietary version in EntryDAO, but should be a major version refactoring
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
+    public long countAllPublished(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker) {
+        final CriteriaBuilder cb = currentSession().getCriteriaBuilder();
+        final CriteriaQuery<Long> q = cb.createQuery(Long.class);
+
+        Root<T> entryRoot = generatePredicate(descriptorLanguage, registry, organization, name, toolname, description, author, checker, cb, q);
+
+        q.select(cb.count(entryRoot));
+        return currentSession().createQuery(q).getSingleResult();
+    }
+
     public List<Label> getLabelByEntryId(long entryId) {
         return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Entry.findLabelByEntryId").setParameter("entryId", entryId));
     }
@@ -294,4 +307,31 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
         }
         query.where(predicates.toArray(new Predicate[]{}));
     }
+
+    protected Predicate andLike(CriteriaBuilder cb, Predicate existingPredicate, Path<String> column, Optional<String> value) {
+        return value.map(val -> cb.and(existingPredicate, cb.like(column, wildcardLike(val))))
+            .orElse(existingPredicate);
+    }
+
+    private String wildcardLike(String value) {
+        return '%' + value + '%';
+    }
+
+
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
+    public List<T> filterTrsToolsGet(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname,
+        String description, String author, Boolean checker, int startIndex, int pageRemaining) {
+
+        final CriteriaBuilder cb = currentSession().getCriteriaBuilder();
+        final CriteriaQuery<T> q = cb.createQuery(typeOfT);
+        generatePredicate(descriptorLanguage, registry, organization, name, toolname, description, author, checker, cb, q);
+        TypedQuery<T> query = currentSession().createQuery(q);
+        query.setFirstResult(startIndex);
+        query.setMaxResults(pageRemaining);
+        return query.getResultList();
+    }
+
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
+    protected abstract Root<T> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker,
+        CriteriaBuilder cb, CriteriaQuery<?> q);
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ServiceDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ServiceDAO.java
@@ -18,6 +18,11 @@ package io.dockstore.webservice.jdbi;
 
 import java.util.List;
 
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.database.WorkflowPath;
 import org.hibernate.SessionFactory;
@@ -40,5 +45,12 @@ public class ServiceDAO extends EntryDAO<Service> {
 
     public List<WorkflowPath> findAllPublishedPaths() {
         return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Service.findAllPublishedPaths"));
+    }
+
+    @Override
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
+    protected Root<Service> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker,
+        CriteriaBuilder cb, CriteriaQuery<?> q) {
+        throw new UnsupportedOperationException("only supported for tools and workflows for now");
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ServiceDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ServiceDAO.java
@@ -43,14 +43,14 @@ public class ServiceDAO extends EntryDAO<Service> {
         return persist(file).getId();
     }
 
-    public List<WorkflowPath> findAllPublishedPaths() {
-        return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Service.findAllPublishedPaths"));
-    }
-
     @Override
     @SuppressWarnings({"checkstyle:ParameterNumber"})
-    protected Root<Service> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker,
-        CriteriaBuilder cb, CriteriaQuery<?> q) {
-        throw new UnsupportedOperationException("only supported for tools and workflows for now");
+    protected Root<Service> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author,
+        Boolean checker, CriteriaBuilder cb, CriteriaQuery<?> q) {
+        throw new UnsupportedOperationException("Only supported for BioWorkflow and Tools");
+    }
+
+    public List<WorkflowPath> findAllPublishedPaths() {
+        return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Service.findAllPublishedPaths"));
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ServiceEntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ServiceEntryDAO.java
@@ -34,8 +34,8 @@ public class ServiceEntryDAO extends EntryDAO<Service> {
 
     @Override
     @SuppressWarnings({"checkstyle:ParameterNumber"})
-    protected Root<Service> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker,
-        CriteriaBuilder cb, CriteriaQuery<?> q) {
-        throw new UnsupportedOperationException("only supported for tools and workflows for now");
+    protected Root<Service> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author,
+        Boolean checker, CriteriaBuilder cb, CriteriaQuery<?> q) {
+        throw new UnsupportedOperationException("Only supported for BioWorkflow and Tools");
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ServiceEntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ServiceEntryDAO.java
@@ -15,6 +15,11 @@
 
 package io.dockstore.webservice.jdbi;
 
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.core.Service;
 import org.hibernate.SessionFactory;
 
@@ -25,5 +30,12 @@ import org.hibernate.SessionFactory;
 public class ServiceEntryDAO extends EntryDAO<Service> {
     public ServiceEntryDAO(SessionFactory factory) {
         super(factory);
+    }
+
+    @Override
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
+    protected Root<Service> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker,
+        CriteriaBuilder cb, CriteriaQuery<?> q) {
+        throw new UnsupportedOperationException("only supported for tools and workflows for now");
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ToolDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ToolDAO.java
@@ -202,7 +202,7 @@ public class ToolDAO extends EntryDAO<Tool> {
     @SuppressWarnings({"checkstyle:ParameterNumber"})
     public List<Tool> filterTrsToolsGet(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname,
         String description, String author, Boolean checker, int startIndex, int pageRemaining) {
-        //TODO: probably a better way of doing this with the predicate builder
+        //TODO: probably a better way of doing this with the predicate builder, we can short circuit since tools are never checkers
         if (checker != null && checker) {
             return new ArrayList<>();
         }
@@ -213,7 +213,7 @@ public class ToolDAO extends EntryDAO<Tool> {
     @Override
     @SuppressWarnings({"checkstyle:ParameterNumber"})
     public long countAllPublished(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker) {
-        //TODO: probably a better way of doing this with the predicate builder
+        //TODO: probably a better way of doing this with the predicate builder, we can short circuit since tools are never checkers
         if (checker != null && checker) {
             return 0;
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ToolDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ToolDAO.java
@@ -51,6 +51,10 @@ public class ToolDAO extends EntryDAO<Tool> {
         return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Tool.findAllPublishedPathsOrderByDbupdatedate").setMaxResults(RSS_ENTRY_LIMIT));
     }
 
+    public List<String> getAllPublishedNamespaces() {
+        return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Tool.getPublishedNamespaces"));
+    }
+
     /**
      * Finds all tools with the given path (ignores tool name)
      * When findPublished is true, will only look at published tools

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ToolDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ToolDAO.java
@@ -189,7 +189,8 @@ public class ToolDAO extends EntryDAO<Tool> {
         predicate = andLike(cb, predicate, entryRoot.get("author"), Optional.ofNullable(author));
 
         if (descriptorLanguage != null) {
-            predicate = cb.and(predicate, cb.equal(entryRoot.get("descriptorType"), descriptorLanguage));
+            // not quite right, this probably doesn't deal with tools that have both but https://hibernate.atlassian.net/browse/HHH-9991 is kicking my butt
+            predicate = cb.and(predicate, cb.equal(entryRoot.get("descriptorType").as(String.class), descriptorLanguage.getShortName()));
         }
         predicate = andLike(cb, predicate, entryRoot.get("registry"), Optional.ofNullable(registry));
 
@@ -197,21 +198,22 @@ public class ToolDAO extends EntryDAO<Tool> {
         return entryRoot;
     }
 
-    //TODO there's probably a better way of doing these overrides when checker is not relevant for tools in generatePredicate
-
     @Override
     @SuppressWarnings({"checkstyle:ParameterNumber"})
     public List<Tool> filterTrsToolsGet(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname,
         String description, String author, Boolean checker, int startIndex, int pageRemaining) {
+        //TODO: probably a better way of doing this with the predicate builder
         if (checker != null && checker) {
             return new ArrayList<>();
         }
-        return super.filterTrsToolsGet(descriptorLanguage, registry, organization, name, toolname, description, author, checker, startIndex, pageRemaining);
+        return super.filterTrsToolsGet(descriptorLanguage, registry, organization, name, toolname,
+            description, author, checker, startIndex, pageRemaining);
     }
 
     @Override
     @SuppressWarnings({"checkstyle:ParameterNumber"})
     public long countAllPublished(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker) {
+        //TODO: probably a better way of doing this with the predicate builder
         if (checker != null && checker) {
             return 0;
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -55,6 +55,10 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
         super(factory);
     }
 
+    public List<String> getAllPublishedOrganizations() {
+        return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Workflow.getPublishedOrganizations"));
+    }
+
     /**
      * Finds all workflows with the given path (ignores workflow name)
      * When findPublished is true, will only look at published workflows
@@ -180,7 +184,7 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
 
     @SuppressWarnings({"checkstyle:ParameterNumber"})
     public List<Workflow> filterTrsToolsGet(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname,
-            String description, String author, Boolean checker) {
+        String description, String author, Boolean checker, int startIndex, int pageRemaining) {
 
         final SourceControlConverter converter = new SourceControlConverter();
         final CriteriaBuilder cb = currentSession().getCriteriaBuilder();
@@ -207,7 +211,8 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
 
         q.where(predicate);
         TypedQuery<Workflow> query = currentSession().createQuery(q);
-
+        query.setFirstResult(startIndex);
+        query.setMaxResults(pageRemaining);
         List<Workflow> workflows = query.getResultList();
         return workflows;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -53,6 +53,13 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
         super(factory);
     }
 
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
+    @Override
+    protected Root<Workflow> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author,
+        Boolean checker, CriteriaBuilder cb, CriteriaQuery<?> q) {
+        throw new UnsupportedOperationException("Only supported for BioWorkflow and Tools");
+    }
+
     public List<String> getAllPublishedOrganizations() {
         return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Workflow.getPublishedOrganizations"));
     }
@@ -178,35 +185,6 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
             throw new CustomWebApplicationException("Entries with the same path exist", HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
         return filteredWorkflows.size() == 1 ? Optional.of(filteredWorkflows.get(0)) : Optional.empty();
-    }
-
-    @SuppressWarnings({"checkstyle:ParameterNumber"})
-    protected Root<Workflow> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker,
-        CriteriaBuilder cb, CriteriaQuery<?> q) {
-
-        final SourceControlConverter converter = new SourceControlConverter();
-        final Root<Workflow> entryRoot = q.from(Workflow.class);
-
-        Predicate predicate = cb.isTrue(entryRoot.get("isPublished"));
-        predicate = andLike(cb, predicate, entryRoot.get("organization"), Optional.ofNullable(organization));
-        predicate = andLike(cb, predicate, entryRoot.get("repository"), Optional.ofNullable(name));
-        predicate = andLike(cb, predicate, entryRoot.get("workflowName"), Optional.ofNullable(toolname));
-        predicate = andLike(cb, predicate, entryRoot.get("description"), Optional.ofNullable(description));
-        predicate = andLike(cb, predicate, entryRoot.get("author"), Optional.ofNullable(author));
-
-        if (descriptorLanguage != null) {
-            predicate = cb.and(predicate, cb.equal(entryRoot.get("descriptorType"), descriptorLanguage));
-        }
-        if (registry != null) {
-            predicate = cb.and(predicate, cb.equal(entryRoot.get("sourceControl"), converter.convertToEntityAttribute(registry)));
-        }
-
-        if (checker != null) {
-            predicate = cb.and(predicate, cb.isTrue(entryRoot.get("isChecker")));
-        }
-
-        q.where(predicate);
-        return entryRoot;
     }
 
     public List<Workflow> findByPaths(List<String> paths, boolean findPublished) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -23,10 +23,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.persistence.NoResultException;
-import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
@@ -183,12 +181,10 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
     }
 
     @SuppressWarnings({"checkstyle:ParameterNumber"})
-    public List<Workflow> filterTrsToolsGet(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname,
-        String description, String author, Boolean checker, int startIndex, int pageRemaining) {
+    protected Root<Workflow> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker,
+        CriteriaBuilder cb, CriteriaQuery<?> q) {
 
         final SourceControlConverter converter = new SourceControlConverter();
-        final CriteriaBuilder cb = currentSession().getCriteriaBuilder();
-        final CriteriaQuery<Workflow> q = cb.createQuery(Workflow.class);
         final Root<Workflow> entryRoot = q.from(Workflow.class);
 
         Predicate predicate = cb.isTrue(entryRoot.get("isPublished"));
@@ -210,20 +206,7 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
         }
 
         q.where(predicate);
-        TypedQuery<Workflow> query = currentSession().createQuery(q);
-        query.setFirstResult(startIndex);
-        query.setMaxResults(pageRemaining);
-        List<Workflow> workflows = query.getResultList();
-        return workflows;
-    }
-
-    private Predicate andLike(CriteriaBuilder cb, Predicate existingPredicate, Path<String> column, Optional<String> value) {
-        return value.map(val -> cb.and(existingPredicate, cb.like(column, wildcardLike(val))))
-                .orElse(existingPredicate);
-    }
-
-    private String wildcardLike(String value) {
-        return '%' + value + '%';
+        return entryRoot;
     }
 
     public List<Workflow> findByPaths(List<String> paths, boolean findPublished) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -105,8 +106,11 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
     /**
      * Avoid using this one, this is quite slow
      *
+     * @deprecated as of 1.11, avoid this one and hopefully delete it
+     * <p></p>
      * @return
      */
+    @Deprecated
     private List<Entry> getPublished() {
         final List<Entry> published = new ArrayList<>();
         published.addAll(toolDAO.findAllPublished());
@@ -156,19 +160,10 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
 
     @Override
     public Response organizationsGet(SecurityContext securityContext) {
-        List<String> organizations = new ArrayList<>();
-        for (Entry c : getPublished()) {
-            String org;
-            if (c instanceof Workflow) {
-                org = ((Workflow)c).getOrganization().toLowerCase();
-            } else {
-                org = ((Tool)c).getNamespace().toLowerCase();
-            }
-            if (!organizations.contains(org)) {
-                organizations.add(org);
-            }
-        }
-        return Response.ok(organizations).build();
+        Set<String> organizations = new HashSet<>();
+        organizations.addAll(toolDAO.getAllPublishedNamespaces());
+        organizations.addAll(workflowDAO.getAllPublishedOrganizations());
+        return Response.ok(new ArrayList<>(organizations)).build();
     }
 
     @Override

--- a/openapi-java-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-client/generated/src/main/resources/pom.xml
@@ -52,8 +52,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.jaxrs</groupId>
           <artifactId>jackson-jaxrs-base</artifactId>
+          <groupId>com.fasterxml.jackson.jaxrs</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -64,8 +64,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -76,8 +76,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -106,8 +106,8 @@
       <scope>provided</scope>
       <exclusions>
         <exclusion>
-          <groupId>*</groupId>
           <artifactId>*</artifactId>
+          <groupId>*</groupId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/swagger-java-bitbucket-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-bitbucket-client/generated/src/main/resources/pom.xml
@@ -31,20 +31,20 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.jaxrs</groupId>
           <artifactId>jackson-jaxrs-base</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.glassfish.jersey.core</groupId>
-          <artifactId>jersey-common</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jersey-common</artifactId>
+          <groupId>org.glassfish.jersey.core</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>jackson-jaxrs-json-provider</artifactId>
+          <groupId>com.fasterxml.jackson.jaxrs</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -67,8 +67,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -79,8 +79,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/swagger-java-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-client/generated/src/main/resources/pom.xml
@@ -52,8 +52,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.jaxrs</groupId>
           <artifactId>jackson-jaxrs-base</artifactId>
+          <groupId>com.fasterxml.jackson.jaxrs</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -64,8 +64,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -76,8 +76,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -106,8 +106,8 @@
       <scope>provided</scope>
       <exclusions>
         <exclusion>
-          <groupId>*</groupId>
           <artifactId>*</artifactId>
+          <groupId>*</groupId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/swagger-java-discourse-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-discourse-client/generated/src/main/resources/pom.xml
@@ -46,20 +46,20 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.jaxrs</groupId>
           <artifactId>jackson-jaxrs-base</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.glassfish.jersey.core</groupId>
-          <artifactId>jersey-common</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jersey-common</artifactId>
+          <groupId>org.glassfish.jersey.core</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>jackson-jaxrs-json-provider</artifactId>
+          <groupId>com.fasterxml.jackson.jaxrs</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -82,8 +82,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -94,8 +94,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/swagger-java-quay-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-quay-client/generated/src/main/resources/pom.xml
@@ -46,20 +46,20 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.jaxrs</groupId>
           <artifactId>jackson-jaxrs-base</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.glassfish.jersey.core</groupId>
-          <artifactId>jersey-common</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jersey-common</artifactId>
+          <groupId>org.glassfish.jersey.core</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>jackson-jaxrs-json-provider</artifactId>
+          <groupId>com.fasterxml.jackson.jaxrs</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -82,8 +82,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -94,8 +94,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/swagger-java-sam-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-sam-client/generated/src/main/resources/pom.xml
@@ -31,20 +31,20 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.jaxrs</groupId>
           <artifactId>jackson-jaxrs-base</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.glassfish.jersey.core</groupId>
-          <artifactId>jersey-common</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jersey-common</artifactId>
+          <groupId>org.glassfish.jersey.core</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>jackson-jaxrs-json-provider</artifactId>
+          <groupId>com.fasterxml.jackson.jaxrs</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -67,8 +67,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -79,8 +79,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/swagger-java-zenodo-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-zenodo-client/generated/src/main/resources/pom.xml
@@ -52,8 +52,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.jaxrs</groupId>
           <artifactId>jackson-jaxrs-base</artifactId>
+          <groupId>com.fasterxml.jackson.jaxrs</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -64,8 +64,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -76,8 +76,8 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
**Description**
Makes TRS more efficient in terms of how it handles paging
Disables services in TRS
Also lowers default limit down to 100

Not the best work, so known follow-up issues that will likely involve more risky refactoring:
SEAB-3917
SEAB-3918
SEAB-3919



**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-522

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
