### PR TITLE
Allow query parameter to load user profiles

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -137,6 +137,21 @@ public class UserResourceIT extends BaseIT {
     }
 
     @Test
+    public void testUserProfileLoading() throws ApiException {
+        // Get the user
+        ApiClient client = getWebClient(USER_2_USERNAME, testingPostgres);
+        UsersApi userApi = new UsersApi(client);
+
+        // Profiles are lazy loaded, and should not be present by default
+        User user = userApi.listUser(USER_2_USERNAME, null);
+        assertNull("User profiles should be null by default", user.getUserProfiles());
+
+        // Load profiles by specifying userProfiles as a query parameter in the API call
+        user = userApi.listUser(USER_2_USERNAME, "userProfiles");
+        assertNotNull("User profiles should be initialized", user.getUserProfiles());
+    }
+
+    @Test
     public void testChangingNameSuccess() throws ApiException {
         ApiClient client = getWebClient(USER_2_USERNAME, testingPostgres);
         UsersApi userApi = new UsersApi(client);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -199,7 +199,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
      */
     private boolean checkIncludes(String include, String field) {
         String includeString = (include == null ? "" : include);
-        ArrayList<String> includeSplit = new ArrayList(Arrays.asList(includeString.split(",")));
+        List<String> includeSplit = Arrays.asList(includeString.split(","));
         return includeSplit.contains(field);
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -197,7 +197,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
      * @param field Field to query for
      * @return True if include has the given field, false otherwise
      */
-    boolean checkIncludes(String include, String field) {
+    private boolean checkIncludes(String include, String field) {
         String includeString = (include == null ? "" : include);
         ArrayList<String> includeSplit = new ArrayList(Arrays.asList(includeString.split(",")));
         return includeSplit.contains(field);

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -4963,6 +4963,11 @@ paths:
         required: true
         schema:
           type: string
+      - description: "Comma-delimited list of fields to include: userProfiles, ..."
+        in: query
+        name: include
+        schema:
+          type: string
       responses:
         "200":
           content:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4446,6 +4446,11 @@ paths:
         description: "Username of user to return"
         required: true
         type: "string"
+      - name: "include"
+        in: "query"
+        description: "Comma-delimited list of fields to include: userProfiles, ..."
+        required: false
+        type: "string"
       responses:
         200:
           description: "successful operation"


### PR DESCRIPTION
**Description**
This PR adds an optional parameter to the `/user/usernames/{username}` API endpoint that will allow you to specify fields to initialize. In this case, the field is `userProfiles`.

Stole the pattern and parsing strategy used for https://dockstore.org/api/static/swagger-ui/index.html#/workflows/getWorkflow.

**Issue**
Ticket: https://ucsc-cgl.atlassian.net/browse/SEAB-4085

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [X] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [X] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [X] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [X] Do not serve user-uploaded binary images through the Dockstore API
- [X] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [X] Do not create cookies, although this may change in the future
