### PR TITLE
remove context from unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,6 @@ workflows:
             - build
           context:
             - sonarcloud
-            - aws
       - workflow-integration-tests:
           <<: *common_filters
           requires:


### PR DESCRIPTION
**Description**
This context seems to be deactivated and unused.
Not sure how to explain why any build passed between the 5th and today though. 
Maybe it only fails-fast for new team members?

**Issue**

possible follow-up for https://github.com/dockstore/dockstore/pull/4850

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
