### PR TITLE
fix api links

### DIFF
--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ApiV2BetaVersionConverter.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ApiV2BetaVersionConverter.java
@@ -16,6 +16,7 @@
 package io.swagger.api.impl;
 
 import com.google.common.collect.Lists;
+import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.openapi.model.Checksum;
 import io.openapi.model.ImageData;
 import io.swagger.model.DescriptorType;
@@ -105,6 +106,8 @@ public final class ApiV2BetaVersionConverter {
         Tool betaTool = new Tool();
         try {
             BeanUtils.copyProperties(betaTool, tool);
+            betaTool.setUrl(betaTool.getUrl().replace(DockstoreWebserviceApplication.GA4GH_API_PATH_V2_FINAL, DockstoreWebserviceApplication.GA4GH_API_PATH_V2_BETA));
+            betaTool.setCheckerUrl(betaTool.getCheckerUrl().replace(DockstoreWebserviceApplication.GA4GH_API_PATH_V2_FINAL, DockstoreWebserviceApplication.GA4GH_API_PATH_V2_BETA));
             betaTool.setToolname(tool.getName());
             betaTool.setHasChecker(tool.isHasChecker());
             Set<String> authors = new HashSet<>();
@@ -138,6 +141,7 @@ public final class ApiV2BetaVersionConverter {
         ToolVersion betaToolVersion = new ToolVersion();
         try {
             BeanUtils.copyProperties(betaToolVersion, toolVersion);
+            betaToolVersion.setUrl(betaToolVersion.getUrl().replace(DockstoreWebserviceApplication.GA4GH_API_PATH_V2_FINAL, DockstoreWebserviceApplication.GA4GH_API_PATH_V2_BETA));
             // look like it has issues converting enums
             betaToolVersion.setDescriptorType(Lists.newArrayList());
             toolVersion.getDescriptorType().forEach(type -> betaToolVersion.getDescriptorType().add(DescriptorType.fromValue(type.name())));

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
@@ -426,7 +426,7 @@ public final class ToolsImplCommon {
         String basePath = MoreObjects.firstNonNull(config.getExternalConfig().getBasePath(), "/");
         // Example without the replace: "/api/" + "/api/ga4gh/v2" + "/tools/" = "/api//api/ga4gh/v2/tools"
         // Example with the replace: "/api/api/ga4gh/v2/tools"
-        String baseURI = basePath + DockstoreWebserviceApplication.GA4GH_API_PATH_V2_BETA.replaceFirst("/", "") + "/tools/";
+        String baseURI = basePath + DockstoreWebserviceApplication.GA4GH_API_PATH_V2_FINAL.replaceFirst("/", "") + "/tools/";
         URI uri = new URI(config.getExternalConfig().getScheme(), null, config.getExternalConfig().getHostname(), port, baseURI, null, null);
         return uri.toString();
     }

--- a/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
+++ b/dockstore-webservice/src/test/java/io/swagger/api/impl/ToolsImplCommonTest.java
@@ -15,6 +15,7 @@
  */
 package io.swagger.api.impl;
 
+import static io.dockstore.webservice.DockstoreWebserviceApplication.GA4GH_API_PATH_V2_BETA;
 import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -334,7 +335,7 @@ public class ToolsImplCommonTest {
         actualWorkflowVersion2.updateVerified();
         actualWorkflowVersion3.updateVerified();
         // Check that Dockstore version is actually has the right verified source
-        String[] expectedVerifiedSource = { "chickenTesterSource", "potatoTesterSource" };
+        String[] expectedVerifiedSource = {"chickenTesterSource", "potatoTesterSource"};
         String[] actualVerifiedSource = actualWorkflowVersion3.getVerifiedSources();
         Assert.assertArrayEquals(expectedVerifiedSource, actualVerifiedSource);
         workflow.addWorkflowVersion(actualWorkflowVersion1);
@@ -372,13 +373,13 @@ public class ToolsImplCommonTest {
                 expectedToolVersion1
                     .setId("#service/github.com/ICGC-TCGA-PanCancer/wdl-pcawg-sanger-cgp-workflow/" + toolname + ":" + reference2);
                 expectedToolVersion1.setUrl(
-                    "http://localhost:8080/api/ga4gh/v2/tools/%23service%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow%2F"
+                    "http://localhost:8080" + GA4GH_API_PATH_V2_BETA + "/tools/%23service%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow%2F"
                         + toolname + "/versions/" + reference2);
             } else {
                 expectedToolVersion1
                     .setId("#workflow/github.com/ICGC-TCGA-PanCancer/wdl-pcawg-sanger-cgp-workflow/" + toolname + ":" + reference2);
                 expectedToolVersion1.setUrl(
-                    "http://localhost:8080/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow%2F"
+                    "http://localhost:8080" + GA4GH_API_PATH_V2_BETA + "/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow%2F"
                         + toolname + "/versions/" + reference2);
             }
         } else {
@@ -386,11 +387,11 @@ public class ToolsImplCommonTest {
             if (isService) {
                 expectedToolVersion1.setId("#service/github.com/ICGC-TCGA-PanCancer/wdl-pcawg-sanger-cgp-workflow:" + reference2);
                 expectedToolVersion1.setUrl(
-                    "http://localhost:8080/api/ga4gh/v2/tools/%23service%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow/versions/"
+                    "http://localhost:8080" + GA4GH_API_PATH_V2_BETA + "/tools/%23service%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow/versions/"
                         + reference2);
             } else {
                 expectedToolVersion1.setUrl(
-                    "http://localhost:8080/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow/versions/"
+                    "http://localhost:8080" + GA4GH_API_PATH_V2_BETA + "/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow/versions/"
                         + reference2);
                 expectedToolVersion1.setId("#workflow/github.com/ICGC-TCGA-PanCancer/wdl-pcawg-sanger-cgp-workflow:" + reference2);
             }
@@ -423,13 +424,13 @@ public class ToolsImplCommonTest {
                 expectedToolVersion2
                     .setId("#service/github.com/ICGC-TCGA-PanCancer/wdl-pcawg-sanger-cgp-workflow/" + toolname + ":" + reference3);
                 expectedToolVersion2.setUrl(
-                    "http://localhost:8080/api/ga4gh/v2/tools/%23service%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow%2F"
+                    "http://localhost:8080" + GA4GH_API_PATH_V2_BETA + "/tools/%23service%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow%2F"
                         + toolname + "/versions/" + reference3);
             } else {
                 expectedToolVersion2
                     .setId("#workflow/github.com/ICGC-TCGA-PanCancer/wdl-pcawg-sanger-cgp-workflow/" + toolname + ":" + reference3);
                 expectedToolVersion2.setUrl(
-                    "http://localhost:8080/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow%2F"
+                    "http://localhost:8080" + GA4GH_API_PATH_V2_BETA + "/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow%2F"
                         + toolname + "/versions/" + reference3);
             }
         } else {
@@ -437,12 +438,12 @@ public class ToolsImplCommonTest {
             if (isService) {
                 expectedToolVersion2.setId("#service/github.com/ICGC-TCGA-PanCancer/wdl-pcawg-sanger-cgp-workflow:" + reference3);
                 expectedToolVersion2.setUrl(
-                    "http://localhost:8080/api/ga4gh/v2/tools/%23service%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow/versions/"
+                    "http://localhost:8080" + GA4GH_API_PATH_V2_BETA + "/tools/%23service%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow/versions/"
                         + reference3);
             } else {
                 expectedToolVersion2.setId("#workflow/github.com/ICGC-TCGA-PanCancer/wdl-pcawg-sanger-cgp-workflow:" + reference3);
                 expectedToolVersion2.setUrl(
-                    "http://localhost:8080/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow/versions/"
+                    "http://localhost:8080" + GA4GH_API_PATH_V2_BETA + "/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow/versions/"
                         + reference3);
             }
         }
@@ -457,32 +458,32 @@ public class ToolsImplCommonTest {
             if (isService) {
                 expectedTool.setId("#service/github.com/ICGC-TCGA-PanCancer/wdl-pcawg-sanger-cgp-workflow/" + toolname);
                 expectedTool.setUrl(
-                    "http://localhost:8080/api/ga4gh/v2/tools/%23service%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow%2F"
+                    "http://localhost:8080" + GA4GH_API_PATH_V2_BETA + "/tools/%23service%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow%2F"
                         + toolname);
             } else {
                 expectedTool.setId("#workflow/github.com/ICGC-TCGA-PanCancer/wdl-pcawg-sanger-cgp-workflow/" + toolname);
                 expectedTool.setUrl(
-                    "http://localhost:8080/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow%2F"
+                    "http://localhost:8080" + GA4GH_API_PATH_V2_BETA + "/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow%2F"
                         + toolname);
             }
             expectedTool.setToolname("wdl-pcawg-sanger-cgp-workflow/" + toolname);
             expectedTool.setCheckerUrl(
-                "http://localhost:8080/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow%2F"
+                "http://localhost:8080" + GA4GH_API_PATH_V2_BETA + "/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow%2F"
                     + toolname);
         } else {
 
             if (isService) {
                 expectedTool.setUrl(
-                    "http://localhost:8080/api/ga4gh/v2/tools/%23service%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow");
+                    "http://localhost:8080" + GA4GH_API_PATH_V2_BETA + "/tools/%23service%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow");
                 expectedTool.setId("#service/github.com/ICGC-TCGA-PanCancer/wdl-pcawg-sanger-cgp-workflow");
             } else {
                 expectedTool.setUrl(
-                    "http://localhost:8080/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow");
+                    "http://localhost:8080" + GA4GH_API_PATH_V2_BETA + "/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow");
                 expectedTool.setId("#workflow/github.com/ICGC-TCGA-PanCancer/wdl-pcawg-sanger-cgp-workflow");
             }
             expectedTool.setToolname("wdl-pcawg-sanger-cgp-workflow");
             expectedTool.setCheckerUrl(
-                "http://localhost:8080/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow");
+                "http://localhost:8080" + GA4GH_API_PATH_V2_BETA + "/tools/%23workflow%2Fgithub.com%2FICGC-TCGA-PanCancer%2Fwdl-pcawg-sanger-cgp-workflow");
         }
         expectedTool.setHasChecker(true);
         expectedTool.setToolclass(ToolClassesApiServiceImpl.getWorkflowClass());


### PR DESCRIPTION
**Description**
Working on API self links, looks like we simply forgot to update the converters and got confused with the caching of headers (these paths are not in the self link headers at all, but are simply part of the response object)

**Issue**
https://github.com/dockstore/dockstore/issues/4881

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
