### PR TITLE
Feature/seab 4040/make getStarredTools endpoint include apptools

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -982,15 +982,15 @@ public class WebhookIT extends BaseIT {
         client.publish(appTool.getId(), publishRequest);
 
         List<io.dockstore.openapi.client.model.Entry> pre = usersApi.getStarredTools();
-        assertEquals(client.getStarredUsers(appTool.getId()).size(), 0);
         assertEquals(pre.stream().filter(e -> e.getId() == appTool.getId()).count(), 0);
+        assertEquals(client.getStarredUsers(appTool.getId()).size(), 0);
 
         client.starEntry(appTool.getId(), new io.swagger.client.model.StarRequest().star(true));
 
         List<io.dockstore.openapi.client.model.Entry> post = usersApi.getStarredTools();
-        assertEquals(client.getStarredUsers(appTool.getId()).size(), 1);
         assertEquals(post.stream().filter(e -> e.getId() == appTool.getId()).count(), 1);
         assertEquals(post.size(), pre.size() + 1);
+        assertEquals(client.getStarredUsers(appTool.getId()).size(), 1);
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -982,15 +982,15 @@ public class WebhookIT extends BaseIT {
         client.publish(appTool.getId(), publishRequest);
 
         List<io.dockstore.openapi.client.model.Entry> pre = usersApi.getStarredTools();
-        assertEquals(pre.stream().filter(e -> e.getId() == appTool.getId()).count(), 0);
-        assertEquals(client.getStarredUsers(appTool.getId()).size(), 0);
+        assertEquals(0, pre.stream().filter(e -> e.getId().equals(appTool.getId())).count());
+        assertEquals(0, client.getStarredUsers(appTool.getId()).size());
 
         client.starEntry(appTool.getId(), new io.swagger.client.model.StarRequest().star(true));
 
         List<io.dockstore.openapi.client.model.Entry> post = usersApi.getStarredTools();
-        assertEquals(post.stream().filter(e -> e.getId() == appTool.getId()).count(), 1);
-        assertEquals(post.size(), pre.size() + 1);
-        assertEquals(client.getStarredUsers(appTool.getId()).size(), 1);
+        assertEquals(1, post.stream().filter(e -> e.getId().equals(appTool.getId())).count());
+        assertEquals(pre.size() + 1, post.size());
+        assertEquals(1, client.getStarredUsers(appTool.getId()).size());
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -981,14 +981,16 @@ public class WebhookIT extends BaseIT {
         testingPostgres.runUpdateStatement("update apptool set actualdefaultversion = " + validVersion.getId() + " where id = " + appTool.getId());
         client.publish(appTool.getId(), publishRequest);
 
-        int preCount = usersApi.getStarredTools().size();
+        List<io.dockstore.openapi.client.model.Entry> pre = usersApi.getStarredTools();
+        assertEquals(client.getStarredUsers(appTool.getId()).size(), 0);
+        assertEquals(pre.stream().filter(e -> e.getId() == appTool.getId()).count(), 0);
 
-        io.dockstore.openapi.client.model.StarRequest starRequest = new io.dockstore.openapi.client.model.StarRequest().star(true);
-        new io.dockstore.openapi.client.api.WorkflowsApi(openApiClient).starEntry1(appTool.getId(), starRequest);
+        client.starEntry(appTool.getId(), new io.swagger.client.model.StarRequest().star(true));
 
-        int postCount = usersApi.getStarredTools().size();
-
-        assertEquals(postCount, preCount + 1);
+        List<io.dockstore.openapi.client.model.Entry> post = usersApi.getStarredTools();
+        assertEquals(client.getStarredUsers(appTool.getId()).size(), 1);
+        assertEquals(post.stream().filter(e -> e.getId() == appTool.getId()).count(), 1);
+        assertEquals(post.size(), pre.size() + 1);
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -776,7 +776,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(value = "Get the authenticated user's starred tools.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Entry.class, responseContainer = "List")
     public Set<Entry> getStarredTools(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user) {
         User u = userDAO.findById(user.getId());
-        return u.getStarredEntries().stream().filter(element -> element instanceof Tool)
+        return u.getStarredEntries().stream().filter(element -> element instanceof Tool || element instanceof AppTool)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 


### PR DESCRIPTION
**Description**
This PR changes the `getStarredTools` endpoint so it returns both starred AppTools and starred Tools.  Previously, it only returned starred Tools.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4040

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
