### PR TITLE
No WDL GitHub App Tools

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -453,7 +453,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     }
 
     /**
-     * Create or retrieve workflows based on Dockstore.yml, add or update tag version
+     * Create or retrieve workflows/GitHub App Tools based on Dockstore.yml, add or update tag version
      * ONLY WORKS FOR v1.2
      * @param repository Repository path (ex. dockstore/dockstore-ui2)
      * @param gitReference Git reference from GitHub (ex. refs/tags/1.0)
@@ -462,7 +462,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @param dockstoreYml
      */
     private void createBioWorkflowsAndVersionsFromDockstoreYml(List<YamlWorkflow> yamlWorkflows, String repository, String gitReference, String installationId, User user,
-            final SourceFile dockstoreYml, boolean isOneStepWorkflow) {
+            final SourceFile dockstoreYml, boolean isTool) {
         GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createGitHubAppRepo(gitHubAppSetup(installationId));
         try {
             final Path gitRefPath = Path.of(gitReference);
@@ -472,12 +472,16 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 }
 
                 String subclass = wf.getSubclass();
+                if (isTool && subclass.equals(DescriptorLanguage.WDL.toString().toLowerCase())) {
+                    throw new CustomWebApplicationException( "Dockstore does not support WDL for tools registered using GitHub Apps.", HttpStatus.SC_BAD_REQUEST);
+                }
+
                 String workflowName = wf.getName();
                 Boolean publish = wf.getPublish();
                 final var defaultVersion = wf.getLatestTagAsDefault();
                 final List<YamlAuthor> yamlAuthors = wf.getAuthors();
 
-                Class workflowType = isOneStepWorkflow ? AppTool.class : BioWorkflow.class;
+                Class workflowType = isTool ? AppTool.class : BioWorkflow.class;
                 Workflow workflow = createOrGetWorkflow(workflowType, repository, user, workflowName, subclass, gitHubSourceCodeRepo);
                 addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion, yamlAuthors);
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -473,7 +473,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
 
                 String subclass = wf.getSubclass();
                 if (isTool && subclass.equals(DescriptorLanguage.WDL.toString().toLowerCase())) {
-                    throw new CustomWebApplicationException( "Dockstore does not support WDL for tools registered using GitHub Apps.", HttpStatus.SC_BAD_REQUEST);
+                    throw new CustomWebApplicationException("Dockstore does not support WDL for tools registered using GitHub Apps.", HttpStatus.SC_BAD_REQUEST);
                 }
 
                 String workflowName = wf.getName();


### PR DESCRIPTION
**Description**
Throws an error that the user can see in the GitHub App Logs if they try to register a WDL tool using GitHub Apps.
Should I also do changes here and in the UI that don't allow new WDL tools at all for 1.12? I think yes.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-3898

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ ] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
