### PR TITLE
handle cwl file formats array

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -263,14 +263,24 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
         return fileFormats;
     }
 
+    private void addFileFormat(Set<FileFormat> fileFormats, Object format) {
+        if (format instanceof String) {
+            FileFormat fileFormat = new FileFormat();
+            fileFormat.setValue((String)format);
+            fileFormats.add(fileFormat);
+        } else {
+            LOG.debug("malformed file format value");
+        }
+    }
+
     private void handlePotentialFormatEntry(Set<FileFormat> fileFormats, Object v) {
         if (v instanceof Map) {
             Map<String, String> outputMap = (Map<String, String>)v;
-            String format = outputMap.get("format");
-            if (format != null) {
-                FileFormat fileFormat = new FileFormat();
-                fileFormat.setValue(format);
-                fileFormats.add(fileFormat);
+            Object format = outputMap.get("format");
+            if (format instanceof List) {
+                ((List<?>)format).forEach(formatElement -> addFileFormat(fileFormats, formatElement));
+            } else {
+                addFileFormat(fileFormats, format);
             }
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -275,7 +275,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
 
     private void handlePotentialFormatEntry(Set<FileFormat> fileFormats, Object v) {
         if (v instanceof Map) {
-            Map<String, String> outputMap = (Map<String, String>)v;
+            Map<String, Object> outputMap = (Map<String, Object>)v;
             Object format = outputMap.get("format");
             if (format instanceof List) {
                 ((List<?>)format).forEach(formatElement -> addFileFormat(fileFormats, formatElement));

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
@@ -31,6 +32,11 @@ import org.mockito.Mockito;
  * @since 1.5.0
  */
 public class CWLHandlerTest {
+
+    private Set<String> toValues(Set<FileFormat> formats) {
+        return formats.stream().map(FileFormat::getValue).collect(Collectors.toSet());
+    }
+
     /**
      * Tests if the input and output file formats can be extracted from a CWL descriptor file
      * @throws Exception
@@ -40,9 +46,19 @@ public class CWLHandlerTest {
         CWLHandler cwlHandler = new CWLHandler();
         String filePath = ResourceHelpers.resourceFilePath("metadata_example4.cwl");
         Set<FileFormat> inputs = cwlHandler.getFileFormats(FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), "inputs");
-        Assert.assertTrue(inputs.stream().anyMatch(input -> input.getValue().equals("http://edamontology.org/format_2572")));
+        Assert.assertEquals(Set.of("http://edamontology.org/format_2572"), toValues(inputs));
         Set<FileFormat> outputs = cwlHandler.getFileFormats(FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), "outputs");
-        Assert.assertTrue(outputs.stream().anyMatch(input -> input.getValue().equals("http://edamontology.org/format_1964")));
+        Assert.assertEquals(Set.of("http://edamontology.org/format_1964"), toValues(outputs));
+    }
+
+    @Test
+    public void getInputFileFormatsSpecifiedAsArray() throws Exception {
+        CWLHandler cwlHandler = new CWLHandler();
+        String filePath = ResourceHelpers.resourceFilePath("metadata_example5.cwl");
+        Set<FileFormat> inputs = cwlHandler.getFileFormats(FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), "inputs");
+        Assert.assertEquals(Set.of("http://edamontology.org/format_2572", "http://edamontology.org/format_2573"), toValues(inputs));
+        Set<FileFormat> outputs = cwlHandler.getFileFormats(FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8), "outputs");
+        Assert.assertEquals(Set.of("http://edamontology.org/format_1964", "http://edamontology.org/format_1965"), toValues(outputs));
     }
 
     @Test

--- a/dockstore-webservice/src/test/resources/metadata_example5.cwl
+++ b/dockstore-webservice/src/test/resources/metadata_example5.cwl
@@ -1,0 +1,69 @@
+#!/usr/bin/env cwl-runner
+
+class: CommandLineTool
+id: Example tool
+label: Example tool
+cwlVersion: v1.0
+doc: |
+    An example tool demonstrating metadata with multiple input and output file formats, specified as arrays. Note that this is an example and the metadata is not necessarily consistent or valid.
+
+requirements:
+  - class: ShellCommandRequirement
+
+hints:
+  - class: ResourceRequirement
+    coresMin: 4
+
+inputs:
+  bam_input:
+    type: File
+    doc: The BAM file used as input
+    format: [ http://edamontology.org/format_2572, http://edamontology.org/format_2573 ]
+    inputBinding:
+      position: 1
+
+stdout: output.txt
+
+outputs:
+  report:
+    type: File
+    format:
+    - http://edamontology.org/format_1964
+    - http://edamontology.org/format_1965
+    outputBinding:
+      glob: "*.txt"
+    doc: A text file that contains a line count
+
+baseCommand: ["wc", "-l"]
+
+$namespaces:
+  s: https://schema.org/
+
+$schemas:
+- http://dublincore.org/2012/06/14/dcterms.rdf
+- http://xmlns.com/foaf/spec/20140114.rdf
+- https://schema.org/version/latest/schema.rdf
+
+s:author:
+  - class: s:Person
+    s:id: https://orcid.org/0000-0002-6130-1021
+    s:email: dyuen@oicr.on.ca
+    s:name: Denis Yuen
+
+s:contributor:
+  - class: s:Person
+    s:id: http://orcid.org/0000-0002-7681-6415
+    s:email: briandoconnor@gmail.com
+    s:name: Brian O'Connor
+  - class: s:Person
+    s:id: https://orcid.org/0000-0002-6130-1021
+    s:email: dyuen@oicr.on.ca
+    s:name: Denis Yuen
+
+s:citation: https://figshare.com/articles/Common_Workflow_Language_draft_3/3115156/2
+s:codeRepository: https://github.com/common-workflow-language/common-workflow-language
+s:dateCreated: "2016-12-13"
+s:license: https://www.apache.org/licenses/LICENSE-2.0
+
+s:keywords: http://edamontology.org/topic_0091 , http://edamontology.org/topic_0622
+s:programmingLanguage: C


### PR DESCRIPTION
**Description**
This PR enhances the webservice parsing code to handle a CWL file which contains file formats specified as an array of file format values.  See the linked issue for an example.

This PR is intentionally limited in scope for the 1.12 release.  For now, I think it's best if the code operates like the related existing code when it encounters a problem: log something, skip the errant value, and continue.

**Issue**
This is the first PR  for https://ucsc-cgl.atlassian.net/browse/SEAB-4033

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
