### PR TITLE
Feature/4240/user profile access

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.fail;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.NonConfidentialTest;
 import io.dockstore.common.TestingPostgres;
+import io.dockstore.webservice.core.Profile;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.User;
@@ -50,6 +51,7 @@ import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.TokensApi;
 import io.swagger.client.api.UsersApi;
+import io.swagger.client.model.UserPrivateInfo;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Collections;
@@ -254,7 +256,7 @@ public class TokenResourceIT {
 
         // Change Account 1 username to CUSTOM_USERNAME2
         UsersApi mainUsersApi = new UsersApi(getWebClient(true, GOOGLE_ACCOUNT_USERNAME1, testingPostgres));
-        io.swagger.client.model.User user = mainUsersApi.changeUsername(CUSTOM_USERNAME2);
+        UserPrivateInfo user = mainUsersApi.changeUsername(CUSTOM_USERNAME2);
         Assert.assertEquals(CUSTOM_USERNAME2, user.getUsername());
 
         registerAndLinkUnavailableTokens(unAuthenticatedTokensApi);
@@ -601,7 +603,7 @@ public class TokenResourceIT {
      */
     private void checkUserProfiles(Long userId, List<String> profileKeys) {
         User user = userDAO.findById(userId);
-        Map<String, User.Profile> userProfiles = user.getUserProfiles();
+        Map<String, Profile> userProfiles = user.getUserProfiles();
         profileKeys.forEach(profileKey -> assertTrue(userProfiles.containsKey(profileKey)));
         if (profileKeys.contains(TokenType.GOOGLE_COM.toString())) {
             checkGoogleUserProfile(userProfiles);
@@ -613,8 +615,8 @@ public class TokenResourceIT {
      *
      * @param userProfiles the user profile to look into and validate
      */
-    private void checkGoogleUserProfile(Map<String, User.Profile> userProfiles) {
-        User.Profile googleProfile = userProfiles.get(TokenType.GOOGLE_COM.toString());
+    private void checkGoogleUserProfile(Map<String, Profile> userProfiles) {
+        Profile googleProfile = userProfiles.get(TokenType.GOOGLE_COM.toString());
         assertTrue(googleProfile.email.equals(GOOGLE_ACCOUNT_USERNAME1) && googleProfile.avatarURL
             .equals("https://dockstore.org/assets/images/dockstore/logo.png") && googleProfile.company == null
             && googleProfile.location == null && googleProfile.name.equals("Beef Stew"));

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -29,7 +29,8 @@ import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
-import io.dockstore.openapi.client.model.PrivilegeRequest;
+import io.dockstore.openapi.client.model.PrivilegeRequestPrivateInfo;
+import io.dockstore.openapi.client.model.ProfilePrivateInfo;
 import io.dockstore.openapi.client.model.SourceControlOrganization;
 import io.dockstore.openapi.client.model.UserInfo;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
@@ -45,9 +46,8 @@ import io.swagger.client.model.Collection;
 import io.swagger.client.model.EntryUpdateTime;
 import io.swagger.client.model.Organization;
 import io.swagger.client.model.OrganizationUpdateTime;
-import io.swagger.client.model.Profile;
 import io.swagger.client.model.Repository;
-import io.swagger.client.model.User;
+import io.swagger.client.model.UserPrivateInfo;
 import io.swagger.client.model.Workflow;
 import java.util.Arrays;
 import java.util.List;
@@ -143,7 +143,7 @@ public class UserResourceIT extends BaseIT {
         UsersApi userApi = new UsersApi(client);
 
         // Profiles are lazy loaded, and should not be present by default
-        User user = userApi.listUser(USER_2_USERNAME, null);
+        UserPrivateInfo user = userApi.listUser(USER_2_USERNAME, null);
         assertNull("User profiles should be null by default", user.getUserProfiles());
 
         // Load profiles by specifying userProfiles as a query parameter in the API call
@@ -172,7 +172,7 @@ public class UserResourceIT extends BaseIT {
 
         UsersApi userUserWebClient = new UsersApi(userWebClient);
         io.dockstore.openapi.client.api.UsersApi openApiUserWebClient = new io.dockstore.openapi.client.api.UsersApi(openApiAdminWebClient);
-        final User user = userUserWebClient.getUser();
+        final UserPrivateInfo user = userUserWebClient.getUser();
         assertFalse(user.getUsername().isEmpty());
 
         openApiUserWebClient.banUser(true, user.getId());
@@ -261,7 +261,7 @@ public class UserResourceIT extends BaseIT {
 
         final WorkflowsApi adminWorkflowsApi = new WorkflowsApi(adminWebClient);
 
-        User user = userApi.getUser();
+        UserPrivateInfo user = userApi.getUser();
         assertNotNull(user);
 
         // try to delete with published workflows & service
@@ -396,7 +396,7 @@ public class UserResourceIT extends BaseIT {
         ApiClient adminWebClient = getWebClient(ADMIN_USERNAME, testingPostgres);
         UsersApi adminUserApi = new UsersApi(adminWebClient);
 
-        User user = userApi.getUser();
+        UserPrivateInfo user = userApi.getUser();
 
         // Test that deleting a user creates a deleteduser entry
         long count = testingPostgres.runSelectStatement("select count(*) from deletedusername", long.class);
@@ -598,7 +598,7 @@ public class UserResourceIT extends BaseIT {
     public void testUpdateUserMetadataFromGithub() {
         ApiClient client = getWebClient(USER_2_USERNAME, testingPostgres);
         UsersApi usersApi = new UsersApi(client);
-        Profile userProfile = usersApi.getUser().getUserProfiles().get("github.com");
+        io.swagger.client.model.ProfilePrivateInfo userProfile = usersApi.getUser().getUserProfiles().get("github.com");
 
         assertNull(userProfile.getName());
         assertNull(userProfile.getEmail());
@@ -642,11 +642,11 @@ public class UserResourceIT extends BaseIT {
         io.dockstore.openapi.client.ApiClient adminWebClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
         io.dockstore.openapi.client.ApiClient userWebClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
 
-        io.dockstore.openapi.client.model.PrivilegeRequest privilegeRequest = new PrivilegeRequest();
+        io.dockstore.openapi.client.model.PrivilegeRequestPrivateInfo privilegeRequest = new PrivilegeRequestPrivateInfo();
         io.dockstore.openapi.client.api.UsersApi adminApi = new io.dockstore.openapi.client.api.UsersApi(adminWebClient);
         io.dockstore.openapi.client.api.UsersApi userApi = new io.dockstore.openapi.client.api.UsersApi(userWebClient);
-        io.dockstore.openapi.client.model.User admin = adminApi.getUser();
-        io.dockstore.openapi.client.model.User user = userApi.getUser();
+        io.dockstore.openapi.client.model.UserPrivateInfo admin = adminApi.getUser();
+        io.dockstore.openapi.client.model.UserPrivateInfo user = userApi.getUser();
 
         privilegeRequest.setAdmin(false);
         privilegeRequest.setCurator(false);
@@ -712,8 +712,8 @@ public class UserResourceIT extends BaseIT {
         io.dockstore.openapi.client.ApiClient userWebClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         io.dockstore.openapi.client.api.UsersApi adminApi = new io.dockstore.openapi.client.api.UsersApi(adminWebClient);
         io.dockstore.openapi.client.api.UsersApi userApi = new io.dockstore.openapi.client.api.UsersApi(userWebClient);
-        io.dockstore.openapi.client.model.User admin = adminApi.getUser();
-        io.dockstore.openapi.client.model.Profile userProfile = userApi.getUser().getUserProfiles().get("github.com");
+        io.dockstore.openapi.client.model.UserPrivateInfo admin = adminApi.getUser();
+        ProfilePrivateInfo userProfile = userApi.getUser().getUserProfiles().get("github.com");
 
         // Should add a test above this to check that the API call should pass once the admin tokens are up to date
         // Testing that the updateLoggedInUserMetadata() should fail if GitHub tokens are expired or absent
@@ -758,7 +758,7 @@ public class UserResourceIT extends BaseIT {
         io.dockstore.openapi.client.ApiClient userWebClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         io.dockstore.openapi.client.api.UsersApi adminApi = new io.dockstore.openapi.client.api.UsersApi(adminWebClient);
         io.dockstore.openapi.client.api.UsersApi userApi = new io.dockstore.openapi.client.api.UsersApi(userWebClient);
-        io.dockstore.openapi.client.model.Profile userProfile = userApi.getUser().getUserProfiles().get("github.com");
+        ProfilePrivateInfo userProfile = userApi.getUser().getUserProfiles().get("github.com");
 
         // Delete all of the tokens (except for Dockstore tokens) for every user
         testingPostgres.runUpdateStatement("DELETE FROM token WHERE tokensource <> 'dockstore'");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -296,6 +296,12 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         // doesn't seem to work, when it does, we could avoid overriding pojo.mustache in swagger
         objectMapper.enable(MapperFeature.ALLOW_EXPLICIT_PROPERTY_RENAMING);
         objectMapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
+
+        // Set the default ObjectMapper view type. This causes attributes that are annotated with an explicit view type
+        // be ignored in the view response unless their view class is explicitly specified. Attributes that aren't annotated with
+        // a view type are included by default.
+        objectMapper.setConfig(objectMapper.getSerializationConfig().withView(Object.class));
+
         // To convert every Date we have to RFC 3339, we can use this
         // objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssz"));
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -300,7 +300,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         // Set the default ObjectMapper view type. This causes attributes that are annotated with an explicit view type
         // be ignored in the view response unless their view class is explicitly specified. Attributes that aren't annotated with
         // a view type are included by default.
-        objectMapper.setConfig(objectMapper.getSerializationConfig().withView(Object.class));
+        // objectMapper.setConfig(objectMapper.getSerializationConfig().withView(Object.class));
 
         // To convert every Date we have to RFC 3339, we can use this
         // objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssz"));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Profile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Profile.java
@@ -1,0 +1,50 @@
+package io.dockstore.webservice.core;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonView;
+import java.io.Serializable;
+import java.sql.Timestamp;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * The profile of a user using a token (Google profile, GitHub profile, etc)
+ * The order of the properties are important, the UI lists these properties in this order.
+ */
+@Embeddable
+public class Profile implements Serializable {
+    @Column(columnDefinition = "text")
+    public String name;
+    @Column(columnDefinition = "text")
+    @JsonView(UserProfileViews.PrivateInfo.class)
+    public String email;
+    @Column(columnDefinition = "text")
+    public String avatarURL;
+    @Column(columnDefinition = "text")
+    public String company;
+    @Column(columnDefinition = "text")
+    public String location;
+    @Column(columnDefinition = "text")
+    public String bio;
+    @Column(columnDefinition = "text")
+    public String link;
+    /**
+     * Redundant with token, but needed since tokens can be deleted.
+     * i.e. if usernames can change and tokens can be deleted, we need somewhere to let
+     * token-less users login
+     */
+    @Column(columnDefinition = "text")
+    public String username;
+    @Column
+    @JsonIgnore
+    public String onlineProfileId;
+
+    @Column(updatable = false)
+    @CreationTimestamp
+    private Timestamp dbCreateDate;
+    @Column()
+    @UpdateTimestamp
+    private Timestamp dbUpdateDate;
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Profile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Profile.java
@@ -16,6 +16,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Embeddable
 public class Profile implements Serializable {
     @Column(columnDefinition = "text")
+    @JsonView(UserProfileViews.PublicInfo.class)
     public String name;
     @Column(columnDefinition = "text")
     @JsonView(UserProfileViews.PrivateInfo.class)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -18,6 +18,7 @@ package io.dockstore.webservice.core;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
 import io.dockstore.webservice.CustomWebApplicationException;
@@ -565,6 +566,7 @@ public class User implements Principal, Comparable<User>, Serializable {
         @Column(columnDefinition = "text")
         public String name;
         @Column(columnDefinition = "text")
+        @JsonView(UserProfilesViews.PrivateInfo.class)
         public String email;
         @Column(columnDefinition = "text")
         public String avatarURL;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -18,7 +18,6 @@ package io.dockstore.webservice.core;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonView;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
 import io.dockstore.webservice.CustomWebApplicationException;
@@ -46,7 +45,6 @@ import java.util.TreeSet;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
-import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -555,45 +553,5 @@ public class User implements Principal, Comparable<User>, Serializable {
 
     public void setUsernameChangeRequired(boolean usernameChangeRequired) {
         this.usernameChangeRequired = usernameChangeRequired;
-    }
-
-    /**
-     * The profile of a user using a token (Google profile, GitHub profile, etc)
-     * The order of the properties are important, the UI lists these properties in this order.
-     */
-    @Embeddable
-    public static class Profile implements Serializable {
-        @Column(columnDefinition = "text")
-        public String name;
-        @Column(columnDefinition = "text")
-        @JsonView(UserProfilesViews.PrivateInfo.class)
-        public String email;
-        @Column(columnDefinition = "text")
-        public String avatarURL;
-        @Column(columnDefinition = "text")
-        public String company;
-        @Column(columnDefinition = "text")
-        public String location;
-        @Column(columnDefinition = "text")
-        public String bio;
-        @Column(columnDefinition = "text")
-        public String link;
-        /**
-         * Redundant with token, but needed since tokens can be deleted.
-         * i.e. if usernames can change and tokens can be deleted, we need somewhere to let
-         * token-less users login
-         */
-        @Column(columnDefinition = "text")
-        public String username;
-        @Column
-        @JsonIgnore
-        public String onlineProfileId;
-
-        @Column(updatable = false)
-        @CreationTimestamp
-        private Timestamp dbCreateDate;
-        @Column()
-        @UpdateTimestamp
-        private Timestamp dbUpdateDate;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/UserProfileViews.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/UserProfileViews.java
@@ -1,0 +1,7 @@
+package io.dockstore.webservice.core;
+
+public class UserProfileViews {
+    public static class PublicInfo { } // View that shows only public user info
+
+    public static class PrivateInfo extends PublicInfo { } // View that reveals all user info
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/UserProfilesViews.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/UserProfilesViews.java
@@ -1,5 +1,0 @@
-package io.dockstore.webservice.core;
-
-public class UserProfilesViews {
-    public static class PrivateInfo { } // View that reveals all user info
-}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/UserProfilesViews.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/UserProfilesViews.java
@@ -1,0 +1,5 @@
+package io.dockstore.webservice.core;
+
+public class UserProfilesViews {
+    public static class PrivateInfo { } // View that reveals all user info
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -40,6 +40,7 @@ import io.dockstore.webservice.core.AppTool;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.LicenseInformation;
+import io.dockstore.webservice.core.Profile;
 import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.SourceControlOrganization;
 import io.dockstore.webservice.core.SourceFile;
@@ -1126,7 +1127,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         // eGit user object
         try {
             GHMyself myself = github.getMyself();
-            User.Profile profile = getProfile(user, myself);
+            Profile profile = getProfile(user, myself);
             profile.email = getEmail(myself);
 
             // Update token. Username on GitHub could have changed and need to collect the GitHub user id as well
@@ -1150,7 +1151,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                 throw new CustomWebApplicationException("Could not find GitHub user profile information on Dockstore with username: " + user.getUsername() + "dockstore userid: " + user.getId(), HttpStatus.SC_NOT_FOUND);
             }
             GHUser ghUser = github.getUser(user.getUserProfiles().get(TokenType.GITHUB_COM.toString()).username);
-            User.Profile profile = getProfile(user, ghUser);
+            Profile profile = getProfile(user, ghUser);
             profile.email = ghUser.getEmail();
 
             // Update token. Username on GitHub could have changed and need to collect the GitHub user id as well
@@ -1205,9 +1206,9 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         return numOfEntriesNotUpdatedWithTopic;
     }
 
-    public User.Profile getProfile(final User user, final GHUser ghUser) throws IOException {
+    public Profile getProfile(final User user, final GHUser ghUser) throws IOException {
         LOG.info("GitHub user profile id is {} and GitHub username is {} for Dockstore user {}", ghUser.getId(), ghUser.getLogin(), user.getUsername());
-        User.Profile profile = new User.Profile();
+        Profile profile = new Profile();
         profile.onlineProfileId = String.valueOf(ghUser.getId());
         profile.username = ghUser.getLogin();
         profile.name = ghUser.getName();
@@ -1217,7 +1218,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         profile.link = StringUtils.isNotEmpty(ghUser.getBlog()) ? ghUser.getBlog() : null;
         profile.location = ghUser.getLocation();
         profile.company = ghUser.getCompany();
-        Map<String, User.Profile> userProfile = user.getUserProfiles();
+        Map<String, Profile> userProfile = user.getUserProfiles();
         userProfile.put(TokenType.GITHUB_COM.toString(), profile);
         user.setAvatarUrl(ghUser.getAvatarUrl());
         return profile;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GoogleHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GoogleHelper.java
@@ -11,6 +11,7 @@ import com.google.api.services.oauth2.model.Tokeninfo;
 import com.google.api.services.oauth2.model.Userinfoplus;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
+import io.dockstore.webservice.core.Profile;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.User;
@@ -65,14 +66,14 @@ public final class GoogleHelper {
      * @param user      The pre-updated User object
      */
     public static void updateUserFromGoogleUserinfoplus(Userinfoplus userinfo, User user) {
-        User.Profile profile = new User.Profile();
+        Profile profile = new Profile();
         profile.avatarURL = userinfo.getPicture();
         profile.email = userinfo.getEmail();
         profile.name = userinfo.getName();
         profile.username = userinfo.getEmail();
         profile.onlineProfileId = userinfo.getId();
         user.setAvatarUrl(userinfo.getPicture());
-        Map<String, User.Profile> userProfile = user.getUserProfiles();
+        Map<String, Profile> userProfile = user.getUserProfiles();
         userProfile.put(TokenType.GOOGLE_COM.toString(), profile);
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
@@ -17,6 +17,7 @@
 package io.dockstore.webservice.permissions;
 
 import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Profile;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
@@ -217,7 +218,7 @@ public class InMemoryPermissionsImpl implements PermissionsInterface {
     }
 
     private String userKey(User user) {
-        User.Profile profile = user.getUserProfiles().get(TokenType.GOOGLE_COM.toString());
+        Profile profile = user.getUserProfiles().get(TokenType.GOOGLE_COM.toString());
         if (profile == null || profile.email == null) {
             return user.getUsername();
         } else {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
@@ -17,6 +17,7 @@
 package io.dockstore.webservice.permissions;
 
 import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Profile;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
@@ -165,7 +166,7 @@ public interface PermissionsInterface {
         return workflow.getUsers().stream()
                 .map(user -> {
                     // This is ugly in order to support both SAM and InMemory authorizers
-                    final User.Profile profile = user.getUserProfiles().get(TokenType.GOOGLE_COM.toString());
+                    final Profile profile = user.getUserProfiles().get(TokenType.GOOGLE_COM.toString());
                     if (profile != null && profile.email != null) {
                         return profile.email;
                     } else {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
@@ -3,6 +3,7 @@ package io.dockstore.webservice.permissions.sam;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
+import io.dockstore.webservice.core.Profile;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.User;
@@ -283,7 +284,7 @@ public class SamPermissionsImpl implements PermissionsInterface {
             if (email.equals(u.getUsername())) {
                 return true;
             }
-            final User.Profile profile = u.getUserProfiles().get(TokenType.GOOGLE_COM.toString());
+            final Profile profile = u.getUserProfiles().get(TokenType.GOOGLE_COM.toString());
             return profile != null && email.equals(profile.email);
         });
         if (isOwner) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -55,7 +55,7 @@ import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.TokenViews;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.User;
-import io.dockstore.webservice.core.UserProfilesViews;
+import io.dockstore.webservice.core.UserProfileViews;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowMode;
 import io.dockstore.webservice.core.database.EntryLite;
@@ -219,7 +219,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @GET
     @Timed
     @UnitOfWork(readOnly = true)
-    @JsonView(UserProfilesViews.PrivateInfo.class)
+    @JsonView(UserProfileViews.PrivateInfo.class)
     @Path("/username/{username}")
     @Operation(operationId = "listUser", description = "Get a user by username.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A user with the specified username", content = @Content(schema = @Schema(implementation = User.class)))
@@ -243,7 +243,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Timed
     @UnitOfWork(readOnly = true)
     @Path("/{userId}")
-    @JsonView(UserProfilesViews.PrivateInfo.class)
+    @JsonView(UserProfileViews.PrivateInfo.class)
     @Operation(operationId = "getSpecificUser", description = "Get user by id.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A user with the specified userId", content = @Content(schema = @Schema(implementation = User.class)))
     @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
@@ -260,7 +260,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Timed
     @UnitOfWork(readOnly = true)
     @Path("/user")
-    @JsonView(UserProfilesViews.PrivateInfo.class)
+    @JsonView(UserProfileViews.PrivateInfo.class)
     @Operation(operationId = "getUser", description = "Get the logged-in user.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "The logged-in user", content = @Content(schema = @Schema(implementation = User.class)))
     @ApiOperation(nickname = "getUser", value = "Get the logged-in user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
@@ -304,7 +304,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Timed
     @UnitOfWork
     @Path("/user/changeUsername")
-    @JsonView(UserProfilesViews.PrivateInfo.class)
+    @JsonView(UserProfileViews.PrivateInfo.class)
     @Operation(operationId = "changeUsername", description = "Change username if possible.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully changed username", content = @Content(schema = @Schema(implementation = User.class)))
     @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = HttpStatusMessageConstants.BAD_REQUEST)
@@ -899,7 +899,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Timed
     @UnitOfWork
     @Path("/user/updateUserMetadata")
-    @JsonView(UserProfilesViews.PrivateInfo.class)
+    @JsonView(UserProfileViews.PrivateInfo.class)
     @Operation(operationId = "updateLoggedInUserMetadata", description = "Update metadata for logged in user.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully updated metadata for logged in user", content = @Content(schema = @Schema(implementation = User.class)))
     @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
@@ -917,7 +917,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Timed
     @UnitOfWork
     @Path("/user/updateAcceptedDocuments")
-    @JsonView(UserProfilesViews.PrivateInfo.class)
+    @JsonView(UserProfileViews.PrivateInfo.class)
     @Operation(operationId = "updateAcceptedDocuments", description = "Update the user's TOS and privacy policy to the latest versions.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "User with updated TOS/Privacy Policy", content = @Content(schema = @Schema(implementation = User.class)))
     @ApiOperation(value = "Update the user's TOS and privacy policy to the latest versions.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class, hidden = true)
@@ -1051,7 +1051,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @UnitOfWork
     @RolesAllowed({"admin"})
     @Path("/{userId}/privileges")
-    @JsonView(UserProfilesViews.PrivateInfo.class)
+    @JsonView(UserProfileViews.PrivateInfo.class)
     @Consumes("application/json")
     @Operation(operationId = "setUserPrivileges", description = "Updates the provided userID to admin or curator status, usable by ADMINs only", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully updated user to admin or curator status", content = @Content(schema = @Schema(implementation = User.class)))

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -55,6 +55,7 @@ import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.TokenViews;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.User;
+import io.dockstore.webservice.core.UserProfilesViews;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowMode;
 import io.dockstore.webservice.core.database.EntryLite;
@@ -218,6 +219,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @GET
     @Timed
     @UnitOfWork(readOnly = true)
+    @JsonView(UserProfilesViews.PrivateInfo.class)
     @Path("/username/{username}")
     @Operation(operationId = "listUser", description = "Get a user by username.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A user with the specified username", content = @Content(schema = @Schema(implementation = User.class)))
@@ -241,6 +243,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Timed
     @UnitOfWork(readOnly = true)
     @Path("/{userId}")
+    @JsonView(UserProfilesViews.PrivateInfo.class)
     @Operation(operationId = "getSpecificUser", description = "Get user by id.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A user with the specified userId", content = @Content(schema = @Schema(implementation = User.class)))
     @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
@@ -257,6 +260,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Timed
     @UnitOfWork(readOnly = true)
     @Path("/user")
+    @JsonView(UserProfilesViews.PrivateInfo.class)
     @Operation(operationId = "getUser", description = "Get the logged-in user.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "The logged-in user", content = @Content(schema = @Schema(implementation = User.class)))
     @ApiOperation(nickname = "getUser", value = "Get the logged-in user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
@@ -300,6 +304,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Timed
     @UnitOfWork
     @Path("/user/changeUsername")
+    @JsonView(UserProfilesViews.PrivateInfo.class)
     @Operation(operationId = "changeUsername", description = "Change username if possible.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully changed username", content = @Content(schema = @Schema(implementation = User.class)))
     @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = HttpStatusMessageConstants.BAD_REQUEST)
@@ -894,6 +899,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Timed
     @UnitOfWork
     @Path("/user/updateUserMetadata")
+    @JsonView(UserProfilesViews.PrivateInfo.class)
     @Operation(operationId = "updateLoggedInUserMetadata", description = "Update metadata for logged in user.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully updated metadata for logged in user", content = @Content(schema = @Schema(implementation = User.class)))
     @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
@@ -911,6 +917,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Timed
     @UnitOfWork
     @Path("/user/updateAcceptedDocuments")
+    @JsonView(UserProfilesViews.PrivateInfo.class)
     @Operation(operationId = "updateAcceptedDocuments", description = "Update the user's TOS and privacy policy to the latest versions.", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "User with updated TOS/Privacy Policy", content = @Content(schema = @Schema(implementation = User.class)))
     @ApiOperation(value = "Update the user's TOS and privacy policy to the latest versions.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class, hidden = true)
@@ -1044,6 +1051,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @UnitOfWork
     @RolesAllowed({"admin"})
     @Path("/{userId}/privileges")
+    @JsonView(UserProfilesViews.PrivateInfo.class)
     @Consumes("application/json")
     @Operation(operationId = "setUserPrivileges", description = "Updates the provided userID to admin or curator status, usable by ADMINs only", security = @SecurityRequirement(name = OPENAPI_JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully updated user to admin or curator status", content = @Content(schema = @Schema(implementation = User.class)))

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -8551,6 +8551,8 @@ components:
           type: string
         company:
           type: string
+        email:
+          type: string
         link:
           type: string
         location:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -4761,7 +4761,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/User_PrivateInfo'
           description: The logged-in user
       security:
       - bearer: []
@@ -4781,7 +4781,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/User_PrivateInfo'
           description: Successfully changed username
         "400":
           description: Bad request
@@ -4832,7 +4832,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/User_PrivateInfo'
           description: User with updated TOS/Privacy Policy
       security:
       - bearer: []
@@ -4861,7 +4861,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/User_PrivateInfo'
           description: Successfully updated metadata for logged in user
         "403":
           description: Forbidden
@@ -4973,7 +4973,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/User_PrivateInfo'
           description: A user with the specified username
         "400":
           description: Bad request
@@ -5060,7 +5060,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/User_PrivateInfo'
           description: A user with the specified userId
         "403":
           description: Forbidden
@@ -5341,14 +5341,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PrivilegeRequest'
+              $ref: '#/components/schemas/PrivilegeRequest_PrivateInfo'
         required: true
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/User_PrivateInfo'
           description: Successfully updated user to admin or curator status
         "403":
           description: Forbidden
@@ -8516,7 +8516,7 @@ components:
           - OWNER
           - WRITER
           - READER
-    PrivilegeRequest:
+    PrivilegeRequest_PrivateInfo:
       type: object
       properties:
         admin:
@@ -8533,6 +8533,23 @@ components:
         company:
           type: string
         email:
+          type: string
+        link:
+          type: string
+        location:
+          type: string
+        name:
+          type: string
+        username:
+          type: string
+    Profile_PrivateInfo:
+      type: object
+      properties:
+        avatarURL:
+          type: string
+        bio:
+          type: string
+        company:
           type: string
         link:
           type: string
@@ -9305,6 +9322,55 @@ components:
           type: string
         tokenType:
           type: string
+    User_PrivateInfo:
+      type: object
+      properties:
+        avatarUrl:
+          type: string
+        curator:
+          type: boolean
+        id:
+          type: integer
+          format: int64
+        isAdmin:
+          type: boolean
+        name:
+          type: string
+        orcid:
+          type: string
+        privacyPolicyVersion:
+          type: string
+          enum:
+          - NONE
+          - PRIVACY_POLICY_VERSION_2_5
+        privacyPolicyVersionAcceptanceDate:
+          type: integer
+          format: int64
+        setupComplete:
+          type: boolean
+        tosacceptanceDate:
+          type: integer
+          format: int64
+        tosversion:
+          type: string
+          enum:
+          - NONE
+          - TOS_VERSION_1
+          - TOS_VERSION_2
+        tosversionAcceptanceDate:
+          type: integer
+          format: int64
+          writeOnly: true
+        userProfiles:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Profile_PrivateInfo'
+        username:
+          type: string
+        usernameChangeRequired:
+          type: boolean
+          description: Indicates whether the user is required to change their username
+            before being allowed to do various operations on Dockstore.
     Validation:
       type: object
       properties:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -7689,6 +7689,8 @@ definitions:
         type: "string"
       company:
         type: "string"
+      email:
+        type: "string"
       link:
         type: "string"
       location:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4241,7 +4241,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/User"
+            $ref: "#/definitions/User_PrivateInfo"
       security:
       - BEARER: []
     delete:
@@ -4286,7 +4286,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/User"
+            $ref: "#/definitions/User_PrivateInfo"
       security:
       - BEARER: []
   /users/user/extended:
@@ -4348,7 +4348,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/User"
+            $ref: "#/definitions/User_PrivateInfo"
       security:
       - BEARER: []
   /users/user/{userId}/bannedStatus:
@@ -4455,7 +4455,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/User"
+            $ref: "#/definitions/User_PrivateInfo"
       security:
       - BEARER: []
   /users/users/entries:
@@ -4530,7 +4530,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/User"
+            $ref: "#/definitions/User_PrivateInfo"
       security:
       - BEARER: []
   /users/{userId}/appTools:
@@ -7680,6 +7680,23 @@ definitions:
         type: "string"
       username:
         type: "string"
+  Profile_PrivateInfo:
+    type: "object"
+    properties:
+      avatarURL:
+        type: "string"
+      bio:
+        type: "string"
+      company:
+        type: "string"
+      link:
+        type: "string"
+      location:
+        type: "string"
+      name:
+        type: "string"
+      username:
+        type: "string"
   PublishRequest:
     type: "object"
     properties:
@@ -8413,6 +8430,79 @@ definitions:
           \ (GitHub, Google, etc)"
         additionalProperties:
           $ref: "#/definitions/Profile"
+      username:
+        type: "string"
+        position: 1
+        description: "Username on dockstore"
+      isAdmin:
+        type: "boolean"
+        position: 2
+        description: "Indicates whether this user is an admin"
+      avatarUrl:
+        type: "string"
+        position: 7
+        description: "URL of user avatar on GitHub/Google that can be selected by\
+          \ the user"
+      name:
+        type: "string"
+        position: 8
+      curator:
+        type: "boolean"
+        position: 11
+        description: "Indicates whether this user is a curator"
+      setupComplete:
+        type: "boolean"
+        position: 12
+        description: "Indicates whether this user has accepted their username"
+      tosacceptanceDate:
+        type: "integer"
+        format: "int64"
+        position: 15
+        description: "Time TOS was accepted"
+        readOnly: true
+      privacyPolicyVersionAcceptanceDate:
+        type: "integer"
+        format: "int64"
+        position: 16
+        description: "Time privacy policy was accepted"
+      usernameChangeRequired:
+        type: "boolean"
+        position: 17
+        description: "Indicates whether the user is required to change their username\
+          \ before being allowed to do various operations on Dockstore."
+    description: "End users for the dockstore"
+  User_PrivateInfo:
+    type: "object"
+    required:
+    - "curator"
+    - "isAdmin"
+    - "setupComplete"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+        description: "Implementation specific ID for the container in this web service"
+        readOnly: true
+      orcid:
+        type: "string"
+      privacyPolicyVersion:
+        type: "string"
+        description: "Indicates which version of the privacy policy the user has accepted"
+        enum:
+        - "NONE"
+        - "PRIVACY_POLICY_VERSION_2_5"
+      tosversion:
+        type: "string"
+        enum:
+        - "NONE"
+        - "TOS_VERSION_1"
+        - "TOS_VERSION_2"
+      userProfiles:
+        type: "object"
+        description: "Profile information of the user retrieved from 3rd party sites\
+          \ (GitHub, Google, etc)"
+        additionalProperties:
+          $ref: "#/definitions/Profile_PrivateInfo"
       username:
         type: "string"
         position: 1

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GoogleHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GoogleHelperTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.services.oauth2.model.Tokeninfo;
 import com.google.api.services.oauth2.model.Userinfoplus;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
+import io.dockstore.webservice.core.Profile;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.User;
 import org.junit.Assert;
@@ -45,7 +46,7 @@ public class GoogleHelperTest {
         when(userinfoplus.getName()).thenReturn(username);
         GoogleHelper.updateUserFromGoogleUserinfoplus(userinfoplus, user);
         Assert.assertEquals(pictureUrl, user.getAvatarUrl());
-        final User.Profile profile = user.getUserProfiles().get(TokenType.GOOGLE_COM.toString());
+        final Profile profile = user.getUserProfiles().get(TokenType.GOOGLE_COM.toString());
         Assert.assertEquals(email, profile.email);
         Assert.assertEquals(username, profile.name);
         Assert.assertEquals(pictureUrl, profile.avatarURL);

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/InMemoryPermissionsImplTest.java
@@ -3,6 +3,7 @@ package io.dockstore.webservice.permissions;
 import static org.mockito.Mockito.when;
 
 import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Profile;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
@@ -39,7 +40,7 @@ public class InMemoryPermissionsImplTest {
         dockstoreOrgWorkflow = Mockito.mock(Workflow.class);
         when(fooWorkflow.getWorkflowPath()).thenReturn("foo");
 
-        User.Profile profile = new User.Profile();
+        Profile profile = new Profile();
         profile.email = JOHN_DOE_EXAMPLE_COM;
         johnDoeUser.getUserProfiles().put(TokenType.GOOGLE_COM.toString(), profile);
         johnDoeUser.setUsername(JOHN_DOE_EXAMPLE_COM);

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/PermissionsInterfaceTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/PermissionsInterfaceTest.java
@@ -3,6 +3,7 @@ package io.dockstore.webservice.permissions;
 import static org.mockito.Mockito.when;
 
 import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Profile;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
@@ -36,13 +37,13 @@ public class PermissionsInterfaceTest {
     public void setup() {
         userJohn = new User();
         userJohn.setUsername(JOHN_DOE_EXAMPLE_COM);
-        final User.Profile profile1 = new User.Profile();
+        final Profile profile1 = new Profile();
         profile1.email = JOHN_DOE_EXAMPLE_COM;
         userJohn.getUserProfiles().put(TokenType.GOOGLE_COM.toString(), profile1);
 
         userJane = new User();
         userJane.setUsername(JANE_DOE_EXAMPLE_COM);
-        final User.Profile profile2 = new User.Profile();
+        final Profile profile2 = new Profile();
         profile2.email = JANE_DOE_EXAMPLE_COM;
         userJane.getUserProfiles().put(TokenType.GOOGLE_COM.toString(), profile2);
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
+import io.dockstore.webservice.core.Profile;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.User;
@@ -143,9 +144,9 @@ public class SamPermissionsImplTest {
         readerAccessPolicyResponseEntry.getPolicy().addRolesItem(SamConstants.READ_POLICY);
         readerAccessPolicyResponseEntry.getPolicy().addMemberEmailsItem(JANE_DOE_GMAIL_COM);
 
-        final User.Profile profile = new User.Profile();
+        final Profile profile = new Profile();
         profile.email = JANE_DOE_GMAIL_COM;
-        final Map<String, User.Profile> map = new HashMap<>();
+        final Map<String, Profile> map = new HashMap<>();
         map.put(TokenType.GOOGLE_COM.toString(), profile);
         when(userMock.getUserProfiles()).thenReturn(map);
     }


### PR DESCRIPTION
**Description**
(Draft - Looking for feedback and advice)

Ticket: https://ucsc-cgl.atlassian.net/browse/SEAB-4240

This PR addresses how we surface user-level information, and is intended to refine what types of information we want publicly/privately displayed for each user profile. Specifically, this PR hides the `email` field of user profiles when accessed publicly, and surfaces it when accessed privately.

On the surface, this seemed like a simple addition of a Jackson data view annotation (`@JsonView(...)`), but the result of this view annotation is a change in the generated classes (i.e. I naively hoped Jackson 'would just figure out' how to handle annotations with no other changes on our end, but it appears Jackson splits out new Class definitions based on the view annotation). The annotation is added in a new `Profile` class located [here](https://github.com/dockstore/dockstore/blob/f93764b723dafca8530094fe329022f2afd4c6e0/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Profile.java).

For example, by adding the `UserProfileViews.PrivateInfo` data view to the `Profile` class, the following new classes are generated:
1. `UserPrivateInfo` generated from the `User` class
2. `ProfilePrivateInfo` generated from the `Profile` class
3. `PrivilegeRequestPrivateInfo` generated from the `PrivilegeRequest` class

It's important to note that these generated class replace the original ones in our api model. That's to say that when accessing the generated sources, the API calls against a User resource don't return a `User` class, but instead a `UserPrivateInfo` class. Because of this, the method I am proposing is causing a sizable refactor for what is otherwise a simple ticket.

So, my questions:
1. I thought the Jackson data view annotation was the 'proper' tool to show/hide attributes of a larger class. Is this incorrect? Perhaps I'm overlooking a much simpler approach.
2. Instead of using annotations, I could attempt to resolve this more programmatically. Perhaps by removing the email field from a user profile and surfacing it as a separate call?
3. Instead of using the existing structure, we could completely separate the User class from the Profiles class, and have them accessed as different resources. This would also incur a relatively large refactor, I suspect.

Additional thoughts:
1. Although ugly, this approach may be worthwhile in the long run as we expand towards a user profiles page, it will allow clean support for public and private user objects.
2. The only other place we user Jackson data views is for the `Token` class, creating the two generated classes `TokenUser` and `TokenAuth`, this is the pattern that inspired the current approach.

**Issue**
A link to a github issue or SEAB- ticket (using that as a prefix)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ ] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
