### PR TITLE
Feature/dock 2090/dashes in collection names

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -1354,6 +1354,7 @@ public class OrganizationIT extends BaseIT {
     private void createCollectionWithGoodName(String name, OrganizationsApi organizationsApi, Long organizationId) {
         Collection collection = stubCollectionObject();
         collection.setName(name);
+        collection.setDisplayName(name);
         organizationsApi.createCollection(organizationId, collection);
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -72,8 +72,9 @@ public class OrganizationIT extends BaseIT {
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
+    private final List<String> goodCollectionNames = Arrays.asList("baa", "baaa", "bAa", "BAA", "baa123", "baa-baa", "b-a-a-a-a", "b0-a-9", "baa-1234", "baa1-234", "zzz");
     // All numbers, too short, bad pattern, too long, foreign characters
-    private final List<String> badNames = Arrays.asList("1234", "ab", "1aab", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "我喜欢狗");
+    private final List<String> badNames = Arrays.asList("1234", "", "a", "ab", "1aab", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "a b", "我喜欢狗", "-", "---", "-abc", "abc-", "a--b");
     // Doesn't have extension, has query parameter at the end, extension is not jpg, jpeg, png, or gif.
     private final List<String> badAvatarUrls = Arrays
         .asList("https://via.placeholder.com/150", "https://media.giphy.com/media/3o7bu4EJkrXG9Bvs9G/giphy.svg",
@@ -1323,7 +1324,7 @@ public class OrganizationIT extends BaseIT {
     }
 
     /**
-     * Helper that creates an Organization with a name that should fail
+     * Helper that creates a Collection with a name that should fail
      *
      * @param name
      * @param organizationsApi
@@ -1342,6 +1343,18 @@ public class OrganizationIT extends BaseIT {
         if (!throwsError) {
             fail("Was able to create a collection with an incorrect name: " + name);
         }
+    }
+
+    /**
+     * Helper that creates a Collection with a name that should succeed
+     *
+     * @param name
+     * @param organizationsApi
+     */
+    private void createCollectionWithGoodName(String name, OrganizationsApi organizationsApi, Long organizationId) {
+        Collection collection = stubCollectionObject();
+        collection.setName(name);
+        organizationsApi.createCollection(organizationId, collection);
     }
 
     @Test
@@ -1621,6 +1634,10 @@ public class OrganizationIT extends BaseIT {
         assertEquals(1, collectionById.getEntries().size());
 
         testVersionRemoval(organizationsApi, organization, collectionId, entryId, versionId, webClientUser2);
+
+        goodCollectionNames.forEach(name -> {
+            createCollectionWithGoodName(name, organizationsApi, organizationID);
+        });
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -72,7 +72,7 @@ public class OrganizationIT extends BaseIT {
     public final ExpectedSystemExit systemExit = ExpectedSystemExit.none();
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
-    private final List<String> goodCollectionNames = Arrays.asList("baa", "baaa", "bAa", "BAA", "baa123", "baa-baa", "b-a-a-a-a", "b0-a-9", "baa-1234", "baa1-234", "zzz");
+    private final List<String> goodCollectionNames = Arrays.asList("baa", "baaa", "bAaaa", "BAAAAA", "baa123", "daa-daa", "d-a-a-a-a", "d0-a-9", "daa-1234", "daa5-678", "aaz", "zaa");
     // All numbers, too short, bad pattern, too long, foreign characters
     private final List<String> badNames = Arrays.asList("1234", "", "a", "ab", "1aab", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "a b", "我喜欢狗", "-", "---", "-abc", "abc-", "a--b");
     // Doesn't have extension, has query parameter at the end, extension is not jpg, jpeg, png, or gif.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -82,10 +82,10 @@ public class Collection implements Serializable, Aliasable {
     private long id;
 
     @Column(nullable = false)
-    @Pattern(regexp = "[a-zA-Z][a-zA-Z\\d]*")
+    @Pattern(regexp = "[a-zA-Z](-?[a-zA-Z\\d])*")
     @Size(min = 3, max = 39)
-    @ApiModelProperty(value = "Name of the collection.", required = true, example = "Alignment", position = 1)
-    @Schema(description = "Name of the collection", required = true, example = "Alignment")
+    @ApiModelProperty(value = "Name of the collection.", required = true, example = "alignment", position = 1)
+    @Schema(description = "Name of the collection", required = true, example = "alignment")
     private String name;
 
     @Column(columnDefinition = "TEXT")

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -7296,10 +7296,10 @@ components:
         name:
           type: string
           description: Name of the collection
-          example: Alignment
+          example: alignment
           maxLength: 39
           minLength: 3
-          pattern: "[a-zA-Z][a-zA-Z\\d]*"
+          pattern: "[a-zA-Z](-?[a-zA-Z\\d])*"
         organizationID:
           type: integer
           format: int64
@@ -7415,10 +7415,10 @@ components:
         name:
           type: string
           description: Name of the collection
-          example: Alignment
+          example: alignment
           maxLength: 39
           minLength: 3
-          pattern: "[a-zA-Z][a-zA-Z\\d]*"
+          pattern: "[a-zA-Z](-?[a-zA-Z\\d])*"
         organizationID:
           type: integer
           format: int64

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -6471,12 +6471,12 @@ definitions:
         readOnly: true
       name:
         type: "string"
-        example: "Alignment"
+        example: "alignment"
         position: 1
         description: "Name of the collection."
         minLength: 3
         maxLength: 39
-        pattern: "[a-zA-Z][a-zA-Z\\d]*"
+        pattern: "[a-zA-Z](-?[a-zA-Z\\d])*"
       description:
         type: "string"
         position: 2


### PR DESCRIPTION
**Description**
This PR adds support for internal, nonconsecutive dashes in collection/category names.  This allows users to use a dash as a substitute for a space.  This can improve the readability of names and anything based upon them, like the collection URLs.

Originally, I intended to include "greediness modifiers" in the new regexp.  However, while the `@Pattern` annotation requires a Java regexp, the openapi generator appears to copy it verbatim to `openapi.yaml`, which the OpenAPI spec says requires an ECMAscript regexp.  The greediness modifiers differ between the two languages, so I left them out, but that's ok, the regexp is pretty simple and DOS-resistant without them, I think.

**Issue**
A link to a github issue or SEAB- ticket (using that as a prefix)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
