### PR TITLE
Regression test with 1.10

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class CommonTestUtilities {
 
-    public static final String OLD_DOCKSTORE_VERSION = "1.11.0";
+    public static final String OLD_DOCKSTORE_VERSION = "1.12.0";
     // Travis is slow, need to wait up to 1 min for webservice to return
     public static final int WAIT_TIME = 60000;
     public static final String PUBLIC_CONFIG_PATH = ResourceHelpers.resourceFilePath("dockstore.yml");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class CommonTestUtilities {
 
-    public static final String OLD_DOCKSTORE_VERSION = "1.10.0";
+    public static final String OLD_DOCKSTORE_VERSION = "1.11.0";
     // Travis is slow, need to wait up to 1 min for webservice to return
     public static final int WAIT_TIME = 60000;
     public static final String PUBLIC_CONFIG_PATH = ResourceHelpers.resourceFilePath("dockstore.yml");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class CommonTestUtilities {
 
-    public static final String OLD_DOCKSTORE_VERSION = "1.9.0";
+    public static final String OLD_DOCKSTORE_VERSION = "1.10.0";
     // Travis is slow, need to wait up to 1 min for webservice to return
     public static final int WAIT_TIME = 60000;
     public static final String PUBLIC_CONFIG_PATH = ResourceHelpers.resourceFilePath("dockstore.yml");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -657,7 +657,7 @@ public class WebhookIT extends BaseIT {
     }
 
     /**
-     * This tests the GitHub release with .dockstore.yml located in /   .github/.dockstore.yml
+     * This tests the GitHub release with .dockstore.yml located in /.github/.dockstore.yml
      */
     @Test
     public void testGithubDirDockstoreYml() throws Exception {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -657,7 +657,7 @@ public class WebhookIT extends BaseIT {
     }
 
     /**
-     * This tests the GitHub release with .dockstore.yml located in /.github/.dockstore.yml
+     * This tests the GitHub release with .dockstore.yml located in /   .github/.dockstore.yml
      */
     @Test
     public void testGithubDirDockstoreYml() throws Exception {


### PR DESCRIPTION
**Description**

Regression tests for 1.13 will now test using CLI 1.11. I think this is right -- we want to support two versions back, right? Or is the intent to only support the previous version? We went 3 versions back for 1.12.

Started the branch name with `release` so the regression tests would run (they passed on the branch).

**Issue**
[SEAB-4172](https://ucsc-cgl.atlassian.net/browse/SEAB-4172)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
