### PR TITLE
Ignore image tag for now

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -1047,7 +1047,7 @@ public class GeneralIT extends BaseIT {
         containersApi.refresh(toolTest.getId());
         DockstoreTool container = containersApi.getContainer(toolTest.getId(), null);
         size = container.getWorkflowVersions().size();
-        size2 = container.getWorkflowVersions().stream().filter(tag -> tag.getImageId().equals("silly old value")).count();
+        size2 = container.getWorkflowVersions().stream().filter(tag -> tag.getImageId() != null && tag.getImageId().equals("silly old value")).count();
         assertTrue(size2 == 0 && size >= 1);
 
         // so should overall refresh
@@ -1055,7 +1055,7 @@ public class GeneralIT extends BaseIT {
         usersApi.refreshToolsByOrganization(userid, "dockstoretestuser2", DOCKSTORE_TOOL_IMPORTS);
         container = containersApi.getContainer(toolTest.getId(), null);
         size = container.getWorkflowVersions().size();
-        size2 = container.getWorkflowVersions().stream().filter(tag -> tag.getImageId().equals("silly old value")).count();
+        size2 = container.getWorkflowVersions().stream().filter(tag -> tag.getImageId() != null && tag.getImageId().equals("silly old value")).count();
         assertTrue(size2 == 0 && size >= 1);
 
         // so should organizational refresh
@@ -1063,7 +1063,7 @@ public class GeneralIT extends BaseIT {
         usersApi.refreshToolsByOrganization(userid, container.getNamespace(), DOCKSTORE_TOOL_IMPORTS);
         container = containersApi.getContainer(toolTest.getId(), null);
         size = container.getWorkflowVersions().size();
-        size2 = container.getWorkflowVersions().stream().filter(tag -> tag.getImageId().equals("silly old value")).count();
+        size2 = container.getWorkflowVersions().stream().filter(tag -> tag.getImageId() != null && tag.getImageId().equals("silly old value")).count();
         assertTrue(size2 == 0 && size >= 1);
     }
 

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
@@ -383,7 +383,7 @@ public final class ToolsImplCommon {
             return true;
         }
         // Hide tags with no image ID (except hosted tools which do not have image IDs)
-        return version instanceof Tag && ((Tag)version).getImageId() == null && !isHosted;
+        return version instanceof Tag && (((Tag)version).getImageId() == null && version.getImages().isEmpty()) && !isHosted;
     }
 
     /**

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.SystemErrRule;
@@ -28,7 +27,6 @@ public class QuayImageRegistryTest {
      * Using calico/node because it has over 3838 tags
      */
     @Test
-    @Ignore("Failing again on 2022-03-22")
     public void getOver500TagsTest() {
         Token token = new Token();
         token.setContent("fakeQuayTokenBecauseWeDontReallyNeedOne");
@@ -41,8 +39,8 @@ public class QuayImageRegistryTest {
         int size = tags.size();
         Assert.assertTrue("Should be able to get more than the default 500 tags", size > 3838);
         tags.forEach(tag -> {
-            Assert.assertNotEquals("Image ID should be populated", null, tag.getImageId());
             Assert.assertTrue("Images should be populated", tag.getImages().size() > 0);
+            Assert.assertTrue("things look kinda sane", !tag.getName().isEmpty() && tag.getImages().stream().noneMatch(img -> img.getImageUpdateDate().isEmpty()));
             // If the tag size is null, that means at least one image with os/arch information was built and uploaded to Quay separately.
             if (tag.getSize() == null) {
                 tag.getImages().stream().forEach(image -> {
@@ -67,8 +65,8 @@ public class QuayImageRegistryTest {
             Assert.fail("There should be at least one tag where there is more than one image");
         }
         tags.forEach(tag -> {
-            Assert.assertNotEquals("Image ID should be populated", null, tag.getImageId());
             Assert.assertTrue("Images should be populated", tag.getImages().size() > 0);
+            Assert.assertTrue("things look kinda sane", !tag.getName().isEmpty() && tag.getImages().stream().noneMatch(img -> img.getImageUpdateDate().isEmpty()));
             // If the tag size is null, that means at least one image with os/arch information was built and uploaded to Quay separately.
             if (tag.getSize() == null) {
                 tag.getImages().stream().forEach(image -> {


### PR DESCRIPTION
**Description**
Looks like the quay.io removed image id
Can't find changelogs, but can wander around https://quay.io/repository/dockstoretestuser2/quayandgithub?tab=tags or any other list of repo tags with developer tools turned on and see there are no image ids

**Issue**
n/a emergent issue
Follow-up, should probably update https://github.com/dockstore/swagger-java-quay-client
Specifically https://github.com/dockstore/swagger-java-quay-client/blob/2.0.1/discovery.formatted.yaml#L588-L609

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
