### PR TITLE
Feature/seab 3845/snapshot GitHub apptools

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -817,12 +817,12 @@ public class GeneralWorkflowIT extends BaseIT {
      */
     @Test
     public void testFreezingInvalidWorkflow() {
-        String versionToSnapshot = "1.0.1";
+        String versionToSnapshot = "1.0";
         ApiClient client = getWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(client);
-        Workflow workflow = manualRegisterAndPublish(workflowsApi, "dockstore-testing/md5sum-checker", "",
+        Workflow workflow = manualRegisterAndPublish(workflowsApi, "dockstore-testing/tagged-apptool", "",
             DescriptorLanguage.CWL.toString(),
-            SourceControl.GITHUB, "/md5sum/md5sum-tool.cwl", false);
+            SourceControl.GITHUB, "/tool.cwl", false);
         Workflow workflowBeforeFreezing = workflowsApi.refresh(workflow.getId(), false);
         WorkflowVersion version =
             workflowBeforeFreezing.getWorkflowVersions().stream().filter(v -> v.getName().equals(versionToSnapshot)).findFirst().get();

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -95,8 +95,8 @@ public class WebhookIT extends BaseIT {
     private final String installationId = "1179416";
     private final String toolAndWorkflowRepo = "DockstoreTestUser2/test-workflows-and-tools";
     private final String toolAndWorkflowRepoToolPath = "DockstoreTestUser2/test-workflows-and-tools/md5sum";
-    private final String taggedToolAndWorkflowRepo = "svonworl/test-workflows-and-tools";
-    private final String taggedToolAndWorkflowRepoPath = "svonworl/test-workflows-and-tools/md5sum";
+    private final String taggedToolRepo = "dockstore-testing/tagged-apptool";
+    private final String taggedToolRepoPath = "dockstore-testing/tagged-apptool/md5sum";
     private final String authorsRepo = "DockstoreTestUser2/test-authors";
     private FileDAO fileDAO;
 
@@ -943,8 +943,8 @@ public class WebhookIT extends BaseIT {
         io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(openApiClient);
         WorkflowsApi client = new WorkflowsApi(webClient);
 
-        client.handleGitHubRelease(taggedToolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/tags/testtag", installationId);
-        Workflow appTool = client.getWorkflowByPath("github.com/" + taggedToolAndWorkflowRepoPath, APPTOOL, "versions,validations");
+        client.handleGitHubRelease(taggedToolRepo, BasicIT.USER_2_USERNAME, "refs/tags/1.0", installationId);
+        Workflow appTool = client.getWorkflowByPath("github.com/" + taggedToolRepoPath, APPTOOL, "versions,validations");
 
         PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         WorkflowVersion validVersion = appTool.getWorkflowVersions().stream().filter(WorkflowVersion::isValid).findFirst().get();
@@ -956,6 +956,7 @@ public class WebhookIT extends BaseIT {
         client.updateWorkflowVersion(appTool.getId(), Lists.newArrayList(validVersion));
 
         // check if version is frozen
+        appTool = client.getWorkflow(appTool.getId(), null);
         validVersion = appTool.getWorkflowVersions().stream().filter(WorkflowVersion::isValid).findFirst().get();
         assertTrue(validVersion.isFrozen());
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -95,6 +95,8 @@ public class WebhookIT extends BaseIT {
     private final String installationId = "1179416";
     private final String toolAndWorkflowRepo = "DockstoreTestUser2/test-workflows-and-tools";
     private final String toolAndWorkflowRepoToolPath = "DockstoreTestUser2/test-workflows-and-tools/md5sum";
+    private final String taggedToolAndWorkflowRepo = "svonworl/test-workflows-and-tools";
+    private final String taggedToolAndWorkflowRepoPath = "svonworl/test-workflows-and-tools/md5sum";
     private final String authorsRepo = "DockstoreTestUser2/test-authors";
     private FileDAO fileDAO;
 
@@ -124,7 +126,7 @@ public class WebhookIT extends BaseIT {
                 "foobar", "wdl", "/test.json");
         workflowApi.manualRegister(SourceControl.GITHUB.name(), DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "/Dockstore.cwl", "",
                 DescriptorLanguage.CWL.getShortName(), "/test.json");
-        
+
         // Refresh should work
         workflow = workflowApi.refresh(workflow.getId(), false);
         assertEquals("Workflow should be FULL mode", Workflow.ModeEnum.FULL, workflow.getMode());
@@ -346,7 +348,7 @@ public class WebhookIT extends BaseIT {
         assertEquals(null, workflow.getDefaultVersion());
 
     }
-    
+
     private io.dockstore.openapi.client.model.Workflow getFoobar1Workflow(io.dockstore.openapi.client.api.WorkflowsApi client) {
         return client.getWorkflowByPath("github.com/" + workflowRepo + "/foobar", WorkflowSubClass.BIOWORKFLOW, "versions");
     }
@@ -933,6 +935,34 @@ public class WebhookIT extends BaseIT {
         Assert.assertFalse(systemOutRule.getLog().contains("Could not submit index to elastic search"));
     }
 
+    @Test
+    public void testSnapshotAppTool() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+        final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        final io.dockstore.openapi.client.ApiClient openApiClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(openApiClient);
+        WorkflowsApi client = new WorkflowsApi(webClient);
+
+        client.handleGitHubRelease(taggedToolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/tags/testtag", installationId);
+        Workflow appTool = client.getWorkflowByPath("github.com/" + taggedToolAndWorkflowRepoPath, APPTOOL, "versions,validations");
+
+        PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
+        WorkflowVersion validVersion = appTool.getWorkflowVersions().stream().filter(WorkflowVersion::isValid).findFirst().get();
+        testingPostgres.runUpdateStatement("update apptool set actualdefaultversion = " + validVersion.getId() + " where id = " + appTool.getId());
+        client.publish(appTool.getId(), publishRequest);
+
+        // snapshot the version
+        validVersion.setFrozen(true);
+        client.updateWorkflowVersion(appTool.getId(), Lists.newArrayList(validVersion));
+
+        // check if version is frozen
+        validVersion = appTool.getWorkflowVersions().stream().filter(WorkflowVersion::isValid).findFirst().get();
+        assertTrue(validVersion.isFrozen());
+
+        // check if image has been created
+        long imageCount = testingPostgres.runSelectStatement("select count(*) from entry_version_image where versionid = " + validVersion.getId(), long.class);
+        assertEquals(1, imageCount);
+    }
 
     @Test
     public void testTRSWithAppTools() throws Exception {


### PR DESCRIPTION
**Description**
This PR changes the webservice so it supports snapshotting apptools.  Initially, it seemed to me like no changes were necessary, but in her ticket review, Kathy noticed that the snapshotting process was not creating/hashing the `dockerPull` image.  See the comments in the issue for more details.  Great catch, Kathy!

The root cause was that the snapshotting code uses `CWLHandler.getContent` to determine the images to snapshot.  In the past, `getContent` was always passed a CWL workflow.  However, with the advent of apptools, it can now be passed a CWL file with class `CommandLineTool` or `ExpressionTool`, which made it fail (it could not find any workflow steps) and return no images, which meant no images were being snapshotted.

This PR modifies `getContent` to process a tool input as a one-step workflow.  This is a bandaid solution: the more elegant approach might be to modify the parsing code so it could handle a tool at any level in the input, rather than as part of a workflow step.  However, the latter is a big change, and didn't seem prudent given how close we are to releasing 1.12.  I suggest we create a ticket to overhaul this code later, if we feel like the approach in the PR isn't a good-enough long term solution.  However, I feel like it's relatively clean, so I'm not sure if that's necessary.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-3845

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
