### PR TITLE
Add pattern validation for /metadata/runner_dependencies (#SEAB-3980)

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * @author gluu
@@ -13,6 +14,9 @@ import java.util.Map;
  */
 public final class PipHelper {
     public static final String DEV_SEM_VER = "development-build";
+
+    // If changing the value below, search for cases where the compiled string is used in-place of the attribute.
+    public static final Pattern SEM_VER_PATTERN = Pattern.compile(String.format("^(\\d+)\\.(\\d+)\\.(\\d+)$|(^%s$)", DEV_SEM_VER));
 
     private PipHelper() { }
 
@@ -68,5 +72,14 @@ public final class PipHelper {
             pipDepMap.put(key, mapValue);
         });
         return pipDepMap;
+    }
+
+    /**
+     * Validates a string that represents a semantic version.
+     * @param semVer String representing a semantic version.
+     * @return true if the semantic version is valid else false.
+     */
+    public static boolean validateSemVer(String semVer) {
+        return Pattern.matches(SEM_VER_PATTERN.pattern(), semVer);
     }
 }

--- a/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
@@ -14,9 +14,8 @@ import java.util.regex.Pattern;
  */
 public final class PipHelper {
     public static final String DEV_SEM_VER = "development-build";
-
-    // If changing the value below, search for cases where the compiled string is used in-place of the attribute.
-    public static final Pattern SEM_VER_PATTERN = Pattern.compile(String.format("^(\\d+)\\.(\\d+)\\.(\\d+)$|(^%s$)", DEV_SEM_VER));
+    public static final String SEM_VER_STRING = "(^(\\d+)\\.(\\d+)\\.(\\d+)$)|(^" + DEV_SEM_VER + "$)";
+    public static final Pattern SEM_VER_PATTERN = Pattern.compile(SEM_VER_STRING);
 
     private PipHelper() { }
 
@@ -80,6 +79,6 @@ public final class PipHelper {
      * @return true if the semantic version is valid else false.
      */
     public static boolean validateSemVer(String semVer) {
-        return Pattern.matches(SEM_VER_PATTERN.pattern(), semVer);
+        return SEM_VER_PATTERN.matcher(semVer).matches();
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MetadataIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MetadataIT.java
@@ -9,6 +9,7 @@ import io.swagger.client.Pair;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,9 +44,9 @@ public class MetadataIT extends BaseIT {
     public void testValidClientVersion() {
         String endpoint = "/metadata/runner_dependencies";
         List<Pair> queryParams = this.queryParams();
-        queryParams.addAll(apiClient.parameterToPairs("", "client_version", "1.2.0"));
+        queryParams.addAll(apiClient.parameterToPairs("", "client_version", "1.13.0"));
         ApiResponse<Object> response = this.get_request(endpoint, queryParams);
-        Assert.assertEquals(200, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.OK_200, response.getStatusCode());
     }
 
     @Category(MetadataResource.class)
@@ -55,7 +56,7 @@ public class MetadataIT extends BaseIT {
         List<Pair> queryParams = this.queryParams();
         queryParams.addAll(apiClient.parameterToPairs("", "client_version", PipHelper.DEV_SEM_VER));
         ApiResponse<Object> response = this.get_request(endpoint, queryParams);
-        Assert.assertEquals(200, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.OK_200, response.getStatusCode());
     }
 
     @Category(MetadataResource.class)
@@ -65,8 +66,8 @@ public class MetadataIT extends BaseIT {
         List<Pair> queryParams = this.queryParams();
         queryParams.addAll(apiClient.parameterToPairs("", "client_version", "1.2"));
         ApiException exception = Assert.assertThrows(ApiException.class, () -> this.get_request(endpoint, queryParams));
-        Assert.assertEquals(400, exception.getCode());
-        Assert.assertEquals("Invalid client version: 1.2. Must match pattern: ^(\\d+)\\.(\\d+)\\.(\\d+)$|(^development-build$)",
+        Assert.assertEquals(HttpStatus.BAD_REQUEST_400, exception.getCode());
+        Assert.assertEquals("Invalid value for client version: `1.2`. Value must be like `1.13.0`)",
                             exception.getResponseBody());
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MetadataIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MetadataIT.java
@@ -1,0 +1,72 @@
+package io.dockstore.client.cli;
+
+import io.dockstore.common.PipHelper;
+import io.dockstore.webservice.resources.MetadataResource;
+import io.swagger.client.ApiClient;
+import io.swagger.client.ApiException;
+import io.swagger.client.ApiResponse;
+import io.swagger.client.Pair;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+import org.junit.experimental.categories.Category;
+
+@Category(OpenApiIT.class)
+public class MetadataIT extends BaseIT {
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+    public ApiClient apiClient = getWebClient();
+
+    public ApiResponse<Object> get_request(String endpoint, List<Pair> queryParams) {
+        return apiClient.invokeAPI(endpoint, "GET", queryParams, null, new HashMap<>(), new HashMap<>(), "application/json",
+                "application/json", new String[] { "BEARER" }, null);
+
+    }
+
+    public List<Pair> queryParams() {
+        List<Pair> queryParams = new ArrayList<>();
+        queryParams.addAll(apiClient.parameterToPairs("", "python_version", "3"));
+        queryParams.addAll(apiClient.parameterToPairs("", "runner", "cwltool"));
+        queryParams.addAll(apiClient.parameterToPairs("", "output", "json"));
+        return queryParams;
+    }
+
+    @Category(MetadataResource.class)
+    @Test
+    public void testValidClientVersion() {
+        String endpoint = "/metadata/runner_dependencies";
+        List<Pair> queryParams = this.queryParams();
+        queryParams.addAll(apiClient.parameterToPairs("", "client_version", "1.2.0"));
+        ApiResponse<Object> response = this.get_request(endpoint, queryParams);
+        Assert.assertEquals(200, response.getStatusCode());
+    }
+
+    @Category(MetadataResource.class)
+    @Test
+    public void testDevelopmentSemanticVersion() {
+        String endpoint = "/metadata/runner_dependencies";
+        List<Pair> queryParams = this.queryParams();
+        queryParams.addAll(apiClient.parameterToPairs("", "client_version", PipHelper.DEV_SEM_VER));
+        ApiResponse<Object> response = this.get_request(endpoint, queryParams);
+        Assert.assertEquals(200, response.getStatusCode());
+    }
+
+    @Category(MetadataResource.class)
+    @Test
+    public void testInvalidClientVersion() {
+        String endpoint = "/metadata/runner_dependencies";
+        List<Pair> queryParams = this.queryParams();
+        queryParams.addAll(apiClient.parameterToPairs("", "client_version", "1.2"));
+        ApiException exception = Assert.assertThrows(ApiException.class, () -> this.get_request(endpoint, queryParams));
+        Assert.assertEquals(400, exception.getCode());
+        Assert.assertEquals("Invalid client version: 1.2. Must match pattern: ^(\\d+)\\.(\\d+)\\.(\\d+)$|(^development-build$)",
+                            exception.getResponseBody());
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -288,7 +288,7 @@ public class MetadataResource {
         }
         boolean unwrap = !("json").equals(output);
         if (!PipHelper.validateSemVer(clientVersion)) {
-            throw new CustomWebApplicationException(String.format("Invalid value for client version: `%s`. Value must be like `1.13.0`)", clientVersion, PipHelper.SEM_VER_STRING),
+            throw new CustomWebApplicationException(String.format("Invalid value for client version: `%s`. Value must be like `1.13.0`)", clientVersion),
                                                     HttpStatus.SC_BAD_REQUEST);
         }
         String fileVersion = PipHelper.convertSemVerToAvailableVersion(clientVersion);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -274,7 +274,7 @@ public class MetadataResource {
         schema = @Schema(implementation = String.class)))
     @ApiOperation(value = "Returns the file containing runner dependencies.", response = String.class)
     public Response getRunnerDependencies(
-            @Parameter(name = "client_version", description = "The Dockstore client version")
+            @Parameter(name = "client_version", description = "The Dockstore client version", schema = @Schema(pattern = "(^(\\d+)\\.(\\d+)\\.(\\d+)$)|(^development-build$)"))
             @ApiParam(value = "The Dockstore client version") @QueryParam("client_version") String clientVersion,
             @Parameter(name = "python_version", description = "Python version, only relevant for the cwltool runner", in = ParameterIn.QUERY, schema = @Schema(defaultValue = "2"))
             @ApiParam(value = "Python version, only relevant for the cwltool runner") @DefaultValue("3") @QueryParam("python_version") String pythonVersion,
@@ -287,6 +287,9 @@ public class MetadataResource {
             return Response.noContent().build();
         }
         boolean unwrap = !("json").equals(output);
+        if (!PipHelper.validateSemVer(clientVersion)) {
+            throw new CustomWebApplicationException("Invalid client version: " + clientVersion + ". Must match pattern: " + PipHelper.SEM_VER_PATTERN.pattern(), HttpStatus.SC_BAD_REQUEST);
+        }
         String fileVersion = PipHelper.convertSemVerToAvailableVersion(clientVersion);
         try {
             String content = Resources.toString(this.getClass().getClassLoader()

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -274,8 +274,8 @@ public class MetadataResource {
         schema = @Schema(implementation = String.class)))
     @ApiOperation(value = "Returns the file containing runner dependencies.", response = String.class)
     public Response getRunnerDependencies(
-            @Parameter(name = "client_version", description = "The Dockstore client version", schema = @Schema(pattern = "(^(\\d+)\\.(\\d+)\\.(\\d+)$)|(^development-build$)"))
-            @ApiParam(value = "The Dockstore client version") @QueryParam("client_version") String clientVersion,
+            @Parameter(name = "client_version", description = "The Dockstore client version (e.g. 1.13.0)", schema = @Schema(pattern = PipHelper.SEM_VER_STRING))
+            @ApiParam(value = "The Dockstore client version (e.g. 1.13.0)") @QueryParam("client_version") String clientVersion,
             @Parameter(name = "python_version", description = "Python version, only relevant for the cwltool runner", in = ParameterIn.QUERY, schema = @Schema(defaultValue = "2"))
             @ApiParam(value = "Python version, only relevant for the cwltool runner") @DefaultValue("3") @QueryParam("python_version") String pythonVersion,
             @Parameter(name = "runner", description = "The tool runner", in = ParameterIn.QUERY, schema = @Schema(defaultValue = "cwltool", allowableValues = {"cwltool"}))
@@ -288,7 +288,8 @@ public class MetadataResource {
         }
         boolean unwrap = !("json").equals(output);
         if (!PipHelper.validateSemVer(clientVersion)) {
-            throw new CustomWebApplicationException("Invalid client version: " + clientVersion + ". Must match pattern: " + PipHelper.SEM_VER_PATTERN.pattern(), HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(String.format("Invalid value for client version: `%s`. Value must be like `1.13.0`)", clientVersion, PipHelper.SEM_VER_STRING),
+                                                    HttpStatus.SC_BAD_REQUEST);
         }
         String fileVersion = PipHelper.convertSemVerToAvailableVersion(clientVersion);
         try {

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3191,7 +3191,7 @@ paths:
       description: "Returns the file containing runner dependencies, NO authentication"
       operationId: getRunnerDependencies
       parameters:
-      - description: The Dockstore client version
+      - description: The Dockstore client version (e.g. 1.13.0)
         in: query
         name: client_version
         schema:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3196,6 +3196,7 @@ paths:
         name: client_version
         schema:
           type: string
+          pattern: (^(\d+)\.(\d+)\.(\d+)$)|(^development-build$)
       - description: "Python version, only relevant for the cwltool runner"
         in: query
         name: python_version

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -2917,7 +2917,7 @@ paths:
       parameters:
       - name: "client_version"
         in: "query"
-        description: "The Dockstore client version"
+        description: "The Dockstore client version (e.g. 1.13.0)"
         required: false
         type: "string"
       - name: "python_version"


### PR DESCRIPTION
**Description**
This PR adds pattern validation for the query parameter `client_version` on the endpoint
`/metadata/runner_dependencies`.

**Issue**
SEAB-3980

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
