### PR TITLE
Feature/dock 2105/improve dockstore yml error messages

### DIFF
--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-common</artifactId>
-  <version>1.12.0-SNAPSHOT</version>
+  <version>1.12.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.12.0</version>
+        <version>1.12.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-common</artifactId>

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/Dockstore12Validator.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/Dockstore12Validator.java
@@ -30,7 +30,7 @@ public class Dockstore12Validator implements ConstraintValidator<ValidDockstore1
     @Override
     public boolean isValid(final DockstoreYaml12 value, final ConstraintValidatorContext context) {
         return value.getService() != null
-            || value.getWorkflows() != null && !value.getWorkflows().isEmpty()
-            || value.getTools() != null && !value.getTools().isEmpty();
+            || value.getWorkflows() != null && !value.getWorkflows().isEmpty()  // NOSONAR suppress incorrect "can't be null" analysis
+            || value.getTools() != null && !value.getTools().isEmpty();  // NOSONAR suppress incorrect "can't be null" analysis
     }
 }

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/Dockstore12Validator.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/Dockstore12Validator.java
@@ -19,7 +19,7 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 /**
- * Validates that a DockstoreYaml12 instance has at least one workflow or at least one service
+ * Validates that a DockstoreYaml12 instance has at least one workflow, tool, or service
  */
 public class Dockstore12Validator implements ConstraintValidator<ValidDockstore12, DockstoreYaml12> {
     @Override
@@ -29,6 +29,8 @@ public class Dockstore12Validator implements ConstraintValidator<ValidDockstore1
 
     @Override
     public boolean isValid(final DockstoreYaml12 value, final ConstraintValidatorContext context) {
-        return value.getService() != null || !value.getWorkflows().isEmpty() || !value.getTools().isEmpty();
+        return value.getService() != null
+            || value.getWorkflows() != null && !value.getWorkflows().isEmpty()
+            || value.getTools() != null && !value.getTools().isEmpty();
     }
 }

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYaml10.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYaml10.java
@@ -19,8 +19,8 @@ public class DockstoreYaml10 implements DockstoreYaml {
     /**
      * Required, expected to always be "1.0" for now.
      */
-    @NotNull(message = "Missing property \"dockstoreVersion\"")
-    @Pattern(regexp = "1\\.0", message = "dockstoreVersion must be 1.0")
+    @NotNull
+    @Pattern(regexp = "1\\.0", message = "must be \"1.0\"")
     public String dockstoreVersion;
 
     /**
@@ -28,14 +28,14 @@ public class DockstoreYaml10 implements DockstoreYaml {
      *
      * Currently only "workflow" is the only value, but other values will be coming.
      */
-    @NotNull(message = "Missing property \"class\"")
-    @Pattern(regexp = "workflow", message = "The class property value must be \"workflow\"")
+    @NotNull
+    @Pattern(regexp = "workflow")
     public String clazz;
 
     /**
      * Required if the clazz is "workflow".
      */
-    @NotNull(message = "Missing property \"primaryDescriptor\"")
+    @NotNull
     public String primaryDescriptor;
     /**
      * Optional if the clazz is "workflow".

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYaml11.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYaml11.java
@@ -15,9 +15,9 @@ public class DockstoreYaml11 implements DockstoreYaml {
 
     private YamlService11 service;
 
+    @NotNull
+    @Pattern(regexp = "1\\.1", message = "must be \"1.1\"")
     @Override
-    @NotNull(message = "Property \"version\" is required")
-    @Pattern(regexp = "1.1", message = "The version property value must be 1.1")
     public String getVersion() {
         return version;
     }
@@ -26,7 +26,7 @@ public class DockstoreYaml11 implements DockstoreYaml {
         this.version = version;
     }
 
-    @NotNull(message = "Property \"service\" is required")
+    @NotNull
     public YamlService11 getService() {
         return service;
     }

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYaml12.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYaml12.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 
 /**
  * The preferred .dockstore.yml since 1.9. Supports workflows, one-step workflows (tools), and services .
@@ -48,7 +49,8 @@ public class DockstoreYaml12 implements DockstoreYaml {
         this.workflows = workflows;
     }
 
-
+    @Valid
+    @NotNull // But may be empty
     public List<YamlWorkflow> getTools() {
         return tools;
     }
@@ -57,6 +59,7 @@ public class DockstoreYaml12 implements DockstoreYaml {
         this.tools = tools;
     }
 
+    @Valid
     public Service12 getService() {
         return service;
     }
@@ -66,6 +69,7 @@ public class DockstoreYaml12 implements DockstoreYaml {
     }
 
     @NotNull
+    @Pattern(regexp = "1\\.2", message = "must be \"1.2\"")
     @Override
     public String getVersion() {
         return version;

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
@@ -386,7 +386,7 @@ public final class DockstoreYamlHelper {
         if (!violations.isEmpty()) {
             throw new DockstoreYamlException(
                 violations.stream()
-                    .map(v -> buildMessageFromViolation(v))
+                    .map(v -> buildMessageFromViolation(v))  // NOSONAR here, a lambda is more understandable than method reference
                     .collect(Collectors.joining("; ")));
         }
     }

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
@@ -213,9 +213,7 @@ public final class DockstoreYamlHelper {
             return yaml.load(content);
         } catch (Exception e) {
             final String exceptionMsg = createExceptionMessage(e);
-            String errorMsg = ERROR_READING_DOCKSTORE_YML;
-            errorMsg += exceptionMsg;
-            LOG.error(errorMsg, e);
+            LOG.error(ERROR_READING_DOCKSTORE_YML + exceptionMsg, e);
             throw new DockstoreYamlException(exceptionMsg);
         }
     }

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
@@ -212,12 +212,24 @@ public final class DockstoreYamlHelper {
             final Yaml yaml = new Yaml(constructor, representer);
             return yaml.load(content);
         } catch (Exception e) {
-            final String exceptionMsg = e.getMessage();
+            final String exceptionMsg = createExceptionMessage(e);
             String errorMsg = ERROR_READING_DOCKSTORE_YML;
             errorMsg += exceptionMsg;
             LOG.error(errorMsg, e);
             throw new DockstoreYamlException(exceptionMsg);
         }
+    }
+
+    private static String createExceptionMessage(Exception e) {
+        // For yaml ConstructorException, use `getProblem()`, which returns the line number, cause, and snippet.
+        // This is thrown on errors during the initial yaml parse, before validation, such as attempting to parse
+        // non-list information as a list, or create an enum from an input string that does not match any of the
+        // enum's values.  The full exception message contains lots of information about the surrounding context,
+        // formatted in a way that can be confusing and hard to read.
+        if (e instanceof org.yaml.snakeyaml.constructor.ConstructorException) {
+            return ((org.yaml.snakeyaml.constructor.ConstructorException)e).getProblem();
+        }
+        return e.getMessage();
     }
 
     /**

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
@@ -26,6 +26,7 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +42,7 @@ public final class DockstoreYamlHelper {
     public static final String ERROR_READING_DOCKSTORE_YML = "Error reading .dockstore.yml: ";
     public static final String UNKNOWN_PROPERTY = "Unknown property: ";
     public static final Pattern WRONG_KEY_PATTERN = Pattern.compile("Unable to find property '(.+)'");
+    private static final int INVALID_VALUE_ECHO_LIMIT = 80;
 
     enum Version {
         ONE_ZERO("1.0") {
@@ -373,10 +375,29 @@ public final class DockstoreYamlHelper {
         final Set<ConstraintViolation<T>> violations = validator.validate(validatee);
         if (!violations.isEmpty()) {
             throw new DockstoreYamlException(
-                    violations.stream()
-                            .map(v -> v.getMessage())
-                            .collect(Collectors.joining("; ")));
+                violations.stream()
+                    .map(v -> buildMessageFromViolation(v))
+                    .collect(Collectors.joining("; ")));
         }
+    }
+
+    private static <T> String buildMessageFromViolation(ConstraintViolation<T> violation) {
+        String message = violation.getMessage();
+
+        // If the violation contains a non-empty property path, add it to the message, with a summary of the invalid value, if present.
+        javax.validation.Path propertyPath = violation.getPropertyPath();
+        if (propertyPath != null) {
+            String propertyPathString = propertyPath.toString();
+            if (propertyPathString != null && !propertyPathString.isEmpty()) {
+                message = String.format("Property \"%s\" %s", propertyPathString, message);
+                Object invalidValue = violation.getInvalidValue();
+                if (invalidValue != null) {
+                    message = String.format("%s (current value: \"%s\")", message, StringUtils.abbreviate(invalidValue.toString(), INVALID_VALUE_ECHO_LIMIT));
+                }
+            }
+        }
+
+        return message;
     }
 
     private static Validator createValidator() {

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
@@ -216,7 +216,7 @@ public final class DockstoreYamlHelper {
             String errorMsg = ERROR_READING_DOCKSTORE_YML;
             errorMsg += exceptionMsg;
             LOG.error(errorMsg, e);
-            throw new DockstoreYamlException(errorMsg);
+            throw new DockstoreYamlException(exceptionMsg);
         }
     }
 

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/Service12.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/Service12.java
@@ -29,7 +29,7 @@ public class Service12 extends AbstractYamlService {
 
     private DescriptorLanguageSubclass subclass;
 
-    @NotNull(message = MISSING_SUBCLASS)
+    @NotNull
     public DescriptorLanguageSubclass getSubclass() {
         return subclass;
     }

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlAuthor.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlAuthor.java
@@ -15,8 +15,6 @@
  */
 package io.dockstore.common.yaml;
 
-import javax.validation.constraints.NotNull;
-
 public class YamlAuthor {
 
     private String name;

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlAuthor.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlAuthor.java
@@ -19,7 +19,6 @@ import javax.validation.constraints.NotNull;
 
 public class YamlAuthor {
 
-    @NotNull
     private String name;
 
     private String role;

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlService11.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlService11.java
@@ -23,7 +23,7 @@ import javax.validation.constraints.NotNull;
 public class YamlService11 extends AbstractYamlService {
     private String type;
 
-    @NotNull(message = "Missing property \"type\"")
+    @NotNull
     public String getType() {
         return type;
     }

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
@@ -18,6 +18,7 @@ package io.dockstore.common.yaml;
 import io.dockstore.common.DescriptorLanguage;
 import java.util.ArrayList;
 import java.util.List;
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 /**
@@ -33,9 +34,9 @@ public class YamlWorkflow {
     public static final String NEW_GALAXY_SUBCLASS = "GALAXY";
 
     private String name;
-    @NotNull(message = "Missing property \"subclass\"")
+    @NotNull
     private String subclass;
-    @NotNull(message = "Missing property \"primaryDescriptorPath\"")
+    @NotNull
     private String primaryDescriptorPath;
 
     /**
@@ -89,6 +90,7 @@ public class YamlWorkflow {
         this.publish = publish;
     }
 
+    @Valid
     public Filters getFilters() {
         return filters;
     }
@@ -97,6 +99,7 @@ public class YamlWorkflow {
         this.filters = filters;
     }
 
+    @Valid
     public List<YamlAuthor> getAuthors() {
         return authors;
     }

--- a/dockstore-common/src/main/resources/ValidationMessages.properties
+++ b/dockstore-common/src/main/resources/ValidationMessages.properties
@@ -1,0 +1,1 @@
+javax.validation.constraints.NotNull.message = is missing but required

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -152,7 +152,7 @@ public class DockstoreYamlTest {
             DockstoreYamlHelper.readDockstoreYaml(content);
             fail("Did not catch invalid subclass");
         } catch (DockstoreYamlHelper.DockstoreYamlException e) {
-            assertTrue(e.getMessage().startsWith(DockstoreYamlHelper.ERROR_READING_DOCKSTORE_YML));
+            assertTrue(e.getMessage().contains("subclass"));
         }
     }
 
@@ -202,7 +202,6 @@ public class DockstoreYamlTest {
                     "]\n");
             fail("Dockstore yaml breaking entities should fail");
         } catch (DockstoreYamlHelper.DockstoreYamlException e) {
-            assertTrue(e.getMessage().startsWith(DockstoreYamlHelper.ERROR_READING_DOCKSTORE_YML));
             // This message is emitted when SafeConstructor is used
             assertTrue(e.getMessage().contains("could not determine a constructor for the tag"));
         }

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -139,7 +139,9 @@ public class DockstoreYamlTest {
             DockstoreYamlHelper.readDockstoreYaml(content);
             fail("Invalid dockstore.yml not caught");
         } catch (DockstoreYamlHelper.DockstoreYamlException e) {
-            System.out.println(e.getMessage());
+            // check that the error message contains the name of the property and an appropriate adjective
+            assertTrue(e.getMessage().contains("primaryDescriptor"));
+            assertTrue(e.getMessage().matches(".*([Mm]issing|[Rr]equired).*"));
         }
     }
 
@@ -165,9 +167,21 @@ public class DockstoreYamlTest {
     public void testEmptyDockstore12() {
         try {
             DockstoreYamlHelper.readAsDockstoreYaml12("version: 1.2");
-            fail("Dockstore yaml with no services and no workflows should fail");
+            fail("Dockstore yaml with no entries should fail");
         } catch (DockstoreYamlHelper.DockstoreYamlException e) {
             assertEquals(ValidDockstore12.AT_LEAST_1_WORKFLOW_OR_TOOL_OR_SERVICE, e.getMessage());
+        }
+    }
+
+    @Test
+    public void testEffectivelyEmptyDockstore12() {
+        for (String emptyProperty: List.of("workflows", "tools", "service")) {
+            try {
+                DockstoreYamlHelper.readDockstoreYaml(String.format("version: 1.2\n%s:\n", emptyProperty));
+                fail("Dockstore yaml with no entries should fail");
+            } catch (DockstoreYamlHelper.DockstoreYamlException e) {
+                assertTrue(e.getMessage().contains(ValidDockstore12.AT_LEAST_1_WORKFLOW_OR_TOOL_OR_SERVICE));
+            }
         }
     }
 

--- a/dockstore-event-consumer/generated/src/main/resources/pom.xml
+++ b/dockstore-event-consumer/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-event-consumer</artifactId>
-  <version>1.12.0-SNAPSHOT</version>
+  <version>1.12.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,13 +30,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-event-consumer/pom.xml
+++ b/dockstore-event-consumer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.12.0</version>
+        <version>1.12.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -30,12 +30,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-integration-testing</artifactId>
-  <version>1.12.0-SNAPSHOT</version>
+  <version>1.12.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -54,13 +54,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.1-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.1-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>openapi-java-client</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.12.0</version>
+        <version>1.12.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-integration-testing</artifactId>
@@ -63,12 +63,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.1-SNAPSHOT</version>
             <!-- looks like these are excluded because they bring in duplicate liquibase.build.properties -->
             <exclusions>
                 <exclusion>
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.1-SNAPSHOT</version>
             <!-- looks like these are excluded because they bring in duplicate liquibase.build.properties -->
             <exclusions>
                 <exclusion>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-client</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-language-plugin-parent</artifactId>
-  <version>1.12.0-SNAPSHOT</version>
+  <version>1.12.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-language-plugin-parent/pom.xml
+++ b/dockstore-language-plugin-parent/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <version>1.12.0</version>
+        <version>1.12.1-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.pf4j</groupId>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-webservice</artifactId>
-  <version>1.12.0-SNAPSHOT</version>
+  <version>1.12.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -84,13 +84,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-language-plugin-parent</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
 
     <parent>
-        <version>1.12.0</version>
+        <version>1.12.1-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -73,12 +73,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-language-plugin-parent</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.zafarkhaja</groupId>
@@ -538,7 +538,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.1-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -33,6 +33,7 @@ import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowMode;
 import io.dockstore.webservice.core.WorkflowVersion;
+import io.dockstore.webservice.helpers.CacheConfigManager;
 import io.dockstore.webservice.helpers.CheckUrlHelper;
 import io.dockstore.webservice.helpers.CheckUrlHelper.TestFileType;
 import io.dockstore.webservice.helpers.FileFormatHelper;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -394,7 +394,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     private String createMessageFromException(Exception ex) {
         String message = ex instanceof CustomWebApplicationException ? ((CustomWebApplicationException)ex).getErrorMessage() : ex.getMessage();
         if (ex instanceof DockstoreYamlHelper.DockstoreYamlException) {
-            message = "Error reading .dockstore.yml: " + message;
+            message = DockstoreYamlHelper.ERROR_READING_DOCKSTORE_YML + message;
         }
         return message;
     }

--- a/dockstore-webservice/src/main/resources/ValidationMessages.properties
+++ b/dockstore-webservice/src/main/resources/ValidationMessages.properties
@@ -1,0 +1,1 @@
+javax.validation.constraints.NotNull.message = is missing but required

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -13,7 +13,7 @@ info:
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
   termsOfService: https://github.com/dockstore/dockstore-ui2/raw/develop/src/assets/docs/Dockstore_Terms_of_Service.pdf
   title: Dockstore API
-  version: 1.12.0-SNAPSHOT
+  version: 1.12.1-SNAPSHOT
 servers:
 - description: Current server when hosted on AWS
   url: /api

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5,7 +5,7 @@ info:
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images. Explore swagger.json for a Swagger 2.0 description\
     \ of our API and explore openapi.yaml for OpenAPI 3.0 descriptions."
-  version: "1.12.0-SNAPSHOT"
+  version: "1.12.1-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/openapi-java-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>openapi-java-client</artifactId>
-  <version>1.12.0-SNAPSHOT</version>
+  <version>1.12.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.1-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/openapi-java-client/pom.xml
+++ b/openapi-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>openapi-java-client</name>
 
     <parent>
-        <version>1.12.0</version>
+        <version>1.12.1-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -325,7 +325,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.1-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>io.dockstore</groupId>
     <artifactId>dockstore</artifactId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>dockstore</name>

--- a/reports/generated/src/main/resources/pom.xml
+++ b/reports/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>reports</artifactId>
-  <version>1.12.0-SNAPSHOT</version>
+  <version>1.12.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,19 +30,19 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-integration-testing</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.12.0</version>
+        <version>1.12.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,17 +29,17 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-integration-testing</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/swagger-java-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-client</artifactId>
-  <version>1.12.0-SNAPSHOT</version>
+  <version>1.12.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.1-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/swagger-java-client/pom.xml
+++ b/swagger-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-client</name>
 
     <parent>
-        <version>1.12.0</version>
+        <version>1.12.1-SNAPSHOT</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -255,7 +255,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.1-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
**Description**
This PR improves the error message that is written to the github apps logs upon a failure to read/validate `.dockstore.yml`.  This PR implements the portion of https://ucsc-cgl.atlassian.net/browse/DOCK-2105 that should I believe should be hotfixed to 1.12.x.  Another [PR](https://github.com/dockstore/dockstore/pull/4844) implements the portion that might be better merged with develop.

The primary improvements are to include a phrase that indicates that the problem was in `.dockstore.yml`, and prefix the constraint violation message with the property name and append the errant value (if available, abbreviated if necessary).  The user sees it when they expand the log entry:

<img width="851" alt="Screen Shot 2022-04-07 at 10 04 48 PM" src="https://user-images.githubusercontent.com/88108675/162368467-0c05f56a-c41d-4130-81ef-05c11ac25469.png">

Constraint violation messages are/should be normalized to verb phrases, so they can be automatically prefixed with a subject.  The `NotNull` message was changed to a more understandable phrase.

This PR also:
* adds the required annotations to validate the full Dockstore YAML object hierarchy, parts of which were not being validated previously.
* fixes the "at least one workflow, tool, or service" validator so it works, previously it would NPE on empty `workflows` or `tools`. I believe the SonarCloud warnings relating to this fix are erroneous.
* bumps the version to `1.12.1-SNAPSHOT`

Now that the system provides the user with actionable feedback on validation failure, we should consider more extensive validations (we could validate email addresses and orcid ids, check that fields are not blank, etc).

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2105

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
