### PR TITLE
Feature/seab 4033/gracefully handle GitHub apps parse errors

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -456,6 +456,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         return lambdaEvent;
     }
 
+    private void cleanup(Workflow workflow) {
+        sessionFactory.getCurrentSession().evict(workflow);
+    }
+
     /**
      * Create or retrieve workflows/GitHub App Tools based on Dockstore.yml, add or update tag version
      * ONLY WORKS FOR v1.2
@@ -492,7 +496,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                     addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion, yamlAuthors);
                 } catch (CustomWebApplicationException ex) {
                     LOG.error("Skipping entry in .dockstore.yml");
-                    // TODO cleanup?
+                    cleanup(workflow);
                     continue;
                 }
 
@@ -544,7 +548,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion, yamlAuthors);
             } catch (CustomWebApplicationException ex) {
                 LOG.error("Skipping entry in .dockstore.yml");
-                // TODO cleanup?
+                cleanup(workflow);
                 return;
             }
 


### PR DESCRIPTION
**Description**
This draft PR explores a potential approach to making `.dockstore.yml` more resistant to unexpected exceptions in the processing code, which currently cause processing to be aborted without any workflows being added/updated.  Thoughts, _please_.

The basic concept is to wrap `addDockstoreYmlVersionToWorkflow()`, which seems to do most of the heavy lifting, in a try-catch, and handle any emerging `CustomWebApplicationExceptions` by logging an error, evicting the in-process `Workflow` object from the cache so that it's not persisted in a half-baked state, and continuing to the next workflow. 

In this implementation, the github-related `IOException` in `addDockstoreYmlVersionToWorkflow()` is handled similarly.

I believe this change makes the outer try-catch in `createBioWorkflowsAndVersionsFromDockstoreYml` obsolete.  I left it in there for now, so you could take a look at it.  I'm planning to use that problem case to test _this_ change.

We're dancing kinda close to the third rail here, risky business. :)

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4033

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ ] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
