### PR TITLE
Query events by user id

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -45,6 +45,7 @@ import io.swagger.client.model.Event;
 import io.swagger.client.model.Event.TypeEnum;
 import io.swagger.client.model.StarRequest;
 import io.swagger.client.model.Tag;
+import io.swagger.client.model.User;
 import io.swagger.client.model.Workflow;
 import io.swagger.model.DescriptorType;
 import java.util.ArrayList;
@@ -336,6 +337,53 @@ public class BasicIT extends BaseIT {
 
         final long count3 = testingPostgres.runSelectStatement("select count(*) from tag where name = 'masterTest'", long.class);
         Assert.assertEquals("there should be no tags", 0, count3);
+
+    }
+    @Test
+    public void testRecentEventsByUser() {
+
+        // Create API client for user
+        ApiClient client = getWebClient(USER_1_USERNAME, testingPostgres);
+
+        UsersApi usersApi = new UsersApi(client);
+        User user = usersApi.getUser();
+        ContainersApi toolsApi = new ContainersApi(client);
+
+        // Register a tool
+        DockstoreTool tool = manualRegisterAndPublish(toolsApi, "dockstoretestuser", "dockerhubandgithub", "regular",
+            "git@github.com:DockstoreTestUser/dockstore-whalesay.git", "/Dockstore.cwl", "/Dockstore.wdl", "/Dockerfile",
+            DockstoreTool.RegistryEnum.DOCKER_HUB, "master", "latest", true);
+
+        // Nothing has been starred so the events API should return an empty collection for the user
+        EventsApi eventsApi = new EventsApi(client);
+        List<Event> events = eventsApi.getEvents(EventSearchType.STARRED_ENTRIES.toString(), 10, 0);
+        Assert.assertTrue("No starred entries, so there should be no events returned", events.isEmpty());
+
+        // Star the tool that was registered above
+        StarRequest starRequest = new StarRequest();
+        starRequest.setStar(true);
+        toolsApi.starEntry(tool.getId(), starRequest);
+
+        // Events API should return
+        events = eventsApi.getEvents(EventSearchType.STARRED_ENTRIES.toString(), 10, 0);
+        assertEquals("The user should return 1 starred entry", 1, events.size());
+
+        // Get the event to compare with another user's request
+        Event event = events.get(0);
+
+        // Create a second client and query for the starred event from the first user
+        ApiClient client2 = getWebClient(USER_2_USERNAME, testingPostgres);
+        EventsApi client2EventsApi = new EventsApi(client2);
+
+        // Get events by user id
+        List<Event> eventsForFirstClient = client2EventsApi.getUserEvents(user.getId(), EventSearchType.STARRED_ENTRIES.toString(), 10, 0);
+        assertEquals("The user should return 1 starred entry", 1, eventsForFirstClient.size());
+
+        // Get the identified event
+        Event event2 = eventsForFirstClient.get(0);
+
+        // Assert the event client2 was able to identify is the same event caused by the first client
+        assertEquals("The two events should have the same ID", event.getId(), event2.getId());
 
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -364,7 +364,7 @@ public class BasicIT extends BaseIT {
         starRequest.setStar(true);
         toolsApi.starEntry(tool.getId(), starRequest);
 
-        // Events API should return
+        // Events API should return 1 event
         events = eventsApi.getEvents(EventSearchType.STARRED_ENTRIES.toString(), 10, 0);
         assertEquals("The user should return 1 starred entry", 1, events.size());
 
@@ -384,7 +384,18 @@ public class BasicIT extends BaseIT {
 
         // Assert the event client2 was able to identify is the same event caused by the first client
         assertEquals("The two events should have the same ID", event.getId(), event2.getId());
+    }
 
+    @Test
+    public void testRecentEventsByUserWithNullInput() {
+
+        // Create a second client and query for the starred event from the first user
+        ApiClient client = getWebClient(USER_2_USERNAME, testingPostgres);
+        EventsApi eventsApi = new EventsApi(client);
+
+        // This should throw an error because no user exists with ID -1
+        systemExit.expectSystemExitWithStatus(org.apache.http.HttpStatus.SC_NOT_FOUND);
+        List<Event> events = eventsApi.getUserEvents(-1L, EventSearchType.STARRED_ENTRIES.toString(), 10, 0);
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -394,8 +394,13 @@ public class BasicIT extends BaseIT {
         EventsApi eventsApi = new EventsApi(client);
 
         // This should throw an error because no user exists with ID -1
-        systemExit.expectSystemExitWithStatus(org.apache.http.HttpStatus.SC_NOT_FOUND);
-        List<Event> events = eventsApi.getUserEvents(-1L, EventSearchType.STARRED_ENTRIES.toString(), 10, 0);
+        try {
+            List<Event> events = eventsApi.getUserEvents(-1L, EventSearchType.STARRED_ENTRIES.toString(), 10, 0);
+            fail("No user exists with ID -1");
+        } catch (ApiException e) {
+            assertTrue(e.getMessage().contains("User not found."));
+
+        }
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
@@ -21,7 +21,6 @@ import static io.dockstore.webservice.jdbi.EventDAO.PAGINATION_RANGE;
 
 import com.codahale.metrics.annotation.Timed;
 import io.dockstore.webservice.CustomWebApplicationException;
-import io.dockstore.webservice.core.Category;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Event;
 import io.dockstore.webservice.core.Organization;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
@@ -96,7 +96,7 @@ public class EventResource {
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A list of events", content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = Event.class))))
     public List<Event> getEvents(@Parameter(hidden = true) @ApiParam(hidden = true) @Auth User user,
         @NotNull @QueryParam("eventSearchType") EventSearchType eventSearchType,
-        @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") int limit,
+        @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") Integer limit,
         @QueryParam("offset") @DefaultValue("0") Integer offset) {
         User userWithSession = this.userDAO.findById(user.getId());
         return getEventsForUser(userWithSession, eventSearchType, limit, offset);
@@ -112,7 +112,7 @@ public class EventResource {
     @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
     public List<Event> getUserEvents(@ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId,
         @NotNull @QueryParam("eventSearchType") EventSearchType eventSearchType,
-        @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") int limit,
+        @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") Integer limit,
         @QueryParam("offset") @DefaultValue("0") Integer offset) {
         User user = this.userDAO.findById(userId);
         checkUserExists(user);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
@@ -93,7 +93,7 @@ public class EventResource {
     @ApiOperation(value = SUMMARY, authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME)}, notes = DESCRIPTION, responseContainer = "List", response = Event.class)
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A list of events", content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = Event.class))))
-    public List<Event> getEvents(@Parameter(hidden = true) @ApiParam(hidden = true) @Auth User user, @QueryParam("event_search_type") EventSearchType eventSearchType, @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") int limit, @QueryParam("offset") @DefaultValue("0") Integer offset) {
+    public List<Event> getEvents(@Parameter(hidden = true) @ApiParam(hidden = true) @Auth User user, @QueryParam("eventSearchType") EventSearchType eventSearchType, @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") int limit, @QueryParam("offset") @DefaultValue("0") Integer offset) {
         User userWithSession = this.userDAO.findById(user.getId());
         return getEventsForUser(userWithSession, eventSearchType, limit, offset);
     }
@@ -107,7 +107,7 @@ public class EventResource {
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A list of events", content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = Event.class))))
     @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
     public List<Event> getUserEvents(@ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId,
-        @QueryParam("event_search_type") EventSearchType eventSearchType,
+        @QueryParam("eventSearchType") EventSearchType eventSearchType,
         @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") int limit,
         @QueryParam("offset") @DefaultValue("0") Integer offset) {
         User user = this.userDAO.findById(userId);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
@@ -21,6 +21,7 @@ import static io.dockstore.webservice.jdbi.EventDAO.PAGINATION_RANGE;
 
 import com.codahale.metrics.annotation.Timed;
 import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Category;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Event;
 import io.dockstore.webservice.core.Organization;
@@ -35,6 +36,7 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -91,6 +93,7 @@ public class EventResource {
     @Operation(description = DESCRIPTION, summary = SUMMARY, security = @SecurityRequirement(name = "bearer"))
     @ApiOperation(value = SUMMARY, authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME)}, notes = DESCRIPTION, responseContainer = "List", response = Event.class)
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A list of events", content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = Event.class))))
     public List<Event> getEvents(@Parameter(hidden = true) @ApiParam(hidden = true) @Auth User user, @QueryParam("event_search_type") EventSearchType eventSearchType, @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") int limit, @QueryParam("offset") @DefaultValue("0") Integer offset) {
         User userWithSession = this.userDAO.findById(user.getId());
         return getEventsForUser(userWithSession, eventSearchType, limit, offset);
@@ -102,7 +105,7 @@ public class EventResource {
     @Path("/{userId}")
     @Operation(description = "No authentication.", summary = "Get events based on filter and user id.")
     @ApiOperation(value = "List recent events for a user.", notes = "No authentication.", response = Event.class, responseContainer = "List")
-    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A list of events", content = @Content(schema = @Schema(implementation = Event.class)))
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A list of events", content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = Event.class))))
     @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
     public List<Event> getUserEvents(@ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId,
         @QueryParam("event_search_type") EventSearchType eventSearchType,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -93,7 +94,10 @@ public class EventResource {
     @ApiOperation(value = SUMMARY, authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME)}, notes = DESCRIPTION, responseContainer = "List", response = Event.class)
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A list of events", content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = Event.class))))
-    public List<Event> getEvents(@Parameter(hidden = true) @ApiParam(hidden = true) @Auth User user, @QueryParam("eventSearchType") EventSearchType eventSearchType, @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") int limit, @QueryParam("offset") @DefaultValue("0") Integer offset) {
+    public List<Event> getEvents(@Parameter(hidden = true) @ApiParam(hidden = true) @Auth User user,
+        @NotNull @QueryParam("eventSearchType") EventSearchType eventSearchType,
+        @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") int limit,
+        @QueryParam("offset") @DefaultValue("0") Integer offset) {
         User userWithSession = this.userDAO.findById(user.getId());
         return getEventsForUser(userWithSession, eventSearchType, limit, offset);
     }
@@ -107,7 +111,7 @@ public class EventResource {
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A list of events", content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = Event.class))))
     @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "User not found")
     public List<Event> getUserEvents(@ApiParam(value = "User ID", required = true) @PathParam("userId") Long userId,
-        @QueryParam("eventSearchType") EventSearchType eventSearchType,
+        @NotNull @QueryParam("eventSearchType") EventSearchType eventSearchType,
         @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") int limit,
         @QueryParam("offset") @DefaultValue("0") Integer offset) {
         User user = this.userDAO.findById(userId);
@@ -124,10 +128,6 @@ public class EventResource {
      * @return A list of events
      */
     private List<Event> getEventsForUser(User user, EventSearchType eventSearchType, int limit, Integer offset) {
-        if (eventSearchType == null) {
-            return Collections.emptyList();
-        }
-
         switch (eventSearchType) {
         case STARRED_ENTRIES:
             Set<Long> entryIDs = user.getStarredEntries().stream().map(Entry::getId).collect(Collectors.toSet());

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -2452,14 +2452,14 @@ paths:
           format: int32
           default: 0
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Event'
-          description: default response
+          description: A list of events
       security:
       - bearer: []
       summary: Get events based on filters.
@@ -2503,7 +2503,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Event'
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
           description: A list of events
         "404":
           description: User not found

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -2430,7 +2430,8 @@ paths:
       operationId: getEvents
       parameters:
       - in: query
-        name: event_search_type
+        name: eventSearchType
+        required: true
         schema:
           type: string
           enum:
@@ -2477,7 +2478,8 @@ paths:
           type: integer
           format: int64
       - in: query
-        name: event_search_type
+        name: eventSearchType
+        required: true
         schema:
           type: string
           enum:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -2465,6 +2465,51 @@ paths:
       summary: Get events based on filters.
       tags:
       - events
+  /events/{userId}:
+    get:
+      description: No authentication.
+      operationId: getUserEvents
+      parameters:
+      - in: path
+        name: userId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - in: query
+        name: event_search_type
+        schema:
+          type: string
+          enum:
+          - STARRED_ENTRIES
+          - STARRED_ORGANIZATION
+          - ALL_STARRED
+      - in: query
+        name: limit
+        schema:
+          type: integer
+          format: int32
+          default: 10
+          maximum: 100
+          minimum: 1
+      - in: query
+        name: offset
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+          description: default response
+      summary: Get events based on filter and user id.
+      tags:
+      - events
   /ga4gh/trs/v2/service-info:
     get:
       operationId: getServiceInfo

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -2499,14 +2499,14 @@ paths:
           format: int32
           default: 0
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Event'
-          description: default response
+                $ref: '#/components/schemas/Event'
+          description: A list of events
+        "404":
+          description: User not found
       summary: Get events based on filter and user id.
       tags:
       - events

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -2724,6 +2724,51 @@ paths:
               $ref: "#/definitions/Event"
       security:
       - BEARER: []
+  /events/{userId}:
+    get:
+      tags:
+      - "events"
+      summary: "List recent events for a user."
+      description: "No authentication."
+      operationId: "getUserEvents"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "userId"
+        in: "path"
+        description: "User ID"
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "event_search_type"
+        in: "query"
+        required: false
+        type: "string"
+        enum:
+        - "STARRED_ENTRIES"
+        - "STARRED_ORGANIZATION"
+        - "ALL_STARRED"
+      - name: "limit"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 10
+        maximum: 100
+        minimum: 1
+        format: "int32"
+      - name: "offset"
+        in: "query"
+        required: false
+        type: "integer"
+        default: 0
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Event"
   /lambdaEvents/{organization}:
     get:
       tags:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -2693,9 +2693,9 @@ paths:
       produces:
       - "application/json"
       parameters:
-      - name: "event_search_type"
+      - name: "eventSearchType"
         in: "query"
-        required: false
+        required: true
         type: "string"
         enum:
         - "STARRED_ENTRIES"
@@ -2740,9 +2740,9 @@ paths:
         required: true
         type: "integer"
         format: "int64"
-      - name: "event_search_type"
+      - name: "eventSearchType"
         in: "query"
-        required: false
+        required: true
         type: "string"
         enum:
         - "STARRED_ENTRIES"


### PR DESCRIPTION
**Description**
This ticket adds a new **_public_** events endpoint, `/events/{userId}`, which returns the events based on the input user ID.

(Some odd CI build errors at the moment, they don't seem related to this PR)

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4313

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [X] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [X] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [X] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [X] Do not serve user-uploaded binary images through the Dockstore API
- [X] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [X] Do not create cookies, although this may change in the future
