### PR TITLE
improve performance of fetching descriptor file via trs

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -419,6 +419,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         ToolsApiServiceImpl.setServiceDAO(serviceDAO);
         ToolsApiServiceImpl.setAppToolDAO(appToolDAO);
         ToolsApiServiceImpl.setFileDAO(fileDAO);
+        ToolsApiServiceImpl.setVersionDAO(versionDAO);
         ToolsApiServiceImpl.setConfig(configuration);
         ToolsApiServiceImpl.setTrsListener(trsListener);
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -44,6 +44,7 @@ import org.apache.commons.lang3.ObjectUtils;
 @Entity
 @SuppressWarnings("checkstyle:magicnumber")
 @Table(name = "tag", uniqueConstraints = @UniqueConstraint(name = "unique_tag_names", columnNames = { "parentid", "name" }))
+
 public class Tag extends Version<Tag> implements Comparable<Tag> {
 
     @Column

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -55,6 +55,7 @@ import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.Check;
+import org.hibernate.annotations.Filter;
 
 /**
  * This describes one tool in the dockstore, extending entry with fields necessary to describe bioinformatics tools.
@@ -164,6 +165,7 @@ public class Tool extends Entry<Tool, Tag> {
     @OrderBy("id")
     @Cascade(CascadeType.DETACH)
     @BatchSize(size = 25)
+    @Filter(name = "versionNameFilter")
     private final SortedSet<Tag> workflowVersions;
 
     @JsonIgnore

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -59,6 +59,9 @@ import org.apache.http.HttpStatus;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import org.hibernate.annotations.UpdateTimestamp;
 
 /**
@@ -80,6 +83,9 @@ import org.hibernate.annotations.UpdateTimestamp;
                 + "version.parent.id = :entryId"),
     @NamedQuery(name = "io.dockstore.webservice.core.Version.getCountByEntryId", query = "SELECT Count(v) FROM Version v WHERE v.parent.id = :id")
 })
+
+@FilterDef(name = "versionNameFilter", parameters = @ParamDef(name = "name", type = "string"), defaultCondition = "LOWER(:name) = LOWER(name)")
+@Filter(name = "versionNameFilter")
 
 @SuppressWarnings("checkstyle:magicnumber")
 public abstract class Version<T extends Version> implements Comparable<T> {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -53,6 +53,7 @@ import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.Check;
+import org.hibernate.annotations.Filter;
 
 /**
  * This describes one workflow in the dockstore, extending Entry with the fields necessary to describe workflows.
@@ -141,6 +142,7 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
     @OrderBy("id")
     @Cascade({ CascadeType.DETACH, CascadeType.SAVE_UPDATE })
     @BatchSize(size = 25)
+    @Filter(name = "versionNameFilter")
     private SortedSet<WorkflowVersion> workflowVersions;
 
     @JsonIgnore

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
@@ -58,4 +58,12 @@ public class VersionDAO<T extends Version> extends AbstractDAO<T> {
         query.setParameter("id", entryId);
         return (long)query.getSingleResult();
     }
+
+    public void enableNameFilter(String name) {
+        currentSession().enableFilter("versionNameFilter").setParameter("name", name);
+    }
+
+    public void disableNameFilter() {
+        currentSession().disableFilter("versionNameFilter");
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -16,7 +16,7 @@
 
 package io.dockstore.webservice.resources.proposedGA4GH;
 
-import static io.openapi.api.impl.ToolsApiServiceImpl.BAD_DECODE_RESPONSE;
+import static io.openapi.api.impl.ToolsApiServiceImpl.BAD_DECODE_REGISTRY_RESPONSE;
 
 import com.google.common.io.Resources;
 import io.dockstore.webservice.CustomWebApplicationException;
@@ -328,7 +328,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
         try {
             parsedID = new ToolsApiServiceImpl.ParsedRegistryID(id);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         Entry<?, ?> entry = impl.getEntry(parsedID, Optional.empty());
         Optional<? extends Version<?>> versionOptional;

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -91,7 +91,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ToolsApiServiceImpl extends ToolsApiService implements AuthenticatedResourceInterface {
-    public static final Response BAD_DECODE_RESPONSE = Response.status(getExtendedStatus(Status.BAD_REQUEST, "Could not decode version")).build();
+    public static final Response BAD_DECODE_VERSION_RESPONSE = Response.status(getExtendedStatus(Status.BAD_REQUEST, "Could not decode version id")).build();
+    public static final Response BAD_DECODE_REGISTRY_RESPONSE = Response.status(getExtendedStatus(Status.BAD_REQUEST, "Could not decode registry id")).build();
 
     // Algorithms should come from: https://github.com/ga4gh-discovery/ga4gh-checksum/blob/master/hash-alg.csv
     public static final String DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS = "sha-256";
@@ -165,7 +166,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         try {
             parsedID = new ParsedRegistryID(id);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         Entry<?, ?> entry = getEntry(parsedID, user);
         return buildToolResponse(entry, null, false);
@@ -177,7 +178,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         try {
             parsedID = new ParsedRegistryID(id);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         Entry<?, ?> entry = getEntry(parsedID, user);
         return buildToolResponse(entry, null, true);
@@ -218,13 +219,13 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         try {
             parsedID = new ParsedRegistryID(id);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         String newVersionId;
         try {
             newVersionId = URLDecoder.decode(versionId, StandardCharsets.UTF_8.displayName());
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_VERSION_RESPONSE;
         }
         Entry<?, ?> entry = getEntry(parsedID, user);
         return buildToolResponse(entry, newVersionId, false);
@@ -346,7 +347,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
             numEntries = getEntries(all, id, alias, toolClass, descriptorType, registry, organization, name, toolname, description, author, checker, user, actualLimit,
                 startIndex);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
 
         List<io.openapi.model.Tool> results = new ArrayList<>();
@@ -588,13 +589,13 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         try {
             parsedID = new ParsedRegistryID(registryId);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         String versionId;
         try {
             versionId = URLDecoder.decode(versionIdParam, StandardCharsets.UTF_8.displayName());
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_VERSION_RESPONSE;
         }
 
         // The performance of this method was poor: to retrieve a single file for a particular entry, it iterates through the entry's Versions, checking them one-by-one until it finds a match.
@@ -812,7 +813,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         try {
             parsedID = new ParsedRegistryID(id);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         Entry<?, ?> entry = getEntry(parsedID, user);
         List<String> primaryDescriptorPaths = new ArrayList<>();

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -598,14 +598,14 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
             return BAD_DECODE_VERSION_RESPONSE;
         }
 
-        // The performance of this method was poor: to retrieve a single file for a particular entry, it iterates through the entry's Versions, checking them one-by-one until it finds a match.
-        // See the related ticket: https://ucsc-cgl.atlassian.net/browse/DOCK-1921
+        // The performance of this method was poor: to retrieve a single file for a particular version of an entry, it iterates through all of the entry's Versions, checking them one-by-one until it finds a match.
+        // See the related issue: https://github.com/dockstore/dockstore/issues/4480
         //
-        // To improve performance, we added the following try block which enables a Filter which limits the subsequent queries to return only Version objects that match the specified version name.
+        // To improve performance, we enable a Filter that limits the subsequent queries to return only Version objects that match the specified version name.
         // Similarly, when the filter is enabled, properly-annotated associations only contain Versions that match the specified version name.
-        // The associated finally disables the Filter upon exit from the try block, so that any subsequently-executed code will see all the Versions, like normal.
-        // Essentially, the following code works the same as the original, except that, from its point-of-view, the only Versions that exist are the ones with the specified name.
-        // Thus, only the Version-of-interest is retrieved from the db, and all the superfluous db version queries are avoided.
+        // Upon exit from the following try block, the Filter is disabled, so that any subsequently-executed code will see all Versions, like normal.
+        // Essentially, the new code works/is the same as the original, except that, from its point-of-view, the only Versions that exist are the ones with the specified name.
+        // Thus, only the Version-of-interest is retrieved from the db, and all of the superfluous version db queries are avoided.
         try {
             versionDAO.enableNameFilter(versionId);
 


### PR DESCRIPTION
**Description**
This PR improves the performance of the TRS file fetching code.  I know it's long, but please read the whole thing, because it will answer many of your questions.

As described in https://ucsc-cgl.atlassian.net/browse/DOCK-1921 #4480, the existing code that fetches a file from a particular version of an entry is very inefficient for entries with lots of versions: it first retrieves the specified `Entry`, then iterates through its `Versions` until it finds one with the specified name, triggering a bunch of db queries.  Some workflows, particularly the Broad's, have hundreds of versions, so it takes the webservice several seconds to retrieve a single file, hammering our database server in the process.

For example, hitting these two TRS endpoints locally caused the webservice to execute 978 and 45 JDBC statements, respectively:
http://localhost:8080/api/ga4gh/v1/tools/%23workflow%2Fgithub.com%2Fbroadinstitute%2Fgatk%2Fcnv_somatic_pair_workflow/versions/master/WDL/descriptor
http://localhost:8080/ga4gh/trs/v2/tools/quay.io%2Fpancancer%2Fpcawg-sanger-cgp-workflow/versions/2.1.0/plain-CWL/descriptor//Dockstore.cwl

To improve performance, I evaluated two "traditional" approaches:
A. Patch the existing code, substituting the iteration with a more efficient query that returned a single version and/or sourcefile.
B. Completely replace the slow code.
Neither approach turned out to be very good. The existing code literally iterates in three different spots, scattered across two different files, involving two different representations of the entry (!).  Some helper functions that I'd need to modify are used for other unrelated purposes.  There's also a lot of logic embedded within, such as to check version visibility.  The "patch" would be messy and error-prone, and if I "gutted", I'd need to painstakingly reconstruct the existing semantics.

So, I went with Approach C, which involves the Hibernate `Filter` feature: https://thorben-janssen.com/hibernate-filter/

A `Filter` allows you to define an SQL condition which the associated db record must meet for it to be included in the results of a query.  The Filter can be dynamically enabled, and when it is, a where clause with that condition is added to all queries for that entity.  It can also be used to filter associations, if they are properly annotated.

In this PR, I define a filter `versionNameFilter` on `Version` and the associations of its subclasses, which limits the returned `Versions` to those that match a specified name, case insensitively.  Then, I modify `getFileByToolVersionID` so it enables the version filter at the point where we know the version name through the end of the method, making sure to disable the filter on exit.  And, voila, the spurious db accesses disappear: the method operates exactly as before, except that it only retrieves a single Version with the specified name, so it iterates once, instead of n times.  It's kinda like executing the existing code in a world where [at most] one Version exists for each entry: the one we're looking for.

Whilst reviewing, note that in `getFileByToolVersionID`, the code between lines 612 and 740 is exactly the same as before, except indented one level deeper, because of the new enclosing `try-finally` statement.  The only non-whitespace changes to `getFileByToolVersionID` are the `try-finally` and the calls to enable and disable the filter.  It would be cool if github's Files Changed page could somehow display that...

After the fix, hitting the two TRS endpoints above caused the webservice to execute 15 JDBC statements each, and the db queries issued for the Broad request take about 40ms, total.

`getFileByToolVersionID` is used by multiple TRS endpoints, so their performance should improve, also.

Previously, when the webservice could not parse the registry ID, the error message indicated a problem with the version.  This PR improves the error messages accordingly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-1921
#4480

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
