### PR TITLE
Use Hibernate filter to improve fetching descriptors performance

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -419,6 +419,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         ToolsApiServiceImpl.setServiceDAO(serviceDAO);
         ToolsApiServiceImpl.setAppToolDAO(appToolDAO);
         ToolsApiServiceImpl.setFileDAO(fileDAO);
+        ToolsApiServiceImpl.setVersionDAO(versionDAO);
         ToolsApiServiceImpl.setConfig(configuration);
         ToolsApiServiceImpl.setTrsListener(trsListener);
         ToolsApiServiceImpl.setAuthorizer(authorizer);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tag.java
@@ -44,6 +44,7 @@ import org.apache.commons.lang3.ObjectUtils;
 @Entity
 @SuppressWarnings("checkstyle:magicnumber")
 @Table(name = "tag", uniqueConstraints = @UniqueConstraint(name = "unique_tag_names", columnNames = { "parentid", "name" }))
+
 public class Tag extends Version<Tag> implements Comparable<Tag> {
 
     @Column

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -55,6 +55,7 @@ import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.Check;
+import org.hibernate.annotations.Filter;
 
 /**
  * This describes one tool in the dockstore, extending entry with fields necessary to describe bioinformatics tools.
@@ -161,6 +162,7 @@ public class Tool extends Entry<Tool, Tag> {
     @OrderBy("id")
     @Cascade(CascadeType.DETACH)
     @BatchSize(size = 25)
+    @Filter(name = "versionNameFilter")
     private final SortedSet<Tag> workflowVersions;
 
     @JsonIgnore

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -59,6 +59,9 @@ import org.apache.http.HttpStatus;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 import org.hibernate.annotations.UpdateTimestamp;
 
 /**
@@ -80,6 +83,9 @@ import org.hibernate.annotations.UpdateTimestamp;
         ),
         @NamedQuery(name = "io.dockstore.webservice.core.Version.getCountByEntryId", query = "SELECT Count(v) FROM Version v WHERE v.parent.id = :id")
 })
+
+@FilterDef(name = "versionNameFilter", parameters = @ParamDef(name = "name", type = "string"), defaultCondition = "LOWER(:name) = LOWER(name)")
+@Filter(name = "versionNameFilter")
 
 @SuppressWarnings("checkstyle:magicnumber")
 public abstract class Version<T extends Version> implements Comparable<T> {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -53,6 +53,7 @@ import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.Check;
+import org.hibernate.annotations.Filter;
 
 /**
  * This describes one workflow in the dockstore, extending Entry with the fields necessary to describe workflows.
@@ -141,6 +142,7 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
     @OrderBy("id")
     @Cascade({ CascadeType.DETACH, CascadeType.SAVE_UPDATE })
     @BatchSize(size = 25)
+    @Filter(name = "versionNameFilter")
     private SortedSet<WorkflowVersion> workflowVersions;
 
     @JsonIgnore

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -170,27 +170,31 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
     /**
      * Return the primary descriptor (i.e. the dockstore.cwl or dockstore.wdl usually, or a single Dockerfile)
      *
-     * @param entryId  internal id for an entry
-     * @param tag      github reference
-     * @param fileType narrow the file to a specific type
+     * @param entryId    internal id for an entry
+     * @param tag        github reference
+     * @param fileType   narrow the file to a specific type
+     * @param versionDAO
      * @return return the primary descriptor or Dockerfile
      */
-    default SourceFile getSourceFile(long entryId, String tag, DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO) {
-        return getSourceFileByPath(entryId, tag, fileType, null, user, fileDAO);
+    default SourceFile getSourceFile(long entryId, String tag, DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO,
+            VersionDAO versionDAO) {
+        return getSourceFileByPath(entryId, tag, fileType, null, user, fileDAO, versionDAO);
     }
 
     /**
      * If path is null, return the first file with the correct path that matches.
      * If path is not null, return the primary descriptor (i.e. the dockstore.cwl or dockstore.wdl usually, or a single Dockerfile)
      *
-     * @param entryId  internal id for an entry
-     * @param tag      github reference
-     * @param fileType narrow the file to a specific type
-     * @param path     a specific path to a file
+     * @param entryId    internal id for an entry
+     * @param tag        github reference
+     * @param fileType   narrow the file to a specific type
+     * @param path       a specific path to a file
+     * @param versionDAO
      * @return a single file depending on parameters
      */
-    default SourceFile getSourceFileByPath(long entryId, String tag, DescriptorLanguage.FileType fileType, String path, Optional<User> user, FileDAO fileDAO) {
-        final Map<String, ImmutablePair<SourceFile, FileDescription>> sourceFiles = this.getSourceFiles(entryId, tag, fileType, user, fileDAO);
+    default SourceFile getSourceFileByPath(long entryId, String tag, DescriptorLanguage.FileType fileType, String path, Optional<User> user, FileDAO fileDAO,
+            VersionDAO versionDAO) {
+        final Map<String, ImmutablePair<SourceFile, FileDescription>> sourceFiles = this.getSourceFiles(entryId, tag, fileType, user, fileDAO, versionDAO);
         for (Map.Entry<String, ImmutablePair<SourceFile, FileDescription>> entry : sourceFiles.entrySet()) {
             if (path != null) {
                 //db stored paths are absolute, convert relative to absolute
@@ -211,8 +215,9 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
      * @param fileType the filetype we want to consider
      * @return a list of SourceFile
      */
-    default List<SourceFile> getAllSecondaryFiles(long workflowId, String tag, DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO) {
-        final Map<String, ImmutablePair<SourceFile, FileDescription>> sourceFiles = this.getSourceFiles(workflowId, tag, fileType, user, fileDAO);
+    default List<SourceFile> getAllSecondaryFiles(long workflowId, String tag, DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO, VersionDAO versionDAO) {
+        final Map<String, ImmutablePair<SourceFile, FileDescription>> sourceFiles = this.getSourceFiles(workflowId, tag, fileType, user, fileDAO,
+                versionDAO);
         return sourceFiles.entrySet().stream()
             .filter(entry -> entry.getValue().getLeft().getType().equals(fileType) && !entry.getValue().right.primaryDescriptor)
             .map(entry -> entry.getValue().getLeft()).collect(Collectors.toList());
@@ -225,102 +230,110 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
      * @param fileType the filetype we want to consider
      * @return a list of SourceFile
      */
-    default List<SourceFile> getAllSourceFiles(long workflowId, String tag, DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO) {
-        final Map<String, ImmutablePair<SourceFile, FileDescription>> sourceFiles = this.getSourceFiles(workflowId, tag, fileType, user, fileDAO);
+    default List<SourceFile> getAllSourceFiles(long workflowId, String tag, DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO, VersionDAO versionDAO) {
+        final Map<String, ImmutablePair<SourceFile, FileDescription>> sourceFiles = this.getSourceFiles(workflowId, tag, fileType, user, fileDAO,
+                versionDAO);
         return sourceFiles.entrySet().stream().filter(entry -> entry.getValue().getLeft().getType().equals(fileType))
             .map(entry -> entry.getValue().getLeft()).collect(Collectors.toList());
     }
 
     /**
      * This returns a map of file paths -> pairs of sourcefiles and descriptions of those sourcefiles
+     *
      * @param workflowId the database id for a workflow
-     * @param tag the version of the workflow
-     * @param fileType the type of file we're interested in
+     * @param tag        the version of the workflow
+     * @param fileType   the type of file we're interested in
+     * @param versionDAO
      * @return a map of file paths -> pairs of sourcefiles and descriptions of those sourcefiles
      */
     default Map<String, ImmutablePair<SourceFile, FileDescription>> getSourceFiles(long workflowId, String tag,
-            DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO) {
-        T entry = getDAO().findById(workflowId);
-        checkOptionalAuthRead(user, entry);
+            DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO, VersionDAO versionDAO) {
+        try {
+            versionDAO.enableNameFilter(tag);
+            T entry = getDAO().findById(workflowId);
+            checkOptionalAuthRead(user, entry);
 
-        // tighten permissions for hosted tools and workflows
-        if (!user.isPresent() || AuthenticatedResourceInterface.userCannotRead(user.get(), entry)) {
-            if (!entry.getIsPublished()) {
-                if (entry instanceof Tool && ((Tool)entry).getMode() == ToolMode.HOSTED) {
-                    throw new CustomWebApplicationException("Entry not published", HttpStatus.SC_FORBIDDEN);
+            // tighten permissions for hosted tools and workflows
+            if (!user.isPresent() || AuthenticatedResourceInterface.userCannotRead(user.get(), entry)) {
+                if (!entry.getIsPublished()) {
+                    if (entry instanceof Tool && ((Tool)entry).getMode() == ToolMode.HOSTED) {
+                        throw new CustomWebApplicationException("Entry not published", HttpStatus.SC_FORBIDDEN);
+                    }
+                    if (entry instanceof Workflow && ((Workflow)entry).getMode() == WorkflowMode.HOSTED) {
+                        throw new CustomWebApplicationException("Entry not published", HttpStatus.SC_FORBIDDEN);
+                    }
                 }
-                if (entry instanceof Workflow && ((Workflow)entry).getMode() == WorkflowMode.HOSTED) {
-                    throw new CustomWebApplicationException("Entry not published", HttpStatus.SC_FORBIDDEN);
-                }
+                this.filterContainersForHiddenTags(entry);
             }
-            this.filterContainersForHiddenTags(entry);
-        }
-        Version tagInstance = null;
+            Version tagInstance = null;
 
-        Map<String, ImmutablePair<SourceFile, FileDescription>> resultMap = new HashMap<>();
+            Map<String, ImmutablePair<SourceFile, FileDescription>> resultMap = new HashMap<>();
 
-        if (tag == null) {
-            // This is an assumption made for quay tools. Workflows will not have a latest unless it is created by the user,
-            // and would thus make more sense to use master for workflows.
-            tag = "latest";
-        }
-        final String finalTagName = tag;
-        tagInstance = entry.getWorkflowVersions().stream().filter(v -> v.getName().equals(finalTagName)).findFirst().orElse(null);
+            if (tag == null) {
+                // This is an assumption made for quay tools. Workflows will not have a latest unless it is created by the user,
+                // and would thus make more sense to use master for workflows.
+                tag = "latest";
+            }
+            final String finalTagName = tag;
+            tagInstance = entry.getWorkflowVersions().stream().filter(v -> v.getName().equals(finalTagName)).findFirst().orElse(null);
 
-        if (tagInstance == null) {
-            throw new CustomWebApplicationException("Invalid or missing tag " + tag + ".", HttpStatus.SC_BAD_REQUEST);
-        }
+            if (tagInstance == null) {
+                throw new CustomWebApplicationException("Invalid or missing tag " + tag + ".", HttpStatus.SC_BAD_REQUEST);
+            }
 
-        if (tagInstance instanceof WorkflowVersion) {
-            final WorkflowVersion workflowVersion = (WorkflowVersion)tagInstance;
-            List<SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(workflowVersion.getId());
-            List<SourceFile> filteredTypes = sourceFiles.stream()
-                .filter(file -> Objects.equals(file.getType(), fileType)).collect(Collectors.toList());
-            for (SourceFile file : filteredTypes) {
-                if (fileType == DescriptorLanguage.FileType.CWL_TEST_JSON || fileType == DescriptorLanguage.FileType.WDL_TEST_JSON || fileType == DescriptorLanguage.FileType.NEXTFLOW_TEST_PARAMS) {
-                    resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(true)));
-                } else {
-                    // looks like this takes into account a potentially different workflow path for a specific version of a workflow
-                    final String workflowPath = workflowVersion.getWorkflowPath();
-                    final String workflowVersionPath = workflowVersion.getWorkflowPath();
-                    final String actualPath =
-                        workflowVersionPath == null || workflowVersionPath.isEmpty() ? workflowPath : workflowVersionPath;
-                    boolean isPrimary = file.getType() == fileType && file.getPath().equalsIgnoreCase(actualPath);
+            if (tagInstance instanceof WorkflowVersion) {
+                final WorkflowVersion workflowVersion = (WorkflowVersion)tagInstance;
+                List<SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(workflowVersion.getId());
+                List<SourceFile> filteredTypes = sourceFiles.stream()
+                    .filter(file -> Objects.equals(file.getType(), fileType)).collect(Collectors.toList());
+                for (SourceFile file : filteredTypes) {
+                    if (fileType == DescriptorLanguage.FileType.CWL_TEST_JSON || fileType == DescriptorLanguage.FileType.WDL_TEST_JSON || fileType == DescriptorLanguage.FileType.NEXTFLOW_TEST_PARAMS) {
+                        resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(true)));
+                    } else {
+                        // looks like this takes into account a potentially different workflow path for a specific version of a workflow
+                        final String workflowPath = workflowVersion.getWorkflowPath();
+                        final String workflowVersionPath = workflowVersion.getWorkflowPath();
+                        final String actualPath =
+                            workflowVersionPath == null || workflowVersionPath.isEmpty() ? workflowPath : workflowVersionPath;
+                        boolean isPrimary = file.getType() == fileType && file.getPath().equalsIgnoreCase(actualPath);
+                        resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(isPrimary)));
+                    }
+                }
+            } else {
+                final Tool tool = (Tool)entry;
+                final Tag toolTag = (Tag)tagInstance;
+                List<SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(toolTag.getId());
+                List<SourceFile> filteredTypes = sourceFiles.stream().filter(file -> Objects.equals(file.getType(), fileType))
+                    .collect(Collectors.toList());
+                for (SourceFile file : filteredTypes) {
+                    // dockerfile is a special case since there always is only a max of one
+                    if (fileType == DescriptorLanguage.FileType.DOCKERFILE || fileType == DescriptorLanguage.FileType.CWL_TEST_JSON
+                        || fileType == DescriptorLanguage.FileType.WDL_TEST_JSON) {
+                        resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(true)));
+                        continue;
+                    }
+
+                    final String toolPath;
+                    String toolVersionPath;
+                    if (fileType == DescriptorLanguage.FileType.DOCKSTORE_CWL) {
+                        toolPath = tool.getDefaultCwlPath();
+                        toolVersionPath = toolTag.getCwlPath();
+                    } else if (fileType == DescriptorLanguage.FileType.DOCKSTORE_WDL) {
+                        toolPath = tool.getDefaultWdlPath();
+                        toolVersionPath = toolTag.getWdlPath();
+                    } else {
+                        throw new CustomWebApplicationException("Format " + fileType + " not valid", HttpStatus.SC_BAD_REQUEST);
+                    }
+
+                    final String actualPath = (toolVersionPath == null || toolVersionPath.isEmpty()) ? toolPath : toolVersionPath;
+                    boolean isPrimary = file.getType() == fileType && actualPath.equalsIgnoreCase(file.getPath());
                     resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(isPrimary)));
                 }
             }
-        } else {
-            final Tool tool = (Tool)entry;
-            final Tag toolTag = (Tag)tagInstance;
-            List<SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(toolTag.getId());
-            List<SourceFile> filteredTypes = sourceFiles.stream().filter(file -> Objects.equals(file.getType(), fileType))
-                .collect(Collectors.toList());
-            for (SourceFile file : filteredTypes) {
-                // dockerfile is a special case since there always is only a max of one
-                if (fileType == DescriptorLanguage.FileType.DOCKERFILE || fileType == DescriptorLanguage.FileType.CWL_TEST_JSON
-                    || fileType == DescriptorLanguage.FileType.WDL_TEST_JSON) {
-                    resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(true)));
-                    continue;
-                }
-
-                final String toolPath;
-                String toolVersionPath;
-                if (fileType == DescriptorLanguage.FileType.DOCKSTORE_CWL) {
-                    toolPath = tool.getDefaultCwlPath();
-                    toolVersionPath = toolTag.getCwlPath();
-                } else if (fileType == DescriptorLanguage.FileType.DOCKSTORE_WDL) {
-                    toolPath = tool.getDefaultWdlPath();
-                    toolVersionPath = toolTag.getWdlPath();
-                } else {
-                    throw new CustomWebApplicationException("Format " + fileType + " not valid", HttpStatus.SC_BAD_REQUEST);
-                }
-
-                final String actualPath = (toolVersionPath == null || toolVersionPath.isEmpty()) ? toolPath : toolVersionPath;
-                boolean isPrimary = file.getType() == fileType && actualPath.equalsIgnoreCase(file.getPath());
-                resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(isPrimary)));
-            }
+            return resultMap;
+        } finally {
+            versionDAO.disableNameFilter();
         }
-        return resultMap;
     }
 
     @SuppressWarnings("lgtm[java/path-injection]")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
@@ -58,4 +58,12 @@ public class VersionDAO<T extends Version> extends AbstractDAO<T> {
         query.setParameter("id", entryId);
         return (long)query.getSingleResult();
     }
+
+    public void enableNameFilter(String name) {
+        currentSession().enableFilter("versionNameFilter").setParameter("name", name);
+    }
+
+    public void disableNameFilter() {
+        currentSession().disableFilter("versionNameFilter");
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -61,6 +61,7 @@ import io.dockstore.webservice.jdbi.TagDAO;
 import io.dockstore.webservice.jdbi.TokenDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import io.dockstore.webservice.jdbi.UserDAO;
+import io.dockstore.webservice.jdbi.VersionDAO;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.swagger.annotations.Api;
@@ -134,6 +135,7 @@ public class DockerRepoResource
     private final LabelDAO labelDAO;
     private final FileDAO fileDAO;
     private final FileFormatDAO fileFormatDAO;
+    private final VersionDAO versionDAO;
     private final HttpClient client;
     private final String bitbucketClientID;
     private final String bitbucketClientSecret;
@@ -154,6 +156,7 @@ public class DockerRepoResource
         this.fileDAO = new FileDAO(sessionFactory);
         this.eventDAO = new EventDAO(sessionFactory);
         this.fileFormatDAO = new FileFormatDAO(sessionFactory);
+        this.versionDAO = new VersionDAO(sessionFactory);
         this.client = client;
 
         this.bitbucketClientID = configuration.getBitbucketClientID();
@@ -882,7 +885,7 @@ public class DockerRepoResource
     public SourceFile dockerfile(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag) {
 
-        return getSourceFile(containerId, tag, DescriptorLanguage.FileType.DOCKERFILE, user, fileDAO);
+        return getSourceFile(containerId, tag, DescriptorLanguage.FileType.DOCKERFILE, user, fileDAO, versionDAO);
     }
 
     // Add for new descriptor types
@@ -897,7 +900,7 @@ public class DockerRepoResource
     public SourceFile primaryDescriptor(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag, @QueryParam("language") String language) {
         final FileType fileType = DescriptorLanguage.getOptionalFileType(language).orElseThrow(() ->  new CustomWebApplicationException("Language not valid", HttpStatus.SC_BAD_REQUEST));
-        return getSourceFile(containerId, tag, fileType, user, fileDAO);
+        return getSourceFile(containerId, tag, fileType, user, fileDAO, versionDAO);
     }
 
     @GET
@@ -912,7 +915,7 @@ public class DockerRepoResource
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
         @PathParam("relative-path") String path, @QueryParam("language") String language) {
         final FileType fileType = DescriptorLanguage.getOptionalFileType(language).orElseThrow(() ->  new CustomWebApplicationException("Language not valid", HttpStatus.SC_BAD_REQUEST));
-        return getSourceFileByPath(containerId, tag, fileType, path, user, fileDAO);
+        return getSourceFileByPath(containerId, tag, fileType, path, user, fileDAO, versionDAO);
     }
 
     @GET
@@ -926,7 +929,7 @@ public class DockerRepoResource
     public List<SourceFile> secondaryDescriptors(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag, @QueryParam("language") DescriptorLanguage language) {
         final FileType fileType = language.getFileType();
-        return getAllSecondaryFiles(containerId, tag, fileType, user, fileDAO);
+        return getAllSecondaryFiles(containerId, tag, fileType, user, fileDAO, versionDAO);
     }
 
     @GET
@@ -941,7 +944,7 @@ public class DockerRepoResource
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
         @ApiParam(value = "Descriptor Type", required = true) @QueryParam("descriptorType") DescriptorLanguage descriptorLanguage) {
         final FileType testParameterType = descriptorLanguage.getTestParamType();
-        return getAllSourceFiles(containerId, tag, testParameterType, user, fileDAO);
+        return getAllSourceFiles(containerId, tag, testParameterType, user, fileDAO, versionDAO);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1127,7 +1127,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId,
         @QueryParam("tag") String tag, @QueryParam("language") String language) {
         final FileType fileType = DescriptorLanguage.getOptionalFileType(language).orElseThrow(() ->  new CustomWebApplicationException("Language not valid", HttpStatus.SC_BAD_REQUEST));
-        return getSourceFile(workflowId, tag, fileType, user, fileDAO);
+        return getSourceFile(workflowId, tag, fileType, user, fileDAO, versionDAO);
     }
 
     @GET
@@ -1142,7 +1142,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag,
         @PathParam("relative-path") String path, @QueryParam("language") DescriptorLanguage language) {
         final FileType fileType = language.getFileType();
-        return getSourceFileByPath(workflowId, tag, fileType, path, user, fileDAO);
+        return getSourceFileByPath(workflowId, tag, fileType, path, user, fileDAO, versionDAO);
     }
 
     @GET
@@ -1156,7 +1156,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     public List<SourceFile> secondaryDescriptors(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth Optional<User> user,
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag, @QueryParam("language") DescriptorLanguage language) {
         final FileType fileType = language.getFileType();
-        return getAllSecondaryFiles(workflowId, tag, fileType, user, fileDAO);
+        return getAllSecondaryFiles(workflowId, tag, fileType, user, fileDAO, versionDAO);
     }
 
 
@@ -1175,7 +1175,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         Workflow workflow = workflowDAO.findById(workflowId);
         checkEntry(workflow);
         FileType testParameterType = workflow.getTestParameterType();
-        return getAllSourceFiles(workflowId, version, testParameterType, user, fileDAO);
+        return getAllSourceFiles(workflowId, version, testParameterType, user, fileDAO, versionDAO);
     }
 
     @PUT

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -16,7 +16,7 @@
 
 package io.dockstore.webservice.resources.proposedGA4GH;
 
-import static io.openapi.api.impl.ToolsApiServiceImpl.BAD_DECODE_RESPONSE;
+import static io.openapi.api.impl.ToolsApiServiceImpl.BAD_DECODE_REGISTRY_RESPONSE;
 
 import com.google.common.io.Resources;
 import io.dockstore.webservice.CustomWebApplicationException;
@@ -329,7 +329,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
         try {
             parsedID = new ToolsApiServiceImpl.ParsedRegistryID(id);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         Entry<?, ?> entry = impl.getEntry(parsedID, Optional.empty());
         Optional<? extends Version<?>> versionOptional;

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -49,6 +49,7 @@ import io.dockstore.webservice.jdbi.EntryDAO;
 import io.dockstore.webservice.jdbi.FileDAO;
 import io.dockstore.webservice.jdbi.ServiceDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
+import io.dockstore.webservice.jdbi.VersionDAO;
 import io.dockstore.webservice.jdbi.WorkflowDAO;
 import io.dockstore.webservice.permissions.PermissionsInterface;
 import io.dockstore.webservice.resources.AuthenticatedResourceInterface;
@@ -91,7 +92,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ToolsApiServiceImpl extends ToolsApiService implements AuthenticatedResourceInterface {
-    public static final Response BAD_DECODE_RESPONSE = Response.status(getExtendedStatus(Status.BAD_REQUEST, "Could not decode version")).build();
+    public static final Response BAD_DECODE_VERSION_RESPONSE = Response.status(getExtendedStatus(Status.BAD_REQUEST, "Could not decode version id")).build();
+    public static final Response BAD_DECODE_REGISTRY_RESPONSE = Response.status(getExtendedStatus(Status.BAD_REQUEST, "Could not decode registry id")).build();
 
     // Algorithms should come from: https://github.com/ga4gh-discovery/ga4gh-checksum/blob/master/hash-alg.csv
     public static final String DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS = "sha-256";
@@ -114,6 +116,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
     private static EntryVersionHelper<Workflow, WorkflowVersion, WorkflowDAO> workflowHelper;
     private static BioWorkflowDAO bioWorkflowDAO;
     private static PermissionsInterface permissionsInterface;
+    private static VersionDAO versionDAO;
 
     public static void setToolDAO(ToolDAO toolDAO) {
         ToolsApiServiceImpl.toolDAO = toolDAO;
@@ -147,6 +150,10 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         ToolsApiServiceImpl.fileDAO = fileDAO;
     }
 
+    public static void setVersionDAO(VersionDAO versionDAO) {
+        ToolsApiServiceImpl.versionDAO = versionDAO;
+    }
+
     public static void setTrsListener(TRSListener listener) {
         ToolsApiServiceImpl.trsListener = listener;
     }
@@ -165,7 +172,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         try {
             parsedID = new ParsedRegistryID(id);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         Entry<?, ?> entry = getEntry(parsedID, user);
         return buildToolResponse(entry, null, false);
@@ -177,7 +184,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         try {
             parsedID = new ParsedRegistryID(id);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         Entry<?, ?> entry = getEntry(parsedID, user);
         return buildToolResponse(entry, null, true);
@@ -218,13 +225,13 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         try {
             parsedID = new ParsedRegistryID(id);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         String newVersionId;
         try {
             newVersionId = URLDecoder.decode(versionId, StandardCharsets.UTF_8.displayName());
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_VERSION_RESPONSE;
         }
         Entry<?, ?> entry = getEntry(parsedID, user);
         return buildToolResponse(entry, newVersionId, false);
@@ -346,7 +353,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
             numEntries = getEntries(all, id, alias, toolClass, descriptorType, registry, organization, name, toolname, description, author, checker, user, actualLimit,
                 startIndex);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
 
         List<io.openapi.model.Tool> results = new ArrayList<>();
@@ -589,6 +596,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
      * @param unwrap       unwrap the file and present the descriptor sans wrapper model
      * @return a specific file wrapped in a response
      */
+    @SuppressWarnings("checkstyle:methodlength")
     private Response getFileByToolVersionID(String registryId, String versionIdParam, DescriptorLanguage.FileType type, String parameterPath,
         boolean unwrap, Optional<User> user) {
         Response.StatusType fileNotFoundStatus = getExtendedStatus(Status.NOT_FOUND,
@@ -599,145 +607,160 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         try {
             parsedID = new ParsedRegistryID(registryId);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         String versionId;
         try {
             versionId = URLDecoder.decode(versionIdParam, StandardCharsets.UTF_8.displayName());
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
-        }
-        Entry<?, ?> entry = getEntry(parsedID, user);
-
-        // check whether this is registered
-        if (entry == null) {
-            Response.StatusType status = getExtendedStatus(Status.NOT_FOUND, "incorrect id");
-            return Response.status(status).build();
+            return BAD_DECODE_VERSION_RESPONSE;
         }
 
-        boolean showHiddenVersions = false;
-        if (user.isPresent() && !AuthenticatedResourceInterface
-                .userCannotRead(user.get(), entry)) {
-            showHiddenVersions = true;
-        }
+        // The performance of this method was poor: to retrieve a single file for a particular version of an entry, it iterates through all of the entry's Versions, checking them one-by-one until it finds a match.
+        // See the related issue: https://github.com/dockstore/dockstore/issues/4480
+        //
+        // To improve performance, we enable a Filter that limits the subsequent queries to return only Version objects that match the specified version name.
+        // Similarly, when the filter is enabled, properly-annotated associations only contain Versions that match the specified version name.
+        // Upon exit from the following try block, the Filter is disabled, so that any subsequently-executed code will see all Versions, like normal.
+        // Essentially, the new code works/is the same as the original, except that, from its point-of-view, the only Versions that exist are the ones with the specified name.
+        // Thus, only the Version-of-interest is retrieved from the db, and all of the superfluous version db queries are avoided.
+        try {
+            versionDAO.enableNameFilter(versionId);
 
-        final io.openapi.model.Tool convertedTool = ToolsImplCommon.convertEntryToTool(entry, config, showHiddenVersions);
+            Entry<?, ?> entry = getEntry(parsedID, user);
 
-        String finalVersionId = versionId;
-        if (convertedTool == null || convertedTool.getVersions() == null) {
-            return Response.status(Status.NOT_FOUND).build();
-        }
-        final Optional<ToolVersion> convertedToolVersion = convertedTool.getVersions().stream()
-            .filter(toolVersion -> toolVersion.getName().equalsIgnoreCase(finalVersionId)).findFirst();
-        Optional<? extends Version<?>> entryVersion;
-        if (entry instanceof Tool) {
-            Tool toolEntry = (Tool)entry;
-            entryVersion = toolEntry.getWorkflowVersions().stream().filter(toolVersion -> toolVersion.getName().equalsIgnoreCase(finalVersionId))
-                .findFirst();
-        } else {
-            Workflow workflowEntry = (Workflow)entry;
-            entryVersion = workflowEntry.getWorkflowVersions().stream()
+            // check whether this is registered
+            if (entry == null) {
+                Response.StatusType status = getExtendedStatus(Status.NOT_FOUND, "incorrect id");
+                return Response.status(status).build();
+            }
+
+            boolean showHiddenVersions = false;
+            if (user.isPresent() && !AuthenticatedResourceInterface
+                    .userCannotRead(user.get(), entry)) {
+                showHiddenVersions = true;
+            }
+
+            final io.openapi.model.Tool convertedTool = ToolsImplCommon.convertEntryToTool(entry, config, showHiddenVersions);
+
+            String finalVersionId = versionId;
+            if (convertedTool == null || convertedTool.getVersions() == null) {
+                return Response.status(Status.NOT_FOUND).build();
+            }
+            final Optional<ToolVersion> convertedToolVersion = convertedTool.getVersions().stream()
                 .filter(toolVersion -> toolVersion.getName().equalsIgnoreCase(finalVersionId)).findFirst();
-        }
-
-        if (entryVersion.isEmpty()) {
-            Response.StatusType status = getExtendedStatus(Status.NOT_FOUND, "version not found");
-            return Response.status(status).build();
-        }
-
-        String urlBuilt;
-        String gitUrl = entry.getGitUrl();
-        if (gitUrl.startsWith(GITHUB_PREFIX)) {
-            urlBuilt = extractHTTPPrefix(gitUrl, entryVersion.get().getReference(), GITHUB_PREFIX, "https://raw.githubusercontent.com/");
-        } else if (gitUrl.startsWith(BITBUCKET_PREFIX)) {
-            urlBuilt = extractHTTPPrefix(gitUrl, entryVersion.get().getReference(), BITBUCKET_PREFIX, "https://bitbucket.org/");
-        } else {
-            LOG.error("Found a git url neither from BitBucket nor GitHub " + gitUrl);
-            urlBuilt = "https://unimplemented_git_repository/";
-        }
-
-        if (convertedToolVersion.isPresent()) {
-            final ToolVersion toolVersion = convertedToolVersion.get();
-            if (type.getCategory().equals(DescriptorLanguage.FileTypeCategory.TEST_FILE)) {
-                // this only works for test parameters associated with tools
-                List<SourceFile> testSourceFiles = new ArrayList<>();
-                try {
-                    testSourceFiles.addAll(toolHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO));
-                } catch (CustomWebApplicationException e) {
-                    LOG.warn("intentionally ignoring failure to get test parameters", e);
-                }
-                try {
-                    testSourceFiles.addAll(workflowHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO));
-                } catch (CustomWebApplicationException e) {
-                    LOG.warn("intentionally ignoring failure to get source files", e);
-                }
-
-                List<FileWrapper> toolTestsList = new ArrayList<>();
-
-                for (SourceFile file : testSourceFiles) {
-                    FileWrapper toolTests = ToolsImplCommon.sourceFileToToolTests(urlBuilt, file);
-                    toolTestsList.add(toolTests);
-                }
-                return Response.status(Status.OK).type(unwrap ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_JSON).entity(
-                    unwrap ? toolTestsList.stream().map(FileWrapper::getContent).filter(Objects::nonNull).collect(Collectors.joining("\n"))
-                        : toolTestsList).build();
-            }
-            if (type == DOCKERFILE) {
-                Optional<SourceFile> potentialDockerfile = entryVersion.get().getSourceFiles().stream()
-                    .filter(sourcefile -> sourcefile.getType() == DOCKERFILE).findFirst();
-                if (potentialDockerfile.isPresent()) {
-                    ExtendedFileWrapper dockerfile = new ExtendedFileWrapper();
-                    //TODO: hook up file checksum here
-                    dockerfile.setChecksum(convertToTRSChecksums(potentialDockerfile.get()));
-                    dockerfile.setContent(potentialDockerfile.get().getContent());
-                    dockerfile.setUrl(urlBuilt + ((Tag)entryVersion.get()).getDockerfilePath());
-                    dockerfile.setOriginalFile(potentialDockerfile.get());
-                    toolVersion.setContainerfile(true);
-                    List<FileWrapper> containerfilesList = new ArrayList<>();
-                    containerfilesList.add(dockerfile);
-                    return Response.status(Status.OK).type(unwrap ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_JSON)
-                        .entity(unwrap ? dockerfile.getContent() : containerfilesList).build();
-                } else {
-                    return Response.status(fileNotFoundStatus).build();
-                }
-            }
-            String path;
-            // figure out primary descriptors and use them if no relative path is specified
+            Optional<? extends Version<?>> entryVersion;
             if (entry instanceof Tool) {
-                if (type == DOCKSTORE_WDL) {
-                    path = ((Tag)entryVersion.get()).getWdlPath();
-                } else if (type == DOCKSTORE_CWL) {
-                    path = ((Tag)entryVersion.get()).getCwlPath();
-                } else {
-                    return Response.status(Status.NOT_FOUND).build();
+                Tool toolEntry = (Tool)entry;
+                entryVersion = toolEntry.getWorkflowVersions().stream().filter(toolVersion -> toolVersion.getName().equalsIgnoreCase(finalVersionId))
+                    .findFirst();
+            } else {
+                Workflow workflowEntry = (Workflow)entry;
+                entryVersion = workflowEntry.getWorkflowVersions().stream()
+                    .filter(toolVersion -> toolVersion.getName().equalsIgnoreCase(finalVersionId)).findFirst();
+            }
+
+            if (entryVersion.isEmpty()) {
+                Response.StatusType status = getExtendedStatus(Status.NOT_FOUND, "version not found");
+                return Response.status(status).build();
+            }
+
+            String urlBuilt;
+            String gitUrl = entry.getGitUrl();
+            if (gitUrl.startsWith(GITHUB_PREFIX)) {
+                urlBuilt = extractHTTPPrefix(gitUrl, entryVersion.get().getReference(), GITHUB_PREFIX, "https://raw.githubusercontent.com/");
+            } else if (gitUrl.startsWith(BITBUCKET_PREFIX)) {
+                urlBuilt = extractHTTPPrefix(gitUrl, entryVersion.get().getReference(), BITBUCKET_PREFIX, "https://bitbucket.org/");
+            } else {
+                LOG.error("Found a git url neither from BitBucket nor GitHub " + gitUrl);
+                urlBuilt = "https://unimplemented_git_repository/";
+            }
+
+            if (convertedToolVersion.isPresent()) {
+                final ToolVersion toolVersion = convertedToolVersion.get();
+                if (type.getCategory().equals(DescriptorLanguage.FileTypeCategory.TEST_FILE)) {
+                    // this only works for test parameters associated with tools
+                    List<SourceFile> testSourceFiles = new ArrayList<>();
+                    try {
+                        testSourceFiles.addAll(toolHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO));
+                    } catch (CustomWebApplicationException e) {
+                        LOG.warn("intentionally ignoring failure to get test parameters", e);
+                    }
+                    try {
+                        testSourceFiles.addAll(workflowHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO));
+                    } catch (CustomWebApplicationException e) {
+                        LOG.warn("intentionally ignoring failure to get source files", e);
+                    }
+
+                    List<FileWrapper> toolTestsList = new ArrayList<>();
+
+                    for (SourceFile file : testSourceFiles) {
+                        FileWrapper toolTests = ToolsImplCommon.sourceFileToToolTests(urlBuilt, file);
+                        toolTestsList.add(toolTests);
+                    }
+                    return Response.status(Status.OK).type(unwrap ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_JSON).entity(
+                        unwrap ? toolTestsList.stream().map(FileWrapper::getContent).filter(Objects::nonNull).collect(Collectors.joining("\n"))
+                            : toolTestsList).build();
                 }
-            } else {
-                path = ((WorkflowVersion)entryVersion.get()).getWorkflowPath();
-            }
-            String searchPath;
-            if (parameterPath != null) {
-                searchPath = parameterPath;
-            } else {
-                searchPath = path;
-            }
+                if (type == DOCKERFILE) {
+                    Optional<SourceFile> potentialDockerfile = entryVersion.get().getSourceFiles().stream()
+                        .filter(sourcefile -> sourcefile.getType() == DOCKERFILE).findFirst();
+                    if (potentialDockerfile.isPresent()) {
+                        ExtendedFileWrapper dockerfile = new ExtendedFileWrapper();
+                        //TODO: hook up file checksum here
+                        dockerfile.setChecksum(convertToTRSChecksums(potentialDockerfile.get()));
+                        dockerfile.setContent(potentialDockerfile.get().getContent());
+                        dockerfile.setUrl(urlBuilt + ((Tag)entryVersion.get()).getDockerfilePath());
+                        dockerfile.setOriginalFile(potentialDockerfile.get());
+                        toolVersion.setContainerfile(true);
+                        List<FileWrapper> containerfilesList = new ArrayList<>();
+                        containerfilesList.add(dockerfile);
+                        return Response.status(Status.OK).type(unwrap ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_JSON)
+                            .entity(unwrap ? dockerfile.getContent() : containerfilesList).build();
+                    } else {
+                        return Response.status(fileNotFoundStatus).build();
+                    }
+                }
+                String path;
+                // figure out primary descriptors and use them if no relative path is specified
+                if (entry instanceof Tool) {
+                    if (type == DOCKSTORE_WDL) {
+                        path = ((Tag)entryVersion.get()).getWdlPath();
+                    } else if (type == DOCKSTORE_CWL) {
+                        path = ((Tag)entryVersion.get()).getCwlPath();
+                    } else {
+                        return Response.status(Status.NOT_FOUND).build();
+                    }
+                } else {
+                    path = ((WorkflowVersion)entryVersion.get()).getWorkflowPath();
+                }
+                String searchPath;
+                if (parameterPath != null) {
+                    searchPath = parameterPath;
+                } else {
+                    searchPath = path;
+                }
 
-            final Set<SourceFile> sourceFiles = entryVersion.get().getSourceFiles();
+                final Set<SourceFile> sourceFiles = entryVersion.get().getSourceFiles();
 
-            Optional<SourceFile> correctSourceFile = lookForFilePath(sourceFiles, searchPath, entryVersion.get().getWorkingDirectory());
-            if (correctSourceFile.isPresent()) {
-                SourceFile sourceFile = correctSourceFile.get();
-                // annoyingly, test json and Dockerfiles include a fullpath whereas descriptors are just relative to the main descriptor,
-                // so in this stream we need to standardize relative to the main descriptor
-                final Path workingPath = Paths.get("/", entryVersion.get().getWorkingDirectory());
-                final Path relativize = workingPath.relativize(Paths.get(StringUtils.prependIfMissing(sourceFile.getAbsolutePath(), "/")));
-                String sourceFileUrl = urlBuilt + StringUtils.prependIfMissing(entryVersion.get().getWorkingDirectory(), "/") + StringUtils
-                    .prependIfMissing(relativize.toString(), "/");
-                ExtendedFileWrapper toolDescriptor = ToolsImplCommon.sourceFileToToolDescriptor(sourceFileUrl, sourceFile);
-                return Response.status(Status.OK).type(unwrap ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_JSON)
-                    .entity(unwrap ? sourceFile.getContent() : toolDescriptor).build();
+                Optional<SourceFile> correctSourceFile = lookForFilePath(sourceFiles, searchPath, entryVersion.get().getWorkingDirectory());
+                if (correctSourceFile.isPresent()) {
+                    SourceFile sourceFile = correctSourceFile.get();
+                    // annoyingly, test json and Dockerfiles include a fullpath whereas descriptors are just relative to the main descriptor,
+                    // so in this stream we need to standardize relative to the main descriptor
+                    final Path workingPath = Paths.get("/", entryVersion.get().getWorkingDirectory());
+                    final Path relativize = workingPath.relativize(Paths.get(StringUtils.prependIfMissing(sourceFile.getAbsolutePath(), "/")));
+                    String sourceFileUrl = urlBuilt + StringUtils.prependIfMissing(entryVersion.get().getWorkingDirectory(), "/") + StringUtils
+                        .prependIfMissing(relativize.toString(), "/");
+                    ExtendedFileWrapper toolDescriptor = ToolsImplCommon.sourceFileToToolDescriptor(sourceFileUrl, sourceFile);
+                    return Response.status(Status.OK).type(unwrap ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_JSON)
+                        .entity(unwrap ? sourceFile.getContent() : toolDescriptor).build();
+                }
             }
+            return Response.status(fileNotFoundStatus).build();
+        } finally {
+            versionDAO.disableNameFilter();
         }
-        return Response.status(fileNotFoundStatus).build();
     }
 
     public static List<Checksum> convertToTRSChecksums(final SourceFile sourceFile) {
@@ -808,7 +831,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         try {
             parsedID = new ParsedRegistryID(id);
         } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-            return BAD_DECODE_RESPONSE;
+            return BAD_DECODE_REGISTRY_RESPONSE;
         }
         Entry<?, ?> entry = getEntry(parsedID, user);
         List<String> primaryDescriptorPaths = new ArrayList<>();

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -682,12 +682,12 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
                     // this only works for test parameters associated with tools
                     List<SourceFile> testSourceFiles = new ArrayList<>();
                     try {
-                        testSourceFiles.addAll(toolHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO));
+                        testSourceFiles.addAll(toolHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO, versionDAO));
                     } catch (CustomWebApplicationException e) {
                         LOG.warn("intentionally ignoring failure to get test parameters", e);
                     }
                     try {
-                        testSourceFiles.addAll(workflowHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO));
+                        testSourceFiles.addAll(workflowHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO, versionDAO));
                     } catch (CustomWebApplicationException e) {
                         LOG.warn("intentionally ignoring failure to get source files", e);
                     }


### PR DESCRIPTION
**Description**
Uses Hibernate version filter to improve proprietary API that fetches descriptors.

Branched off Steve's PR #4974 that introduces the feature. Assuming tests pass and this gets approved, we should merge that one first, then this one.

For each of the two endpoints in the Slack discussion linked to in the issue, reduces the number of JDBC statements from 807 to 14.

**Issue**
#4975 

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
