### PR TITLE
Harvest checksums for GitHub Container Registry tools

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -1211,7 +1211,7 @@ public class GeneralIT extends BaseIT {
         refreshAfterDeletedTag(toolApi, tool, tags);
 
         // mimic getting a registry being slow/not responding and verify we do not delete the image information we already have by going to an invalid url.
-        testingPostgres.runUpdateStatement("update tool set name = 'thisnamedoesnotexist' where giturl = 'git@gitlab.com:NatalieEO/dockstore-tool-bamstats.git'");
+        testingPostgres.runUpdateStatement("update tool set name = 'thisnamedoesnotexist' where id=" + tool.getId());
         toolApi.refresh(tool.getId());
         List<Tag> updatedTags = toolApi.getContainer(tool.getId(), null).getWorkflowVersions();
         verifyChecksumsAreSaved(updatedTags);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -1219,6 +1219,7 @@ public class GeneralIT extends BaseIT {
 
 
     private void verifyChecksumsAreSaved(List<Tag> tags) {
+        assertTrue("The list of tags should not be empty", tags.size() > 0);
         for (Tag tag : tags) {
             List<Image> images = tag.getImages();
             assertTrue("Tag should have an image", images.size() > 0);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -57,6 +57,7 @@ import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.DockstoreTool;
 import io.swagger.client.model.DockstoreTool.TopicSelectionEnum;
 import io.swagger.client.model.Entry;
+import io.swagger.client.model.Image;
 import io.swagger.client.model.PublishRequest;
 import io.swagger.client.model.SourceFile;
 import io.swagger.client.model.Tag;
@@ -361,6 +362,40 @@ public class GeneralIT extends BaseIT {
         tool.setRegistryString(Registry.GITLAB.getDockerPath());
         tool.setGitUrl("git@gitlab.com:NatalieEO/dockstore-tool-bamstats.git");
         tool.setPrivateAccess(false);
+        return tool;
+    }
+
+    private DockstoreTool registerManualGitHubContainerRegistryToolAndAddTag() {
+        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        ContainersApi toolApi = new ContainersApi(webClient);
+        ContainertagsApi toolTagsApi = new ContainertagsApi(webClient);
+        DockstoreTool tool = new DockstoreTool();
+        tool.setMode(DockstoreTool.ModeEnum.MANUAL_IMAGE_PATH);
+
+        // This image is used for the tool: https://ghcr.io/homebrew/core/python/3.9:3.9.6
+        tool.setRegistryString(Registry.GITHUB_CONTAINER_REGISTRY.getDockerPath());
+        tool.setNamespace("homebrew");
+        tool.setName("core/python/3.9");
+        tool.setDefaultDockerfilePath("/Dockerfile");
+        tool.setDefaultCwlPath("/Dockstore.cwl");
+        tool.setDefaultWdlPath("/Dockstore.wdl");
+        tool.setDefaultCWLTestParameterFile("/test.cwl.json");
+        tool.setDefaultWDLTestParameterFile("/test.wdl.json");
+        tool.setIsPublished(false);
+        // This actually exists: https://bitbucket.org/DockstoreTestUser/dockstore-whalesay-2/src/master/
+        tool.setGitUrl("git@bitbucket.org:DockstoreTestUser/dockstore-whalesay-2.git");
+        tool.setPrivateAccess(false);
+
+        tool = toolApi.registerManual(tool);
+
+        // Add a tag
+        List<Tag> tags = new ArrayList<>();
+        Tag tag = new Tag();
+        tag.setName("3.9.6");
+        tag.setReference("master");
+        tags.add(tag);
+        toolTagsApi.addTags(tool.getId(), tags);
+        tool = toolApi.refresh(tool.getId());
         return tool;
     }
 
@@ -1162,8 +1197,31 @@ public class GeneralIT extends BaseIT {
         verifyChecksumsAreSaved(updatedTags);
     }
 
+    @Test
+    public void testGrabChecksumFromGitHubContainerRegistry() {
+        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        ContainersApi toolApi = new ContainersApi(webClient);
+        ContainertagsApi toolTagsApi = new ContainertagsApi(webClient);
+        DockstoreTool tool = registerManualGitHubContainerRegistryToolAndAddTag();
+        List<Tag> tags = toolApi.getContainer(tool.getId(), null).getWorkflowVersions();
+        verifyChecksumsAreSaved(tags);
+
+        // Check for case where user deletes tag and creates new one of same name.
+        // Check that the new imageid and checksums are grabbed on refresh. Also check the old images have been deleted.
+        refreshAfterDeletedTag(toolApi, tool, tags);
+
+        // mimic getting a registry being slow/not responding and verify we do not delete the image information we already have by going to an invalid url.
+        testingPostgres.runUpdateStatement("update tool set name = 'thisnamedoesnotexist' where giturl = 'git@gitlab.com:NatalieEO/dockstore-tool-bamstats.git'");
+        toolApi.refresh(tool.getId());
+        List<Tag> updatedTags = toolApi.getContainer(tool.getId(), null).getWorkflowVersions();
+        verifyChecksumsAreSaved(updatedTags);
+    }
+
+
     private void verifyChecksumsAreSaved(List<Tag> tags) {
         for (Tag tag : tags) {
+            List<Image> images = tag.getImages();
+            assertTrue("Tag should have an image", images.size() > 0);
             String hashType = tag.getImages().get(0).getChecksums().get(0).getType();
             String checksum = tag.getImages().get(0).getChecksums().get(0).getChecksum();
             assertNotNull(hashType);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -45,6 +45,7 @@ import io.dockstore.webservice.jdbi.TagDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import io.dockstore.webservice.jdbi.UserDAO;
 import io.dockstore.webservice.languages.LanguageHandlerFactory;
+import io.dockstore.webservice.languages.LanguageHandlerInterface;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URL;
@@ -329,6 +330,8 @@ public abstract class AbstractImageRegistry {
             toolTags = getTagsDockerHub(tool);
         } else if (tool.getRegistry().equals(Registry.GITLAB.getDockerPath())) {
             toolTags = getTagsGitLab(tool);
+        } else if (tool.getRegistry().equals((Registry.GITHUB_CONTAINER_REGISTRY.getDockerPath()))) {
+            toolTags = getTagsGitHubContainerRegistry(tool);
         } else {
             toolTags = getTags(tool);
         }
@@ -565,8 +568,9 @@ public abstract class AbstractImageRegistry {
             }
         }
 
-        // For tools from dockerhub, grab/update the image and checksum information
-        if (tool.getRegistry().equals(Registry.DOCKER_HUB.getDockerPath()) || tool.getRegistry().equals(Registry.GITLAB.getDockerPath())) {
+        // For tools from dockerhub, gitlab, and github container registry, grab/update the image and checksum information
+        if (tool.getRegistry().equals(Registry.DOCKER_HUB.getDockerPath()) || tool.getRegistry().equals(Registry.GITLAB.getDockerPath())
+                || tool.getRegistry().equals(Registry.GITHUB_CONTAINER_REGISTRY.getDockerPath())) {
             updateNonQuayImageInformation(newTags, tool, existingTags);
         }
 
@@ -623,6 +627,7 @@ public abstract class AbstractImageRegistry {
                 for (Tag oldTag : existingTags) {
                     if (oldTag.getName().equals(newTag.getName())) {
                         updateImageInformation(tool, newTag, oldTag);
+                        break;
                     }
                 }
             }
@@ -696,6 +701,35 @@ public abstract class AbstractImageRegistry {
             LOG.error("Unable to get GitLab response for " + repo, ex);
         }
         return Collections.emptyList();
+    }
+
+    private List<Tag> getTagsGitHubContainerRegistry(Tool tool) {
+        final Registry registry = Registry.GITHUB_CONTAINER_REGISTRY;
+        final List<Tag> tags = new ArrayList<>();
+        final String repo = tool.getNamespace() + '/' + tool.getName();
+
+        // Get image information for the tool's tags
+        for (Tag tag : tool.getWorkflowVersions()) {
+            // Determine if the tag is the 'latest' tag
+            LanguageHandlerInterface.DockerSpecifier specifier;
+            if (tag.getName().equals("latest")) {
+                specifier = LanguageHandlerInterface.DockerSpecifier.LATEST;
+            } else {
+                specifier = LanguageHandlerInterface.DockerSpecifier.TAG;
+            }
+
+            Set<Image> images = DockerRegistryAPIHelper.getImages(registry, repo, specifier, tag.getName());
+            if (images.isEmpty()) {
+                LOG.error("Could not get image and checksum information for {}/{}:{} from {}", tool.getNamespace(), tool.getName(), tag.getName(), registry.getFriendlyName());
+                continue;
+            }
+
+            Tag newTag = new Tag();
+            newTag.setName(tag.getName());
+            newTag.setImages(images);
+            tags.add(newTag);
+        }
+        return tags;
     }
 
     private void updateFiles(Tool tool, Tag tag, final FileDAO fileDAO, SourceCodeRepoInterface sourceCodeRepo, String username) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -720,7 +720,7 @@ public abstract class AbstractImageRegistry {
 
             Set<Image> images = DockerRegistryAPIHelper.getImages(registry, repo, specifier, tag.getName());
             if (images.isEmpty()) {
-                LOG.error("Could not get image and checksum information for {}/{}:{} from {}", tool.getNamespace(), tool.getName(), tag.getName(), registry.getFriendlyName());
+                LOG.error("Could not get image and checksum information for {}:{} from {}", repo, tag.getName(), registry.getFriendlyName());
                 continue;
             }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -708,7 +708,8 @@ public abstract class AbstractImageRegistry {
         final List<Tag> tags = new ArrayList<>();
         final String repo = tool.getNamespace() + '/' + tool.getName();
 
-        // Get image information for the tool's tags
+        // Get image information for the tool's tags.
+        // No need to get all tags belonging to the container because image information is only updated for existing tool tags
         for (Tag tag : tool.getWorkflowVersions()) {
             // Determine if the tag is the 'latest' tag
             LanguageHandlerInterface.DockerSpecifier specifier;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DockerRegistryAPIHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/DockerRegistryAPIHelper.java
@@ -127,7 +127,7 @@ public final class DockerRegistryAPIHelper {
                 }
             } else {
                 if (digestHeader.startsWith(DIGEST_HASH_ALGORITHM)) { // Digest header should have the form sha256:<digest>
-                    digest = digestHeader.split(DIGEST_HASH_ALGORITHM + ":")[0];
+                    digest = digestHeader.split(DIGEST_HASH_ALGORITHM + ":")[1]; // sha256:<digest> splits to ["", <digest>]
                 } else {
                     LOG.error("Could not retrieve a {} digest for {}", DIGEST_HASH_ALGORITHM, imageNameMessage);
                     return images;


### PR DESCRIPTION
**Description**
This PR harvests checksums for GitHub Container Registry tools, which was the only thing missing in the webservice for GHCR tools. The checksum is harvested the same way it's harvested for GHCR workflows, using the Docker Registry API.

Will also have a small PR for the front-end to allow GHCR tools with slashes in their repo name to be registered.

**Issue**
#4353 

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
