### PR TITLE
Remove language specific code to simplify adding a new language

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
@@ -93,7 +93,7 @@ public enum DescriptorLanguage {
     private final String friendlyName;
 
     /**
-     * This is the primary descriptor filetype stored for files of this language in the database
+     * This is the primary descriptor file type stored for files of this language in the database
      */
     private final FileType fileType;
 
@@ -219,7 +219,13 @@ public enum DescriptorLanguage {
     public enum FileType {
         // Add supported descriptor types here
         DOCKSTORE_SMK(FileTypeCategory.GENERIC_DESCRIPTOR), SMK_TEST_PARAMS(FileTypeCategory.TEST_FILE),
-        DOCKSTORE_CWL(FileTypeCategory.GENERIC_DESCRIPTOR), DOCKSTORE_WDL(FileTypeCategory.GENERIC_DESCRIPTOR), DOCKERFILE(FileTypeCategory.CONTAINERFILE), CWL_TEST_JSON(FileTypeCategory.TEST_FILE), WDL_TEST_JSON(FileTypeCategory.TEST_FILE), NEXTFLOW(FileTypeCategory.GENERIC_DESCRIPTOR), NEXTFLOW_CONFIG(FileTypeCategory.PRIMARY_DESCRIPTOR), NEXTFLOW_TEST_PARAMS(FileTypeCategory.TEST_FILE), DOCKSTORE_YML(FileTypeCategory.OTHER), DOCKSTORE_SERVICE_YML(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_SERVICE_TEST_JSON(FileTypeCategory.TEST_FILE), DOCKSTORE_SERVICE_OTHER(FileTypeCategory.OTHER), DOCKSTORE_GXFORMAT2(FileTypeCategory.GENERIC_DESCRIPTOR), GXFORMAT2_TEST_FILE(FileTypeCategory.TEST_FILE),
+        DOCKSTORE_CWL(FileTypeCategory.GENERIC_DESCRIPTOR), CWL_TEST_JSON(FileTypeCategory.TEST_FILE),
+        DOCKSTORE_WDL(FileTypeCategory.GENERIC_DESCRIPTOR), WDL_TEST_JSON(FileTypeCategory.TEST_FILE),
+        DOCKERFILE(FileTypeCategory.CONTAINERFILE),
+        NEXTFLOW(FileTypeCategory.GENERIC_DESCRIPTOR), NEXTFLOW_CONFIG(FileTypeCategory.PRIMARY_DESCRIPTOR), NEXTFLOW_TEST_PARAMS(FileTypeCategory.TEST_FILE),
+        DOCKSTORE_YML(FileTypeCategory.OTHER),
+        DOCKSTORE_SERVICE_YML(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_SERVICE_TEST_JSON(FileTypeCategory.TEST_FILE), DOCKSTORE_SERVICE_OTHER(FileTypeCategory.OTHER),
+        DOCKSTORE_GXFORMAT2(FileTypeCategory.GENERIC_DESCRIPTOR), GXFORMAT2_TEST_FILE(FileTypeCategory.TEST_FILE),
         DOCKSTORE_SWL(FileTypeCategory.GENERIC_DESCRIPTOR), SWL_TEST_JSON(FileTypeCategory.TEST_FILE);
         // DOCKSTORE-2428 - demo how to add new workflow language
 

--- a/dockstore-language-plugin-parent/src/main/java/io/dockstore/language/MinimalLanguageInterface.java
+++ b/dockstore-language-plugin-parent/src/main/java/io/dockstore/language/MinimalLanguageInterface.java
@@ -47,7 +47,7 @@ public interface MinimalLanguageInterface extends ExtensionPoint {
     /**
      * Find all files that would be useful to display to a user (hopefully all files needed to launch a workflow)
      *
-     * @param initialPath path to the intial descriptor as set by the user (e.g. /example_directory/Dockstore.cwl)
+     * @param initialPath path to the initial descriptor as set by the user (e.g. /example_directory/Dockstore.cwl)
      * @param contents    contents of the initial descriptor
      * @param reader      get additional files and their content
      * @return a map from absolute paths (relative to the root of the repo, e.g. "common.cwl" as opposed to "../common.cwl") to their file types and content

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -113,25 +113,32 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
             String content = file.getContent();
             String absolutePath = file.getAbsolutePath();
 
-            MinimalLanguageInterface.GenericFileType fileType;
-            switch (file.getType().getCategory()) {
+            FileType fileType = file.getType();
+            if (fileType == null) {
+                LOG.error("Could not determine file type for source file {}", file.getPath());
+                throw new CustomWebApplicationException("Could not determine file type for source file "
+                    + file.getPath(), HttpStatus.SC_METHOD_FAILURE);
+            }
+            MinimalLanguageInterface.GenericFileType genericFileType;
+            switch (fileType.getCategory()) {
             case GENERIC_DESCRIPTOR:
             case PRIMARY_DESCRIPTOR:
             case SECONDARY_DESCRIPTOR:
             case OTHER:
-                fileType = MinimalLanguageInterface.GenericFileType.IMPORTED_DESCRIPTOR;
+                genericFileType = MinimalLanguageInterface.GenericFileType.IMPORTED_DESCRIPTOR;
                 break;
             case TEST_FILE:
-                fileType = MinimalLanguageInterface.GenericFileType.TEST_PARAMETER_FILE;
+                genericFileType = MinimalLanguageInterface.GenericFileType.TEST_PARAMETER_FILE;
                 break;
             case CONTAINERFILE:
-                fileType = MinimalLanguageInterface.GenericFileType.CONTAINERFILE;
+                genericFileType = MinimalLanguageInterface.GenericFileType.CONTAINERFILE;
                 break;
             default:
                 LOG.error("Could not determine file type category for source file {}", file.getPath());
-                throw new CustomWebApplicationException("Could not determine file type category for source file " + file.getPath(), HttpStatus.SC_METHOD_FAILURE);
+                throw new CustomWebApplicationException("Could not determine file type category for source file "
+                    + file.getPath(), HttpStatus.SC_METHOD_FAILURE);
             }
-            Pair<String, MinimalLanguageInterface.GenericFileType> indexedFile = new ImmutablePair<>(content, fileType);
+            Pair<String, MinimalLanguageInterface.GenericFileType> indexedFile = new ImmutablePair<>(content, genericFileType);
             indexedFiles.put(absolutePath, indexedFile);
         }
         return indexedFiles;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -127,7 +127,7 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
             } else if (fileTypeCategory == FileTypeCategory.CONTAINERFILE) {
                 fileType = MinimalLanguageInterface.GenericFileType.CONTAINERFILE;
             } else {
-                LOG.error("could not determine file type catagory, so setting file type to CONTAINER for source file ", file.getPath());
+                LOG.info(String.format("Could not determine file type catagory, so setting file type to CONTAINER for source file %s", file.getPath()));
                 fileType = MinimalLanguageInterface.GenericFileType.CONTAINERFILE;
             }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -18,7 +18,6 @@ package io.dockstore.webservice.languages;
 import com.google.gson.Gson;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.DescriptorLanguage.FileType;
-import io.dockstore.common.DescriptorLanguage.FileTypeCategory;
 import io.dockstore.common.VersionTypeValidation;
 import io.dockstore.language.CompleteLanguageInterface;
 import io.dockstore.language.MinimalLanguageInterface;
@@ -115,22 +114,23 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
             String absolutePath = file.getAbsolutePath();
 
             MinimalLanguageInterface.GenericFileType fileType;
-
-            FileTypeCategory fileTypeCategory = file.getType().getCategory();
-            if (fileTypeCategory == FileTypeCategory.GENERIC_DESCRIPTOR
-                || fileTypeCategory == FileTypeCategory.PRIMARY_DESCRIPTOR
-                || fileTypeCategory == FileTypeCategory.SECONDARY_DESCRIPTOR
-                || fileTypeCategory == FileTypeCategory.OTHER) {
+            switch (file.getType().getCategory()) {
+            case GENERIC_DESCRIPTOR:
+            case PRIMARY_DESCRIPTOR:
+            case SECONDARY_DESCRIPTOR:
+            case OTHER:
                 fileType = MinimalLanguageInterface.GenericFileType.IMPORTED_DESCRIPTOR;
-            } else if (fileTypeCategory == FileTypeCategory.TEST_FILE) {
+                break;
+            case TEST_FILE:
                 fileType = MinimalLanguageInterface.GenericFileType.TEST_PARAMETER_FILE;
-            } else if (fileTypeCategory == FileTypeCategory.CONTAINERFILE) {
+                break;
+            case CONTAINERFILE:
                 fileType = MinimalLanguageInterface.GenericFileType.CONTAINERFILE;
-            } else {
-                LOG.info("Could not determine file type category, so setting file type to CONTAINER for source file {}", file.getPath());
-                fileType = MinimalLanguageInterface.GenericFileType.CONTAINERFILE;
+                break;
+            default:
+                LOG.error("Could not determine file type category for source file {}", file.getPath());
+                throw new CustomWebApplicationException("Could not determine file type category for source file " + file.getPath(), HttpStatus.SC_METHOD_FAILURE);
             }
-
             Pair<String, MinimalLanguageInterface.GenericFileType> indexedFile = new ImmutablePair<>(content, fileType);
             indexedFiles.put(absolutePath, indexedFile);
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -63,8 +63,8 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
 
     @Override
     public Version parseWorkflowContent(String filepath, String content, Set<SourceFile> sourceFiles, Version version) {
-        final MinimalLanguageInterface.WorkflowMetadata workflowMetadata = minimalLanguageInterface
-            .parseWorkflowForMetadata(filepath, content, new HashMap<>());
+        final MinimalLanguageInterface.WorkflowMetadata workflowMetadata =
+            minimalLanguageInterface.parseWorkflowForMetadata(filepath, content, new HashMap<>());
         // Add authors from descriptor if there are no .dockstore.yml authors
         if (workflowMetadata.getAuthor() != null && version.getAuthors().isEmpty()) {
             Author author = new Author(workflowMetadata.getAuthor());
@@ -115,9 +115,9 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
 
             FileType fileType = file.getType();
             if (fileType == null) {
-                LOG.error("Could not determine file type for source file {}", file.getPath());
-                throw new CustomWebApplicationException("Could not determine file type for source file "
-                    + file.getPath(), HttpStatus.SC_METHOD_FAILURE);
+                LOG.error("File type for source file {} is null", file.getPath());
+                throw new CustomWebApplicationException("File type for source file "
+                    + file.getPath() + " is null", HttpStatus.SC_METHOD_FAILURE);
             }
             MinimalLanguageInterface.GenericFileType genericFileType;
             switch (fileType.getCategory()) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -127,7 +127,7 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
             } else if (fileTypeCategory == FileTypeCategory.CONTAINERFILE) {
                 fileType = MinimalLanguageInterface.GenericFileType.CONTAINERFILE;
             } else {
-                LOG.info(String.format("Could not determine file type catagory, so setting file type to CONTAINER for source file %s", file.getPath()));
+                LOG.info("Could not determine file type category, so setting file type to CONTAINER for source file {}", file.getPath());
                 fileType = MinimalLanguageInterface.GenericFileType.CONTAINERFILE;
             }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
@@ -258,10 +258,21 @@ public class HostedWorkflowResource extends AbstractHostedEntryResource<Workflow
         descriptorValidation = new Validation(identifiedType, validDescriptorSet);
         version.addOrUpdateValidation(descriptorValidation);
 
-        DescriptorLanguage.FileType testParameterType = null;
+        DescriptorLanguage descriptorLanguage = null;
+        try {
+            // get the descriptor language associated with this file
+            descriptorLanguage = DescriptorLanguage.getDescriptorLanguage(identifiedType);
+        } catch (UnsupportedOperationException exception) {
+            // if the file type was not a valid workflow file type throw an exception
+            throw new CustomWebApplicationException(identifiedType + " is not a valid workflow or test file type.", HttpStatus.SC_BAD_REQUEST);
+        }
 
-        testParameterType = DescriptorLanguage.getDescriptorLanguage(identifiedType).getTestParamType();
+        DescriptorLanguage.FileType testParameterType = DescriptorLanguage.getDescriptorLanguage(identifiedType).getTestParamType();
         if (testParameterType != null) {
+            // if the type of the file is already a test file then this is an error
+            if (testParameterType == identifiedType) {
+                throw new CustomWebApplicationException(identifiedType + " is a test file type, not a valid workflow type.", HttpStatus.SC_BAD_REQUEST);
+            }
             VersionTypeValidation validTestParameterSet = LanguageHandlerFactory.getInterface(identifiedType).validateTestParameterSet(sourceFiles);
             Validation testParameterValidation = new Validation(testParameterType, validTestParameterSet);
             version.addOrUpdateValidation(testParameterValidation);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
@@ -267,7 +267,7 @@ public class HostedWorkflowResource extends AbstractHostedEntryResource<Workflow
             throw new CustomWebApplicationException(identifiedType + " is not a valid workflow or test file type.", HttpStatus.SC_BAD_REQUEST);
         }
 
-        DescriptorLanguage.FileType testParameterType = DescriptorLanguage.getDescriptorLanguage(identifiedType).getTestParamType();
+        DescriptorLanguage.FileType testParameterType = descriptorLanguage.getTestParamType();
         if (testParameterType != null) {
             // if the type of the file is already a test file then this is an error
             if (testParameterType == identifiedType) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
@@ -259,26 +259,8 @@ public class HostedWorkflowResource extends AbstractHostedEntryResource<Workflow
         version.addOrUpdateValidation(descriptorValidation);
 
         DescriptorLanguage.FileType testParameterType = null;
-        switch (identifiedType) {
-        case DOCKSTORE_SMK:
-            testParameterType = DescriptorLanguage.FileType.SMK_TEST_PARAMS;
-            break;
-        case DOCKSTORE_CWL:
-            testParameterType = DescriptorLanguage.FileType.CWL_TEST_JSON;
-            break;
-        case DOCKSTORE_WDL:
-            testParameterType = DescriptorLanguage.FileType.WDL_TEST_JSON;
-            break;
-        case DOCKSTORE_GXFORMAT2:
-            testParameterType = DescriptorLanguage.FileType.GXFORMAT2_TEST_FILE;
-            break;
-        case NEXTFLOW_CONFIG:
-            // Nextflow does not have test parameter files, so do not fail
-            break;
-        default:
-            throw new CustomWebApplicationException(identifiedType + " is not a valid workflow type.", HttpStatus.SC_BAD_REQUEST);
-        }
 
+        testParameterType = DescriptorLanguage.getDescriptorLanguage(identifiedType).getTestParamType();
         if (testParameterType != null) {
             VersionTypeValidation validTestParameterSet = LanguageHandlerFactory.getInterface(identifiedType).validateTestParameterSet(sourceFiles);
             Validation testParameterValidation = new Validation(testParameterType, validTestParameterSet);

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
@@ -190,6 +190,9 @@ public final class ToolsImplCommon {
 
             final Set<SourceFile> sourceFiles = version.getSourceFiles();
             for (SourceFile file : sourceFiles) {
+
+                //                DescriptorLanguage descriptorLanguage = DescriptorLanguage.getDescriptorLanguage(file.getType());
+
                 switch (file.getType()) {
                 case DOCKSTORE_SMK:
                     toolVersion.addDescriptorTypeItem(DescriptorType.SMK);

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
@@ -190,9 +190,6 @@ public final class ToolsImplCommon {
 
             final Set<SourceFile> sourceFiles = version.getSourceFiles();
             for (SourceFile file : sourceFiles) {
-
-                //                DescriptorLanguage descriptorLanguage = DescriptorLanguage.getDescriptorLanguage(file.getType());
-
                 switch (file.getType()) {
                 case DOCKSTORE_SMK:
                     toolVersion.addDescriptorTypeItem(DescriptorType.SMK);

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.SystemErrRule;
@@ -25,7 +26,7 @@ public class QuayImageRegistryTest {
      * This tests that when there are over 500 tags, we can use the paginated endpoint to retrieve all of them instead.
      * Using calico/node because it has over 3838 tags
      */
-    //    @Ignore("https://github.com/dockstore/dockstore/issues/4663")
+    @Ignore("https://github.com/dockstore/dockstore/issues/4663")
     @Test
     public void getOver500TagsTest() {
         Token token = new Token();

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
@@ -56,9 +56,6 @@ public class LanguagePluginHandlerTest {
 
     @Test
     public void parseWorkflowContentTest() throws IOException {
-        final ToolDAO toolDAO = Mockito.mock(ToolDAO.class);
-        when(toolDAO.findAllByPath(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(null);
-
         Set<SourceFile> sourceFileSet = new TreeSet<>();
 
         SourceFile mainDescriptorSourceFile = createSourceFile(MAIN_DESCRIPTOR_CWL, MAIN_DESCRIPTOR_CWL_RESOURCE_PATH, FileType.DOCKSTORE_CWL);
@@ -70,15 +67,12 @@ public class LanguagePluginHandlerTest {
         Version workflowVersion = new WorkflowVersion();
         workflowVersion = minimalLanguageHandler.parseWorkflowContent(SECONDARY_DESCRIPTOR_CWL,
             mainDescriptorSourceFile.getContent(), sourceFileSet, workflowVersion);
-        Assert.assertTrue(workflowVersion.getAuthor().equals("Shakespeare")
-            && workflowVersion.getEmail().equals("globetheater@bard.com"));
+        Assert.assertEquals("Shakespeare", workflowVersion.getAuthor());
+        Assert.assertEquals("globetheater@bard.com", workflowVersion.getEmail());
     }
 
     @Test
     public void sourcefilesToIndexedFilesViaValidateWorkflowSetNullTypeTest() throws IOException {
-        final ToolDAO toolDAO = Mockito.mock(ToolDAO.class);
-        when(toolDAO.findAllByPath(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(null);
-
         Set<SourceFile> sourceFileSet = new TreeSet<>();
 
         SourceFile otherFileSourceFile = createSourceFile(OTHER_FILE, OTHER_FILE_RESOURCE_PATH, FileType.DOCKSTORE_YML);
@@ -158,9 +152,6 @@ public class LanguagePluginHandlerTest {
 
     @Test
     public void processImportsTest() throws IOException {
-        final ToolDAO toolDAO = Mockito.mock(ToolDAO.class);
-        when(toolDAO.findAllByPath(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(null);
-
         SourceFile mainDescriptorSourceFile = createSourceFile(MAIN_DESCRIPTOR_CWL, MAIN_DESCRIPTOR_CWL_RESOURCE_PATH, FileType.DOCKSTORE_CWL);
         LanguagePluginHandler minimalLanguageHandler = new LanguagePluginHandler(TestLanguage.class);
         Version emptyVersion = new WorkflowVersion();

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
@@ -53,7 +53,6 @@ public class LanguagePluginHandlerTest {
     public static final String OTHER_FILE_RESOURCE_PATH = "tools-cwl-workflow-experiments/cwl/.dockstore.yml";
     public static final String OTHER_FILE = "/" + OTHER_FILE_RESOURCE_PATH;
     public static final String SERVICE_DESCRIPTOR_RESOURCE_PATH = "tools-cwl-workflow-experiments/cwl/service.yml";
-    public static final String SERVICE_DESCRIPTOR = "/" + SERVICE_DESCRIPTOR_RESOURCE_PATH;
 
     @Test
     public void parseWorkflowContentTest() throws IOException {
@@ -168,15 +167,15 @@ public class LanguagePluginHandlerTest {
         Map<String, SourceFile> importedFilesMap = minimalLanguageHandler.processImports("whatever", mainDescriptorSourceFile.getContent(),
                 emptyVersion, new ToolsCWLWorkflowExpSourceCodeRepoInterface(), MAIN_DESCRIPTOR_CWL);
         SourceFile secondarySourceFile = importedFilesMap.get(SECONDARY_DESCRIPTOR_CWL_RESOURCE_PATH);
-        Assert.assertTrue(secondarySourceFile.getType() == FileType.DOCKSTORE_CWL);
+        Assert.assertSame(secondarySourceFile.getType(), FileType.DOCKSTORE_CWL);
         SourceFile testInputFile = importedFilesMap.get(TEST_INPUT_FILE_RESOURCE_PATH);
-        Assert.assertTrue(testInputFile.getType() == FileType.CWL_TEST_JSON);
+        Assert.assertSame(testInputFile.getType(), FileType.CWL_TEST_JSON);
         SourceFile dockerFile = importedFilesMap.get(DOCKERFILE_RESOURCE_PATH);
-        Assert.assertTrue(dockerFile.getType() == FileType.DOCKERFILE);
+        Assert.assertSame(dockerFile.getType(), FileType.DOCKERFILE);
         SourceFile serviceFile = importedFilesMap.get(SERVICE_DESCRIPTOR_RESOURCE_PATH);
         // eventually will be DescriptorLanguage.FileType.DOCKSTORE_SERVICE_YML
         // when services are enabled?
-        Assert.assertTrue(serviceFile.getType() == FileType.DOCKSTORE_CWL);
+        Assert.assertSame(serviceFile.getType(), FileType.DOCKSTORE_CWL);
 
     }
 
@@ -242,28 +241,22 @@ public class LanguagePluginHandlerTest {
             // This will be executed via the sourcefilesToIndexedFilesViaValidateWorkflowSetNullTypeTest test code
             // and some files may not be present depending on the inputs to the test
             if (indexedFiles.containsKey(MAIN_DESCRIPTOR_CWL)) {
-                Assert.assertTrue(indexedFiles.get(MAIN_DESCRIPTOR_CWL).getRight()
-                    == MinimalLanguageInterface.GenericFileType.IMPORTED_DESCRIPTOR);
+                Assert.assertSame(indexedFiles.get(MAIN_DESCRIPTOR_CWL).getRight(), MinimalLanguageInterface.GenericFileType.IMPORTED_DESCRIPTOR);
             }
             if (indexedFiles.containsKey(SECONDARY_DESCRIPTOR_CWL)) {
-                Assert.assertTrue(indexedFiles.get(SECONDARY_DESCRIPTOR_CWL).getRight()
-                    == MinimalLanguageInterface.GenericFileType.IMPORTED_DESCRIPTOR);
+                Assert.assertSame(indexedFiles.get(SECONDARY_DESCRIPTOR_CWL).getRight(), MinimalLanguageInterface.GenericFileType.IMPORTED_DESCRIPTOR);
             }
             if (indexedFiles.containsKey(TEST_INPUT_FILE)) {
-                Assert.assertTrue(indexedFiles.get(TEST_INPUT_FILE).getRight()
-                    == GenericFileType.TEST_PARAMETER_FILE);
+                Assert.assertSame(indexedFiles.get(TEST_INPUT_FILE).getRight(), GenericFileType.TEST_PARAMETER_FILE);
             }
             if (indexedFiles.containsKey(DOCKERFILE)) {
-                Assert.assertTrue(indexedFiles.get(DOCKERFILE).getRight()
-                    == GenericFileType.CONTAINERFILE);
+                Assert.assertSame(indexedFiles.get(DOCKERFILE).getRight(), GenericFileType.CONTAINERFILE);
             }
             if (indexedFiles.containsKey(PRIMARY_DESCRIPTOR)) {
-                Assert.assertTrue(indexedFiles.get(PRIMARY_DESCRIPTOR).getRight()
-                    == GenericFileType.IMPORTED_DESCRIPTOR);
+                Assert.assertSame(indexedFiles.get(PRIMARY_DESCRIPTOR).getRight(), GenericFileType.IMPORTED_DESCRIPTOR);
             }
             if (indexedFiles.containsKey(OTHER_FILE)) {
-                Assert.assertTrue(indexedFiles.get(OTHER_FILE).getRight()
-                    == GenericFileType.IMPORTED_DESCRIPTOR);
+                Assert.assertSame(indexedFiles.get(OTHER_FILE).getRight(), GenericFileType.IMPORTED_DESCRIPTOR);
             }
 
             return new VersionTypeValidation(true, Collections.emptyMap());

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
@@ -1,0 +1,370 @@
+package io.dockstore.webservice.languages;
+
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.util.Charsets;
+import com.google.common.io.Files;
+import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.common.DescriptorLanguage.FileType;
+import io.dockstore.common.VersionTypeValidation;
+import io.dockstore.language.MinimalLanguageInterface;
+import io.dockstore.language.RecommendedLanguageInterface;
+import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Entry;
+import io.dockstore.webservice.core.SourceControlOrganization;
+import io.dockstore.webservice.core.SourceFile;
+import io.dockstore.webservice.core.Version;
+import io.dockstore.webservice.core.Workflow;
+import io.dockstore.webservice.core.WorkflowVersion;
+import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
+import io.dockstore.webservice.jdbi.ToolDAO;
+import io.dropwizard.testing.ResourceHelpers;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.HttpStatus;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+// TODO add coverage for CompleteLanguageInterface
+public class LanguagePluginHandlerTest {
+    public static final String MAIN_DESCRIPTOR_CWL_RESOURCE_PATH = "tools-cwl-workflow-experiments/cwl/workflow_docker.cwl";
+    public static final String MAIN_DESCRIPTOR_CWL = "/" + MAIN_DESCRIPTOR_CWL_RESOURCE_PATH;
+    public static final String SECONDARY_DESCRIPTOR_CWL_RESOURCE_PATH = "tools-cwl-workflow-experiments/cwl/complex_computation_docker.cwl";
+    public static final String SECONDARY_DESCRIPTOR_CWL = "/" + SECONDARY_DESCRIPTOR_CWL_RESOURCE_PATH;
+    public static final String PRIMARY_DESCRIPTOR_RESOURCE_PATH = "tools-cwl-workflow-experiments/cwl/nextflow.config";
+    public static final String PRIMARY_DESCRIPTOR = "/" + PRIMARY_DESCRIPTOR_RESOURCE_PATH;
+    public static final String DOCKERFILE_RESOURCE_PATH = "tools-cwl-workflow-experiments/cwl/Dockerfile";
+    public static final String DOCKERFILE = "/" + DOCKERFILE_RESOURCE_PATH;
+    public static final String TEST_INPUT_FILE_RESOURCE_PATH = "tools-cwl-workflow-experiments/cwl/workflow.json";
+    public static final String TEST_INPUT_FILE = "/" + TEST_INPUT_FILE_RESOURCE_PATH;
+    public static final String OTHER_FILE_RESOURCE_PATH = "tools-cwl-workflow-experiments/cwl/.dockstore.yml";
+    public static final String OTHER_FILE = "/" + OTHER_FILE_RESOURCE_PATH;
+    public static final String SERVICE_DESCRIPTOR_RESOURCE_PATH = "tools-cwl-workflow-experiments/cwl/service.yml";
+    public static final String SERVICE_DESCRIPTOR = "/" + SERVICE_DESCRIPTOR_RESOURCE_PATH;
+
+    @Test
+    public void parseWorkflowContentTest() throws IOException {
+        final ToolDAO toolDAO = Mockito.mock(ToolDAO.class);
+        when(toolDAO.findAllByPath(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(null);
+
+        Set<SourceFile> sourceFileSet = new TreeSet<>();
+
+        SourceFile mainDescriptorSourceFile = createSourceFile(MAIN_DESCRIPTOR_CWL, MAIN_DESCRIPTOR_CWL_RESOURCE_PATH, FileType.DOCKSTORE_CWL);
+        sourceFileSet.add(mainDescriptorSourceFile);
+        SourceFile secondaryDescriptorSourceFile = createSourceFile(SECONDARY_DESCRIPTOR_CWL, SECONDARY_DESCRIPTOR_CWL_RESOURCE_PATH, FileType.DOCKSTORE_CWL);
+        sourceFileSet.add(secondaryDescriptorSourceFile);
+
+        LanguagePluginHandler minimalLanguageHandler = new LanguagePluginHandler(TestLanguage.class);
+        Version workflowVersion = new WorkflowVersion();
+        workflowVersion = minimalLanguageHandler.parseWorkflowContent(SECONDARY_DESCRIPTOR_CWL,
+            mainDescriptorSourceFile.getContent(), sourceFileSet, workflowVersion);
+        Assert.assertTrue(workflowVersion.getAuthor().equals("Shakespeare")
+            && workflowVersion.getEmail().equals("globetheater@bard.com"));
+    }
+
+    @Test
+    public void sourcefilesToIndexedFilesViaValidateWorkflowSetNullTypeTest() throws IOException {
+        final ToolDAO toolDAO = Mockito.mock(ToolDAO.class);
+        when(toolDAO.findAllByPath(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(null);
+
+        Set<SourceFile> sourceFileSet = new TreeSet<>();
+
+        SourceFile otherFileSourceFile = createSourceFile(OTHER_FILE, OTHER_FILE_RESOURCE_PATH, FileType.DOCKSTORE_YML);
+        sourceFileSet.add(otherFileSourceFile);
+        SourceFile primaryFileSourceFile = createSourceFile(PRIMARY_DESCRIPTOR, PRIMARY_DESCRIPTOR_RESOURCE_PATH, FileType.NEXTFLOW_CONFIG);
+        sourceFileSet.add(primaryFileSourceFile);
+        SourceFile dockerFileSourceFile = createSourceFile(DOCKERFILE, DOCKERFILE_RESOURCE_PATH, FileType.DOCKERFILE);
+        sourceFileSet.add(dockerFileSourceFile);
+        SourceFile testSourceFile = createSourceFile(TEST_INPUT_FILE, TEST_INPUT_FILE_RESOURCE_PATH, FileType.CWL_TEST_JSON);
+        sourceFileSet.add(testSourceFile);
+        SourceFile mainDescriptorSourceFile = createSourceFile(MAIN_DESCRIPTOR_CWL, MAIN_DESCRIPTOR_CWL_RESOURCE_PATH, FileType.DOCKSTORE_CWL);
+        sourceFileSet.add(mainDescriptorSourceFile);
+
+        SourceFile secondaryDescriptorSourceFile = createSourceFile(SECONDARY_DESCRIPTOR_CWL, SECONDARY_DESCRIPTOR_CWL_RESOURCE_PATH, FileType.DOCKSTORE_CWL);
+        // setting the file type to null should cause an exception
+        // in the LanguagePluginHandler sourcefilesToIndexedFiles method
+        secondaryDescriptorSourceFile.setType(null);
+        sourceFileSet.add(secondaryDescriptorSourceFile);
+
+        LanguagePluginHandler minimalLanguageHandler = new LanguagePluginHandler(TestLanguage.class);
+
+        try {
+            minimalLanguageHandler.validateWorkflowSet(sourceFileSet, SECONDARY_DESCRIPTOR_CWL);
+            Assert.fail("Expected method error");
+        } catch (CustomWebApplicationException e) {
+            // ValidateWorkflowSet can intercept the original exception and
+            // return HttpStatus.SC_UNPROCESSABLE_ENTITY
+            Assert.assertTrue("Did not get correct status code",
+                e.getResponse().getStatus() == HttpStatus.SC_UNPROCESSABLE_ENTITY
+                    || e.getResponse().getStatus() == HttpStatus.SC_METHOD_FAILURE);
+        }
+
+        secondaryDescriptorSourceFile.setType(FileType.DOCKSTORE_CWL);
+        sourceFileSet.clear();
+
+        sourceFileSet.add(otherFileSourceFile);
+        sourceFileSet.add(primaryFileSourceFile);
+        sourceFileSet.add(mainDescriptorSourceFile);
+        sourceFileSet.add(secondaryDescriptorSourceFile);
+        sourceFileSet.add(testSourceFile);
+        sourceFileSet.add(dockerFileSourceFile);
+        VersionTypeValidation versionTypeValidation = minimalLanguageHandler.validateWorkflowSet(sourceFileSet, MAIN_DESCRIPTOR_CWL);
+        Assert.assertTrue(versionTypeValidation.isValid());
+
+        sourceFileSet.clear();
+        // Missing main descriptor should cause an invalid version validation
+        sourceFileSet.add(secondaryDescriptorSourceFile);
+        versionTypeValidation = minimalLanguageHandler.validateWorkflowSet(sourceFileSet, MAIN_DESCRIPTOR_CWL);
+        Assert.assertTrue(!versionTypeValidation.isValid()
+            && versionTypeValidation.getMessage().containsValue("Missing the primary descriptor."));
+
+    }
+
+
+    // TODO add coverage for CompleteLanguageInterface
+    @Test
+    public void getContentTest() throws IOException {
+        Set<SourceFile> secondarySourceFiles = new TreeSet<>();
+        final ToolDAO toolDAO = Mockito.mock(ToolDAO.class);
+        when(toolDAO.findAllByPath(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(null);
+
+        SourceFile mainDescriptorSourceFile = createSourceFile(MAIN_DESCRIPTOR_CWL, MAIN_DESCRIPTOR_CWL_RESOURCE_PATH, FileType.DOCKSTORE_CWL);
+        SourceFile secondaryDescriptorSourceFile = createSourceFile(SECONDARY_DESCRIPTOR_CWL, SECONDARY_DESCRIPTOR_CWL_RESOURCE_PATH, FileType.DOCKSTORE_CWL);
+        secondarySourceFiles.add(secondaryDescriptorSourceFile);
+
+        LanguagePluginHandler minimalLanguageHandler = new LanguagePluginHandler(TestLanguage.class);
+        Optional<String> content = Optional.empty();
+        try {
+            content = minimalLanguageHandler.getContent(MAIN_DESCRIPTOR_CWL,
+                mainDescriptorSourceFile.getContent(), secondarySourceFiles,
+                LanguageHandlerInterface.Type.TOOLS, toolDAO);
+        } catch (CustomWebApplicationException e) {
+            Assert.fail("getContentTest should have passed");
+        }
+        Assert.assertTrue(content.isEmpty());
+    }
+
+    @Test
+    public void processImportsTest() throws IOException {
+        final ToolDAO toolDAO = Mockito.mock(ToolDAO.class);
+        when(toolDAO.findAllByPath(Mockito.anyString(), Mockito.anyBoolean())).thenReturn(null);
+
+        SourceFile mainDescriptorSourceFile = createSourceFile(MAIN_DESCRIPTOR_CWL, MAIN_DESCRIPTOR_CWL_RESOURCE_PATH, FileType.DOCKSTORE_CWL);
+        LanguagePluginHandler minimalLanguageHandler = new LanguagePluginHandler(TestLanguage.class);
+        Version emptyVersion = new WorkflowVersion();
+        Map<String, SourceFile> importedFilesMap = minimalLanguageHandler.processImports("whatever", mainDescriptorSourceFile.getContent(),
+                emptyVersion, new ToolsCWLWorkflowExpSourceCodeRepoInterface(), MAIN_DESCRIPTOR_CWL);
+        SourceFile secondarySourceFile = importedFilesMap.get(SECONDARY_DESCRIPTOR_CWL_RESOURCE_PATH);
+        Assert.assertTrue(secondarySourceFile.getType() == FileType.DOCKSTORE_CWL);
+        SourceFile testInputFile = importedFilesMap.get(TEST_INPUT_FILE_RESOURCE_PATH);
+        Assert.assertTrue(testInputFile.getType() == FileType.CWL_TEST_JSON);
+        SourceFile dockerFile = importedFilesMap.get(DOCKERFILE_RESOURCE_PATH);
+        Assert.assertTrue(dockerFile.getType() == FileType.DOCKERFILE);
+        SourceFile serviceFile = importedFilesMap.get(SERVICE_DESCRIPTOR_RESOURCE_PATH);
+        // eventually will be DescriptorLanguage.FileType.DOCKSTORE_SERVICE_YML
+        // when services are enabled?
+        Assert.assertTrue(serviceFile.getType() == FileType.DOCKSTORE_CWL);
+
+    }
+
+    public SourceFile createSourceFile(String filePath, String fileResourcePath, FileType fileType) throws IOException {
+        File resourceFile = new File(ResourceHelpers.resourceFilePath(fileResourcePath));
+        String sourceFileContents = Files.asCharSource(resourceFile, Charsets.UTF_8).read();
+        SourceFile sourceFile = new SourceFile();
+        sourceFile.setType(fileType);
+        sourceFile.setContent(sourceFileContents);
+        sourceFile.setAbsolutePath(filePath);
+        sourceFile.setPath(filePath);
+        return sourceFile;
+    }
+
+    public static class TestLanguage implements RecommendedLanguageInterface {
+
+        // MinimalLanguageInterface
+        @Override
+        public DescriptorLanguage getDescriptorLanguage() {
+            return DescriptorLanguage.CWL;
+        }
+
+        @Override
+        public Pattern initialPathPattern() {
+            return null;
+        }
+
+        @Override
+        public Map<String, Pair<String, GenericFileType>> indexWorkflowFiles(String initialPath,
+            String contents, FileReader reader) {
+            Map<String, Pair<String, GenericFileType>> results = new HashMap<>();
+
+            // fake getting the imported descriptor contents from the main descriptor
+            String importedContents = reader.readFile(SECONDARY_DESCRIPTOR_CWL_RESOURCE_PATH);
+            results.put(SECONDARY_DESCRIPTOR_CWL_RESOURCE_PATH, new ImmutablePair<>(importedContents, GenericFileType.IMPORTED_DESCRIPTOR));
+            String testFileContents = reader.readFile(TEST_INPUT_FILE_RESOURCE_PATH);
+            results.put(TEST_INPUT_FILE_RESOURCE_PATH, new ImmutablePair<>(testFileContents, GenericFileType.TEST_PARAMETER_FILE));
+            String dockerfileContents = reader.readFile(DOCKERFILE_RESOURCE_PATH);
+            results.put(DOCKERFILE_RESOURCE_PATH, new ImmutablePair<>(dockerfileContents, GenericFileType.CONTAINERFILE));
+            String serviceContents = reader.readFile(SERVICE_DESCRIPTOR_RESOURCE_PATH);
+            results.put(SERVICE_DESCRIPTOR_RESOURCE_PATH, new ImmutablePair<>(serviceContents, GenericFileType.IMPORTED_DESCRIPTOR));
+            return results;
+        }
+
+        @Override
+        public WorkflowMetadata parseWorkflowForMetadata(String initialPath, String contents,
+            Map<String, Pair<String, GenericFileType>> indexedFiles) {
+            WorkflowMetadata workflowMetadata = new WorkflowMetadata();
+            workflowMetadata.setAuthor("Shakespeare");
+            workflowMetadata.setEmail("globetheater@bard.com");
+            return workflowMetadata;
+        }
+
+
+        // RecommendedLanguageInterface
+        @Override
+        public String launchInstructions(String trsID) {
+            return null;
+        }
+
+        @Override
+        public VersionTypeValidation validateWorkflowSet(String initialPath, String contents, Map<String, Pair<String, GenericFileType>> indexedFiles) {
+            // This will be executed via the sourcefilesToIndexedFilesViaValidateWorkflowSetNullTypeTest test code
+            // and some files may not be present depending on the inputs to the test
+            if (indexedFiles.containsKey(MAIN_DESCRIPTOR_CWL)) {
+                Assert.assertTrue(indexedFiles.get(MAIN_DESCRIPTOR_CWL).getRight()
+                    == MinimalLanguageInterface.GenericFileType.IMPORTED_DESCRIPTOR);
+            }
+            if (indexedFiles.containsKey(SECONDARY_DESCRIPTOR_CWL)) {
+                Assert.assertTrue(indexedFiles.get(SECONDARY_DESCRIPTOR_CWL).getRight()
+                    == MinimalLanguageInterface.GenericFileType.IMPORTED_DESCRIPTOR);
+            }
+            if (indexedFiles.containsKey(TEST_INPUT_FILE)) {
+                Assert.assertTrue(indexedFiles.get(TEST_INPUT_FILE).getRight()
+                    == GenericFileType.TEST_PARAMETER_FILE);
+            }
+            if (indexedFiles.containsKey(DOCKERFILE)) {
+                Assert.assertTrue(indexedFiles.get(DOCKERFILE).getRight()
+                    == GenericFileType.CONTAINERFILE);
+            }
+            if (indexedFiles.containsKey(PRIMARY_DESCRIPTOR)) {
+                Assert.assertTrue(indexedFiles.get(PRIMARY_DESCRIPTOR).getRight()
+                    == GenericFileType.IMPORTED_DESCRIPTOR);
+            }
+            if (indexedFiles.containsKey(OTHER_FILE)) {
+                Assert.assertTrue(indexedFiles.get(OTHER_FILE).getRight()
+                    == GenericFileType.IMPORTED_DESCRIPTOR);
+            }
+
+            return new VersionTypeValidation(true, Collections.emptyMap());
+        }
+
+        @Override
+        public VersionTypeValidation validateTestParameterSet(Map<String, Pair<String, GenericFileType>> indexedFiles) {
+            return null;
+        }
+    }
+
+    /**
+     * Reads files from /tools-cwl-workflow-experiments/cwl directory in resources. Only need to truly implement two methods; the rest are
+     * never called from parseWorkflowContent
+     */
+    private static class ToolsCWLWorkflowExpSourceCodeRepoInterface extends SourceCodeRepoInterface {
+        @Override
+        public String readGitRepositoryFile(String repositoryId, DescriptorLanguage.FileType fileType, Version version,
+            String specificPath) {
+            return this.readFile(repositoryId, specificPath, null);
+        }
+
+        @Override
+        public String readFile(String repositoryId, String fileName, String reference) {
+            try {
+                final File file = new File(ResourceHelpers.resourceFilePath(fileName));
+                return FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                return null;
+            }
+        }
+
+        @Override
+        public String getREADMEContent(String repositoryId, String branch) {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return "toolscwlworkflowexperiments";
+        }
+
+        @Override
+        public void setLicenseInformation(Entry entry, String gitRepository) {
+
+        }
+
+        // From here on down these methods are not invoked in our tests
+        @Override
+        public List<String> listFiles(String repositoryId, String pathToDirectory, String reference) {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> getWorkflowGitUrl2RepositoryId() {
+            return null;
+        }
+
+        @Override
+        public boolean checkSourceCodeValidity() {
+            return false;
+        }
+
+        @Override
+        public Workflow initializeWorkflow(String repositoryId, Workflow workflow) {
+            return null;
+        }
+
+        @Override
+        public Workflow setupWorkflowVersions(String repositoryId, Workflow workflow, Optional<Workflow> existingWorkflow,
+            Map<String, WorkflowVersion> existingDefaults, Optional<String> versionName, boolean hardRefresh) {
+            return null;
+        }
+
+        @Override
+        public String getRepositoryId(Entry entry) {
+            return null;
+        }
+
+        @Override
+        public String getMainBranch(Entry entry, String repositoryId) {
+            return null;
+        }
+
+        @Override
+        public SourceFile getSourceFile(String path, String id, String branch, DescriptorLanguage.FileType type) {
+            return null;
+        }
+
+        @Override
+        public List<SourceControlOrganization> getOrganizations() {
+            return null;
+        }
+
+        @Override
+        public void updateReferenceType(String repositoryId, Version version) {
+
+        }
+        @Override
+        public String getCommitID(String repositoryId, Version version) {
+            return null;
+        }
+    }
+}

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
@@ -167,15 +167,15 @@ public class LanguagePluginHandlerTest {
         Map<String, SourceFile> importedFilesMap = minimalLanguageHandler.processImports("whatever", mainDescriptorSourceFile.getContent(),
                 emptyVersion, new ToolsCWLWorkflowExpSourceCodeRepoInterface(), MAIN_DESCRIPTOR_CWL);
         SourceFile secondarySourceFile = importedFilesMap.get(SECONDARY_DESCRIPTOR_CWL_RESOURCE_PATH);
-        Assert.assertSame(secondarySourceFile.getType(), FileType.DOCKSTORE_CWL);
+        Assert.assertSame(FileType.DOCKSTORE_CWL, secondarySourceFile.getType());
         SourceFile testInputFile = importedFilesMap.get(TEST_INPUT_FILE_RESOURCE_PATH);
-        Assert.assertSame(testInputFile.getType(), FileType.CWL_TEST_JSON);
+        Assert.assertSame(FileType.CWL_TEST_JSON, testInputFile.getType());
         SourceFile dockerFile = importedFilesMap.get(DOCKERFILE_RESOURCE_PATH);
-        Assert.assertSame(dockerFile.getType(), FileType.DOCKERFILE);
+        Assert.assertSame(FileType.DOCKERFILE, dockerFile.getType());
         SourceFile serviceFile = importedFilesMap.get(SERVICE_DESCRIPTOR_RESOURCE_PATH);
         // eventually will be DescriptorLanguage.FileType.DOCKSTORE_SERVICE_YML
         // when services are enabled?
-        Assert.assertSame(serviceFile.getType(), FileType.DOCKSTORE_CWL);
+        Assert.assertSame(FileType.DOCKSTORE_CWL, serviceFile.getType());
 
     }
 
@@ -241,22 +241,22 @@ public class LanguagePluginHandlerTest {
             // This will be executed via the sourcefilesToIndexedFilesViaValidateWorkflowSetNullTypeTest test code
             // and some files may not be present depending on the inputs to the test
             if (indexedFiles.containsKey(MAIN_DESCRIPTOR_CWL)) {
-                Assert.assertSame(indexedFiles.get(MAIN_DESCRIPTOR_CWL).getRight(), MinimalLanguageInterface.GenericFileType.IMPORTED_DESCRIPTOR);
+                Assert.assertSame(MinimalLanguageInterface.GenericFileType.IMPORTED_DESCRIPTOR, indexedFiles.get(MAIN_DESCRIPTOR_CWL).getRight());
             }
             if (indexedFiles.containsKey(SECONDARY_DESCRIPTOR_CWL)) {
-                Assert.assertSame(indexedFiles.get(SECONDARY_DESCRIPTOR_CWL).getRight(), MinimalLanguageInterface.GenericFileType.IMPORTED_DESCRIPTOR);
+                Assert.assertSame(MinimalLanguageInterface.GenericFileType.IMPORTED_DESCRIPTOR, indexedFiles.get(SECONDARY_DESCRIPTOR_CWL).getRight());
             }
             if (indexedFiles.containsKey(TEST_INPUT_FILE)) {
-                Assert.assertSame(indexedFiles.get(TEST_INPUT_FILE).getRight(), GenericFileType.TEST_PARAMETER_FILE);
+                Assert.assertSame(GenericFileType.TEST_PARAMETER_FILE, indexedFiles.get(TEST_INPUT_FILE).getRight());
             }
             if (indexedFiles.containsKey(DOCKERFILE)) {
-                Assert.assertSame(indexedFiles.get(DOCKERFILE).getRight(), GenericFileType.CONTAINERFILE);
+                Assert.assertSame( GenericFileType.CONTAINERFILE, indexedFiles.get(DOCKERFILE).getRight());
             }
             if (indexedFiles.containsKey(PRIMARY_DESCRIPTOR)) {
-                Assert.assertSame(indexedFiles.get(PRIMARY_DESCRIPTOR).getRight(), GenericFileType.IMPORTED_DESCRIPTOR);
+                Assert.assertSame(GenericFileType.IMPORTED_DESCRIPTOR, indexedFiles.get(PRIMARY_DESCRIPTOR).getRight());
             }
             if (indexedFiles.containsKey(OTHER_FILE)) {
-                Assert.assertSame(indexedFiles.get(OTHER_FILE).getRight(), GenericFileType.IMPORTED_DESCRIPTOR);
+                Assert.assertSame(GenericFileType.IMPORTED_DESCRIPTOR, indexedFiles.get(OTHER_FILE).getRight());
             }
 
             return new VersionTypeValidation(true, Collections.emptyMap());

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
@@ -241,7 +241,7 @@ public class LanguagePluginHandlerTest {
                 Assert.assertSame(GenericFileType.TEST_PARAMETER_FILE, indexedFiles.get(TEST_INPUT_FILE).getRight());
             }
             if (indexedFiles.containsKey(DOCKERFILE)) {
-                Assert.assertSame( GenericFileType.CONTAINERFILE, indexedFiles.get(DOCKERFILE).getRight());
+                Assert.assertSame(GenericFileType.CONTAINERFILE, indexedFiles.get(DOCKERFILE).getRight());
             }
             if (indexedFiles.containsKey(PRIMARY_DESCRIPTOR)) {
                 Assert.assertSame(GenericFileType.IMPORTED_DESCRIPTOR, indexedFiles.get(PRIMARY_DESCRIPTOR).getRight());

--- a/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/.dockstore.yml
+++ b/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/.dockstore.yml
@@ -1,0 +1,6 @@
+version: 1.2
+workflows:
+  - subclass: CWL
+    primaryDescriptorPath: /workflow_docker.cwl
+    testParameterFiles:
+      - /workflow.json

--- a/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/Dockerfile
+++ b/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/Dockerfile
@@ -1,0 +1,7 @@
+FROM frolvlad/alpine-python3:latest
+
+LABEL maintainer="marc.zimmermann@inf.ethz.ch"
+
+RUN mkdir -p /data/input && mkdir /data/output && mkdir /scripts
+COPY pipeline_code/complex_computation.py /scripts
+COPY pipeline_code/line_counts.sh /scripts

--- a/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/complex_computation_docker.cwl
+++ b/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/complex_computation_docker.cwl
@@ -1,0 +1,34 @@
+#!/usr/bin/env cwltool
+
+cwlVersion: v1.0
+class: CommandLineTool
+
+baseCommand: [python3, /scripts/complex_computation.py]
+
+requirements:
+- class: DockerRequirement
+  dockerPull: quay.io/ratschlab/workflow-experiment
+
+inputs:
+  input_file:
+    type: File
+    inputBinding:
+      position: 1
+    label: "input file"
+
+  exponent:
+    type: int
+    inputBinding:
+      position: 2
+    label: "exponent to regulate runtime"
+
+arguments:
+  - valueFrom: $(runtime.outdir)/$(inputs.input_file.nameroot).res
+    position: 3
+
+outputs:
+  counts:
+    type: File
+    outputBinding:
+      glob: "*.res"
+    doc: "number of lines in file"

--- a/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/line_counts_docker.cwl
+++ b/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/line_counts_docker.cwl
@@ -1,0 +1,28 @@
+#!/usr/bin/env cwltool
+
+cwlVersion: v1.0
+class: CommandLineTool
+
+requirements:
+- class: DockerRequirement
+  dockerPull: quay.io/ratschlab/workflow-experiment
+
+baseCommand: [/scripts/line_counts.sh]
+
+inputs:
+  input_file:
+    type: File
+    inputBinding:
+      position: 1
+    label: "input file"
+
+arguments:
+  - valueFrom: $(runtime.outdir)
+    position: 2
+
+outputs:
+  counts:
+    type: File
+    outputBinding:
+      glob: "*.cnt"
+    doc: "number of lines in file"

--- a/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/nextflow.config
+++ b/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/nextflow.config
@@ -1,0 +1,13 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for AWS Batch
+ * -------------------------------------------------
+ * Imported under the 'awsbatch' Nextflow profile in nextflow.config
+ * Uses docker for software depedencies automagically, so not specified here.
+ */
+
+aws.region = params.awsregion
+process.executor = 'awsbatch'
+process.queue = params.awsqueue
+executor.awscli = '/home/ec2-user/miniconda/bin/aws'
+params.tracedir = './'

--- a/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/service.yml
+++ b/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/service.yml
@@ -1,0 +1,1 @@
+service yaml file

--- a/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/workflow.json
+++ b/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/workflow.json
@@ -1,0 +1,7 @@
+{
+  "input_file": {
+    "class": "File",
+    "path": "foo.txt"
+  },
+  "compute_exponent": 1
+}

--- a/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/workflow_docker.cwl
+++ b/dockstore-webservice/src/test/resources/tools-cwl-workflow-experiments/cwl/workflow_docker.cwl
@@ -1,0 +1,37 @@
+cwlVersion: v1.0
+class: Workflow
+
+doc: |
+   [![Docker Repository on Quay](https://quay.io/repository/ratschlab/workflow-experiment/status "Docker Repository on Quay")](https://quay.io/repository/ratschlab/workflow-experiment)
+   Very simple and very artifical workflow to experiment with containers and cwl.
+
+#dct:creator:
+#  foaf:name: Marc Zimmermann
+#  foaf:mbox: marc.zimmermann@inf.ethz.ch
+
+inputs:
+  input_file: File
+  compute_exponent: int
+
+outputs:
+  cnt:
+    type: File
+    outputSource: count/counts
+
+  res:
+    type: File
+    outputSource: compute/counts
+
+steps:
+  count:
+    run: line_counts_docker.cwl
+    in:
+      input_file: input_file
+    out: [counts]
+
+  compute:
+    run: complex_computation_docker.cwl
+    in:
+      input_file: count/counts
+      exponent: compute_exponent
+    out: [counts]


### PR DESCRIPTION
**Description**
Replaces workflow language specific code with more generic language methods so editing of said code is not necessary when adding support for a new language to Dockstore. This addresses new language support for workflows but not Tools.

There is still language specific code for Tools in the webservice.

The UI language specific code will be addressed in a separate ticket.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-3910

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
