### PR TITLE
DOCK-2186: include specified "filters" in TRS toolsGet next_page and last_page links

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2FinalIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2FinalIT.java
@@ -32,6 +32,7 @@ import io.dockstore.openapi.client.model.ToolVersion;
 import io.openapi.model.Service;
 import java.util.List;
 import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
@@ -398,4 +399,14 @@ public class GA4GHV2FinalIT extends GA4GHIT {
         // reset DB for other tests
         CommonTestUtilities.dropAndCreateWithTestData(SUPPORT, false);
     }
+
+    @Test
+    public void testGetHeaderLinksContainFilters() throws Exception {
+        Response response = checkedResponse(baseURL + "tools?toolClass=Tool&limit=1");
+        MultivaluedMap<String, Object> headers = response.getHeaders();
+        Assert.assertTrue(headers.get("self_link").toString().contains("toolClass=Tool"));
+        Assert.assertTrue(headers.get("last_page").toString().contains("toolClass=Tool"));
+        Assert.assertTrue(headers.get("next_page").toString().contains("toolClass=Tool"));
+    }
+
 }

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -375,6 +375,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         final long numPages = numEntries.sum() / actualLimit;
         responseBuilder.header("last_page", createUrlString(scheme, hostname, port, path, positionQuery(encodedQuery, actualLimit, numPages)));
 
+        trsListener.loadTRSResponse(hashcode, responseBuilder);
         return responseBuilder.build();
     }
 

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -370,7 +370,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         responseBuilder.header("current_limit", actualLimit);
         responseBuilder.header("self_link", createUrlString(scheme, hostname, port, path, query));
         if (startIndex + actualLimit < numEntries.sum()) {
-            responseBuilder.header("next_page", createUrlString(scheme, hostname, port, path, positionQuery(query, actualLimit, offsetInteger + 1)));
+            responseBuilder.header("next_page", createUrlString(scheme, hostname, port, path, positionQuery(query, actualLimit, offsetInteger + 1L)));
         }
         final long numPages = numEntries.sum() / actualLimit;
         responseBuilder.header("last_page", createUrlString(scheme, hostname, port, path, positionQuery(query, actualLimit, numPages)));
@@ -546,12 +546,6 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
             }
         }
         return entry;
-    }
-
-    private void handleParameter(String parameter, String queryName, List<String> filters) {
-        if (parameter != null) {
-            filters.add(queryName + "=" + parameter);
-        }
     }
 
     /**


### PR DESCRIPTION
**Description**
This PR corrects the `toolsGet` TRS endpoint so it includes the specified querystring "filters" (such as `toolClass=Workflow`) in the `next_page` and `last_page` URLs that it sends as headers in the response.  The prior code copied fields from the source URL to the generated URLs, by name, one-by-one, but appeared to have gotten out of sync and no longer completely enumerated all possible filter fields.  While in there, I cleaned up the adjacent code.

The solution is to rewrite the original querystring, by adding/substituting the appropriate values for the `limit` and `offset` fields, and use the result as the querystring of the forementioned URLs, precluding the possibility of similar bugs in the future.

In the prior code, the `self_link` URL, which is also included in the response, was constructed from the original query string.  I don't think that this technique introduces a security issue, since we're reusing part of a URL which has been submitted to and parsed by the webservice already, and we're reflecting the information in an inert form (as the querystring of a URL in a custom header), but please do consider any possible attack surfaces as you peruse this PR.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2186
https://github.com/dockstore/dockstore/issues/4957

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
