### PR TITLE
DOCK-2066: fix nextflow 500s

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -281,7 +281,11 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
      * @return Input channel name
      */
     private String getInputChannelNameForEXPR(GroovySourceAST exprAST) {
-        return exprAST == null ? null : exprAST.getFirstChild().getFirstChild().getNextSibling().getFirstChild().getText();
+        try {
+            return exprAST.getFirstChild().getFirstChild().getNextSibling().getFirstChild().getText();
+        } catch (NullPointerException e) {
+            return null;
+        }
     }
 
     /**
@@ -292,7 +296,7 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
      */
     private String getProcessValue(GroovySourceAST processAST) {
         try {
-            return processAST == null ? null : processAST.getNextSibling().getFirstChild().getFirstChild().getText();
+            return processAST.getNextSibling().getFirstChild().getFirstChild().getText();
         } catch (NullPointerException e) {
             return null;
         }
@@ -462,6 +466,9 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
         try {
             StringBuilder builder = new StringBuilder();
             final List<GroovySourceAST> process = getGroovySourceASTList(mainDescriptor, "helpMessage");
+            if (process == null) {
+                return null;
+            }
             process.forEach(ast -> getHelpMessage(ast, builder, new HashSet<GroovySourceAST>()));
             return builder.toString();
         } catch (IOException | TokenStreamException | RecognitionException e) {
@@ -510,6 +517,9 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
      */
     private List<GroovySourceAST> getGroovySourceASTList(String mainDescriptor, String keyword)
         throws RecognitionException, TokenStreamException, IOException {
+        if (mainDescriptor == null) {
+            return null;
+        }
         try (InputStream stream = IOUtils.toInputStream(mainDescriptor, StandardCharsets.UTF_8)) {
             GroovyRecognizer make = GroovyRecognizer.make(new GroovyLexer(stream));
             make.compilationUnit();
@@ -530,6 +540,9 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
         if (mainDescriptor != null) {
             try {
                 List<GroovySourceAST> processList = getGroovySourceASTList(mainDescriptor, "process");
+                if (processList == null) {
+                    return map;
+                }
                 Map<String, List<String>> processNameToInputChannels = new HashMap<>();
                 Map<String, List<String>> processNameToOutputChannels = new HashMap<>();
 
@@ -572,6 +585,9 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
         if (mainDescriptor != null) {
             try {
                 List<GroovySourceAST> processList = getGroovySourceASTList(mainDescriptor, "process");
+                if (processList == null) {
+                    return map;
+                }
 
                 for (GroovySourceAST processAST : processList) {
                     String processName = getProcessValue(processAST);


### PR DESCRIPTION
**Description**
This PR fixes some 500s in the nextflow parsing code.  Kathy took care of lots of the previous 500s (yay!), but I sensed there were a few more lurking, so I tried to be proactive and fix them.

The final step of this PR was to remove some `ifs` that were rendered unnecessary.  This changed the indent level of a lot of code.  To see the changes prior to this step, view https://github.com/dockstore/dockstore/commit/95be530d369319bdca7682637ec8afeab55318b0

Changes in this PR:
1. Check the result of `getGroovySourceASTList` for null, which is returned not only when `mainDescriptor` is empty, but potentially in other cases, too.
2. Fix potential NPEs from `getInputChannelNameForEXPR`.
3. Simplify code in `getProcessValue` to match change number 2.
4. Modify `getGroovySourceASTList` so it handles the null `mainDescriptor` case, ensuring that any other future uses will do the right thing.

Note: I was not able to reproduce the bug with Charles' query, but I could with Kathy's.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2066
#4730

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
