### PR TITLE
switch to temurin image for Java 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
-FROM openjdk:11.0.12-jdk
+FROM eclipse-temurin:17.0.2_8-jdk-focal
 
 # wipe them out, all of them, to reduce CVEs
 RUN apt-get purge -y -- *python*  && apt-get -y autoremove
+
 # Update the APT cache
 # prepare for Java download
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends \
-    locales \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+    && apt-get install -y --no-install-recommends
+# note locale settings seem redundant, temurin already has en_US.UTF-8 set
+#    locales \
+#    && apt-get clean \
+#    && rm -rf /var/lib/apt/lists/* \
+#    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+# ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # copy the jar not ending in 's', to make sure we get don't get the one ending in 'sources'
 COPY dockstore-webservice/target/dockstore-webservice*[^s].jar /home


### PR DESCRIPTION
**Description**
Switch to Java 17 image, seems to have locale `en_US.UTF-8` baked in 

https://adoptium.net/faq.html

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4082


Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
