### PR TITLE
DOCK-2105: change GitHub apps log separator to newlines

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -711,7 +711,7 @@ public abstract class SourceCodeRepoInterface {
             version.addOrUpdateValidation(descriptorValidation);
         } else {
             Map<String, String> validationMessage = new HashMap<>();
-            validationMessage.put(mainDescriptorPath, "Missing the primary descriptor.");
+            validationMessage.put(mainDescriptorPath, "Primary descriptor file not found.");
             VersionTypeValidation noPrimaryDescriptor = new VersionTypeValidation(false, validationMessage);
             Validation noPrimaryDescriptorValidation = new Validation(identifiedType, noPrimaryDescriptor);
             version.addOrUpdateValidation(noPrimaryDescriptorValidation);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -86,7 +86,7 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
                 content = mainDescriptor.get().getContent();
             } else {
                 Map<String, String> validationMessage = new HashMap<>();
-                validationMessage.put("Unknown", "Missing the primary descriptor.");
+                validationMessage.put("Unknown", "Primary descriptor file not found.");
                 return new VersionTypeValidation(false, validationMessage);
             }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -547,7 +547,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     private String computeValidationMessage(Validation validation) {
         try {
             JSONObject json = new JSONObject(validation.getMessage());
-            return json.keySet().stream().map(key -> String.format("In file '%s': %s", key, json.get(key))).collect(Collectors.joining("\n"));
+            return json.keySet().stream().map(key -> String.format("File '%s': %s", key, json.get(key))).collect(Collectors.joining("\n"));
         } catch (JSONException ex) {
             LOG.info("Exception processing validation message JSON", ex);
             return null;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -547,7 +547,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     private String computeValidationMessage(Validation validation) {
         try {
             JSONObject json = new JSONObject(validation.getMessage());
-            return json.keySet().stream().map(key -> String.format("File '%s': %s", key, json.get(key))).collect(Collectors.joining("\n"));
+            return json.keySet().stream().map(key -> String.format("- File '%s': %s", key, json.get(key))).collect(Collectors.joining("\n"));
         } catch (JSONException ex) {
             LOG.info("Exception processing validation message JSON", ex);
             return null;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -529,7 +529,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             if (isNotEmpty(validations)) {
                 String subMessage = computeMultiValidationMessage(validations);
                 if (StringUtils.isNotEmpty(subMessage)) {
-                    return String.format("In version '%s' of %s '%s': %s", workflowAndVersion.getVersionName(), workflowAndVersion.getWorkflowType().getTerm(), computeWorkflowName(workflowAndVersion), subMessage);
+                    return String.format("In version '%s' of %s '%s':\n%s", workflowAndVersion.getVersionName(), workflowAndVersion.getWorkflowType().getTerm(), computeWorkflowName(workflowAndVersion), subMessage);
                 }
             }
             return null;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -533,7 +533,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 }
             }
             return null;
-        }).filter(StringUtils::isNotEmpty).collect(Collectors.joining(" "));
+        }).filter(StringUtils::isNotEmpty).collect(Collectors.joining("\n"));
 
         if (StringUtils.isNotEmpty(message)) {
             event.setMessage(message);
@@ -541,13 +541,13 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     }
 
     private String computeMultiValidationMessage(Set<Validation> validations) {
-        return validations.stream().filter(v -> !v.isValid()).map(v -> computeValidationMessage(v)).filter(StringUtils::isNotEmpty).collect(Collectors.joining(" "));
+        return validations.stream().filter(v -> !v.isValid()).map(v -> computeValidationMessage(v)).filter(StringUtils::isNotEmpty).collect(Collectors.joining("\n"));
     }
 
     private String computeValidationMessage(Validation validation) {
         try {
             JSONObject json = new JSONObject(validation.getMessage());
-            return json.keySet().stream().map(key -> String.format("file '%s': %s", key, json.get(key))).collect(Collectors.joining(" "));
+            return json.keySet().stream().map(key -> String.format("In file '%s': %s", key, json.get(key))).collect(Collectors.joining("\n"));
         } catch (JSONException ex) {
             LOG.info("Exception processing validation message JSON", ex);
             return null;

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
@@ -122,7 +122,7 @@ public class LanguagePluginHandlerTest {
         sourceFileSet.add(secondaryDescriptorSourceFile);
         versionTypeValidation = minimalLanguageHandler.validateWorkflowSet(sourceFileSet, MAIN_DESCRIPTOR_CWL);
         Assert.assertTrue(!versionTypeValidation.isValid()
-            && versionTypeValidation.getMessage().containsValue("Missing the primary descriptor."));
+            && versionTypeValidation.getMessage().containsValue("Primary descriptor file not found."));
 
     }
 


### PR DESCRIPTION
**Description**
This PR changes the formatting of the github log messages which are based on failed `Validations` so that the submessages are separated by newlines rather than spaces.  In other words, each submessage now appears on its own line.  It also changes the error message from a failed validation associated with a missing primary descriptor file, so the message describes that the file was not found, rather than sort of implying that the missing file itself was missing the primary descriptor. 

An assocated PR will change the UI to format the newlines as newlines. https://github.com/dockstore/dockstore-ui2/pull/1524

Yes, there are repeated strings.  However, amongst the classes in which the string repeated, there didn't seem to be a place that made sense for a constant to reside.  Someday, if we decide to create a class to hold shared error messages and other strings like this, we can put it there.

The motivation for this PR was kathy's review ticket feedback.  

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2105

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
