### PR TITLE
Use integer offsets on /published endpoints (SEAB-3979)

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiCRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiCRUDClientIT.java
@@ -127,7 +127,7 @@ public class OpenApiCRUDClientIT extends BaseIT {
         ContainersApi containersApi = new ContainersApi(getWebClient(ADMIN_USERNAME, testingPostgres));
 
         // cleanup to make math easier
-        final List<DockstoreTool> dockstoreTools = containersApi.allPublishedContainers("0", 100, null, null, null);
+        final List<DockstoreTool> dockstoreTools = containersApi.allPublishedContainers(0, 100, null, null, null);
         for (DockstoreTool tool : dockstoreTools) {
             // Publish tool
             PublishRequest pub = CommonTestUtilities.createPublishRequest(false);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -160,9 +160,9 @@ public class SwaggerClientIT extends BaseIT {
 
         // do some minor testing on pagination, majority of tests are in WorkflowIT.testPublishingAndListingOfPublished for now
         // TODO: better testing of pagination when we use it
-        List<DockstoreTool> pagedToolsLowercase = containersApi.allPublishedContainers("0", 1, "test", "stars", "desc");
+        List<DockstoreTool> pagedToolsLowercase = containersApi.allPublishedContainers(0, 1, "test", "stars", "desc");
         assertEquals(1, pagedToolsLowercase.size());
-        List<DockstoreTool> pagedToolsUppercase = containersApi.allPublishedContainers("0", 1, "TEST", "stars", "desc");
+        List<DockstoreTool> pagedToolsUppercase = containersApi.allPublishedContainers(0, 1, "TEST", "stars", "desc");
         assertEquals(1, pagedToolsUppercase.size());
         assertEquals(pagedToolsLowercase, pagedToolsUppercase);
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -1051,7 +1051,7 @@ public class WorkflowIT extends BaseIT {
         List<Workflow> workflows = workflowApi.allPublishedWorkflows(null, null, null, null, null, false, null);
         // test offset
         assertEquals("offset does not seem to be working",
-            workflowApi.allPublishedWorkflows("1", null, null, null, null, false, null).get(0).getId(), workflows.get(1).getId());
+            workflowApi.allPublishedWorkflows(1, null, null, null, null, false, null).get(0).getId(), workflows.get(1).getId());
         // test limit
         assertEquals(1, workflowApi.allPublishedWorkflows(null, 1, null, null, null, false, null).size());
         // test custom sort column

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -262,7 +262,8 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
         processQuery(filter, sortCol, sortOrder, cb, query, entry);
         query.select(entry);
 
-        TypedQuery<T> typedQuery = currentSession().createQuery(query).setFirstResult(offset).setMaxResults(limit);
+        int primitiveOffset = (offset != null) ? offset : 0;
+        TypedQuery<T> typedQuery = currentSession().createQuery(query).setFirstResult(primitiveOffset).setMaxResults(limit);
         return typedQuery.getResultList();
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -16,7 +16,6 @@
 
 package io.dockstore.webservice.jdbi;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.core.Category;
@@ -252,19 +251,18 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
         return list(this.currentSession().getNamedQuery("Entry.getCollectionEntries").setParameter("collectionId", collectionId));
     }
 
-    public List<T> findAllPublished(String offset, Integer limit, String filter, String sortCol, String sortOrder) {
+    public List<T> findAllPublished(Integer offset, Integer limit, String filter, String sortCol, String sortOrder) {
         return findAllPublished(offset, limit, filter, sortCol, sortOrder, typeOfT);
     }
 
-    public List<T> findAllPublished(String offset, Integer limit, String filter, String sortCol, String sortOrder, Class<T> classType) {
+    public List<T> findAllPublished(Integer offset, Integer limit, String filter, String sortCol, String sortOrder, Class<T> classType) {
         CriteriaBuilder cb = currentSession().getCriteriaBuilder();
         CriteriaQuery<T> query = criteriaQuery();
         Root<T> entry = query.from(classType != null ? classType : typeOfT);
         processQuery(filter, sortCol, sortOrder, cb, query, entry);
         query.select(entry);
 
-        int primitiveOffset = Integer.parseInt(MoreObjects.firstNonNull(offset, "0"));
-        TypedQuery<T> typedQuery = currentSession().createQuery(query).setFirstResult(primitiveOffset).setMaxResults(limit);
+        TypedQuery<T> typedQuery = currentSession().createQuery(query).setFirstResult(offset).setMaxResults(limit);
         return typedQuery.getResultList();
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -761,7 +761,7 @@ public class DockerRepoResource
     @ApiOperation(value = "List all published tools.", tags = {
         "containers"}, notes = "NO authentication", response = Tool.class, responseContainer = "List")
     public List<Tool> allPublishedContainers(
-        @ApiParam(value = "Start index of paging. If not specified in the request, this will start at the beginning of the results.") @DefaultValue("0") @QueryParam("offset") Integer offset,
+        @ApiParam(value = "Start index of paging. If not specified in the request, this will start at the beginning of the results.", defaultValue = "0") @DefaultValue("0") @QueryParam("offset") Integer offset,
         @ApiParam(value = "Amount of records to return in a given page, limited to "
             + PAGINATION_LIMIT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
         @ApiParam(value = "Filter, this is a search string that filters the results.") @DefaultValue("") @QueryParam("filter") String filter,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -761,7 +761,7 @@ public class DockerRepoResource
     @ApiOperation(value = "List all published tools.", tags = {
         "containers"}, notes = "NO authentication", response = Tool.class, responseContainer = "List")
     public List<Tool> allPublishedContainers(
-        @ApiParam(value = "Start index of paging. Pagination results can be based on numbers or other values chosen by the registry implementor (for example, SHA values). If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.") @QueryParam("offset") String offset,
+        @ApiParam(value = "Start index of paging. If not specified in the request, this will start at the beginning of the results.") @DefaultValue("0") @QueryParam("offset") Integer offset,
         @ApiParam(value = "Amount of records to return in a given page, limited to "
             + PAGINATION_LIMIT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
         @ApiParam(value = "Filter, this is a search string that filters the results.") @DefaultValue("") @QueryParam("filter") String filter,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -761,7 +761,8 @@ public class DockerRepoResource
     @ApiOperation(value = "List all published tools.", tags = {
         "containers"}, notes = "NO authentication", response = Tool.class, responseContainer = "List")
     public List<Tool> allPublishedContainers(
-        @ApiParam(value = "Start index of paging. If not specified in the request, this will start at the beginning of the results.", defaultValue = "0") @DefaultValue("0") @QueryParam("offset") Integer offset,
+        @ApiParam(value = "Start index of paging. If not specified in the request, this will start at the beginning of the results.",
+                defaultValue = "0") @DefaultValue("0") @QueryParam("offset") Integer offset,
         @ApiParam(value = "Amount of records to return in a given page, limited to "
             + PAGINATION_LIMIT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
         @ApiParam(value = "Filter, this is a search string that filters the results.") @DefaultValue("") @QueryParam("filter") String filter,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -780,7 +780,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @ApiOperation(value = "List all published workflows.", tags = {
         "workflows"}, notes = "NO authentication", response = Workflow.class, responseContainer = "List")
     public List<Workflow> allPublishedWorkflows(
-        @ApiParam(value = "Start index of paging. If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.") @DefaultValue("0") @QueryParam("offset") Integer offset,
+        @ApiParam(value = "Start index of paging. If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.", defaultValue = "0") @DefaultValue("0") @QueryParam("offset") Integer offset,
         @ApiParam(value = "Amount of records to return in a given page, limited to "
             + PAGINATION_LIMIT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
         @ApiParam(value = "Filter, this is a search string that filters the results.") @DefaultValue("") @QueryParam("filter") String filter,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -780,7 +780,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @ApiOperation(value = "List all published workflows.", tags = {
         "workflows"}, notes = "NO authentication", response = Workflow.class, responseContainer = "List")
     public List<Workflow> allPublishedWorkflows(
-        @ApiParam(value = "Start index of paging. Pagination results can be based on numbers or other values chosen by the registry implementor (for example, SHA values). If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.") @QueryParam("offset") String offset,
+        @ApiParam(value = "Start index of paging. If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.") @DefaultValue("0") @QueryParam("offset") Integer offset,
         @ApiParam(value = "Amount of records to return in a given page, limited to "
             + PAGINATION_LIMIT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
         @ApiParam(value = "Filter, this is a search string that filters the results.") @DefaultValue("") @QueryParam("filter") String filter,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -780,7 +780,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @ApiOperation(value = "List all published workflows.", tags = {
         "workflows"}, notes = "NO authentication", response = Workflow.class, responseContainer = "List")
     public List<Workflow> allPublishedWorkflows(
-        @ApiParam(value = "Start index of paging. If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.", defaultValue = "0") @DefaultValue("0") @QueryParam("offset") Integer offset,
+        @ApiParam(value = "Start index of paging. If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.",
+                defaultValue = "0") @DefaultValue("0") @QueryParam("offset") Integer offset,
         @ApiParam(value = "Amount of records to return in a given page, limited to "
             + PAGINATION_LIMIT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
         @ApiParam(value = "Filter, this is a search string that filters the results.") @DefaultValue("") @QueryParam("filter") String filter,

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1206,7 +1206,9 @@ paths:
       - in: query
         name: offset
         schema:
-          type: string
+          type: integer
+          format: int32
+          default: 0
       - in: query
         name: limit
         schema:
@@ -6092,7 +6094,9 @@ paths:
       - in: query
         name: offset
         schema:
-          type: string
+          type: integer
+          format: int32
+          default: 0
       - in: query
         name: limit
         schema:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -1591,12 +1591,12 @@ paths:
       parameters:
       - name: "offset"
         in: "query"
-        description: "Start index of paging. Pagination results can be based on numbers\
-          \ or other values chosen by the registry implementor (for example, SHA values).\
-          \ If this exceeds the current result set return an empty set.  If not specified\
-          \ in the request, this will start at the beginning of the results."
+        description: "Start index of paging. If not specified in the request, this\
+          \ will start at the beginning of the results."
         required: false
-        type: "string"
+        type: "integer"
+        default: 0
+        format: "int32"
       - name: "limit"
         in: "query"
         description: "Amount of records to return in a given page, limited to 100"
@@ -5382,12 +5382,13 @@ paths:
       parameters:
       - name: "offset"
         in: "query"
-        description: "Start index of paging. Pagination results can be based on numbers\
-          \ or other values chosen by the registry implementor (for example, SHA values).\
-          \ If this exceeds the current result set return an empty set.  If not specified\
-          \ in the request, this will start at the beginning of the results."
+        description: "Start index of paging. If this exceeds the current result set\
+          \ return an empty set.  If not specified in the request, this will start\
+          \ at the beginning of the results."
         required: false
-        type: "string"
+        type: "integer"
+        default: 0
+        format: "int32"
       - name: "limit"
         in: "query"
         description: "Amount of records to return in a given page, limited to 100"


### PR DESCRIPTION
**Description**
Updates offset query parameter in `/container/published` and `/workflows/published` endpoints to be an integer.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-3979

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
