### PR TITLE
enabling TRS paging for services and apptools

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiCRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiCRUDClientIT.java
@@ -18,9 +18,12 @@ package io.dockstore.client.cli;
 
 import static io.openapi.api.impl.ToolClassesApiServiceImpl.COMMAND_LINE_TOOL;
 import static io.openapi.api.impl.ToolClassesApiServiceImpl.WORKFLOW;
+import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.Lists;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.Constants;
+import io.dockstore.common.Registry;
 import io.dockstore.common.Utilities;
 import io.dockstore.openapi.client.ApiClient;
 import io.dockstore.openapi.client.api.Ga4Ghv20Api;
@@ -31,7 +34,16 @@ import io.dockstore.openapi.client.model.ToolClass;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dropwizard.testing.DropwizardTestSupport;
+import io.dropwizard.testing.ResourceHelpers;
+import io.swagger.client.api.ContainersApi;
+import io.swagger.client.api.HostedApi;
+import io.swagger.client.model.DockstoreTool;
+import io.swagger.client.model.PublishRequest;
+import io.swagger.client.model.SourceFile;
+import io.swagger.model.DescriptorType;
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.apache.commons.configuration2.INIConfiguration;
 import org.apache.commons.io.FileUtils;
@@ -103,6 +115,90 @@ public class OpenApiCRUDClientIT extends BaseIT {
         Assert.assertFalse(workflows.isEmpty());
         Assert.assertFalse(tools.isEmpty());
         Assert.assertEquals(workflows.size() + tools.size(), allStuff.size());
+    }
 
+
+    @Test
+    public void testGA4GHBigPaging() throws IOException {
+        ApiClient webClient = new ApiClient();
+        File configFile = FileUtils.getFile("src", "test", "resources", "config");
+        INIConfiguration parseConfig = Utilities.parseConfig(configFile.getAbsolutePath());
+        webClient.setBasePath(parseConfig.getString(Constants.WEBSERVICE_BASE_PATH));
+        ContainersApi containersApi = new ContainersApi(getWebClient(ADMIN_USERNAME, testingPostgres));
+
+        // cleanup to make math easier
+        final List<DockstoreTool> dockstoreTools = containersApi.allPublishedContainers("0", 100, null, null, null);
+        for (DockstoreTool tool : dockstoreTools) {
+            // Publish tool
+            PublishRequest pub = CommonTestUtilities.createPublishRequest(false);
+            containersApi.publish(tool.getId(), pub);
+        }
+
+        // create  a pile of workflows to test with
+        for (int i = 0; i < 100; i++) {
+            HostedApi api = new HostedApi(getWebClient(ADMIN_USERNAME, testingPostgres));
+            DockstoreTool hostedTool = api
+                .createHostedTool("awesomeTool" + i, Registry.QUAY_IO.getDockerPath().toLowerCase(), DescriptorType.CWL.toString(), "coolNamespace", null);
+            SourceFile descriptorFile = new SourceFile();
+            descriptorFile
+                .setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("tar-param.cwl")), StandardCharsets.UTF_8));
+            descriptorFile.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
+            descriptorFile.setPath("/Dockstore.cwl");
+            descriptorFile.setAbsolutePath("/Dockstore.cwl");
+            SourceFile dockerfile = new SourceFile();
+            dockerfile.setContent("FROM ubuntu:latest");
+            dockerfile.setType(SourceFile.TypeEnum.DOCKERFILE);
+            dockerfile.setPath("/Dockerfile");
+            dockerfile.setAbsolutePath("/Dockerfile");
+            DockstoreTool dockstoreTool = api.editHostedTool(hostedTool.getId(), Lists.newArrayList(descriptorFile, dockerfile));
+            assertTrue("a tool lacks a date", dockstoreTool.getLastModifiedDate() != null && dockstoreTool.getLastModified() != 0);
+
+            SourceFile file2 = new SourceFile();
+            file2.setContent("{\"message\": \"Hello world!\"}");
+            file2.setType(SourceFile.TypeEnum.CWL_TEST_JSON);
+            file2.setPath("/test.json");
+            file2.setAbsolutePath("/test.json");
+            // add one file and include the old one implicitly
+            api.editHostedTool(hostedTool.getId(), Lists.newArrayList(file2));
+            api.editHostedTool(hostedTool.getId(), Lists.newArrayList(descriptorFile, file2, dockerfile));
+            // Publish tool
+            PublishRequest pub = CommonTestUtilities.createPublishRequest(true);
+            containersApi.publish(hostedTool.getId(), pub);
+        }
+
+
+        Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(webClient);
+        final List<Tool> allStuff = ga4Ghv20Api
+            .toolsGet(null, null, null, null, null, null, null, null, null, null, null, null, Integer.MAX_VALUE);
+        final List<Tool> workflows = ga4Ghv20Api
+            .toolsGet(null, null, WORKFLOW, null, null, null, null, null, null, null, null, null, Integer.MAX_VALUE);
+        final List<Tool> tools = ga4Ghv20Api
+            .toolsGet(null, null, COMMAND_LINE_TOOL, null, null, null, null, null, null, null, null, null, Integer.MAX_VALUE);
+
+        System.out.println(allStuff.size());
+        System.out.println(workflows.size());
+        System.out.println(tools.size());
+
+        Assert.assertFalse(workflows.isEmpty());
+        Assert.assertFalse(tools.isEmpty());
+        // capped due to page size
+        Assert.assertEquals(100, allStuff.size());
+        Assert.assertEquals(1, workflows.size());
+        Assert.assertEquals(100, tools.size());
+
+        // check on paging structure when not mixing tools and workflows
+        final List<Tool> firstToolPage = ga4Ghv20Api.toolsGet(null, null, COMMAND_LINE_TOOL, null, null, null, null, null, null, null, null, "0", 10);
+        Assert.assertEquals("awesomeTool0", firstToolPage.get(0).getName());
+        Assert.assertEquals("awesomeTool9", firstToolPage.get(firstToolPage.size() - 1).getName());
+        final List<Tool> secondToolPage = ga4Ghv20Api.toolsGet(null, null, COMMAND_LINE_TOOL, null, null, null, null, null, null, null, null, "1", 10);
+        Assert.assertEquals("awesomeTool10", secondToolPage.get(0).getName());
+        Assert.assertEquals("awesomeTool19", secondToolPage.get(firstToolPage.size() - 1).getName());
+        final List<Tool> lastToolPage = ga4Ghv20Api.toolsGet(null, null, COMMAND_LINE_TOOL, null, null, null, null, null, null, null, null, "9", 10);
+        Assert.assertEquals("awesomeTool90", lastToolPage.get(0).getName());
+        Assert.assertEquals("awesomeTool99", lastToolPage.get(firstToolPage.size() - 1).getName());
+
+        // check on paging structure when mixing tools and workflows
+        final List<Tool> mixedPage = ga4Ghv20Api.toolsGet(null, null, null, null, null, null, null, null, null, null, null, "3", 30);
+        Assert.assertEquals(2, mixedPage.stream().map(Tool::getToolclass).distinct().count());
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -20,6 +20,8 @@ package io.dockstore.webservice;
 
 import static io.dockstore.client.cli.WorkflowIT.DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME;
 import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
+import static io.openapi.api.impl.ToolClassesApiServiceImpl.COMMAND_LINE_TOOL;
+import static io.openapi.api.impl.ToolClassesApiServiceImpl.WORKFLOW;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -930,6 +932,73 @@ public class WebhookIT extends BaseIT {
         client.publish(workflow.getId(), publishRequest);
         Assert.assertFalse(systemOutRule.getLog().contains("Could not submit index to elastic search"));
     }
+
+
+    @Test
+    public void testTRSWithAppTools() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+        final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        final io.dockstore.openapi.client.ApiClient openApiClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(openApiClient);
+        WorkflowsApi client = new WorkflowsApi(webClient);
+
+        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/main", installationId);
+        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/invalid-workflow", installationId);
+        client.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/invalidTool", installationId);
+        Workflow appTool = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepoToolPath, APPTOOL, "versions,validations");
+        Workflow workflow = client.getWorkflowByPath("github.com/" + toolAndWorkflowRepo, BIOWORKFLOW, "versions,validations");        // publish endpoint updates elasticsearch index
+        PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
+        WorkflowVersion validVersion = appTool.getWorkflowVersions().stream().filter(WorkflowVersion::isValid).findFirst().get();
+        testingPostgres.runUpdateStatement("update apptool set actualdefaultversion = " + validVersion.getId() + " where id = " + appTool.getId());
+        client.publish(appTool.getId(), publishRequest);
+        client.publish(workflow.getId(), publishRequest);
+
+
+        Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openApiClient);
+        List<io.dockstore.openapi.client.model.Tool> tools = ga4Ghv20Api.toolsGet(null, null, null, null, null, null, null, null, null, null, null, null, null);
+        assertEquals(2, tools.size());
+
+        // testing filters of various kinds
+
+        tools = ga4Ghv20Api.toolsGet(null, null, null, null, null, null, null, null, null, null, true, null, null);
+        // neither the apptool or the regular workflow are checkers
+        assertEquals(0, tools.size());
+        tools = ga4Ghv20Api.toolsGet(null, null, null, null, null, null, null, null, null, null, false, null, null);
+        // neither the apptool or the regular workflow are checkers
+        assertEquals(2, tools.size());
+        tools = ga4Ghv20Api.toolsGet(null, null, WORKFLOW, null, null, null, null, null, null, null, false, null, null);
+        // the apptool is a commandline tool and not a workflow
+        assertEquals(1, tools.size());
+        tools = ga4Ghv20Api.toolsGet(null, null, COMMAND_LINE_TOOL, null, null, null, null, null, null, null, false, null, null);
+        // the apptool is a commandline tool and not a workflow
+        assertEquals(1, tools.size());
+        tools = ga4Ghv20Api.toolsGet(null, null, SERVICE, null, null, null, null, null, null, null, false, null, null);
+        // neither are services
+        assertEquals(0, tools.size());
+        tools = ga4Ghv20Api.toolsGet(null, null, null, DescriptorLanguage.SERVICE.getShortName(), null, null, null, null, null, null, false, null, null);
+        // neither are services this way either
+        assertEquals(0, tools.size());
+
+        // testing paging
+
+        tools = ga4Ghv20Api.toolsGet(null, null, null, DescriptorLanguage.CWL.getShortName(), null, null, null, null, null, null, false, String.valueOf(-1), 1);
+        // should just go to first page
+        assertEquals(1, tools.size());
+        assertEquals(WORKFLOW, tools.get(0).getToolclass().getDescription());
+        tools = ga4Ghv20Api.toolsGet(null, null, null, DescriptorLanguage.CWL.getShortName(), null, null, null, null, null, null, false, String.valueOf(0), 1);
+        // first page
+        assertEquals(1, tools.size());
+        assertEquals(WORKFLOW, tools.get(0).getToolclass().getDescription());
+        tools = ga4Ghv20Api.toolsGet(null, null, null, DescriptorLanguage.CWL.getShortName(), null, null, null, null, null, null, false, String.valueOf(1), 1);
+        // second page
+        assertEquals(1, tools.size());
+        assertEquals(COMMAND_LINE_TOOL, tools.get(0).getToolclass().getDescription());
+        tools = ga4Ghv20Api.toolsGet(null, null, null, DescriptorLanguage.CWL.getShortName(), null, null, null, null, null, null, false, String.valueOf(1000), 1);
+        //TODO should just go to second page, but for now I guess you just scroll off into nothingness
+        assertEquals(0, tools.size());
+
+    }
+
 
     @Test
     public void testDuplicatePathsAcrossTables() throws Exception {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -913,27 +913,22 @@ public class WebhookIT extends BaseIT {
         client.publish(workflow.getId(), publishRequest);
         Assert.assertFalse(systemOutRule.getLog().contains("Could not submit index to elastic search"));
 
-        boolean apptoolTRSworking = false;
-        if (apptoolTRSworking) {
-            //TODO; need to fix this, we need app tools in TRS but with paging as well to get this working right
+        Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openApiClient);
+        final List<io.dockstore.openapi.client.model.Tool> tools = ga4Ghv20Api.toolsGet(null, null, null, null, null, null, null, null, null, null, null, null, null);
+        assertEquals(2, tools.size());
 
-            Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(openApiClient);
-            final List<io.dockstore.openapi.client.model.Tool> tools = ga4Ghv20Api.toolsGet(null, null, null, null, null, null, null, null, null, null, null, null, null);
-            assertEquals(2, tools.size());
+        final io.dockstore.openapi.client.model.Tool tool = ga4Ghv20Api.toolsIdGet("github.com/DockstoreTestUser2/test-workflows-and-tools/md5sum");
+        assertNotNull(tool);
+        assertEquals("CommandLineTool", tool.getToolclass().getDescription());
 
-            final io.dockstore.openapi.client.model.Tool tool = ga4Ghv20Api.toolsIdGet("github.com/DockstoreTestUser2/test-workflows-and-tools/md5sum");
-            assertNotNull(tool);
-            assertEquals("CommandLineTool", tool.getToolclass().getDescription());
+        final Tool trsWorkflow = ga4Ghv20Api.toolsIdGet(ToolsImplCommon.WORKFLOW_PREFIX + "/github.com/DockstoreTestUser2/test-workflows-and-tools");
+        assertNotNull(trsWorkflow);
+        assertEquals("Workflow", trsWorkflow.getToolclass().getDescription());
 
-            final Tool trsWorkflow = ga4Ghv20Api.toolsIdGet(ToolsImplCommon.WORKFLOW_PREFIX + "/github.com/DockstoreTestUser2/test-workflows-and-tools");
-            assertNotNull(trsWorkflow);
-            assertEquals("Workflow", trsWorkflow.getToolclass().getDescription());
-
-            publishRequest.setPublish(false);
-            client.publish(appTool.getId(), publishRequest);
-            client.publish(workflow.getId(), publishRequest);
-            Assert.assertFalse(systemOutRule.getLog().contains("Could not submit index to elastic search"));
-        }
+        publishRequest.setPublish(false);
+        client.publish(appTool.getId(), publishRequest);
+        client.publish(workflow.getId(), publishRequest);
+        Assert.assertFalse(systemOutRule.getLog().contains("Could not submit index to elastic search"));
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/resources/fixtures/toolClasses.json
+++ b/dockstore-integration-testing/src/test/resources/fixtures/toolClasses.json
@@ -8,5 +8,10 @@
     "id": "1",
     "name": "Workflow",
     "description": "Workflow"
+  },
+  {
+    "id": "2",
+    "name": "Service",
+    "description": "Service"
   }
 ]

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -80,6 +80,7 @@ import io.dockstore.webservice.jdbi.BioWorkflowDAO;
 import io.dockstore.webservice.jdbi.DeletedUsernameDAO;
 import io.dockstore.webservice.jdbi.EventDAO;
 import io.dockstore.webservice.jdbi.FileDAO;
+import io.dockstore.webservice.jdbi.ServiceDAO;
 import io.dockstore.webservice.jdbi.TagDAO;
 import io.dockstore.webservice.jdbi.TokenDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
@@ -339,6 +340,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         final TokenDAO tokenDAO = new TokenDAO(hibernate.getSessionFactory());
         final DeletedUsernameDAO deletedUsernameDAO = new DeletedUsernameDAO(hibernate.getSessionFactory());
         final ToolDAO toolDAO = new ToolDAO(hibernate.getSessionFactory());
+        final ServiceDAO serviceDAO = new ServiceDAO(hibernate.getSessionFactory());
         final FileDAO fileDAO = new FileDAO(hibernate.getSessionFactory());
         final WorkflowDAO workflowDAO = new WorkflowDAO(hibernate.getSessionFactory());
         final AppToolDAO appToolDAO = new AppToolDAO(hibernate.getSessionFactory());
@@ -412,6 +414,8 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         ToolsApiServiceImpl.setToolDAO(toolDAO);
         ToolsApiServiceImpl.setWorkflowDAO(workflowDAO);
         ToolsApiServiceImpl.setBioWorkflowDAO(bioWorkflowDAO);
+        ToolsApiServiceImpl.setServiceDAO(serviceDAO);
+        ToolsApiServiceImpl.setAppToolDAO(appToolDAO);
         ToolsApiServiceImpl.setFileDAO(fileDAO);
         ToolsApiServiceImpl.setConfig(configuration);
         ToolsApiServiceImpl.setTrsListener(trsListener);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/AppToolDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/AppToolDAO.java
@@ -38,11 +38,11 @@ public class AppToolDAO extends EntryDAO<AppTool> {
         final SourceControlConverter converter = new SourceControlConverter();
         final Root<AppTool> entryRoot = q.from(AppTool.class);
 
-        Predicate predicate = getBioWorkflowPredicate(descriptorLanguage, registry, organization, name, toolname, description, author, cb, converter, entryRoot);
+        Predicate predicate = getWorkflowPredicate(descriptorLanguage, registry, organization, name, toolname, description, author, checker, cb, converter, entryRoot);
 
+        // apptool is never a checker workflow
         if (checker != null && checker) {
-            // tools are never checker workflows
-            predicate = cb.and(predicate, cb.isFalse(cb.literal(false)));
+            predicate = cb.isFalse(cb.literal(true));
         }
 
         q.where(predicate);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/BioWorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/BioWorkflowDAO.java
@@ -24,7 +24,6 @@ import io.dockstore.webservice.core.database.MyWorkflows;
 import io.dockstore.webservice.core.database.RSSWorkflowPath;
 import io.dockstore.webservice.core.database.WorkflowPath;
 import java.util.List;
-import java.util.Optional;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
@@ -48,24 +47,7 @@ public class BioWorkflowDAO extends EntryDAO<BioWorkflow> {
         final SourceControlConverter converter = new SourceControlConverter();
         final Root<BioWorkflow> entryRoot = q.from(BioWorkflow.class);
 
-        Predicate predicate = cb.isTrue(entryRoot.get("isPublished"));
-        predicate = andLike(cb, predicate, entryRoot.get("organization"), Optional.ofNullable(organization));
-        predicate = andLike(cb, predicate, entryRoot.get("repository"), Optional.ofNullable(name));
-        predicate = andLike(cb, predicate, entryRoot.get("workflowName"), Optional.ofNullable(toolname));
-        predicate = andLike(cb, predicate, entryRoot.get("description"), Optional.ofNullable(description));
-        predicate = andLike(cb, predicate, entryRoot.get("author"), Optional.ofNullable(author));
-
-        if (descriptorLanguage != null) {
-            predicate = cb.and(predicate, cb.equal(entryRoot.get("descriptorType"), descriptorLanguage));
-        }
-        if (registry != null) {
-            predicate = cb.and(predicate, cb.equal(entryRoot.get("sourceControl"), converter.convertToEntityAttribute(registry)));
-        }
-
-        if (checker != null) {
-            predicate = cb.and(predicate, cb.isTrue(entryRoot.get("isChecker")));
-        }
-
+        Predicate predicate = getBioWorkflowPredicate(descriptorLanguage, registry, organization, name, toolname, description, author, cb, converter, entryRoot);
         q.where(predicate);
         return entryRoot;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/BioWorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/BioWorkflowDAO.java
@@ -47,7 +47,12 @@ public class BioWorkflowDAO extends EntryDAO<BioWorkflow> {
         final SourceControlConverter converter = new SourceControlConverter();
         final Root<BioWorkflow> entryRoot = q.from(BioWorkflow.class);
 
-        Predicate predicate = getBioWorkflowPredicate(descriptorLanguage, registry, organization, name, toolname, description, author, cb, converter, entryRoot);
+        Predicate predicate = getWorkflowPredicate(descriptorLanguage, registry, organization, name, toolname, description, author, checker, cb, converter, entryRoot);
+
+        // its tempting to put this in EntryDAO, but something goes wrong with generics/inheritance
+        if (checker != null) {
+            predicate = cb.and(predicate, cb.equal(entryRoot.get("isChecker"), checker));
+        }
         q.where(predicate);
         return entryRoot;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -25,6 +25,7 @@ import io.dockstore.webservice.core.CollectionEntry;
 import io.dockstore.webservice.core.CollectionOrganization;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Label;
+import io.dockstore.webservice.core.SourceControlConverter;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
@@ -388,4 +389,23 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
     @SuppressWarnings({"checkstyle:ParameterNumber"})
     protected abstract Root<T> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker,
         CriteriaBuilder cb, CriteriaQuery<?> q);
+
+    @SuppressWarnings({"checkstyle:ParameterNumber"})
+    protected Predicate getBioWorkflowPredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, CriteriaBuilder cb,
+        SourceControlConverter converter, Root<?> entryRoot) {
+        Predicate predicate = cb.isTrue(entryRoot.get("isPublished"));
+        predicate = andLike(cb, predicate, entryRoot.get("organization"), Optional.ofNullable(organization));
+        predicate = andLike(cb, predicate, entryRoot.get("repository"), Optional.ofNullable(name));
+        predicate = andLike(cb, predicate, entryRoot.get("workflowName"), Optional.ofNullable(toolname));
+        predicate = andLike(cb, predicate, entryRoot.get("description"), Optional.ofNullable(description));
+        predicate = andLike(cb, predicate, entryRoot.get("author"), Optional.ofNullable(author));
+
+        if (descriptorLanguage != null) {
+            predicate = cb.and(predicate, cb.equal(entryRoot.get("descriptorType"), descriptorLanguage));
+        }
+        if (registry != null) {
+            predicate = cb.and(predicate, cb.equal(entryRoot.get("sourceControl"), converter.convertToEntityAttribute(registry)));
+        }
+        return predicate;
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -379,7 +379,9 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
 
         final CriteriaBuilder cb = currentSession().getCriteriaBuilder();
         final CriteriaQuery<T> q = cb.createQuery(typeOfT);
-        generatePredicate(descriptorLanguage, registry, organization, name, toolname, description, author, checker, cb, q);
+        final Root<T> tRoot = generatePredicate(descriptorLanguage, registry, organization, name, toolname, description, author, checker, cb, q);
+        // order by id
+        q.orderBy(cb.asc(tRoot.get("id")));
         TypedQuery<T> query = currentSession().createQuery(q);
         query.setFirstResult(startIndex);
         query.setMaxResults(pageRemaining);
@@ -391,8 +393,8 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
         CriteriaBuilder cb, CriteriaQuery<?> q);
 
     @SuppressWarnings({"checkstyle:ParameterNumber"})
-    protected Predicate getBioWorkflowPredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, CriteriaBuilder cb,
-        SourceControlConverter converter, Root<?> entryRoot) {
+    protected Predicate getWorkflowPredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker,
+        CriteriaBuilder cb, SourceControlConverter converter, Root<?> entryRoot) {
         Predicate predicate = cb.isTrue(entryRoot.get("isPublished"));
         predicate = andLike(cb, predicate, entryRoot.get("organization"), Optional.ofNullable(organization));
         predicate = andLike(cb, predicate, entryRoot.get("repository"), Optional.ofNullable(name));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ServiceDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ServiceDAO.java
@@ -18,10 +18,12 @@ package io.dockstore.webservice.jdbi;
 
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.core.Service;
+import io.dockstore.webservice.core.SourceControlConverter;
 import io.dockstore.webservice.core.database.WorkflowPath;
 import java.util.List;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import org.hibernate.SessionFactory;
 
@@ -43,9 +45,15 @@ public class ServiceDAO extends EntryDAO<Service> {
 
     @Override
     @SuppressWarnings({"checkstyle:ParameterNumber"})
-    protected Root<Service> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author,
-        Boolean checker, CriteriaBuilder cb, CriteriaQuery<?> q) {
-        throw new UnsupportedOperationException("Only supported for BioWorkflow and Tools");
+    protected Root<Service> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker,
+        CriteriaBuilder cb, CriteriaQuery<?> q) {
+
+        final SourceControlConverter converter = new SourceControlConverter();
+        final Root<Service> entryRoot = q.from(Service.class);
+
+        Predicate predicate = getBioWorkflowPredicate(descriptorLanguage, registry, organization, name, toolname, description, author, cb, converter, entryRoot);
+        q.where(predicate);
+        return entryRoot;
     }
 
     public List<WorkflowPath> findAllPublishedPaths() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ServiceDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ServiceDAO.java
@@ -51,7 +51,13 @@ public class ServiceDAO extends EntryDAO<Service> {
         final SourceControlConverter converter = new SourceControlConverter();
         final Root<Service> entryRoot = q.from(Service.class);
 
-        Predicate predicate = getBioWorkflowPredicate(descriptorLanguage, registry, organization, name, toolname, description, author, cb, converter, entryRoot);
+        Predicate predicate = getWorkflowPredicate(descriptorLanguage, registry, organization, name, toolname, description, author, checker, cb, converter, entryRoot);
+
+        // apptool is never a checker workflow
+        if (checker != null && checker) {
+            predicate = cb.isFalse(cb.literal(true));
+        }
+
         q.where(predicate);
         return entryRoot;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ToolDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ToolDAO.java
@@ -23,7 +23,6 @@ import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.database.RSSToolPath;
 import io.dockstore.webservice.core.database.ToolPath;
 import io.dockstore.webservice.helpers.JsonLdRetriever;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -211,6 +210,10 @@ public class ToolDAO extends EntryDAO<Tool> {
         predicate = andLike(cb, predicate, entryRoot.get("toolname"), Optional.ofNullable(toolname));
         predicate = andLike(cb, predicate, entryRoot.get("description"), Optional.ofNullable(description));
         predicate = andLike(cb, predicate, entryRoot.get("author"), Optional.ofNullable(author));
+        if (checker != null && checker) {
+            // tools are never checker workflows
+            predicate = cb.and(predicate, cb.isFalse(cb.literal(false)));
+        }
 
         if (descriptorLanguage != null) {
             // not quite right, this probably doesn't deal with tools that have both but https://hibernate.atlassian.net/browse/HHH-9991 is kicking my butt
@@ -220,27 +223,5 @@ public class ToolDAO extends EntryDAO<Tool> {
 
         q.where(predicate);
         return entryRoot;
-    }
-
-    @Override
-    @SuppressWarnings({"checkstyle:ParameterNumber"})
-    public List<Tool> filterTrsToolsGet(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname,
-        String description, String author, Boolean checker, int startIndex, int pageRemaining) {
-        //TODO: probably a better way of doing this with the predicate builder, we can short circuit since tools are never checkers
-        if (checker != null && checker) {
-            return new ArrayList<>();
-        }
-        return super.filterTrsToolsGet(descriptorLanguage, registry, organization, name, toolname,
-            description, author, checker, startIndex, pageRemaining);
-    }
-
-    @Override
-    @SuppressWarnings({"checkstyle:ParameterNumber"})
-    public long countAllPublished(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker) {
-        //TODO: probably a better way of doing this with the predicate builder, we can short circuit since tools are never checkers
-        if (checker != null && checker) {
-            return 0;
-        }
-        return super.countAllPublished(descriptorLanguage, registry, organization, name, toolname, description, author, checker);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ToolDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/ToolDAO.java
@@ -212,7 +212,7 @@ public class ToolDAO extends EntryDAO<Tool> {
         predicate = andLike(cb, predicate, entryRoot.get("author"), Optional.ofNullable(author));
         if (checker != null && checker) {
             // tools are never checker workflows
-            predicate = cb.and(predicate, cb.isFalse(cb.literal(false)));
+            predicate = cb.isFalse(cb.literal(true));
         }
 
         if (descriptorLanguage != null) {

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolClassesApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolClassesApiServiceImpl.java
@@ -62,6 +62,7 @@ public class ToolClassesApiServiceImpl extends ToolClassesApiService {
         final List<ToolClass> toolTypes = new ArrayList<>();
         toolTypes.add(getCommandLineToolClass());
         toolTypes.add(getWorkflowClass());
+        toolTypes.add(getServiceClass());
         return Response.ok().entity(toolTypes).build();
     }
 }

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -473,19 +473,20 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
                     startIndex = startIndex - entriesConsidered;
                 }
 
-                if (startIndex < typeDAO.right) {
+                if (startIndex < typeDAO.right && isCorrectToolClass(toolClass, typeDAO.left)) {
                     // then we want at least some of whatever this DAO returns
-                    // Add them if user didn't provide a tool class or the tool class provided matches
-                    if (toolClass == null || typeDAO.left.equalsIgnoreCase(toolClass)) {
-                        // TODO we used to handle languages for tools here, test this
-                        all.addAll(typeDAO.middle
-                            .filterTrsToolsGet(descriptorLanguage, registry, organization, name, toolname, description, author, checker, Math.toIntExact(startIndex), Math.toIntExact(pageRemaining)));
-                    }
+                    // TODO we used to handle languages for tools here, test this
+                    all.addAll(typeDAO.middle
+                        .filterTrsToolsGet(descriptorLanguage, registry, organization, name, toolname, description, author, checker, Math.toIntExact(startIndex), Math.toIntExact(pageRemaining)));
                 }
                 entriesConsidered = typeDAO.right;
             }
         }
         return new NumberOfEntityTypes(numTools, numWorkflows, numAppTools, numServices);
+    }
+
+    private boolean isCorrectToolClass(String toolClass, String daoToolClass) {
+        return toolClass == null || daoToolClass.equalsIgnoreCase(toolClass);
     }
 
 
@@ -965,10 +966,10 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
 
     private static class NumberOfEntityTypes {
 
-        public long numTools;
-        public long numWorkflows;
-        public long numAppTools;
-        public long numServices;
+        public final long numTools;
+        public final long numWorkflows;
+        public final long numAppTools;
+        public final long numServices;
 
         NumberOfEntityTypes(long numTools, long numWorkflows, long numAppTools, long numServices) {
             this.numTools = numTools;

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -327,6 +327,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         int offsetInteger = 0;
         if (offset != null) {
             offsetInteger = Integer.parseInt(offset);
+            offsetInteger = Math.max(offsetInteger, 0);
         }
         // note, there's a subtle change in definition here, TRS uses offset to indicate the page number, JPA uses index in the result set
         int startIndex = offsetInteger * actualLimit;
@@ -464,9 +465,9 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
 
             for (ImmutableTriple<String, EntryDAO, Long> typeDAO : typeDAOs) {
                 if (!all.isEmpty()) {
-                    // if we got any tools, overflow into the very start of workflows
+                    // if we got any tools, overflow into the very start of the next type of stuff
                     startIndex = 0;
-                    pageRemaining = Math.max(pageRemaining - all.size(), 0);
+                    pageRemaining = Math.max(actualLimit - all.size(), 0);
                 } else {
                     // on the other hand, if we skipped all tools then, adjust the start index accordingly
                     // TODO: conversion might bite us much later

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolClassesApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolClassesApiServiceImpl.java
@@ -56,6 +56,7 @@ public class ToolClassesApiServiceImpl extends ToolClassesApiService {
         final List<ToolClass> toolTypes = new ArrayList<ToolClass>();
         toolTypes.add(getCommandLineToolClass());
         toolTypes.add(getWorkflowClass());
+        toolTypes.add(getServiceClass());
         return Response.ok().entity(toolTypes).build();
     }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.SystemErrRule;
@@ -25,7 +26,7 @@ public class QuayImageRegistryTest {
      * This tests that when there are over 500 tags, we can use the paginated endpoint to retrieve all of them instead.
      * Using calico/node because it has over 3838 tags
      */
-    //    @Ignore("https://github.com/dockstore/dockstore/issues/4663")
+    @Ignore("https://github.com/dockstore/dockstore/issues/4663 and possibly https://github.com/dockstore/dockstore/pull/4753")
     @Test
     public void getOver500TagsTest() {
         Token token = new Token();


### PR DESCRIPTION
**Description**
* add services and apptools to TRS
* distinguish between api versions and use real limit for cache
* also re-enabling TRS app tool tests
* also expanding tests to build some confidence

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-3917
https://ucsc-cgl.atlassian.net/browse/DOCK-2070
part of https://ucsc-cgl.atlassian.net/browse/SEAB-3936

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
