### PR TITLE
Constrain sourcefile path db columns

### DIFF
--- a/dockstore-webservice/src/main/resources/migrations.1.13.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.13.0.xml
@@ -36,4 +36,11 @@
             <where>name = ''</where>
         </update>
     </changeSet>
+    <changeSet author="svonworl" id="constrainSourceFilePaths">
+        <sql dbms="postgresql">
+            <comment>Add some constraints to limit SourceFile paths to a "safe" set of characters</comment>
+            alter table sourcefile add constraint sourcefile_path_limit check (path ~ '^[-a-zA-Z0-9./_]*$');
+            alter table sourcefile add constraint sourcefile_absolutepath_limit check (absolutepath ~ '^[-a-zA-Z0-9./_]*$');
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**Description**
This PR implements the db constraint portion of https://ucsc-cgl.atlassian.net/browse/SEAB-4269.  PR #4907, which is targeted to `hotfix/1.12.1`, implements the rest of the issue.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4269

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
