### PR TITLE
Convert empty string names and links in user profiles to null

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -600,7 +600,7 @@ public class UserResourceIT extends BaseIT {
         UsersApi usersApi = new UsersApi(client);
         Profile userProfile = usersApi.getUser().getUserProfiles().get("github.com");
 
-        assertEquals("", userProfile.getName());
+        assertNull(userProfile.getName());
         assertNull(userProfile.getEmail());
         assertNull(userProfile.getAvatarURL());
         assertNull(userProfile.getBio());
@@ -618,7 +618,7 @@ public class UserResourceIT extends BaseIT {
         assertEquals("I am a test user", userProfile.getBio());
         assertEquals("Toronto", userProfile.getLocation());
         assertNull(userProfile.getCompany());
-        assertEquals("", userProfile.getLink());
+        assertNull(userProfile.getLink());
         assertEquals("DockstoreTestUser2", userProfile.getUsername());
 
         io.dockstore.openapi.client.ApiClient userWebClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
@@ -726,6 +726,7 @@ public class UserResourceIT extends BaseIT {
         }
 
         // DockstoreUser2's profile elements should be initially set to null since the GitHub metadata isn't synced yet
+        assertNull(userProfile.getName());
         assertNull(userProfile.getEmail());
         assertNull(userProfile.getAvatarURL());
         assertNull(userProfile.getLocation());
@@ -738,12 +739,13 @@ public class UserResourceIT extends BaseIT {
         adminApi.updateUserMetadata();
 
         userProfile = userApi.getUser().getUserProfiles().get("github.com");
+        assertNull(userProfile.getName());
         assertEquals("dockstore.test.user2@gmail.com", userProfile.getEmail());
         assertTrue(userProfile.getAvatarURL().endsWith("githubusercontent.com/u/17859829?v=4"));
         assertEquals("Toronto", userProfile.getLocation());
         assertEquals("I am a test user", userProfile.getBio());
         assertNull(userProfile.getCompany());
-        assertEquals("", userProfile.getLink());
+        assertNull(userProfile.getLink());
         assertEquals("DockstoreTestUser2", userProfile.getUsername());
     }
 
@@ -756,12 +758,12 @@ public class UserResourceIT extends BaseIT {
         io.dockstore.openapi.client.ApiClient userWebClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         io.dockstore.openapi.client.api.UsersApi adminApi = new io.dockstore.openapi.client.api.UsersApi(adminWebClient);
         io.dockstore.openapi.client.api.UsersApi userApi = new io.dockstore.openapi.client.api.UsersApi(userWebClient);
-        io.dockstore.openapi.client.model.User admin = adminApi.getUser();
         io.dockstore.openapi.client.model.Profile userProfile = userApi.getUser().getUserProfiles().get("github.com");
 
         // Delete all of the tokens (except for Dockstore tokens) for every user
         testingPostgres.runUpdateStatement("DELETE FROM token WHERE tokensource <> 'dockstore'");
 
+        assertNull(userProfile.getName());
         assertNull(userProfile.getEmail());
         assertNull(userProfile.getAvatarURL());
         assertNull(userProfile.getLocation());
@@ -771,9 +773,10 @@ public class UserResourceIT extends BaseIT {
 
         // Call the API method while the caller has no token
         // An error should not be thrown and the call should pass, but every user should not have their GitHub information synced
-        userApi.updateUserMetadata();
+        adminApi.updateUserMetadata();
 
         userProfile = userApi.getUser().getUserProfiles().get("github.com");
+        assertNull(userProfile.getName());
         assertNull(userProfile.getEmail());
         assertNull(userProfile.getAvatarURL());
         assertNull(userProfile.getLocation());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1190,7 +1190,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         profile.avatarURL = ghUser.getAvatarUrl();
         profile.bio = ghUser.getBio();
         // The GitHub blog field is the only one that uses an empty string for an unset value. Set it to null if there's no value.
-        profile.link = ghUser.getBlog().isEmpty() ? null : ghUser.getBlog();
+        profile.link = StringUtils.isNotEmpty(ghUser.getBlog()) ? ghUser.getBlog() : null;
         profile.location = ghUser.getLocation();
         profile.company = ghUser.getCompany();
         Map<String, User.Profile> userProfile = user.getUserProfiles();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1189,7 +1189,8 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         profile.name = ghUser.getName();
         profile.avatarURL = ghUser.getAvatarUrl();
         profile.bio = ghUser.getBio();
-        profile.link = ghUser.getBlog();
+        // The GitHub blog field is the only one that uses an empty string for an unset value. Set it to null if there's no value.
+        profile.link = ghUser.getBlog().isEmpty() ? null : ghUser.getBlog();
         profile.location = ghUser.getLocation();
         profile.company = ghUser.getCompany();
         Map<String, User.Profile> userProfile = user.getUserProfiles();

--- a/dockstore-webservice/src/main/resources/migrations.1.13.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.13.0.xml
@@ -26,4 +26,14 @@
             <column name="bio" type="text"/>
         </addColumn>
     </changeSet>
+    <changeSet author="ktran" id="convertUserProfileEmptyStringToNull">
+        <update tableName="user_profile">
+            <column name="link"/>
+            <where>link = ''</where>
+        </update>
+        <update tableName="user_profile">
+            <column name="name"/>
+            <where>name = ''</where>
+        </update>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**Description**
This PR converts empty string names and links (previously bios, but PR #4865 renamed this column to links) to null values in the DB. 

The issue only mentions links, but I checked the other columns in the table and the name column also had empty strings. All of the empty string names were from GitHub, but GitHub no longer returns empty strings for unset names which is why I didn't check if the name is empty when syncing GitHub user metadata.

Note that Google user profiles don't sync bios or links, so these columns are always null.

**Issue**
#4840 

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
