### PR TITLE
add replicas

### DIFF
--- a/dockstore-webservice/src/main/resources/queries/mapping_tool.json
+++ b/dockstore-webservice/src/main/resources/queries/mapping_tool.json
@@ -1,7 +1,8 @@
 {
   "settings": {
     "index": {
-      "number_of_replicas": 0,
+      "number_of_shards" : 1,
+      "number_of_replicas": 1,
       "analysis": {
         "filter": {
           "english_stop": {

--- a/dockstore-webservice/src/main/resources/queries/mapping_workflow.json
+++ b/dockstore-webservice/src/main/resources/queries/mapping_workflow.json
@@ -1,7 +1,8 @@
 {
   "settings": {
     "index": {
-      "number_of_replicas": 0,
+      "number_of_shards" : 1,
+      "number_of_replicas": 1,
       "analysis": {
         "filter": {
           "english_stop": {


### PR DESCRIPTION
**Description**
By default, ES uses 5 shards, but after reading that's way to many for the amount of data we're using and can lead to performance degradation. I also added replicas since that is also supposed to improve performance. I should have another PR for the cloudformation templates, but all the configurations I've tried so far still result in errors in the logs, so I'm hoping having this will help.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-3829

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
