### PR TITLE
lower log level for spammy message

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Sha256Converter.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Sha256Converter.java
@@ -12,7 +12,9 @@ public class Sha256Converter implements AttributeConverter<List<Checksum>, Strin
 
     @Override
     public String convertToDatabaseColumn(final List<Checksum> attribute) {
-        LOG.error("sha256 column is read-only, should not be writing to the database");
+        // while technically, this should never be called since we should never be re-writing sha256
+        // nonetheless, hibernate seems to stage/simulate deletions even on select queries leading to this being called
+        LOG.debug("sha256 column is read-only, should not be writing to the database");
         return null;
     }
 


### PR DESCRIPTION
**Description**
Suppress warning
For future implementers, gave https://www.baeldung.com/hibernate-immutable a shot on the accessor methods and https://docs.jboss.org/hibernate/orm/5.2/javadocs/org/hibernate/annotations/GenerationTime.html to no avail. 
While hibernate as a whole seems to understand that these fields are not to be updated, it still calls this method to simulate/stage something.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4340

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
