### PR TITLE
Change ElasticSearch reindexing configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,35 +57,35 @@ workflows:
           context:
             - sonarcloud
             - aws
-#      - workflow-integration-tests:
-#          <<: *common_filters
-#          requires:
-#            - build
-#          context: sonarcloud
-#      - language-parsing-tests:
-#          <<: *common_filters
-#          requires:
-#            - build
-#          context: sonarcloud
-#      - tool-integration-tests:
-#          <<: *common_filters
-#          requires:
-#            - build
-#          context: sonarcloud
-#      - integration-tests:
-#          <<: *common_filters
-#          requires:
-#            - build
-#          context: sonarcloud
-#      - regression-integration-tests:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - /^release.*$/
-#          requires:
-#            - build
-#          context: sonarcloud
+      - workflow-integration-tests:
+          <<: *common_filters
+          requires:
+            - build
+          context: sonarcloud
+      - language-parsing-tests:
+          <<: *common_filters
+          requires:
+            - build
+          context: sonarcloud
+      - tool-integration-tests:
+          <<: *common_filters
+          requires:
+            - build
+          context: sonarcloud
+      - integration-tests:
+          <<: *common_filters
+          requires:
+            - build
+          context: sonarcloud
+      - regression-integration-tests:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release.*$/
+          requires:
+            - build
+          context: sonarcloud
 jobs:
   regression-integration-tests:
     executor: machine_integration_test_exec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,35 +57,35 @@ workflows:
           context:
             - sonarcloud
             - aws
-      - workflow-integration-tests:
-          <<: *common_filters
-          requires:
-            - build
-          context: sonarcloud
-      - language-parsing-tests:
-          <<: *common_filters
-          requires:
-            - build
-          context: sonarcloud
-      - tool-integration-tests:
-          <<: *common_filters
-          requires:
-            - build
-          context: sonarcloud
-      - integration-tests:
-          <<: *common_filters
-          requires:
-            - build
-          context: sonarcloud
-      - regression-integration-tests:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release.*$/
-          requires:
-            - build
-          context: sonarcloud
+#      - workflow-integration-tests:
+#          <<: *common_filters
+#          requires:
+#            - build
+#          context: sonarcloud
+#      - language-parsing-tests:
+#          <<: *common_filters
+#          requires:
+#            - build
+#          context: sonarcloud
+#      - tool-integration-tests:
+#          <<: *common_filters
+#          requires:
+#            - build
+#          context: sonarcloud
+#      - integration-tests:
+#          <<: *common_filters
+#          requires:
+#            - build
+#          context: sonarcloud
+#      - regression-integration-tests:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - /^release.*$/
+#          requires:
+#            - build
+#          context: sonarcloud
 jobs:
   regression-integration-tests:
     executor: machine_integration_test_exec

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -36,6 +36,7 @@ import io.dockstore.webservice.helpers.ElasticSearchHelper;
 import io.dockstore.webservice.helpers.StateManagerMode;
 import io.dropwizard.jackson.Jackson;
 import java.io.IOException;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -292,7 +293,14 @@ public class ElasticListener implements StateListenerInterface {
 
     private int getEnv(final String name, final int defaultValue) {
         final String envValue = System.getenv(name);
-        return envValue == null ? defaultValue : Integer.parseInt(envValue);
+        if (envValue != null) {
+            try {
+                return Integer.parseInt(envValue);
+            } catch (NumberFormatException ex) {
+                LOGGER.error(MessageFormat.format("Value {0} specified for {1} is not numeric, defaulting back to {2}", envValue, name, defaultValue), ex);
+            }
+        }
+        return defaultValue;
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -280,12 +280,12 @@ public class ElasticListener implements StateListenerInterface {
      */
     private void configureBulkProcessorBuilder(Builder builder) {
         // Default is 5MB
-        final int bulkSizeKb = getEnv("BULK_SIZE_KB", 2500);
+        final int bulkSizeKb = getEnv("ESCLIENT_BULK_SIZE_KB", 2500);
         builder.setBulkSize(new ByteSizeValue(bulkSizeKb, ByteSizeUnit.KB));
 
         // Defaults are 50ms, 8 retries (leaving number of retries the same).
-        final int initialDelayMs = getEnv("BACKOFF_INITIAL_DELAY", 500);
-        final int maxNumberOfRetries = getEnv("BACKOFF_RETRIES", 8);
+        final int initialDelayMs = getEnv("ESCLIENT_BACKOFF_INITIAL_DELAY", 500);
+        final int maxNumberOfRetries = getEnv("ESCLIENT_BACKOFF_RETRIES", 8);
         builder.setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(
             initialDelayMs), maxNumberOfRetries));
     }


### PR DESCRIPTION
**Description**

Decreased the bulk size of requests to ES, as well as increased the delay time between retries.

Configurable with environment variables as an emergency, e.g., ES crashes in prod, and the data has grown enough that reindexing doesn't work, we could set env variables in the docker-compose .env file (so we don't have to make a new build to reindex).

I did this twice in staging and it worked both times. Takes about 2 minutes.

My intention was to play around with the variable values until I got it working, but it worked right away with these changes, so I decided to leave it.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-3829

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
