### PR TITLE
Modified config.yml so that it sends coverage results for the unit test to codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,8 @@ jobs:
           environment:
             TESTING_PROFILE: automated-review
   unit_test: # runs not using Workflows must have a `build` job as entry point
+    environment:
+      TESTING_PROFILE: unit_test
     parameters:
       aws_bucket:
         type: string


### PR DESCRIPTION
**Description**
This change should send details of the coverage of the unit_tests to github whenever pull request are made.

As such I am not tagging any reviewers yet as I want to ensure that my proposed fix actually works. I will update this pull request when I confirm that the correct codecov results are sent to this PR.

**Issue**
[DOCK-2032](https://ucsc-cgl.atlassian.net/browse/DOCK-2032)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ ] Check the Snyk dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
