### PR TITLE
Hotfix TRS file-fetching performance improvements

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -419,6 +419,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         ToolsApiServiceImpl.setServiceDAO(serviceDAO);
         ToolsApiServiceImpl.setAppToolDAO(appToolDAO);
         ToolsApiServiceImpl.setFileDAO(fileDAO);
+        ToolsApiServiceImpl.setVersionDAO(versionDAO);
         ToolsApiServiceImpl.setConfig(configuration);
         ToolsApiServiceImpl.setTrsListener(trsListener);
         ToolsApiServiceImpl.setAuthorizer(authorizer);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -44,6 +44,7 @@ import org.apache.commons.lang3.ObjectUtils;
 @Entity
 @SuppressWarnings("checkstyle:magicnumber")
 @Table(name = "tag", uniqueConstraints = @UniqueConstraint(name = "unique_tag_names", columnNames = { "parentid", "name" }))
+
 public class Tag extends Version<Tag> implements Comparable<Tag> {
 
     @Column

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -55,6 +55,7 @@ import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.Check;
+import org.hibernate.annotations.Filter;
 
 /**
  * This describes one tool in the dockstore, extending entry with fields necessary to describe bioinformatics tools.
@@ -161,6 +162,7 @@ public class Tool extends Entry<Tool, Tag> {
     @OrderBy("id")
     @Cascade(CascadeType.DETACH)
     @BatchSize(size = 25)
+    @Filter(name = "versionNameFilter")
     private final SortedSet<Tag> workflowVersions;
 
     @JsonIgnore

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -59,6 +59,9 @@ import org.apache.http.HttpStatus;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import org.hibernate.annotations.UpdateTimestamp;
 
 /**
@@ -80,6 +83,9 @@ import org.hibernate.annotations.UpdateTimestamp;
         ),
         @NamedQuery(name = "io.dockstore.webservice.core.Version.getCountByEntryId", query = "SELECT Count(v) FROM Version v WHERE v.parent.id = :id")
 })
+
+@FilterDef(name = "versionNameFilter", parameters = @ParamDef(name = "name", type = "string"), defaultCondition = "LOWER(:name) = LOWER(name)")
+@Filter(name = "versionNameFilter")
 
 @SuppressWarnings("checkstyle:magicnumber")
 public abstract class Version<T extends Version> implements Comparable<T> {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -53,6 +53,7 @@ import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.Check;
+import org.hibernate.annotations.Filter;
 
 /**
  * This describes one workflow in the dockstore, extending Entry with the fields necessary to describe workflows.
@@ -141,6 +142,7 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
     @OrderBy("id")
     @Cascade({ CascadeType.DETACH, CascadeType.SAVE_UPDATE })
     @BatchSize(size = 25)
+    @Filter(name = "versionNameFilter")
     private SortedSet<WorkflowVersion> workflowVersions;
 
     @JsonIgnore

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
@@ -58,4 +58,12 @@ public class VersionDAO<T extends Version> extends AbstractDAO<T> {
         query.setParameter("id", entryId);
         return (long)query.getSingleResult();
     }
+
+    public void enableNameFilter(String name) {
+        currentSession().enableFilter("versionNameFilter").setParameter("name", name);
+    }
+
+    public void disableNameFilter() {
+        currentSession().disableFilter("versionNameFilter");
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -16,7 +16,7 @@
 
 package io.dockstore.webservice.resources.proposedGA4GH;
 
-import static io.openapi.api.impl.ToolsApiServiceImpl.BAD_DECODE_RESPONSE;
+import static io.openapi.api.impl.ToolsApiServiceImpl.BAD_DECODE_REGISTRY_RESPONSE;
 
 import com.google.common.io.Resources;
 import io.dockstore.webservice.CustomWebApplicationException;
@@ -329,7 +329,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
         try {
             parsedID = new ToolsApiServiceImpl.ParsedRegistryID(id);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         Entry<?, ?> entry = impl.getEntry(parsedID, Optional.empty());
         Optional<? extends Version<?>> versionOptional;

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -49,6 +49,7 @@ import io.dockstore.webservice.jdbi.EntryDAO;
 import io.dockstore.webservice.jdbi.FileDAO;
 import io.dockstore.webservice.jdbi.ServiceDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
+import io.dockstore.webservice.jdbi.VersionDAO;
 import io.dockstore.webservice.jdbi.WorkflowDAO;
 import io.dockstore.webservice.permissions.PermissionsInterface;
 import io.dockstore.webservice.resources.AuthenticatedResourceInterface;
@@ -91,7 +92,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ToolsApiServiceImpl extends ToolsApiService implements AuthenticatedResourceInterface {
-    public static final Response BAD_DECODE_RESPONSE = Response.status(getExtendedStatus(Status.BAD_REQUEST, "Could not decode version")).build();
+    public static final Response BAD_DECODE_VERSION_RESPONSE = Response.status(getExtendedStatus(Status.BAD_REQUEST, "Could not decode version id")).build();
+    public static final Response BAD_DECODE_REGISTRY_RESPONSE = Response.status(getExtendedStatus(Status.BAD_REQUEST, "Could not decode registry id")).build();
 
     // Algorithms should come from: https://github.com/ga4gh-discovery/ga4gh-checksum/blob/master/hash-alg.csv
     public static final String DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS = "sha-256";
@@ -114,6 +116,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
     private static EntryVersionHelper<Workflow, WorkflowVersion, WorkflowDAO> workflowHelper;
     private static BioWorkflowDAO bioWorkflowDAO;
     private static PermissionsInterface permissionsInterface;
+    private static VersionDAO versionDAO;
 
     public static void setToolDAO(ToolDAO toolDAO) {
         ToolsApiServiceImpl.toolDAO = toolDAO;
@@ -147,6 +150,10 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         ToolsApiServiceImpl.fileDAO = fileDAO;
     }
 
+    public static void setVersionDAO(VersionDAO versionDAO) {
+        ToolsApiServiceImpl.versionDAO = versionDAO;
+    }
+
     public static void setTrsListener(TRSListener listener) {
         ToolsApiServiceImpl.trsListener = listener;
     }
@@ -165,7 +172,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         try {
             parsedID = new ParsedRegistryID(id);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         Entry<?, ?> entry = getEntry(parsedID, user);
         return buildToolResponse(entry, null, false);
@@ -177,7 +184,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         try {
             parsedID = new ParsedRegistryID(id);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         Entry<?, ?> entry = getEntry(parsedID, user);
         return buildToolResponse(entry, null, true);
@@ -218,13 +225,13 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         try {
             parsedID = new ParsedRegistryID(id);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         String newVersionId;
         try {
             newVersionId = URLDecoder.decode(versionId, StandardCharsets.UTF_8.displayName());
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_VERSION_RESPONSE;
         }
         Entry<?, ?> entry = getEntry(parsedID, user);
         return buildToolResponse(entry, newVersionId, false);
@@ -346,7 +353,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
             numEntries = getEntries(all, id, alias, toolClass, descriptorType, registry, organization, name, toolname, description, author, checker, user, actualLimit,
                 startIndex);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
 
         List<io.openapi.model.Tool> results = new ArrayList<>();
@@ -589,6 +596,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
      * @param unwrap       unwrap the file and present the descriptor sans wrapper model
      * @return a specific file wrapped in a response
      */
+    @SuppressWarnings("checkstyle:methodlength")
     private Response getFileByToolVersionID(String registryId, String versionIdParam, DescriptorLanguage.FileType type, String parameterPath,
         boolean unwrap, Optional<User> user) {
         Response.StatusType fileNotFoundStatus = getExtendedStatus(Status.NOT_FOUND,
@@ -599,145 +607,160 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         try {
             parsedID = new ParsedRegistryID(registryId);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         String versionId;
         try {
             versionId = URLDecoder.decode(versionIdParam, StandardCharsets.UTF_8.displayName());
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
-        }
-        Entry<?, ?> entry = getEntry(parsedID, user);
-
-        // check whether this is registered
-        if (entry == null) {
-            Response.StatusType status = getExtendedStatus(Status.NOT_FOUND, "incorrect id");
-            return Response.status(status).build();
+            return BAD_DECODE_VERSION_RESPONSE;
         }
 
-        boolean showHiddenVersions = false;
-        if (user.isPresent() && !AuthenticatedResourceInterface
-                .userCannotRead(user.get(), entry)) {
-            showHiddenVersions = true;
-        }
+        // The performance of this method was poor: to retrieve a single file for a particular version of an entry, it iterates through all of the entry's Versions, checking them one-by-one until it finds a match.
+        // See the related issue: https://github.com/dockstore/dockstore/issues/4480
+        //
+        // To improve performance, we enable a Filter that limits the subsequent queries to return only Version objects that match the specified version name.
+        // Similarly, when the filter is enabled, properly-annotated associations only contain Versions that match the specified version name.
+        // Upon exit from the following try block, the Filter is disabled, so that any subsequently-executed code will see all Versions, like normal.
+        // Essentially, the new code works/is the same as the original, except that, from its point-of-view, the only Versions that exist are the ones with the specified name.
+        // Thus, only the Version-of-interest is retrieved from the db, and all of the superfluous version db queries are avoided.
+        try {
+            versionDAO.enableNameFilter(versionId);
 
-        final io.openapi.model.Tool convertedTool = ToolsImplCommon.convertEntryToTool(entry, config, showHiddenVersions);
+            Entry<?, ?> entry = getEntry(parsedID, user);
 
-        String finalVersionId = versionId;
-        if (convertedTool == null || convertedTool.getVersions() == null) {
-            return Response.status(Status.NOT_FOUND).build();
-        }
-        final Optional<ToolVersion> convertedToolVersion = convertedTool.getVersions().stream()
-            .filter(toolVersion -> toolVersion.getName().equalsIgnoreCase(finalVersionId)).findFirst();
-        Optional<? extends Version<?>> entryVersion;
-        if (entry instanceof Tool) {
-            Tool toolEntry = (Tool)entry;
-            entryVersion = toolEntry.getWorkflowVersions().stream().filter(toolVersion -> toolVersion.getName().equalsIgnoreCase(finalVersionId))
-                .findFirst();
-        } else {
-            Workflow workflowEntry = (Workflow)entry;
-            entryVersion = workflowEntry.getWorkflowVersions().stream()
+            // check whether this is registered
+            if (entry == null) {
+                Response.StatusType status = getExtendedStatus(Status.NOT_FOUND, "incorrect id");
+                return Response.status(status).build();
+            }
+
+            boolean showHiddenVersions = false;
+            if (user.isPresent() && !AuthenticatedResourceInterface
+                    .userCannotRead(user.get(), entry)) {
+                showHiddenVersions = true;
+            }
+
+            final io.openapi.model.Tool convertedTool = ToolsImplCommon.convertEntryToTool(entry, config, showHiddenVersions);
+
+            String finalVersionId = versionId;
+            if (convertedTool == null || convertedTool.getVersions() == null) {
+                return Response.status(Status.NOT_FOUND).build();
+            }
+            final Optional<ToolVersion> convertedToolVersion = convertedTool.getVersions().stream()
                 .filter(toolVersion -> toolVersion.getName().equalsIgnoreCase(finalVersionId)).findFirst();
-        }
-
-        if (entryVersion.isEmpty()) {
-            Response.StatusType status = getExtendedStatus(Status.NOT_FOUND, "version not found");
-            return Response.status(status).build();
-        }
-
-        String urlBuilt;
-        String gitUrl = entry.getGitUrl();
-        if (gitUrl.startsWith(GITHUB_PREFIX)) {
-            urlBuilt = extractHTTPPrefix(gitUrl, entryVersion.get().getReference(), GITHUB_PREFIX, "https://raw.githubusercontent.com/");
-        } else if (gitUrl.startsWith(BITBUCKET_PREFIX)) {
-            urlBuilt = extractHTTPPrefix(gitUrl, entryVersion.get().getReference(), BITBUCKET_PREFIX, "https://bitbucket.org/");
-        } else {
-            LOG.error("Found a git url neither from BitBucket nor GitHub " + gitUrl);
-            urlBuilt = "https://unimplemented_git_repository/";
-        }
-
-        if (convertedToolVersion.isPresent()) {
-            final ToolVersion toolVersion = convertedToolVersion.get();
-            if (type.getCategory().equals(DescriptorLanguage.FileTypeCategory.TEST_FILE)) {
-                // this only works for test parameters associated with tools
-                List<SourceFile> testSourceFiles = new ArrayList<>();
-                try {
-                    testSourceFiles.addAll(toolHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO));
-                } catch (CustomWebApplicationException e) {
-                    LOG.warn("intentionally ignoring failure to get test parameters", e);
-                }
-                try {
-                    testSourceFiles.addAll(workflowHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO));
-                } catch (CustomWebApplicationException e) {
-                    LOG.warn("intentionally ignoring failure to get source files", e);
-                }
-
-                List<FileWrapper> toolTestsList = new ArrayList<>();
-
-                for (SourceFile file : testSourceFiles) {
-                    FileWrapper toolTests = ToolsImplCommon.sourceFileToToolTests(urlBuilt, file);
-                    toolTestsList.add(toolTests);
-                }
-                return Response.status(Status.OK).type(unwrap ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_JSON).entity(
-                    unwrap ? toolTestsList.stream().map(FileWrapper::getContent).filter(Objects::nonNull).collect(Collectors.joining("\n"))
-                        : toolTestsList).build();
-            }
-            if (type == DOCKERFILE) {
-                Optional<SourceFile> potentialDockerfile = entryVersion.get().getSourceFiles().stream()
-                    .filter(sourcefile -> sourcefile.getType() == DOCKERFILE).findFirst();
-                if (potentialDockerfile.isPresent()) {
-                    ExtendedFileWrapper dockerfile = new ExtendedFileWrapper();
-                    //TODO: hook up file checksum here
-                    dockerfile.setChecksum(convertToTRSChecksums(potentialDockerfile.get()));
-                    dockerfile.setContent(potentialDockerfile.get().getContent());
-                    dockerfile.setUrl(urlBuilt + ((Tag)entryVersion.get()).getDockerfilePath());
-                    dockerfile.setOriginalFile(potentialDockerfile.get());
-                    toolVersion.setContainerfile(true);
-                    List<FileWrapper> containerfilesList = new ArrayList<>();
-                    containerfilesList.add(dockerfile);
-                    return Response.status(Status.OK).type(unwrap ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_JSON)
-                        .entity(unwrap ? dockerfile.getContent() : containerfilesList).build();
-                } else {
-                    return Response.status(fileNotFoundStatus).build();
-                }
-            }
-            String path;
-            // figure out primary descriptors and use them if no relative path is specified
+            Optional<? extends Version<?>> entryVersion;
             if (entry instanceof Tool) {
-                if (type == DOCKSTORE_WDL) {
-                    path = ((Tag)entryVersion.get()).getWdlPath();
-                } else if (type == DOCKSTORE_CWL) {
-                    path = ((Tag)entryVersion.get()).getCwlPath();
-                } else {
-                    return Response.status(Status.NOT_FOUND).build();
+                Tool toolEntry = (Tool)entry;
+                entryVersion = toolEntry.getWorkflowVersions().stream().filter(toolVersion -> toolVersion.getName().equalsIgnoreCase(finalVersionId))
+                    .findFirst();
+            } else {
+                Workflow workflowEntry = (Workflow)entry;
+                entryVersion = workflowEntry.getWorkflowVersions().stream()
+                    .filter(toolVersion -> toolVersion.getName().equalsIgnoreCase(finalVersionId)).findFirst();
+            }
+
+            if (entryVersion.isEmpty()) {
+                Response.StatusType status = getExtendedStatus(Status.NOT_FOUND, "version not found");
+                return Response.status(status).build();
+            }
+
+            String urlBuilt;
+            String gitUrl = entry.getGitUrl();
+            if (gitUrl.startsWith(GITHUB_PREFIX)) {
+                urlBuilt = extractHTTPPrefix(gitUrl, entryVersion.get().getReference(), GITHUB_PREFIX, "https://raw.githubusercontent.com/");
+            } else if (gitUrl.startsWith(BITBUCKET_PREFIX)) {
+                urlBuilt = extractHTTPPrefix(gitUrl, entryVersion.get().getReference(), BITBUCKET_PREFIX, "https://bitbucket.org/");
+            } else {
+                LOG.error("Found a git url neither from BitBucket nor GitHub " + gitUrl);
+                urlBuilt = "https://unimplemented_git_repository/";
+            }
+
+            if (convertedToolVersion.isPresent()) {
+                final ToolVersion toolVersion = convertedToolVersion.get();
+                if (type.getCategory().equals(DescriptorLanguage.FileTypeCategory.TEST_FILE)) {
+                    // this only works for test parameters associated with tools
+                    List<SourceFile> testSourceFiles = new ArrayList<>();
+                    try {
+                        testSourceFiles.addAll(toolHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO));
+                    } catch (CustomWebApplicationException e) {
+                        LOG.warn("intentionally ignoring failure to get test parameters", e);
+                    }
+                    try {
+                        testSourceFiles.addAll(workflowHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO));
+                    } catch (CustomWebApplicationException e) {
+                        LOG.warn("intentionally ignoring failure to get source files", e);
+                    }
+
+                    List<FileWrapper> toolTestsList = new ArrayList<>();
+
+                    for (SourceFile file : testSourceFiles) {
+                        FileWrapper toolTests = ToolsImplCommon.sourceFileToToolTests(urlBuilt, file);
+                        toolTestsList.add(toolTests);
+                    }
+                    return Response.status(Status.OK).type(unwrap ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_JSON).entity(
+                        unwrap ? toolTestsList.stream().map(FileWrapper::getContent).filter(Objects::nonNull).collect(Collectors.joining("\n"))
+                            : toolTestsList).build();
                 }
-            } else {
-                path = ((WorkflowVersion)entryVersion.get()).getWorkflowPath();
-            }
-            String searchPath;
-            if (parameterPath != null) {
-                searchPath = parameterPath;
-            } else {
-                searchPath = path;
-            }
+                if (type == DOCKERFILE) {
+                    Optional<SourceFile> potentialDockerfile = entryVersion.get().getSourceFiles().stream()
+                        .filter(sourcefile -> sourcefile.getType() == DOCKERFILE).findFirst();
+                    if (potentialDockerfile.isPresent()) {
+                        ExtendedFileWrapper dockerfile = new ExtendedFileWrapper();
+                        //TODO: hook up file checksum here
+                        dockerfile.setChecksum(convertToTRSChecksums(potentialDockerfile.get()));
+                        dockerfile.setContent(potentialDockerfile.get().getContent());
+                        dockerfile.setUrl(urlBuilt + ((Tag)entryVersion.get()).getDockerfilePath());
+                        dockerfile.setOriginalFile(potentialDockerfile.get());
+                        toolVersion.setContainerfile(true);
+                        List<FileWrapper> containerfilesList = new ArrayList<>();
+                        containerfilesList.add(dockerfile);
+                        return Response.status(Status.OK).type(unwrap ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_JSON)
+                            .entity(unwrap ? dockerfile.getContent() : containerfilesList).build();
+                    } else {
+                        return Response.status(fileNotFoundStatus).build();
+                    }
+                }
+                String path;
+                // figure out primary descriptors and use them if no relative path is specified
+                if (entry instanceof Tool) {
+                    if (type == DOCKSTORE_WDL) {
+                        path = ((Tag)entryVersion.get()).getWdlPath();
+                    } else if (type == DOCKSTORE_CWL) {
+                        path = ((Tag)entryVersion.get()).getCwlPath();
+                    } else {
+                        return Response.status(Status.NOT_FOUND).build();
+                    }
+                } else {
+                    path = ((WorkflowVersion)entryVersion.get()).getWorkflowPath();
+                }
+                String searchPath;
+                if (parameterPath != null) {
+                    searchPath = parameterPath;
+                } else {
+                    searchPath = path;
+                }
 
-            final Set<SourceFile> sourceFiles = entryVersion.get().getSourceFiles();
+                final Set<SourceFile> sourceFiles = entryVersion.get().getSourceFiles();
 
-            Optional<SourceFile> correctSourceFile = lookForFilePath(sourceFiles, searchPath, entryVersion.get().getWorkingDirectory());
-            if (correctSourceFile.isPresent()) {
-                SourceFile sourceFile = correctSourceFile.get();
-                // annoyingly, test json and Dockerfiles include a fullpath whereas descriptors are just relative to the main descriptor,
-                // so in this stream we need to standardize relative to the main descriptor
-                final Path workingPath = Paths.get("/", entryVersion.get().getWorkingDirectory());
-                final Path relativize = workingPath.relativize(Paths.get(StringUtils.prependIfMissing(sourceFile.getAbsolutePath(), "/")));
-                String sourceFileUrl = urlBuilt + StringUtils.prependIfMissing(entryVersion.get().getWorkingDirectory(), "/") + StringUtils
-                    .prependIfMissing(relativize.toString(), "/");
-                ExtendedFileWrapper toolDescriptor = ToolsImplCommon.sourceFileToToolDescriptor(sourceFileUrl, sourceFile);
-                return Response.status(Status.OK).type(unwrap ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_JSON)
-                    .entity(unwrap ? sourceFile.getContent() : toolDescriptor).build();
+                Optional<SourceFile> correctSourceFile = lookForFilePath(sourceFiles, searchPath, entryVersion.get().getWorkingDirectory());
+                if (correctSourceFile.isPresent()) {
+                    SourceFile sourceFile = correctSourceFile.get();
+                    // annoyingly, test json and Dockerfiles include a fullpath whereas descriptors are just relative to the main descriptor,
+                    // so in this stream we need to standardize relative to the main descriptor
+                    final Path workingPath = Paths.get("/", entryVersion.get().getWorkingDirectory());
+                    final Path relativize = workingPath.relativize(Paths.get(StringUtils.prependIfMissing(sourceFile.getAbsolutePath(), "/")));
+                    String sourceFileUrl = urlBuilt + StringUtils.prependIfMissing(entryVersion.get().getWorkingDirectory(), "/") + StringUtils
+                        .prependIfMissing(relativize.toString(), "/");
+                    ExtendedFileWrapper toolDescriptor = ToolsImplCommon.sourceFileToToolDescriptor(sourceFileUrl, sourceFile);
+                    return Response.status(Status.OK).type(unwrap ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_JSON)
+                        .entity(unwrap ? sourceFile.getContent() : toolDescriptor).build();
+                }
             }
+            return Response.status(fileNotFoundStatus).build();
+        } finally {
+            versionDAO.disableNameFilter();
         }
-        return Response.status(fileNotFoundStatus).build();
     }
 
     public static List<Checksum> convertToTRSChecksums(final SourceFile sourceFile) {
@@ -808,7 +831,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         try {
             parsedID = new ParsedRegistryID(id);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         Entry<?, ?> entry = getEntry(parsedID, user);
         List<String> primaryDescriptorPaths = new ArrayList<>();


### PR DESCRIPTION
**Description**
This PR cherrypicks the TRS file-retrieval endpoint db performance improvement PR https://github.com/dockstore/dockstore/pull/4866 into the hotfix/1.12.1 branch.

**Issue**
Intended to address DNAStack-related db performance issues in production.
Original tickets:
https://ucsc-cgl.atlassian.net/browse/DOCK-1921 #4480

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
