### PR TITLE
fix manual topic to be compatible with app tools

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -966,6 +966,26 @@ public class WebhookIT extends BaseIT {
     }
 
     @Test
+    public void testChangingAppToolTopics() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
+        final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        final io.dockstore.openapi.client.ApiClient openApiClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(openApiClient);
+        WorkflowsApi client = new WorkflowsApi(webClient);
+
+        client.handleGitHubRelease(taggedToolRepo, BasicIT.USER_2_USERNAME, "refs/tags/1.0", installationId);
+        Workflow appTool = client.getWorkflowByPath("github.com/" + taggedToolRepoPath, APPTOOL, "versions,validations");
+
+        PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
+        client.publish(appTool.getId(), publishRequest);
+
+        String newTopic = "this is a new topic";
+        appTool.setTopicManual(newTopic);
+        appTool = client.updateWorkflow(appTool.getId(), appTool);
+        assertEquals(appTool.getTopicManual(), newTopic);
+    }
+
+    @Test
     public void testTRSWithAppTools() throws Exception {
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
         final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/AppTool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/AppTool.java
@@ -43,6 +43,9 @@ public class AppTool extends Workflow {
 
     @Override
     public void setParentEntry(Entry parentEntry) {
+        if (parentEntry == null) {
+            return;
+        }
         throw new UnsupportedOperationException("AppTool cannot be a checker workflow");
     }
 
@@ -53,6 +56,9 @@ public class AppTool extends Workflow {
 
     @Override
     public void setIsChecker(boolean isChecker) {
+        if (!isChecker) {
+            return;
+        }
         throw new UnsupportedOperationException("AppTool cannot be a checker workflow");
     }
 


### PR DESCRIPTION
**Description**
Allows for github app tools to successfully set a manual topic

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4038

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
