### PR TITLE
Upgrade swagger-ui to avoid XSS

### DIFF
--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -61,7 +61,6 @@ POM as their parent.
         <cwlavro.version>2.0.4.7</cwlavro.version>
         <okhttp.version>4.7.0</okhttp.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <swagger-ui.version>4.12.0</swagger-ui.version>
         <httpcomponents.version>4.5.13</httpcomponents.version>
         <httpcore.version>4.4.14</httpcore.version>
         <httpasyncclient.version>4.1.4</httpasyncclient.version>

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -61,7 +61,7 @@ POM as their parent.
         <cwlavro.version>2.0.4.7</cwlavro.version>
         <okhttp.version>4.7.0</okhttp.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <swagger-ui.version>3.25.0</swagger-ui.version>
+        <swagger-ui.version>4.12.0</swagger-ui.version>
         <httpcomponents.version>4.5.13</httpcomponents.version>
         <httpcore.version>4.4.14</httpcore.version>
         <httpasyncclient.version>4.1.4</httpasyncclient.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <openapi-annotations-version>2.1.7</openapi-annotations-version>
         <!-- Used for liquibase maven plugin. Somehow use version from bom-internal instead -->
         <postgresql.version>42.2.23</postgresql.version>
-        <swagger-ui.version>3.25.0</swagger-ui.version>
+        <swagger-ui.version>4.12.0</swagger-ui.version>
         <maven-surefire.version>3.0.0-M5</maven-surefire.version>
         <maven-failsafe.version>2.21.0</maven-failsafe.version>
 


### PR DESCRIPTION
**Description**

Swagger-UI is outdated and vulnerable to an XSS. This change upgrades it to the latest version. This fix should be followed by a method that better allows this to be scanned by our vulnerability management tools.

**Issue**

https://ucsc-cgl.atlassian.net/browse/SEAB-4536

A link to a github issue or SEAB- ticket (using that as a prefix)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [n/a] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [n/a] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [n/a] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
