### PR TITLE
Feature/dock 2105/log negative validations in GitHub apps logs

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/EntryType.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/EntryType.java
@@ -6,8 +6,18 @@ package io.dockstore.common;
  * @since 1.8.0
  */
 public enum EntryType {
-    TOOL,
-    WORKFLOW,
-    SERVICE,
-    APPTOOL
+    TOOL("tool"),
+    WORKFLOW("workflow"),
+    SERVICE("service"),
+    APPTOOL("tool");
+
+    private final String term;
+
+    EntryType(String term) {
+        this.term = term;
+    }
+
+    public String getTerm() {
+        return term;
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -557,7 +557,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     private String computeWorkflowName(WorkflowAndVersion workflowAndVersion) {
         String name = workflowAndVersion.getWorkflowName();
         String repository = workflowAndVersion.getWorkflowRepository();
-        return name != null ? name : repository;
+        return name != null ? String.format("%s/%s", repository, name) : repository;
     }
 
     private boolean isNotEmpty(Collection<?> c) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -10,6 +10,7 @@ import static io.dockstore.webservice.core.WorkflowMode.STUB;
 import com.google.common.collect.Sets;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.DescriptorLanguageSubclass;
+import io.dockstore.common.EntryType;
 import io.dockstore.common.SourceControl;
 import io.dockstore.common.Utilities;
 import io.dockstore.common.yaml.DockstoreYaml12;
@@ -528,7 +529,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             if (isNotEmpty(validations)) {
                 String subMessage = computeMultiValidationMessage(validations);
                 if (StringUtils.isNotEmpty(subMessage)) {
-                    return String.format("In version '%s' of entry '%s': %s", workflowAndVersion.getVersionName(), computeWorkflowName(workflowAndVersion), subMessage);
+                    return String.format("In version '%s' of %s '%s': %s", workflowAndVersion.getVersionName(), workflowAndVersion.getWorkflowType().getTerm(), computeWorkflowName(workflowAndVersion), subMessage);
                 }
             }
             return null;
@@ -955,6 +956,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
 
         public Set<Validation> getVersionValidations() {
             return version.getValidations();
+        }
+
+        public EntryType getWorkflowType() {
+            return workflow.getEntryType();
         }
 
         public String getWorkflowName() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -531,7 +531,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             if (isNonEmpty(validations)) {
                 String subMessage = computeMultiValidationMessage(validations);
                 if (isNonEmpty(subMessage)) {
-                    return String.format("In version '%s' of entry '%s': %s", version.getName(), workflow.getWorkflowName(), subMessage);
+                    return String.format("In version '%s' of entry '%s': %s", version.getName(), computeName(workflow), subMessage);
                 }
             }
             return null;
@@ -551,6 +551,12 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         } catch (JSONException ex) {
             return null;
         }
+    }
+
+    private String computeName(Workflow workflow) {
+        String name = workflow.getWorkflowName();
+        String repository = workflow.getRepository();
+        return name != null ? name : repository;
     }
 
     private boolean isNonEmpty(String s) {


### PR DESCRIPTION
**Description**
This PR saves any non-valid `Validation` messages generated during a "successful" github apps update (meaning that `.dockstore.yml` was read and validated) to the `LambdaEvent` that is written to the github apps logs.  This PR implements the more experimental portion of https://ucsc-cgl.atlassian.net/browse/DOCK-2105 and is probably better merged with develop.

A non-valid `Validation` message is generated when there's an extra property in `.dockstore.yml` that's named similarly to an expected property, when a referenced file is missing, etc.

This PR does not change the semantics of the update process in any way, except to attach the `Validation` information to the `LambdaEvent`.

Essentially, this PR bubbles the list of updated workflows/versions up to the code that updates the github apps logs, extracts the messages from the associated non-valid `Validation`s, formats them into a single message, and saves it with the `LambdaEvent`.  When the user expands the corresponding github logs entry, they see it:

<img width="960" alt="Screen Shot 2022-04-07 at 9 49 07 PM" src="https://user-images.githubusercontent.com/88108675/162366954-bb1a588d-b9a8-4843-9714-c371b5e4c93b.png">

Right now, it's a kind of a wall of text, but readable enough that a user (that's savvy enough to write a `.dockstore.yml`) can debug their problems.  Essentially, this is the same information that is displayed above each file in the file tabs, but aggregated  and presented in a single location where the user can find it.

Although I'd be ok with merging this PR with the functionality as-is, this PR is also a proof-of-concept - an idea about what to do with the available `Validation` information, but not necessarily the final solution.  Things to think about while reviewing:
1) what validation information should we display?  we could display version info and instructions instead ("error in version x, look there for more details").
2) is a github apps update with validation failures really a "success"?  using the same information, we could detect failures.
3) should we improve the presentation?  this could involve adding formatting to the message (markdown?) or changing the data representation.
4) should we display "valid" Validation messages, too?
 
**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2105

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
