### PR TITLE
hook up initiator user to events endpoint and test

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BasicIT.java
@@ -293,6 +293,10 @@ public class BasicIT extends BaseIT {
         List<Event> eventsForFirstClient = client2EventsApi.getUserEvents(user.getId(), EventSearchType.STARRED_ENTRIES.toString(), 10, 0);
         assertEquals("The user should return 1 starred entry", 1, eventsForFirstClient.size());
 
+        // Get user initiated events by user id
+        List<Event> profileEventsForFirstClient = client2EventsApi.getUserEvents(user.getId(), EventSearchType.PROFILE.toString(), 10, 0);
+        assertTrue("The user events should be all intiiated by the client", !profileEventsForFirstClient.isEmpty() && profileEventsForFirstClient.stream().allMatch(e -> Objects.equals(e.getInitiatorUser().getId(), user.getId())));
+
         // Get the identified event
         Event event2 = eventsForFirstClient.get(0);
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -37,6 +37,7 @@ import org.hibernate.annotations.UpdateTimestamp;
     @NamedQuery(name = "io.dockstore.webservice.core.Event.deleteByEntryId", query = "DELETE from Event e where e.tool.id = :entryId OR e.workflow.id = :entryId OR e.apptool.id = :entryId"),
     @NamedQuery(name = "io.dockstore.webservice.core.Event.deleteByOrganizationId", query = "DELETE from Event e WHERE e.organization.id = :organizationId"),
     @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByUserId", query = "SELECT e FROM Event e where e.user.id = :userId"),
+    @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByInitiatorUserId", query = "SELECT e FROM Event e where e.initiatorUser.id = :initiatorUser"),
     @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByEntryId", query = "SELECT e FROM Event e where e.workflow.id = :entryId OR e.tool.id = :entryId OR e.apptool.id = :entryId"),
     @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllForOrganization", query = "SELECT eve FROM Event eve WHERE eve.organization.id = :organizationId ORDER BY id DESC"),
     @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByOrganizationIds", query = "SELECT e FROM Event e WHERE e.organization.id in :organizationIDs ORDER BY id DESC"),

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
@@ -49,6 +49,14 @@ public class EventDAO extends AbstractDAO<Event> {
         return list(query);
     }
 
+    public List<Event> findEventsForInitiatorUser(long initiatorUser, Integer offset, Integer limit) {
+        Query<Event> query = namedTypedQuery("io.dockstore.webservice.core.Event.findAllByInitiatorUserId")
+            .setParameter("initiatorUser", initiatorUser)
+            .setFirstResult(offset)
+            .setMaxResults(limit);
+        return list(query);
+    }
+
     public long countAllEventsForOrganization(long organizationId) {
         final Query query = namedQuery("io.dockstore.webservice.core.Event.countAllForOrganization")
                 .setParameter("organizationId", organizationId);
@@ -136,7 +144,7 @@ public class EventDAO extends AbstractDAO<Event> {
     public <T extends Entry> void publishEvent(boolean publish, User user, T entry) {
         final Builder builder = entry.getEventBuilder()
             .withType(publish ? EventType.PUBLISH_ENTRY : EventType.UNPUBLISH_ENTRY)
-            .withUser(user);
+            .withUser(user).withInitiatorUser(user);
         final Event event = builder.build();
         create(event);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
@@ -146,6 +146,10 @@ public class EventResource {
                 .findAllByOrganizationIdsOrEntryIds(organizationIDs2, entryIDs2, offset, limit);
             eagerLoadEventEntries(allByOrganizationIdsOrEntryIds);
             return allByOrganizationIdsOrEntryIds;
+        case PROFILE:
+            List<Event> eventsByUserID = this.eventDAO.findEventsForInitiatorUser(user.getId(), offset, limit);
+            eagerLoadEventEntries(eventsByUserID);
+            return eventsByUserID;
         default:
             return Collections.emptyList();
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventSearchType.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventSearchType.java
@@ -15,11 +15,15 @@
 
 package io.dockstore.webservice.resources;
 
-// STARRED_ENTRIES return events related to starred entries
-// STARRED_ORGANIZATION return events related to starred organization
-// STARRED returns events related to both starred entries AND starred organizations
+/**
+ * STARRED_ENTRIES return events related to starred entries (i.e. what has the user starred and finds interesting)
+ * STARRED_ORGANIZATION return events related to starred organization (i.e. what organizations has the user starred and finds interesting?)
+ * STARRED returns events related to both starred entries AND starred organizations
+ * PROFILE returns events about the user that others would be interested in (i.e. what has the user done that is interesting to others?)
+ */
 public enum EventSearchType  {
     STARRED_ENTRIES,
     STARRED_ORGANIZATION,
-    ALL_STARRED
+    ALL_STARRED,
+    PROFILE
 }

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -2440,6 +2440,7 @@ paths:
           - STARRED_ENTRIES
           - STARRED_ORGANIZATION
           - ALL_STARRED
+          - PROFILE
       - in: query
         name: limit
         schema:
@@ -2488,6 +2489,7 @@ paths:
           - STARRED_ENTRIES
           - STARRED_ORGANIZATION
           - ALL_STARRED
+          - PROFILE
       - in: query
         name: limit
         schema:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -2709,6 +2709,7 @@ paths:
         - "STARRED_ENTRIES"
         - "STARRED_ORGANIZATION"
         - "ALL_STARRED"
+        - "PROFILE"
       - name: "limit"
         in: "query"
         required: false
@@ -2756,6 +2757,7 @@ paths:
         - "STARRED_ENTRIES"
         - "STARRED_ORGANIZATION"
         - "ALL_STARRED"
+        - "PROFILE"
       - name: "limit"
         in: "query"
         required: false


### PR DESCRIPTION
**Description**
Hooks up a new mode to get the initiator user
I think this is the one other users would be interested 

Note most actions that distinguish between "UserId" (a user that is the subject of an action, say, the user being added to an org vs "InitiatiorID (a user that started an action, say the administrator that added a user to an org" have to do with manipulating organizations. Added publishing, I think this gets us started

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4476

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
