### PR TITLE
optimize github apps log retrieval for common cases

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -324,7 +324,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
      * Determine if the user can access the specified organization.
      * Incorporates some optimizations for the common cases, and falls back to getMyOrganizations()
      */
-    public boolean canAccessOrganization(String organization) {
+    public boolean isOneOfMyOrganizations(String organization) {
         try {
             // The following could be an OR conditional, but it would be hard to comment, and you would have to grok the short-circuiting to understand it...
             // The user can always access their own account.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -302,7 +302,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
     /**
      * Get a list of all the orgs a user has access to
-     * Based on the ALL repository filter, since getAllOrganizations() does not return user accounts.
+     * Based on the ALL repository filter, since getAllOrganizations() does not return personal user accounts.
      * @return
      */
     public Set<String> getMyOrganizations() {
@@ -321,18 +321,18 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     }
 
     /**
-     * Determine if the user can access the specified organization.
+     * Determine if the specified organization is one that github considers the user has "access" to.
      * Incorporates some optimizations for the common cases, and falls back to getMyOrganizations()
      */
     public boolean isOneOfMyOrganizations(String organization) {
         try {
-            // The following could be an OR conditional, but it would be hard to comment, and you would have to grok the short-circuiting to understand it...
+            // The following statements could be condensed into a single OR conditional, but it would be hard to comment, and you would have to grok the short-circuiting to understand it...
             // The user can always access their own account.
             if (organization.equals(githubTokenUsername)) {
                 return true;
             }
             // Check the list of organizations that github says the user can "access".
-            // Note that getAllOrganizations() only returns organizations, not user accounts.
+            // Note that getAllOrganizations() only returns organizations, not personal user accounts.
             if (github.getMyself().getAllOrganizations().stream().anyMatch(org -> org.getLogin().equals(organization))) {
                 return true;
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -24,7 +24,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
-import java.util.Set;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -61,15 +60,18 @@ public class LambdaEventResource {
             @ApiParam(value = PAGINATION_OFFSET_TEXT) @QueryParam("offset") @DefaultValue("0") String offset,
             @ApiParam(value = PAGINATION_LIMIT_TEXT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit) {
         User authUser = userDAO.findById(user.getId());
-        List<Token> githubToken = tokenDAO.findGithubByUserId(authUser.getId());
-        if (githubToken.size() == 0) {
+        List<Token> githubTokens = tokenDAO.findGithubByUserId(authUser.getId());
+        if (githubTokens.size() == 0) {
             throw new CustomWebApplicationException("You do not have GitHub connected to your account.", HttpStatus.SC_BAD_REQUEST);
         }
+        Token githubToken = githubTokens.get(0);
 
-        GitHubSourceCodeRepo sourceCodeRepoInterface = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(githubToken.get(0));
-        Set<String> organizations = sourceCodeRepoInterface.getMyOrganizations();
-        if (!organizations.contains(organization)) {
-            throw new CustomWebApplicationException("You do not have access to the GitHub organization '" + organization + "'", HttpStatus.SC_UNAUTHORIZED);
+        // If the organization isn't the user's github account, check github to see if we have access to the organization.
+        if (!organization.equals(githubToken.getUsername())) {
+            GitHubSourceCodeRepo sourceCodeRepoInterface = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(githubToken);
+            if (!sourceCodeRepoInterface.canAccessOrganization(organization)) {
+                throw new CustomWebApplicationException("You do not have access to the GitHub organization '" + organization + "'", HttpStatus.SC_UNAUTHORIZED);
+            }
         }
 
         return lambdaEventDAO.findByOrganization(organization, offset, limit);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -61,7 +61,7 @@ public class LambdaEventResource {
             @ApiParam(value = PAGINATION_LIMIT_TEXT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit) {
         User authUser = userDAO.findById(user.getId());
         List<Token> githubTokens = tokenDAO.findGithubByUserId(authUser.getId());
-        if (githubTokens.size() == 0) {
+        if (githubTokens.isEmpty()) {
             throw new CustomWebApplicationException("You do not have GitHub connected to your account.", HttpStatus.SC_BAD_REQUEST);
         }
         Token githubToken = githubTokens.get(0);
@@ -69,7 +69,7 @@ public class LambdaEventResource {
         // If the organization isn't the user's github account, check github to see if we have access to the organization.
         if (!organization.equals(githubToken.getUsername())) {
             GitHubSourceCodeRepo sourceCodeRepoInterface = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(githubToken);
-            if (!sourceCodeRepoInterface.canAccessOrganization(organization)) {
+            if (!sourceCodeRepoInterface.isOneOfMyOrganizations(organization)) {
                 throw new CustomWebApplicationException("You do not have access to the GitHub organization '" + organization + "'", HttpStatus.SC_UNAUTHORIZED);
             }
         }


### PR DESCRIPTION
**Description**
This PR optimizes the github apps logs retrieval endpoint for certain common cases.

In https://ucsc-cgl.atlassian.net/browse/SEAB-4037, Denis reported that the github apps logs were "kinda pokey".  I instrumented the suspect endpoint, and found that the delays were caused by the github api, mostly in the call to `getMyOrganizations`, which calls kohsuke's `github.getMyself().listRepositories`.  The underlying GitHub endpoint returns all repos to which Denis has "access" (owns, member of org, collaborator to), which in his case is hundreds (thousands?) of repos, and takes a while.

By themselves, the db accesses are fast, the indexes look good, no problems there...

So, I implemented a couple of optimizations for some common cases:
1. If the "organization" is the github user's name, the user has access, no github api calls necessary.
2. The code uses `github.getMyself().getAllOrganizations` to determine the organizations the user has "access" to, which is much faster than `listRepositories`, and takes about 0.4s for my account.

The code then falls back to the current method which handles "access" to other personal accounts (I wasn't able to optimize any further because there isn't a corresponding kohsuke github lib API call like `getAllOrganizations` which does the same thing, but for personal accounts, and there didn't seem to be any other more efficient methods exposed).  So, if we don't hit one of the two optimizations, this PR may increase the total delay, but not by much.  I did increase the page size for the `listRepositories` call to 100, perhaps that will improve performance a little.

Assuming the github endpoints that back `listRepositories` and `getAllOrganizations` share the same notion of "access", which the docs vaguely imply, this PR returns same log subset as before.

Addendum: there appears to be GitHub endpoints/parameters that might allow us to optimize further, which the kohsuke github lib does not provide access to.  If we're willing to use another library, or access the endpoints ourselves, we might be able to do better. 

Also, note that the inefficiency is related to the current (reasonable) log entry display criteria ("access" as defined by github).  If we changed the criteria for log entry display to be "is the user is a member of the org?" or "the repo is public?", the logic gets much simpler, and the performance problems go away.
 
**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4037

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
