### PR TITLE
Add LGTM suppression comment for false positive

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -114,6 +114,12 @@ swagger-java-sam-client/pom.xml:.*broadinstitute/sam/de13d1d
 # dockstore-webservice/src/main/java/io/swagger/model/ToolDescriptor.java
 dockstore-webservice/src/main/java/io/swagger/model/ToolDescriptor.java:.*pcawg_delly_workflow/ea2a
 
+# dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java:99:.*broadinstitute/gatk@sha256:98b2f223dce4282c144d249e7e1f47d400ae349404409d01e87df2efeebac439
+dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java:102:.*d7bb0589725587f2f67d0340edb81fd1fcba6c5f38166639cf2a252c939aa30c
+dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java:530:.*c404618e908391e50953e1ead94fe05dbbddbf532bd5c89b935ef34a9ca130d3
+
+
 # README.md:.*
 README.md:.*https://github.com/dockstore/dockstore/blob/
 README.md:.*https://app.codacy.com/app/dockstore/dockstore

--- a/dockstore-common/src/main/java/io/dockstore/common/LanguageHandlerHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/LanguageHandlerHelper.java
@@ -21,7 +21,7 @@ public final class LanguageHandlerHelper {
             return relativePath;
         }
 
-        Path workDir = Paths.get(parentPath);
+        Path workDir = Paths.get(parentPath); // lgtm[java/path-injection]
 
         // If the workDir is the root, leave it. If it is not the root, set workDir to the parent of parentPath
         workDir = !Objects.equals(parentPath, workDir.getRoot().toString()) ? workDir.getParent() : workDir;

--- a/dockstore-common/src/main/java/io/dockstore/common/LanguageHandlerHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/LanguageHandlerHelper.java
@@ -18,7 +18,7 @@ public final class LanguageHandlerHelper {
      * @param relativePath Relative path the parent file
      * @return Absolute version of relative path
      */
-    public static String convertRelativePathToAbsolutePathImports(String parentPath, String relativePath) {
+    public static String unsafeConvertRelativePathToAbsolutePath(String parentPath, String relativePath) {
         if (relativePath.startsWith("/")) {
             return relativePath;
         }

--- a/dockstore-common/src/main/java/io/dockstore/common/LanguageHandlerHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/LanguageHandlerHelper.java
@@ -12,11 +12,13 @@ public final class LanguageHandlerHelper {
 
     /**
      * Resolves a relative path based on an absolute parent path
+     * Should only be used with workflow imports and not for using
+     * untrusted inputs for traversing the filesystem.
      * @param parentPath Absolute path to parent file
      * @param relativePath Relative path the parent file
      * @return Absolute version of relative path
      */
-    public static String convertRelativePathToAbsolutePath(String parentPath, String relativePath) {
+    public static String convertRelativePathToAbsolutePathImports(String parentPath, String relativePath) {
         if (relativePath.startsWith("/")) {
             return relativePath;
         }

--- a/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
+++ b/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
@@ -449,7 +449,7 @@ case class MapResolver(filePath: String) extends ImportResolver {
 
   override protected def innerResolver(path: String, currentResolvers: List[ImportResolver]): Checked[ImportResolver.ResolvedImportBundle] = {
     val importPath = path.replaceFirst("file://", "")
-    val absolutePath = LanguageHandlerHelper.convertRelativePathToAbsolutePath(this.filePath, importPath)
+    val absolutePath = LanguageHandlerHelper.convertRelativePathToAbsolutePathImports(this.filePath, importPath)
     val content = secondaryWdlFiles.get(absolutePath)
     val mapResolver = MapResolver(absolutePath)
     mapResolver.setSecondaryFiles(this.secondaryWdlFiles)

--- a/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
+++ b/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
@@ -449,7 +449,7 @@ case class MapResolver(filePath: String) extends ImportResolver {
 
   override protected def innerResolver(path: String, currentResolvers: List[ImportResolver]): Checked[ImportResolver.ResolvedImportBundle] = {
     val importPath = path.replaceFirst("file://", "")
-    val absolutePath = LanguageHandlerHelper.convertRelativePathToAbsolutePathImports(this.filePath, importPath)
+    val absolutePath = LanguageHandlerHelper.unsafeConvertRelativePathToAbsolutePath(this.filePath, importPath)
     val content = secondaryWdlFiles.get(absolutePath)
     val mapResolver = MapResolver(absolutePath)
     mapResolver.setSecondaryFiles(this.secondaryWdlFiles)

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
@@ -112,8 +112,8 @@ public class CromwellIT {
     @Test
     public void testPathResolver() {
         Assert.assertEquals("/module00a/Module00a.wdl", LanguageHandlerHelper
-                .convertRelativePathToAbsolutePathImports("/GATKSVPipelineClinical.wdl", "module00a/Module00a.wdl"));
+                .unsafeConvertRelativePathToAbsolutePath("/GATKSVPipelineClinical.wdl", "module00a/Module00a.wdl"));
         Assert.assertEquals("/a/importA.wdl", LanguageHandlerHelper
-                .convertRelativePathToAbsolutePathImports("/parent/parent.wdl", "../a/importA.wdl"));
+                .unsafeConvertRelativePathToAbsolutePath("/parent/parent.wdl", "../a/importA.wdl"));
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CromwellIT.java
@@ -112,8 +112,8 @@ public class CromwellIT {
     @Test
     public void testPathResolver() {
         Assert.assertEquals("/module00a/Module00a.wdl", LanguageHandlerHelper
-                .convertRelativePathToAbsolutePath("/GATKSVPipelineClinical.wdl", "module00a/Module00a.wdl"));
+                .convertRelativePathToAbsolutePathImports("/GATKSVPipelineClinical.wdl", "module00a/Module00a.wdl"));
         Assert.assertEquals("/a/importA.wdl", LanguageHandlerHelper
-                .convertRelativePathToAbsolutePath("/parent/parent.wdl", "../a/importA.wdl"));
+                .convertRelativePathToAbsolutePathImports("/parent/parent.wdl", "../a/importA.wdl"));
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -535,7 +535,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 // handle imports and includes
                 if (mapValue instanceof String) {
                     setImportsBasedOnMapValue(parsedInformation, (String)mapValue);
-                    absoluteImportPath = convertRelativePathToAbsolutePath(parentFilePath, (String)mapValue);
+                    absoluteImportPath = convertRelativePathToAbsolutePathImports(parentFilePath, (String)mapValue);
                     handleAndProcessImport(repositoryId, absoluteImportPath, version, imports, (String)mapValue, sourceCodeRepoInterface);
                 }
             } else if (e.getKey().equalsIgnoreCase("run")) {
@@ -545,7 +545,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 //  run: revtool.cwl
                 if (mapValue instanceof String) {
                     setImportsBasedOnMapValue(parsedInformation, (String)mapValue);
-                    absoluteImportPath = convertRelativePathToAbsolutePath(parentFilePath, (String)mapValue);
+                    absoluteImportPath = convertRelativePathToAbsolutePathImports(parentFilePath, (String)mapValue);
                     handleAndProcessImport(repositoryId, absoluteImportPath, version, imports, (String)mapValue, sourceCodeRepoInterface);
                 } else if (mapValue instanceof Map) {
                     // this handles the case where an import is used
@@ -1137,7 +1137,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 // See https://datatracker.ietf.org/doc/html/rfc8089
                 childPath = childPath.replaceFirst("^file:/*+", "/");
             }
-            return LanguageHandlerHelper.convertRelativePathToAbsolutePath(parentPath, childPath);
+            return LanguageHandlerHelper.convertRelativePathToAbsolutePathImports(parentPath, childPath);
         }
 
         private String loadFile(String loadPath, String notFoundValue) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -535,7 +535,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 // handle imports and includes
                 if (mapValue instanceof String) {
                     setImportsBasedOnMapValue(parsedInformation, (String)mapValue);
-                    absoluteImportPath = convertRelativePathToAbsolutePathImports(parentFilePath, (String)mapValue);
+                    absoluteImportPath = unsafeConvertRelativePathToAbsolutePath(parentFilePath, (String)mapValue);
                     handleAndProcessImport(repositoryId, absoluteImportPath, version, imports, (String)mapValue, sourceCodeRepoInterface);
                 }
             } else if (e.getKey().equalsIgnoreCase("run")) {
@@ -545,7 +545,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 //  run: revtool.cwl
                 if (mapValue instanceof String) {
                     setImportsBasedOnMapValue(parsedInformation, (String)mapValue);
-                    absoluteImportPath = convertRelativePathToAbsolutePathImports(parentFilePath, (String)mapValue);
+                    absoluteImportPath = unsafeConvertRelativePathToAbsolutePath(parentFilePath, (String)mapValue);
                     handleAndProcessImport(repositoryId, absoluteImportPath, version, imports, (String)mapValue, sourceCodeRepoInterface);
                 } else if (mapValue instanceof Map) {
                     // this handles the case where an import is used
@@ -1137,7 +1137,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 // See https://datatracker.ietf.org/doc/html/rfc8089
                 childPath = childPath.replaceFirst("^file:/*+", "/");
             }
-            return LanguageHandlerHelper.convertRelativePathToAbsolutePathImports(parentPath, childPath);
+            return LanguageHandlerHelper.unsafeConvertRelativePathToAbsolutePath(parentPath, childPath);
         }
 
         private String loadFile(String loadPath, String notFoundValue) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -1002,8 +1002,8 @@ public interface LanguageHandlerInterface {
      * @param relativePath Relative path the parent file
      * @return Absolute version of relative path
      */
-    default String convertRelativePathToAbsolutePathImports(String parentPath, String relativePath) {
-        return LanguageHandlerHelper.convertRelativePathToAbsolutePathImports(parentPath, relativePath);
+    default String unsafeConvertRelativePathToAbsolutePath(String parentPath, String relativePath) {
+        return LanguageHandlerHelper.unsafeConvertRelativePathToAbsolutePath(parentPath, relativePath);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -1002,8 +1002,8 @@ public interface LanguageHandlerInterface {
      * @param relativePath Relative path the parent file
      * @return Absolute version of relative path
      */
-    default String convertRelativePathToAbsolutePath(String parentPath, String relativePath) {
-        return LanguageHandlerHelper.convertRelativePathToAbsolutePath(parentPath, relativePath);
+    default String convertRelativePathToAbsolutePathImports(String parentPath, String relativePath) {
+        return LanguageHandlerHelper.convertRelativePathToAbsolutePathImports(parentPath, relativePath);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -140,7 +140,7 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
         suspectedConfigImports.add(mainScriptPath);
 
         for (String filename : suspectedConfigImports) {
-            String filenameAbsolutePath = convertRelativePathToAbsolutePath(filepath, filename);
+            String filenameAbsolutePath = convertRelativePathToAbsolutePathImports(filepath, filename);
             Optional<SourceFile> sourceFile = sourceCodeRepoInterface
                 .readFile(repositoryId, version, DescriptorLanguage.FileType.NEXTFLOW, filenameAbsolutePath);
             if (sourceFile.isPresent()) {
@@ -176,7 +176,7 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
         Matcher m = IMPORT_PATTERN.matcher(content);
         while (m.find()) {
             String path = getRelativeImportPathFromLine(m.group(), workingDirectoryForFile);
-            String absoluteImportPath = convertRelativePathToAbsolutePath(workingDirectoryForFile, path);
+            String absoluteImportPath = convertRelativePathToAbsolutePathImports(workingDirectoryForFile, path);
             handleImport(repositoryId, version, imports, path, sourceCodeRepoInterface, absoluteImportPath);
         }
         Map<String, SourceFile> recursiveImports = new HashMap<>();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -140,7 +140,7 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
         suspectedConfigImports.add(mainScriptPath);
 
         for (String filename : suspectedConfigImports) {
-            String filenameAbsolutePath = convertRelativePathToAbsolutePathImports(filepath, filename);
+            String filenameAbsolutePath = unsafeConvertRelativePathToAbsolutePath(filepath, filename);
             Optional<SourceFile> sourceFile = sourceCodeRepoInterface
                 .readFile(repositoryId, version, DescriptorLanguage.FileType.NEXTFLOW, filenameAbsolutePath);
             if (sourceFile.isPresent()) {
@@ -176,7 +176,7 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
         Matcher m = IMPORT_PATTERN.matcher(content);
         while (m.find()) {
             String path = getRelativeImportPathFromLine(m.group(), workingDirectoryForFile);
-            String absoluteImportPath = convertRelativePathToAbsolutePathImports(workingDirectoryForFile, path);
+            String absoluteImportPath = unsafeConvertRelativePathToAbsolutePath(workingDirectoryForFile, path);
             handleImport(repositoryId, version, imports, path, sourceCodeRepoInterface, absoluteImportPath);
         }
         Map<String, SourceFile> recursiveImports = new HashMap<>();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -89,7 +89,7 @@ public class WDLHandler implements LanguageHandlerInterface {
                 String match = m.group(1);
                 if (!match.startsWith("http://") && !match.startsWith("https://")) { // Don't resolve URLs
                     String localRelativePath = match.replaceFirst("file://", "");
-                    String absolutePath = LanguageHandlerHelper.convertRelativePathToAbsolutePath(parent, localRelativePath);
+                    String absolutePath = LanguageHandlerHelper.convertRelativePathToAbsolutePathImports(parent, localRelativePath);
                     if (absolutePaths.contains(absolutePath)) {
                         throw new ParseException(ERROR_PARSING_WORKFLOW_RECURSIVE_LOCAL_IMPORT + absolutePath, 0);
                     }
@@ -408,7 +408,7 @@ public class WDLHandler implements LanguageHandlerInterface {
         }
 
         for (String importPath : currentFileImports) {
-            String absoluteImportPath = convertRelativePathToAbsolutePath(currentFilePath, importPath);
+            String absoluteImportPath = convertRelativePathToAbsolutePathImports(currentFilePath, importPath);
             if (!imports.containsKey(absoluteImportPath)) {
                 SourceFile importFile = new SourceFile();
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -89,7 +89,7 @@ public class WDLHandler implements LanguageHandlerInterface {
                 String match = m.group(1);
                 if (!match.startsWith("http://") && !match.startsWith("https://")) { // Don't resolve URLs
                     String localRelativePath = match.replaceFirst("file://", "");
-                    String absolutePath = LanguageHandlerHelper.convertRelativePathToAbsolutePathImports(parent, localRelativePath);
+                    String absolutePath = LanguageHandlerHelper.unsafeConvertRelativePathToAbsolutePath(parent, localRelativePath);
                     if (absolutePaths.contains(absolutePath)) {
                         throw new ParseException(ERROR_PARSING_WORKFLOW_RECURSIVE_LOCAL_IMPORT + absolutePath, 0);
                     }
@@ -408,7 +408,7 @@ public class WDLHandler implements LanguageHandlerInterface {
         }
 
         for (String importPath : currentFileImports) {
-            String absoluteImportPath = convertRelativePathToAbsolutePathImports(currentFilePath, importPath);
+            String absoluteImportPath = unsafeConvertRelativePathToAbsolutePath(currentFilePath, importPath);
             if (!imports.containsKey(absoluteImportPath)) {
                 SourceFile importFile = new SourceFile();
 


### PR DESCRIPTION
**Description**
Suppressing an LGTM alert that was determined to be a false positive. This path lookup is for searching within relative imports and does not allow arbitrary path injection to the webservice file system.

Assuming this works more or less as expected will suggest going through the remaining 5 alerts and likely doing the same.

**Issue**

https://ucsc-cgl.atlassian.net/browse/SEAB-3877

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
