### PR TITLE
Initialize apptool property in events

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
@@ -113,6 +113,7 @@ public class EventResource {
             Hibernate.initialize(event.getWorkflow());
             Hibernate.initialize(event.getCollection());
             Hibernate.initialize(event.getInitiatorUser());
+            Hibernate.initialize(event.getApptool());
         });
     }
 }


### PR DESCRIPTION
**Description**
Initialize apptool property in events.

Ideally there would  be tests, but there's no easy place to hook into (existing event tests don't have collections or app tools, collections tests don't have events or app tools, app tool tests don't have collections or events), so I'm proposing skipping them for this change, given the proximity to the release. But I can add if need be; let me know.

**Issue**
#4800

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
