### PR TITLE
Handle quay tags that are manifest lists

### DIFF
--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-common</artifactId>
-  <version>1.12.0-beta.1-SNAPSHOT</version>
+  <version>1.12.0-beta.2-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/dockstore-event-consumer/generated/src/main/resources/pom.xml
+++ b/dockstore-event-consumer/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-event-consumer</artifactId>
-  <version>1.12.0-beta.1-SNAPSHOT</version>
+  <version>1.12.0-beta.2-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,13 +30,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.0-beta.1-SNAPSHOT</version>
+      <version>1.12.0-beta.2-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.12.0-beta.1-SNAPSHOT</version>
+      <version>1.12.0-beta.2-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-integration-testing</artifactId>
-  <version>1.12.0-beta.1-SNAPSHOT</version>
+  <version>1.12.0-beta.2-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -54,13 +54,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.12.0-beta.1-SNAPSHOT</version>
+      <version>1.12.0-beta.2-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.0-beta.1-SNAPSHOT</version>
+      <version>1.12.0-beta.2-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.0-beta.1-SNAPSHOT</version>
+      <version>1.12.0-beta.2-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>openapi-java-client</artifactId>
-      <version>1.12.0-beta.1-SNAPSHOT</version>
+      <version>1.12.0-beta.2-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-language-plugin-parent</artifactId>
-  <version>1.12.0-beta.1-SNAPSHOT</version>
+  <version>1.12.0-beta.2-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.0-beta.1-SNAPSHOT</version>
+      <version>1.12.0-beta.2-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-quay-client</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-quay-client</artifactId>
-      <version>2.0.1-SNAPSHOT</version>
+      <version>2.0.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-webservice</artifactId>
-  <version>1.12.0-beta.1-SNAPSHOT</version>
+  <version>1.12.0-beta.2-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -84,13 +84,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.0-beta.1-SNAPSHOT</version>
+      <version>1.12.0-beta.2-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-language-plugin-parent</artifactId>
-      <version>1.12.0-beta.1-SNAPSHOT</version>
+      <version>1.12.0-beta.2-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-quay-client</artifactId>
-            <version>2.0.1-SNAPSHOT</version>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-quay-client</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
@@ -133,7 +133,7 @@ public class QuayImageRegistry extends AbstractImageRegistry {
                         List<Image> images = handleMultiArchQuayTags(tool, quayTag, g, cleanedQuayTagList);
                         multiImageQuayTags.put(quayTag, images);
                     } catch (ApiException ex) {
-                        System.out.println("Unable to handle manifest list for QuayTag " + quayTag.getName() + " in repo " + repo);
+                        LOG.info("Unable to handle manifest list for QuayTag " + quayTag.getName() + " in repo " + repo);
                     }
 
                 }
@@ -170,7 +170,7 @@ public class QuayImageRegistry extends AbstractImageRegistry {
         LOG.info(quayToken.getUsername() + " ======================= Getting image for tag {}================================", quayTag.getName());
         QuayRepoManifest quayRepoManifest;
         DockerManifestList manifestList;
-        List<Image> images = new ArrayList<Image>();
+        List<Image> images = new ArrayList<>();
         quayRepoManifest = manifestApi.getRepoManifest(quayTag.getManifestDigest(), tool.getNamespace() + '/' + tool.getName());
         try {
             manifestList = g.fromJson(quayRepoManifest.getManifestData(), DockerManifestList.class);
@@ -202,7 +202,7 @@ public class QuayImageRegistry extends AbstractImageRegistry {
         final Tag tag = new Tag();
         BeanUtils.copyProperties(tag, quayTag);
         // If we were unable to get the list of images from the manifest list, then an empty image list will be added to the tag.
-        if (quayTag.isIsManifestList()) {
+        if (quayTag.isIsManifestList() != null && quayTag.isIsManifestList()) {
             List<Image> images = multiImageQuayTags.get(quayTag);
             tag.getImages().addAll(images);
         } else {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
@@ -129,6 +129,7 @@ public class QuayImageRegistry extends AbstractImageRegistry {
             quayTags.stream().forEach(quayTag -> {
                 if (quayTag.isIsManifestList() != null && quayTag.isIsManifestList()) {
                     try {
+                        // Store the collected Image(s) into a map that consists of <Original Manifest List Quay Tag, List<Images>>.
                         List<Image> images = handleMultiArchQuayTags(tool, quayTag, g, cleanedQuayTagList);
                         multiImageQuayTags.put(quayTag, images);
                     } catch (ApiException ex) {
@@ -156,7 +157,7 @@ public class QuayImageRegistry extends AbstractImageRegistry {
     /**
      * For each manifest in the list:
      * Find the matching Quay tag (using the digest)
-     * Store the collected Image(s) into a map that consists of <Original Manifest List Quay Tag, List<Images>>.
+     * Gather and return the associated images
      * Remove the matching Quay tag from the list so that a Dockstore version is not created based off of it.
      *
      * @param tool a tool from Dockstore

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
@@ -132,7 +132,7 @@ public class QuayImageRegistry extends AbstractImageRegistry {
                         List<Image> images = handleMultiArchQuayTags(tool, quayTag, g, cleanedQuayTagList);
                         multiImageQuayTags.put(quayTag, images);
                     } catch (ApiException ex) {
-                        System.out.println("Unable to handle manifest list for QuayTag " + quayTag.getName() + " in repo " + repo );
+                        System.out.println("Unable to handle manifest list for QuayTag " + quayTag.getName() + " in repo " + repo);
                     }
 
                 }

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -13,7 +13,7 @@ info:
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
   termsOfService: https://github.com/dockstore/dockstore-ui2/raw/develop/src/assets/docs/Dockstore_Terms_of_Service.pdf
   title: Dockstore API
-  version: 1.12.0-beta.1-SNAPSHOT
+  version: 1.12.0-beta.2-SNAPSHOT
 servers:
 - description: Current server when hosted on AWS
   url: /api

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5,7 +5,7 @@ info:
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images. Explore swagger.json for a Swagger 2.0 description\
     \ of our API and explore openapi.yaml for OpenAPI 3.0 descriptions."
-  version: "1.12.0-beta.1-SNAPSHOT"
+  version: "1.12.0-beta.2-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/openapi-java-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>openapi-java-client</artifactId>
-  <version>1.12.0-beta.1-SNAPSHOT</version>
+  <version>1.12.0-beta.2-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.0-beta.1-SNAPSHOT</version>
+      <version>1.12.0-beta.2-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/reports/generated/src/main/resources/pom.xml
+++ b/reports/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>reports</artifactId>
-  <version>1.12.0-beta.1-SNAPSHOT</version>
+  <version>1.12.0-beta.2-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,19 +30,19 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.0-beta.1-SNAPSHOT</version>
+      <version>1.12.0-beta.2-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.0-beta.1-SNAPSHOT</version>
+      <version>1.12.0-beta.2-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-integration-testing</artifactId>
-      <version>1.12.0-beta.1-SNAPSHOT</version>
+      <version>1.12.0-beta.2-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/swagger-java-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-client</artifactId>
-  <version>1.12.0-beta.1-SNAPSHOT</version>
+  <version>1.12.0-beta.2-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.0-beta.1-SNAPSHOT</version>
+      <version>1.12.0-beta.2-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
**Description**
I searched through the logs and I couldn't find the error actually occurring in production, but we should handle this regardless. If users upload images with specific arch/os information, then Quay lists the original tag in their API as not having a size and is categorized as a being a manifest list. You need to use it's manifest digest to get the list of manifests which then need to be used to find the corresponding Quay tags.

So this PR will make a Dockstore version based off of the Quay tag that does not have the size and store the corresponding/related Quay tags in its list of images.

Needed to change the Quay Swagger as well https://github.com/dockstore/swagger-java-quay-client/pull/3 so I guess I need to make a release for this to build?

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-3928

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
