### PR TITLE
re-create snyk suggestion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,6 @@ jobs:
     environment:
       TESTING_PROFILE: regression-integration-tests
     steps:
-      - old_python
       - setup_machine
       - setup_test
       - setup_postgres_docker
@@ -153,7 +152,6 @@ jobs:
     environment:
       TESTING_PROFILE: language-parsing-tests
     steps:
-      - old_python
       - setup_machine
       - install-pip
       - run:
@@ -376,16 +374,6 @@ commands:
           command: |
             docker exec -it -u postgres postgres1 psql -c "create user dockstore with password 'dockstore' createdb;"
             docker exec -it -u postgres postgres1 psql -c "create database webservice_test with owner = dockstore;"
-  old_python: # Need Python 3.6 for old Dockstore 1.7 requirements.txt
-    steps:
-      - run:
-          name: Install & use Python 3.6
-          command: |
-            sudo add-apt-repository ppa:deadsnakes/ppa
-            sudo apt-get update
-            sudo apt-get install python3.6 python3.6-dev python3.6-distutils python3-virtualenv
-            virtualenv -p /usr/bin/python3.6 venv
-            echo 'source venv/bin/activate' >> ~/.bashrc
   setup_machine:
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ executors:
     resource_class: medium+
   machine_integration_test_exec:
     machine: # run the steps with Ubuntu VM, warning this VM does not have a Java 17 equivalent (yet)
-      image: ubuntu-2204:2022.04.2
+      image: ubuntu-2004:202104-01
     environment:
       PGHOST: 127.0.0.1
     resource_class: medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
       - run: 
           name: build sam-cli
           command: |
-            pip3 install aws-sam-cli
+            pip3 install aws-sam-cli==1.52.0
             sudo apt install unzip
             wget https://github.com/dockstore/lambda/releases/download/0.1.6-SNAPSHOT/wdl-parsing.zip
             unzip wdl-parsing.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,8 +168,7 @@ jobs:
             unzip wdl-parsing.zip
             cd wdl-parsing
             # docker pull amazon/aws-sam-cli-build-image-java11
-            # cannot seem to `sam build --use-container` using local jdk and mvn instead
-            sam build --use-container --debug
+            sam build --debug
       - run:
           name: run sam-cli
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
           command: |
             pip3 install aws-sam-cli==1.52.0
             sudo apt install unzip
-            wget https://github.com/dockstore/lambda/releases/download/0.1.6-SNAPSHOT/wdl-parsing.zip
+            wget https://github.com/dockstore/lambda/releases/download/0.1.6-SNAPSHOT/wdl-parsing3.zip
             unzip wdl-parsing.zip
             cd wdl-parsing
             # docker pull amazon/aws-sam-cli-build-image-java11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,8 @@ jobs:
       - run: 
           name: build sam-cli
           command: |
+            # workaround https://github.com/aws/aws-sam-cli/issues/3791#issuecomment-1096604840
+            pip3 install Jinja2==2.11.3
             pip3 install aws-sam-cli==1.52.0
             sudo apt install unzip
             wget -O wdl-parsing.zip https://github.com/dockstore/lambda/releases/download/0.1.6-SNAPSHOT/wdl-parsing3.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
           command: |
             pip3 install aws-sam-cli==1.52.0
             sudo apt install unzip
-            wget https://github.com/dockstore/lambda/releases/download/0.1.6-SNAPSHOT/wdl-parsing3.zip
+            wget -O wdl-parsing.zip https://github.com/dockstore/lambda/releases/download/0.1.6-SNAPSHOT/wdl-parsing3.zip
             unzip wdl-parsing.zip
             cd wdl-parsing
             # docker pull amazon/aws-sam-cli-build-image-java11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,8 @@ jobs:
             unzip wdl-parsing.zip
             cd wdl-parsing
             # docker pull amazon/aws-sam-cli-build-image-java11
-            sam build --debug
+            # cannot seem to `sam build --use-container` using local jdk and mvn instead
+            sam build --use-container --debug
       - run:
           name: run sam-cli
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ executors:
     resource_class: medium+
   machine_integration_test_exec:
     machine: # run the steps with Ubuntu VM, warning this VM does not have a Java 17 equivalent (yet)
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2204:2022.04.2
     environment:
       PGHOST: 127.0.0.1
     resource_class: medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,7 @@ commands:
           name: install pip
           command: |
             sudo apt update
-            sudo apt install python3-distutils python3-dev python3-pip
+            sudo apt install python3-distutils python3-dev python3-pip libxml2-dev libxslt-dev
             # For debug purposes, a python3 version was installed in the image, pip is untagged
             python3 --version
             pip3 --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ jobs:
             cd wdl-parsing
             # docker pull amazon/aws-sam-cli-build-image-java11
             # cannot seem to `sam build --use-container` using local jdk and mvn instead
-            sam build --use-container
+            sam build --use-container --debug
       - run:
           name: run sam-cli
           command: |

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 355 third-party dependencies.
+Lists of 357 third-party dependencies.
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.12:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.12:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-slf4j (com.typesafe.akka:akka-slf4j_2.12:2.5.32 - https://akka.io/)
@@ -257,6 +257,10 @@ Lists of 355 third-party dependencies.
      (MIT License) JUL to SLF4J bridge (org.slf4j:jul-to-slf4j:1.7.36 - http://www.slf4j.org)
      (Eclipse Public License 1.0) JUnit (junit:junit:4.13.1 - http://junit.org)
      (Apache License 2.0) JVM Integration for Metrics (io.dropwizard.metrics:metrics-jvm:4.2.9 - https://metrics.dropwizard.io/metrics-jvm)
+     (The Apache License, Version 2.0) Kotlin Stdlib (org.jetbrains.kotlin:kotlin-stdlib:1.6.20 - https://kotlinlang.org/)
+     (The Apache License, Version 2.0) Kotlin Stdlib Common (org.jetbrains.kotlin:kotlin-stdlib-common:1.6.20 - https://kotlinlang.org/)
+     (The Apache License, Version 2.0) Kotlin Stdlib Jdk7 (org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.31 - https://kotlinlang.org/)
+     (The Apache License, Version 2.0) Kotlin Stdlib Jdk8 (org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31 - https://kotlinlang.org/)
      (The Apache Software License, Version 2.0) lang-mustache (org.elasticsearch.plugin:lang-mustache-client:7.10.2 - https://github.com/elastic/elasticsearch)
      (WDL License https://github.com/openwdl/wdl/blob/master/LICENSE) language-factory-core (org.broadinstitute:language-factory-core_2.12:77 - no url defined)
      (Apache License, Version 2.0) Liquibase (org.liquibase:liquibase-core:4.9.1 - http://www.liquibase.org/liquibase-root/liquibase-dist)
@@ -303,12 +307,10 @@ Lists of 355 third-party dependencies.
      (Apache License, Version 2.0) Netty/Transport/Native/Epoll (io.netty:netty-transport-native-epoll:4.1.72.Final - https://netty.io/netty-transport-native-epoll/)
      (Apache License, Version 2.0) Netty/Transport/Native/Unix/Common (io.netty:netty-transport-native-unix-common:4.1.72.Final - https://netty.io/netty-transport-native-unix-common/)
      (Apache License, Version 2.0) Objenesis (org.objenesis:objenesis:3.2 - http://objenesis.org/objenesis)
-     (The Apache Software License, Version 2.0) okhttp (com.squareup.okhttp3:okhttp:4.7.0 - https://square.github.io/okhttp/)
-     (The Apache Software License, Version 2.0) Okio (com.squareup.okio:okio:2.6.0 - https://github.com/square/okio/)
+     (The Apache Software License, Version 2.0) okhttp (com.squareup.okhttp3:okhttp:4.10.0 - https://square.github.io/okhttp/)
+     (The Apache Software License, Version 2.0) okio (com.squareup.okio:okio-jvm:3.0.0 - https://github.com/square/okio/)
      (The Apache License, Version 2.0) OpenCensus (io.opencensus:opencensus-api:0.31.0 - https://github.com/census-instrumentation/opencensus-java)
      (MIT License) ORCID - Model (org.orcid:orcid-model:3.0.4 - http://github.com/ORCID/orcid-model)
-     (The Apache License, Version 2.0) org.jetbrains.kotlin:kotlin-stdlib (org.jetbrains.kotlin:kotlin-stdlib:1.3.71 - https://kotlinlang.org/)
-     (The Apache License, Version 2.0) org.jetbrains.kotlin:kotlin-stdlib-common (org.jetbrains.kotlin:kotlin-stdlib-common:1.3.71 - https://kotlinlang.org/)
      (EPL 2.0) (GPL2 w/ CPE) OSGi resource locator (org.glassfish.hk2:osgi-resource-locator:1.0.3 - https://projects.eclipse.org/projects/ee4j/osgi-resource-locator)
      (MIT) parser (org.typelevel:jawn-parser_2.12:1.1.2 - http://github.com/typelevel/jawn)
      (The Apache Software License, Version 2.0) PF4J (org.pf4j:pf4j:3.2.0 - http://nexus.sonatype.org/oss-repository-hosting.html/pf4j-parent/pf4j)

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -64,7 +64,7 @@ POM as their parent.
         <postgresql.version>42.3.3</postgresql.version>
         <mockito.version>3.12.4</mockito.version>
         <cwlavro.version>2.0.4.7</cwlavro.version>
-        <okhttp.version>4.7.0</okhttp.version>
+        <okhttp.version>4.10.0</okhttp.version>
         <slf4j.version>1.7.36</slf4j.version>
         <swagger-ui.version>3.25.0</swagger-ui.version>
         <httpcomponents.version>4.5.13</httpcomponents.version>
@@ -1061,12 +1061,12 @@ POM as their parent.
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib</artifactId>
-                <version>1.3.71</version>
+                <version>1.6.20</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib-common</artifactId>
-                <version>1.3.71</version>
+                <version>1.6.20</version>
             </dependency>
 
 

--- a/dockstore-common/src/test/java/io/dockstore/client/cli/CWLClientIT.java
+++ b/dockstore-common/src/test/java/io/dockstore/client/cli/CWLClientIT.java
@@ -16,6 +16,7 @@
 
 package io.dockstore.client.cli;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.io.Resources;
@@ -63,9 +64,9 @@ public class CWLClientIT {
         final CWL cwl = new CWL();
         final ImmutablePair<String, String> output = cwl.parseCWL(resource.getFile());
         final Map<String, String> typeMap = cwl.extractCWLTypes(output.getLeft());
-        assertTrue(typeMap.size() == 3);
-        assertTrue("int".equals(typeMap.get("mem_gb")));
-        assertTrue("File".equals(typeMap.get("bam_input")));
+        assertEquals(3, typeMap.size());
+        assertEquals("int", typeMap.get("mem_gb"));
+        assertEquals("File", typeMap.get("bam_input"));
     }
 
     @Test

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -594,7 +594,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>4.7.0</version>
+      <version>4.10.0</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/dockstore-webservice/src/main/resources/requirements/1.10.0/requirements3.txt
+++ b/dockstore-webservice/src/main/resources/requirements/1.10.0/requirements3.txt
@@ -19,7 +19,7 @@ psutil==5.7.2
 pydot==1.4.1
 pyparsing==2.4.7
 python-dateutil==2.8.1
-rdflib==4.2.2
+rdflib==5.0.0
 rdflib-jsonld==0.5.0
 requests==2.24.0
 ruamel.yaml==0.16.5

--- a/dockstore-webservice/src/main/resources/requirements/1.10.0/requirements3.txt
+++ b/dockstore-webservice/src/main/resources/requirements/1.10.0/requirements3.txt
@@ -19,7 +19,7 @@ psutil==5.7.2
 pydot==1.4.1
 pyparsing==2.4.7
 python-dateutil==2.8.1
-rdflib==5.0.0
+rdflib==4.2.2
 rdflib-jsonld==0.5.0
 requests==2.24.0
 ruamel.yaml==0.16.5


### PR DESCRIPTION
**Description**
snyk doesn't understand generated pom.xml files well enough to auto-create upgrade PR
also transitive dependencies may mess it up

Ran into an issue with the sam-cli dying, went on a wild goose chase ended up with the following
- wdl-parsing lambda patched to try main maven repo first rather than broad first (broad artifactory seems very slow recently, should be redirecting to main repo anyway)
- took out python 3.6 (looked like dead-end code supporting CLI 1.7 regression testing which we don't do anymore)
- that broke the python sam install in a couple ways including https://github.com/aws/aws-sam-cli/issues/3791#issuecomment-1096604840
- oh, BTW, current CLI is broken on python 3.10 anyway due to https://github.com/ckan/ckanext-dcat/pull/213 (opening [ticket just in case)](https://github.com/dockstore/dockstore/issues/4961)

**Issue**
https://github.com/dockstore/dockstore/pull/4947
https://ucsc-cgl.atlassian.net/browse/SEAB-4489

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
