### PR TITLE
4663/ handle null Quay tag size

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -59,7 +59,7 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
 
     @Column
     @ApiModelProperty(value = "Size of the image", position = 103)
-    private long size;
+    private Long size;
 
     @Column(columnDefinition = "text", nullable = false)
     @JsonProperty("dockerfile_path")
@@ -164,11 +164,11 @@ public class Tag extends Version<Tag> implements Comparable<Tag> {
     }
 
     @JsonProperty
-    public long getSize() {
+    public Long getSize() {
         return size;
     }
 
-    public void setSize(long size) {
+    public void setSize(Long size) {
         this.size = size;
     }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.SystemErrRule;
@@ -26,7 +25,7 @@ public class QuayImageRegistryTest {
      * This tests that when there are over 500 tags, we can use the paginated endpoint to retrieve all of them instead.
      * Using calico/node because it has over 3838 tags
      */
-    @Ignore("https://github.com/dockstore/dockstore/issues/4663")
+    //    @Ignore("https://github.com/dockstore/dockstore/issues/4663")
     @Test
     public void getOver500TagsTest() {
         Token token = new Token();
@@ -40,8 +39,14 @@ public class QuayImageRegistryTest {
         int size = tags.size();
         Assert.assertTrue("Should be able to get more than the default 500 tags", size > 3838);
         tags.forEach(tag -> {
-            Assert.assertNotEquals("Image ID should be populated", null, tag.getImageId());
-            Assert.assertTrue("Images should be populated", tag.getImages().size() > 0);
+            if (tag.getSize() == null) {
+                Assert.assertNull("Image ID shouldn't be populated", tag.getImageId());
+
+            } else {
+                Assert.assertNotEquals("Image ID should be populated", null, tag.getImageId());
+                Assert.assertTrue("Images should be populated", tag.getImages().size() > 0);
+            }
+
         });
         Set<String> collect = tags.parallelStream().map(Version::getName).collect(Collectors.toSet());
         int distinctSize = collect.size();

--- a/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
+++ b/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
@@ -125,7 +125,7 @@ public class ToolsImplCommonTest {
         Tag tag = new Tag();
         tag.setImageId("sampleImageId");
         tag.setName("sampleTag");
-        tag.setSize(0);
+        tag.setSize(0L);
         tag.setDockerfilePath("/Dockerfile");
         tag.setCwlPath("/Dockstore.cwl");
         tag.setAutomated(true);
@@ -137,7 +137,7 @@ public class ToolsImplCommonTest {
         Tag hiddenTag = new Tag();
         hiddenTag.setImageId("hiddenImageId");
         hiddenTag.setName("hiddenName");
-        hiddenTag.setSize(9001);
+        hiddenTag.setSize(9001L);
         hiddenTag.setDockerfilePath("/Dockerfile");
         hiddenTag.setCwlPath("HiddenDockstore.cwl");
         hiddenTag.setAutomated(true);


### PR DESCRIPTION
**Description**
The error was being caused by multi-arch images being pushed to Quay. This PR let's the code continue without failing and fixes the test that was being ignored, but it's not quite correct.

 Dockstore currently supports multi-arch images for DockerHub and saves this info as a list of Images for each Version. The DockerHub API makes it clear that the different images actually belong to the same version. However, the Quay API isn't as clear...So PR will make separate tags with one image each (where the image can have the size and imageid be null)

I think it's possible to store it in the same way, but it seems complicated looking through their API.

**Issue**
#4663 

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ ] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
