### PR TITLE
used descriptor and new galaxy default desc name

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
@@ -166,6 +166,10 @@ public enum DescriptorLanguage {
             .filter(lang -> StringUtils.containsIgnoreCase(descriptorType, lang.toString())).findFirst().map(DescriptorLanguage::getFileType);
     }
 
+    public static FileType getTestFileTypeFromDescriptorLanguageString(String descriptorType) {
+       return convertShortStringToEnum(descriptorType).getTestParamType();
+    }
+
     public FileType getTestParamType() {
         return testParamType;
     }

--- a/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
@@ -251,7 +251,7 @@ public enum DescriptorLanguage {
         case NEXTFLOW:
             return "/nextflow.config";
         case GXFORMAT2:
-            return "/Dockstore.yml";
+            return "/workflow-name.yml";
         default:
             return null;
         }

--- a/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
@@ -167,7 +167,7 @@ public enum DescriptorLanguage {
     }
 
     public static FileType getTestFileTypeFromDescriptorLanguageString(String descriptorType) {
-       return convertShortStringToEnum(descriptorType).getTestParamType();
+        return convertShortStringToEnum(descriptorType).getTestParamType();
     }
 
     public FileType getTestParamType() {

--- a/dockstore-common/src/test/java/io/dockstore/common/DescriptorLanguageTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/DescriptorLanguageTest.java
@@ -45,4 +45,13 @@ public class DescriptorLanguageTest {
         Assert.assertEquals(FileType.WDL_TEST_JSON, DescriptorLanguage.WDL.getTestParamType());
         Assert.assertEquals(FileType.NEXTFLOW_TEST_PARAMS, DescriptorLanguage.NEXTFLOW.getTestParamType());
     }
+
+    @Test
+    public void testGetTestFileTypeFromDescriptorLanguageString() {
+        Assert.assertEquals(FileType.CWL_TEST_JSON, DescriptorLanguage.getTestFileTypeFromDescriptorLanguageString(DescriptorLanguage.CWL.toString()));
+        Assert.assertEquals(FileType.WDL_TEST_JSON, DescriptorLanguage.getTestFileTypeFromDescriptorLanguageString(DescriptorLanguage.WDL.toString()));
+        Assert.assertEquals(FileType.NEXTFLOW_TEST_PARAMS,
+            DescriptorLanguage.getTestFileTypeFromDescriptorLanguageString(DescriptorLanguage.NEXTFLOW.toString()));
+    }
+
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -69,7 +69,6 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
-import io.swagger.model.DescriptorType;
 import io.swagger.quay.client.model.QuayRepo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -997,7 +996,7 @@ public class DockerRepoResource
 
         // Add new test parameter files
         FileType fileType =
-            (descriptorType.toUpperCase().equals(DescriptorType.CWL.toString())) ? DescriptorLanguage.FileType.CWL_TEST_JSON : DescriptorLanguage.FileType.WDL_TEST_JSON;
+            (descriptorType.toUpperCase().equals(DescriptorLanguage.CWL.toString())) ? DescriptorLanguage.FileType.CWL_TEST_JSON : DescriptorLanguage.FileType.WDL_TEST_JSON;
         createTestParameters(testParameterPaths, tag, sourceFiles, fileType, fileDAO);
         PublicStateManager.getInstance().handleIndexUpdate(tool, StateManagerMode.UPDATE);
         return tag.getSourceFiles();
@@ -1033,7 +1032,7 @@ public class DockerRepoResource
 
         // Remove test parameter files
         FileType fileType =
-            (descriptorType.toUpperCase().equals(DescriptorType.CWL.toString())) ? DescriptorLanguage.FileType.CWL_TEST_JSON : DescriptorLanguage.FileType.WDL_TEST_JSON;
+            (descriptorType.toUpperCase().equals(DescriptorLanguage.CWL.toString())) ? DescriptorLanguage.FileType.CWL_TEST_JSON : DescriptorLanguage.FileType.WDL_TEST_JSON;
         for (String path : testParameterPaths) {
             boolean fileDeleted = sourceFiles.removeIf((SourceFile v) -> v.getPath().equals(path) && v.getType() == fileType);
             if (!fileDeleted) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -996,7 +996,7 @@ public class DockerRepoResource
 
         // Add new test parameter files
         FileType fileType =
-            (descriptorType.toUpperCase().equals(DescriptorLanguage.CWL.toString())) ? DescriptorLanguage.FileType.CWL_TEST_JSON : DescriptorLanguage.FileType.WDL_TEST_JSON;
+            (descriptorType.equalsIgnoreCase(DescriptorLanguage.CWL.toString())) ? DescriptorLanguage.FileType.CWL_TEST_JSON : DescriptorLanguage.FileType.WDL_TEST_JSON;
         createTestParameters(testParameterPaths, tag, sourceFiles, fileType, fileDAO);
         PublicStateManager.getInstance().handleIndexUpdate(tool, StateManagerMode.UPDATE);
         return tag.getSourceFiles();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -995,8 +995,7 @@ public class DockerRepoResource
         Set<SourceFile> sourceFiles = tag.getSourceFiles();
 
         // Add new test parameter files
-        FileType fileType =
-            (descriptorType.equalsIgnoreCase(DescriptorLanguage.CWL.toString())) ? DescriptorLanguage.FileType.CWL_TEST_JSON : DescriptorLanguage.FileType.WDL_TEST_JSON;
+        FileType fileType = DescriptorLanguage.getTestFileTypeFromDescriptorLanguageString(descriptorType);
         createTestParameters(testParameterPaths, tag, sourceFiles, fileType, fileDAO);
         PublicStateManager.getInstance().handleIndexUpdate(tool, StateManagerMode.UPDATE);
         return tag.getSourceFiles();
@@ -1031,8 +1030,7 @@ public class DockerRepoResource
         Set<SourceFile> sourceFiles = tag.getSourceFiles();
 
         // Remove test parameter files
-        FileType fileType =
-            (descriptorType.toUpperCase().equals(DescriptorLanguage.CWL.toString())) ? DescriptorLanguage.FileType.CWL_TEST_JSON : DescriptorLanguage.FileType.WDL_TEST_JSON;
+        FileType fileType = DescriptorLanguage.getTestFileTypeFromDescriptorLanguageString(descriptorType);
         for (String path : testParameterPaths) {
             boolean fileDeleted = sourceFiles.removeIf((SourceFile v) -> v.getPath().equals(path) && v.getType() == fileType);
             if (!fileDeleted) {


### PR DESCRIPTION
**Description**
Use workflow-name.yml for the default Galaxy descriptor to better distinguish the name from our .dockstore.yml file.
Reduces the amount of language specific code in order to make it easier to add new language support

**Issue**
Addresses https://ucsc-cgl.atlassian.net/browse/SEAB-4012
Related to UI PR https://github.com/dockstore/dockstore-ui2/pull/1492. You will probably need to use the UI PR in conjunction with this one to register hosted Galaxy workflows.


Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
