### PR TITLE
Expose published app tools in proprietary API

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -154,8 +154,8 @@ public class ServiceIT extends BaseIT {
         final CreateContent invoke = new CreateContent().invoke();
         final ApiClient webClient = getWebClient(true, false);
         WorkflowsApi client = new WorkflowsApi(webClient);
-        final List<io.swagger.client.model.Workflow> services = client.allPublishedWorkflows(null, null, null, null, null, true);
-        final List<io.swagger.client.model.Workflow> workflows = client.allPublishedWorkflows(null, null, null, null, null, false);
+        final List<io.swagger.client.model.Workflow> services = client.allPublishedWorkflows(null, null, null, null, null, true, null);
+        final List<io.swagger.client.model.Workflow> workflows = client.allPublishedWorkflows(null, null, null, null, null, false, null);
         assertTrue(workflows.size() >= 2 && workflows.stream()
             .noneMatch(workflow -> workflow.getDescriptorType().getValue().equalsIgnoreCase(DescriptorLanguage.SERVICE.toString())));
         Client jerseyClient = new JerseyClientBuilder(SUPPORT.getEnvironment()).build("test client");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -972,6 +972,9 @@ public class WebhookIT extends BaseIT {
         client.publish(appTool.getId(), publishRequest);
         client.publish(workflow.getId(), publishRequest);
         Assert.assertFalse(systemOutRule.getLog().contains("Could not submit index to elastic search"));
+
+
+
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -769,6 +769,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         return publishedWorkflow;
     }
 
+    @SuppressWarnings("checkstyle:ParameterNumber")
     @GET
     @Timed
     @UnitOfWork(readOnly = true)
@@ -783,12 +784,13 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         @ApiParam(value = "Filter, this is a search string that filters the results.") @DefaultValue("") @QueryParam("filter") String filter,
         @ApiParam(value = "Sort column") @DefaultValue("stars") @QueryParam("sortCol") String sortCol,
         @ApiParam(value = "Sort order", allowableValues = "asc,desc") @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
-        @ApiParam(value = "services", defaultValue = "false") @DefaultValue("false") @QueryParam("services") boolean services,
+        @ApiParam(value = "Should only be used by Dockstore CLI versions < 1.12.0. Indicates whether to get a service or workflow") @DefaultValue("false") @QueryParam("services") boolean services,
+        @ApiParam(value = "Which workflow subclass to retrieve. If present takes precedence over services parameter", defaultValue = "") @QueryParam("subclass") WorkflowSubClass subclass,
         @Context HttpServletResponse response) {
         // delete the next line if GUI pagination is not working by 1.5.0 release
         int maxLimit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);
-        List<Workflow> workflows = workflowDAO.findAllPublished(offset, maxLimit, filter, sortCol, sortOrder, (Class<Workflow>)(services
-            ? Service.class : BioWorkflow.class));
+        List<Workflow> workflows = workflowDAO.findAllPublished(offset, maxLimit, filter, sortCol, sortOrder,
+            (Class<Workflow>) workflowSubClass(services, subclass));
         filterContainersForHiddenTags(workflows);
         stripContent(workflows);
         EntryDAO entryDAO = services ? serviceEntryDAO : bioWorkflowDAO;
@@ -1896,6 +1898,13 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         if (checkIncludes(include, AUTHORS)) {
             Hibernate.initialize(workflowVersion.getOrcidAuthors());
         }
+    }
+
+    private Class<? extends Workflow> workflowSubClass(boolean services, WorkflowSubClass subClass) {
+        if (subClass != null) {
+            return getSubClass(subClass);
+        }
+        return services ? Service.class : BioWorkflow.class;
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -785,7 +785,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         @ApiParam(value = "Sort column") @DefaultValue("stars") @QueryParam("sortCol") String sortCol,
         @ApiParam(value = "Sort order", allowableValues = "asc,desc") @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
         @ApiParam(value = "Should only be used by Dockstore CLI versions < 1.12.0. Indicates whether to get a service or workflow") @DefaultValue("false") @QueryParam("services") boolean services,
-        @ApiParam(value = "Which workflow subclass to retrieve. If present takes precedence over services parameter", defaultValue = "") @QueryParam("subclass") WorkflowSubClass subclass,
+        @ApiParam(value = "Which workflow subclass to retrieve. If present takes precedence over services parameter") @QueryParam("subclass") WorkflowSubClass subclass,
         @Context HttpServletResponse response) {
         // delete the next line if GUI pagination is not working by 1.5.0 release
         int maxLimit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -6104,6 +6104,10 @@ paths:
         schema:
           type: boolean
           default: false
+      - in: query
+        name: subclass
+        schema:
+          $ref: '#/components/schemas/WorkflowSubClass'
       responses:
         default:
           content:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5410,10 +5410,21 @@ paths:
         - "desc"
       - name: "services"
         in: "query"
-        description: "services"
+        description: "Should only be used by Dockstore CLI versions < 1.12.0. Indicates\
+          \ whether to get a service or workflow"
         required: false
         type: "boolean"
         default: false
+      - name: "subclass"
+        in: "query"
+        description: "Which workflow subclass to retrieve. If present takes precedence\
+          \ over services parameter"
+        required: false
+        type: "string"
+        enum:
+        - "BIOWORKFLOW"
+        - "SERVICE"
+        - "APPTOOL"
       responses:
         200:
           description: "successful operation"


### PR DESCRIPTION
**Description**
Surface App Tools on the published workflows endpoint.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4047

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
