### PR TITLE
Rename user_profile bio to blogLink and sync GitHub bio

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -95,7 +95,7 @@ public final class CommonTestUtilities {
         application.run("db", "drop-all", "--confirm-delete-everything", dropwizardConfigurationFile);
         application
             .run("db", "migrate", dropwizardConfigurationFile, "--include", "1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,"
-                    + "1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0");
+                    + "1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0");
     }
 
     /**
@@ -116,7 +116,7 @@ public final class CommonTestUtilities {
                 isNewApplication);
 
         List<String> migrationList = Arrays
-            .asList("1.3.0.generated", "1.3.1.consistency", "test", "1.4.0",  "1.5.0", "test_1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0");
+            .asList("1.3.0.generated", "1.3.1.consistency", "test", "1.4.0",  "1.5.0", "test_1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0");
         runMigration(migrationList, application, dropwizardConfigurationFile);
     }
 
@@ -133,7 +133,7 @@ public final class CommonTestUtilities {
                 isNewApplication);
 
         List<String> migrationList = Arrays
-                .asList("1.3.0.generated", "1.3.1.consistency", "test", "add_test_tools", "1.4.0",  "1.5.0", "test_1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0");
+                .asList("1.3.0.generated", "1.3.1.consistency", "test", "add_test_tools", "1.4.0",  "1.5.0", "test_1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0");
         runMigration(migrationList, application, dropwizardConfigurationFile);
     }
 
@@ -203,7 +203,7 @@ public final class CommonTestUtilities {
 
         List<String> migrationList = Arrays
             .asList("1.3.0.generated", "1.3.1.consistency", "test.confidential1", "1.4.0", "1.5.0", "test.confidential1_1.5.0", "1.6.0",
-                "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0");
+                "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0");
         runMigration(migrationList, application, configPath);
     }
 
@@ -247,7 +247,7 @@ public final class CommonTestUtilities {
         List<String> migrationList = Arrays
             .asList("1.3.0.generated", "1.3.1.consistency", "test.confidential2", "1.4.0", "1.5.0", "test.confidential2_1.5.0", "1.6.0",
 
-                "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0");
+                "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0");
         runMigration(migrationList, application, configPath);
     }
 
@@ -265,7 +265,7 @@ public final class CommonTestUtilities {
         List<String> migrationList = Arrays
                 .asList("1.3.0.generated", "1.3.1.consistency", "test.confidential2", "add_test_tools", "1.4.0", "1.5.0", "test.confidential2_1.5.0", "1.6.0",
 
-                        "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0");
+                        "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0");
         runMigration(migrationList, application, configPath);
     }
 
@@ -295,7 +295,7 @@ public final class CommonTestUtilities {
         application.run("db", "drop-all", "--confirm-delete-everything", CONFIDENTIAL_CONFIG_PATH);
         application
             .run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0,samepaths");
-        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.7.0, 1.8.0, 1.9.0,1.10.0,1.11.0, 1.12.0");
+        application.run("db", "migrate", CONFIDENTIAL_CONFIG_PATH, "--include", "1.7.0, 1.8.0, 1.9.0,1.10.0,1.11.0, 1.12.0, 1.13.0");
 
     }
 
@@ -312,7 +312,7 @@ public final class CommonTestUtilities {
         application.run("db", "drop-all", "--confirm-delete-everything", CONFIDENTIAL_CONFIG_PATH);
         List<String> migrationList = Arrays
                 .asList("1.3.0.generated", "1.3.1.consistency", "test", "1.4.0", "testworkflow", "1.5.0", "test_1.5.0", "1.6.0", "1.7.0",
-                        "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0");
+                        "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0");
         runMigration(migrationList, application, CONFIDENTIAL_CONFIG_PATH);
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -606,7 +606,7 @@ public class UserResourceIT extends BaseIT {
         assertNull(userProfile.getBio());
         assertNull(userProfile.getLocation());
         assertNull(userProfile.getCompany());
-        assertNull(userProfile.getBlogLink());
+        assertNull(userProfile.getLink());
         assertEquals("DockstoreTestUser2", userProfile.getUsername());
 
         usersApi.updateLoggedInUserMetadata("github.com");
@@ -618,7 +618,7 @@ public class UserResourceIT extends BaseIT {
         assertEquals("I am a test user", userProfile.getBio());
         assertEquals("Toronto", userProfile.getLocation());
         assertNull(userProfile.getCompany());
-        assertEquals("", userProfile.getBlogLink());
+        assertEquals("", userProfile.getLink());
         assertEquals("DockstoreTestUser2", userProfile.getUsername());
 
         io.dockstore.openapi.client.ApiClient userWebClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
@@ -731,7 +731,7 @@ public class UserResourceIT extends BaseIT {
         assertNull(userProfile.getLocation());
         assertNull(userProfile.getBio());
         assertNull(userProfile.getCompany());
-        assertNull(userProfile.getBlogLink());
+        assertNull(userProfile.getLink());
 
         // The API call updateUserMetadata() should not throw an error and exit if any users' tokens are out of date or absent
         // Additionally, the API call should go through and sync DockstoreTestUser2's GitHub data
@@ -743,7 +743,7 @@ public class UserResourceIT extends BaseIT {
         assertEquals("Toronto", userProfile.getLocation());
         assertEquals("I am a test user", userProfile.getBio());
         assertNull(userProfile.getCompany());
-        assertEquals("", userProfile.getBlogLink());
+        assertEquals("", userProfile.getLink());
         assertEquals("DockstoreTestUser2", userProfile.getUsername());
     }
 
@@ -767,7 +767,7 @@ public class UserResourceIT extends BaseIT {
         assertNull(userProfile.getLocation());
         assertNull(userProfile.getBio());
         assertNull(userProfile.getCompany());
-        assertNull(userProfile.getBlogLink());
+        assertNull(userProfile.getLink());
 
         // Call the API method while the caller has no token
         // An error should not be thrown and the call should pass, but every user should not have their GitHub information synced
@@ -779,7 +779,7 @@ public class UserResourceIT extends BaseIT {
         assertNull(userProfile.getLocation());
         assertNull(userProfile.getBio());
         assertNull(userProfile.getCompany());
-        assertNull(userProfile.getBlogLink());
+        assertNull(userProfile.getLink());
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -606,18 +606,19 @@ public class UserResourceIT extends BaseIT {
         assertNull(userProfile.getBio());
         assertNull(userProfile.getLocation());
         assertNull(userProfile.getCompany());
+        assertNull(userProfile.getBlogLink());
         assertEquals("DockstoreTestUser2", userProfile.getUsername());
 
-        final User user = usersApi.updateLoggedInUserMetadata("github.com");
+        usersApi.updateLoggedInUserMetadata("github.com");
         userProfile = usersApi.getUser().getUserProfiles().get("github.com");
 
-        System.out.println(usersApi.getUser().getUserProfiles().get("github.com"));
         assertNull(userProfile.getName());
         assertEquals("dockstore.test.user2@gmail.com", userProfile.getEmail());
         assertTrue(userProfile.getAvatarURL().endsWith("githubusercontent.com/u/17859829?v=4"));
-        assertEquals("", userProfile.getBio());
+        assertEquals("I am a test user", userProfile.getBio());
         assertEquals("Toronto", userProfile.getLocation());
         assertNull(userProfile.getCompany());
+        assertEquals("", userProfile.getBlogLink());
         assertEquals("DockstoreTestUser2", userProfile.getUsername());
 
         io.dockstore.openapi.client.ApiClient userWebClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
@@ -728,6 +729,9 @@ public class UserResourceIT extends BaseIT {
         assertNull(userProfile.getEmail());
         assertNull(userProfile.getAvatarURL());
         assertNull(userProfile.getLocation());
+        assertNull(userProfile.getBio());
+        assertNull(userProfile.getCompany());
+        assertNull(userProfile.getBlogLink());
 
         // The API call updateUserMetadata() should not throw an error and exit if any users' tokens are out of date or absent
         // Additionally, the API call should go through and sync DockstoreTestUser2's GitHub data
@@ -737,6 +741,10 @@ public class UserResourceIT extends BaseIT {
         assertEquals("dockstore.test.user2@gmail.com", userProfile.getEmail());
         assertTrue(userProfile.getAvatarURL().endsWith("githubusercontent.com/u/17859829?v=4"));
         assertEquals("Toronto", userProfile.getLocation());
+        assertEquals("I am a test user", userProfile.getBio());
+        assertNull(userProfile.getCompany());
+        assertEquals("", userProfile.getBlogLink());
+        assertEquals("DockstoreTestUser2", userProfile.getUsername());
     }
 
     /**
@@ -757,6 +765,9 @@ public class UserResourceIT extends BaseIT {
         assertNull(userProfile.getEmail());
         assertNull(userProfile.getAvatarURL());
         assertNull(userProfile.getLocation());
+        assertNull(userProfile.getBio());
+        assertNull(userProfile.getCompany());
+        assertNull(userProfile.getBlogLink());
 
         // Call the API method while the caller has no token
         // An error should not be thrown and the call should pass, but every user should not have their GitHub information synced
@@ -766,6 +777,9 @@ public class UserResourceIT extends BaseIT {
         assertNull(userProfile.getEmail());
         assertNull(userProfile.getAvatarURL());
         assertNull(userProfile.getLocation());
+        assertNull(userProfile.getBio());
+        assertNull(userProfile.getCompany());
+        assertNull(userProfile.getBlogLink());
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -574,6 +574,8 @@ public class User implements Principal, Comparable<User>, Serializable {
         public String location;
         @Column(columnDefinition = "text")
         public String bio;
+        @Column(columnDefinition = "text")
+        public String blogLink;
         /**
          * Redundant with token, but needed since tokens can be deleted.
          * i.e. if usernames can change and tokens can be deleted, we need somewhere to let

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -575,7 +575,7 @@ public class User implements Principal, Comparable<User>, Serializable {
         @Column(columnDefinition = "text")
         public String bio;
         @Column(columnDefinition = "text")
-        public String blogLink;
+        public String link;
         /**
          * Redundant with token, but needed since tokens can be deleted.
          * i.e. if usernames can change and tokens can be deleted, we need somewhere to let

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1189,7 +1189,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         profile.name = ghUser.getName();
         profile.avatarURL = ghUser.getAvatarUrl();
         profile.bio = ghUser.getBio();
-        profile.blogLink = ghUser.getBlog();
+        profile.link = ghUser.getBlog();
         profile.location = ghUser.getLocation();
         profile.company = ghUser.getCompany();
         Map<String, User.Profile> userProfile = user.getUserProfiles();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1188,7 +1188,8 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         profile.username = ghUser.getLogin();
         profile.name = ghUser.getName();
         profile.avatarURL = ghUser.getAvatarUrl();
-        profile.bio = ghUser.getBlog();  // ? not sure about this mapping in the new api
+        profile.bio = ghUser.getBio();
+        profile.blogLink = ghUser.getBlog();
         profile.location = ghUser.getLocation();
         profile.company = ghUser.getCompany();
         Map<String, User.Profile> userProfile = user.getUserProfiles();

--- a/dockstore-webservice/src/main/resources/migrations.1.13.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.13.0.xml
@@ -1,0 +1,29 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<!--
+  ~    Copyright 2022 OICR and UCSC
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
+                   context="1.13.0">
+    <changeSet author="ktran" id="migrateBioToBlogLink">
+        <!-- Rename 'bio' to 'bloglink' because the bio we were retrieving was actually the blog link -->
+        <renameColumn tableName="user_profile" oldColumnName="bio" newColumnName="bloglink" columnDataType="text"/>
+        <!-- Add the bio column back -->
+        <addColumn tableName="user_profile">
+            <column name="bio" type="text"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.13.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.13.0.xml
@@ -19,9 +19,9 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
                    context="1.13.0">
     <changeSet author="ktran" id="migrateBioToBlogLink">
-        <!-- Rename 'bio' to 'bloglink' because the bio we were retrieving was actually the blog link -->
-        <renameColumn tableName="user_profile" oldColumnName="bio" newColumnName="bloglink" columnDataType="text"/>
-        <!-- Add the bio column back -->
+        <!-- Rename 'bio' to 'link' because the bio we were retrieving was actually the blog link in the GitHub user profile -->
+        <renameColumn tableName="user_profile" oldColumnName="bio" newColumnName="link" columnDataType="text"/>
+        <!-- Add the 'bio' column back -->
         <addColumn tableName="user_profile">
             <column name="bio" type="text"/>
         </addColumn>

--- a/dockstore-webservice/src/main/resources/migrations.xml
+++ b/dockstore-webservice/src/main/resources/migrations.xml
@@ -41,4 +41,5 @@
     <include file="migrations.1.10.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.11.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.12.0.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.1.13.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -8530,11 +8530,11 @@ components:
           type: string
         bio:
           type: string
-        blogLink:
-          type: string
         company:
           type: string
         email:
+          type: string
+        link:
           type: string
         location:
           type: string

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -8530,6 +8530,8 @@ components:
           type: string
         bio:
           type: string
+        blogLink:
+          type: string
         company:
           type: string
         email:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -7668,11 +7668,11 @@ definitions:
         type: "string"
       bio:
         type: "string"
-      blogLink:
-        type: "string"
       company:
         type: "string"
       email:
+        type: "string"
+      link:
         type: "string"
       location:
         type: "string"

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -7668,6 +7668,8 @@ definitions:
         type: "string"
       bio:
         type: "string"
+      blogLink:
+        type: "string"
       company:
         type: "string"
       email:

--- a/propose_migration.sh
+++ b/propose_migration.sh
@@ -27,8 +27,8 @@ rm dockstore-webservice/target/detected-migrations.xml || true
 
 ## load up the old database based on current migration
 rm dockstore-webservice/target/dockstore-webservice-*sources.jar || true
-# java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.consistency,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0 # uncomment this line if you want to diff with an already loaded db dump
-java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.generated,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0 # uncomment this line if you want to generate a DB from scratch with migrations
+java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.consistency,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0 # uncomment this line if you want to diff with an already loaded db dump
+# java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.generated,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0 # uncomment this line if you want to generate a DB from scratch with migrations
 
 ## create the new database based on JPA (ugly, should really create a proper dw command if this works)
 ## remove timeout for mac devices, will have to break manually

--- a/propose_migration.sh
+++ b/propose_migration.sh
@@ -27,8 +27,8 @@ rm dockstore-webservice/target/detected-migrations.xml || true
 
 ## load up the old database based on current migration
 rm dockstore-webservice/target/dockstore-webservice-*sources.jar || true
-java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.consistency,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0 # uncomment this line if you want to diff with an already loaded db dump
-# java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.generated,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0 # uncomment this line if you want to generate a DB from scratch with migrations
+# java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.consistency,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0 # uncomment this line if you want to diff with an already loaded db dump
+java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.generated,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0 # uncomment this line if you want to generate a DB from scratch with migrations
 
 ## create the new database based on JPA (ugly, should really create a proper dw command if this works)
 ## remove timeout for mac devices, will have to break manually


### PR DESCRIPTION
**Description**
It appeared like the GitHub bio was not syncing to Dockstore, but in reality, we were syncing the GitHub profile's blog link to our `bio` column. 

On GitHub:
![image](https://user-images.githubusercontent.com/25287123/164274214-cca46d43-b894-4bb4-8817-2ca1ad887ee1.png)

On Dockstore:
![image](https://user-images.githubusercontent.com/25287123/164275120-b7b981c5-a40a-425f-ba93-d517f913225e.png)

This PR renames the `bio` column to `blogLink` because all the data that's in the `bio` column should be links, especially since this [one time endpoint](https://github.com/dockstore/dockstore/blob/141fa45d823767f25abb2ee48359571027e68c59/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java#L742) was run in 1.11 (?) to sync the GitHub profiles of all users to get their online profile IDs. This blog link isn't surfaced in the UI yet, so I'll create a ticket for that.

The migration re-adds the `bio` column and syncs the actual bio to this column. 

**Issue**
#4839 

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
