### PR TITLE
Use versionNameFilter for proprietary API

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -170,27 +170,31 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
     /**
      * Return the primary descriptor (i.e. the dockstore.cwl or dockstore.wdl usually, or a single Dockerfile)
      *
-     * @param entryId  internal id for an entry
-     * @param tag      github reference
-     * @param fileType narrow the file to a specific type
+     * @param entryId    internal id for an entry
+     * @param tag        github reference
+     * @param fileType   narrow the file to a specific type
+     * @param versionDAO
      * @return return the primary descriptor or Dockerfile
      */
-    default SourceFile getSourceFile(long entryId, String tag, DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO) {
-        return getSourceFileByPath(entryId, tag, fileType, null, user, fileDAO);
+    default SourceFile getSourceFile(long entryId, String tag, DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO,
+            VersionDAO versionDAO) {
+        return getSourceFileByPath(entryId, tag, fileType, null, user, fileDAO, versionDAO);
     }
 
     /**
      * If path is null, return the first file with the correct path that matches.
      * If path is not null, return the primary descriptor (i.e. the dockstore.cwl or dockstore.wdl usually, or a single Dockerfile)
      *
-     * @param entryId  internal id for an entry
-     * @param tag      github reference
-     * @param fileType narrow the file to a specific type
-     * @param path     a specific path to a file
+     * @param entryId    internal id for an entry
+     * @param tag        github reference
+     * @param fileType   narrow the file to a specific type
+     * @param path       a specific path to a file
+     * @param versionDAO
      * @return a single file depending on parameters
      */
-    default SourceFile getSourceFileByPath(long entryId, String tag, DescriptorLanguage.FileType fileType, String path, Optional<User> user, FileDAO fileDAO) {
-        final Map<String, ImmutablePair<SourceFile, FileDescription>> sourceFiles = this.getSourceFiles(entryId, tag, fileType, user, fileDAO);
+    default SourceFile getSourceFileByPath(long entryId, String tag, DescriptorLanguage.FileType fileType, String path, Optional<User> user, FileDAO fileDAO,
+            VersionDAO versionDAO) {
+        final Map<String, ImmutablePair<SourceFile, FileDescription>> sourceFiles = this.getSourceFiles(entryId, tag, fileType, user, fileDAO, versionDAO);
         for (Map.Entry<String, ImmutablePair<SourceFile, FileDescription>> entry : sourceFiles.entrySet()) {
             if (path != null) {
                 //db stored paths are absolute, convert relative to absolute
@@ -211,8 +215,9 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
      * @param fileType the filetype we want to consider
      * @return a list of SourceFile
      */
-    default List<SourceFile> getAllSecondaryFiles(long workflowId, String tag, DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO) {
-        final Map<String, ImmutablePair<SourceFile, FileDescription>> sourceFiles = this.getSourceFiles(workflowId, tag, fileType, user, fileDAO);
+    default List<SourceFile> getAllSecondaryFiles(long workflowId, String tag, DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO, VersionDAO versionDAO) {
+        final Map<String, ImmutablePair<SourceFile, FileDescription>> sourceFiles = this.getSourceFiles(workflowId, tag, fileType, user, fileDAO,
+                versionDAO);
         return sourceFiles.entrySet().stream()
             .filter(entry -> entry.getValue().getLeft().getType().equals(fileType) && !entry.getValue().right.primaryDescriptor)
             .map(entry -> entry.getValue().getLeft()).collect(Collectors.toList());
@@ -225,102 +230,110 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
      * @param fileType the filetype we want to consider
      * @return a list of SourceFile
      */
-    default List<SourceFile> getAllSourceFiles(long workflowId, String tag, DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO) {
-        final Map<String, ImmutablePair<SourceFile, FileDescription>> sourceFiles = this.getSourceFiles(workflowId, tag, fileType, user, fileDAO);
+    default List<SourceFile> getAllSourceFiles(long workflowId, String tag, DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO, VersionDAO versionDAO) {
+        final Map<String, ImmutablePair<SourceFile, FileDescription>> sourceFiles = this.getSourceFiles(workflowId, tag, fileType, user, fileDAO,
+                versionDAO);
         return sourceFiles.entrySet().stream().filter(entry -> entry.getValue().getLeft().getType().equals(fileType))
             .map(entry -> entry.getValue().getLeft()).collect(Collectors.toList());
     }
 
     /**
      * This returns a map of file paths -> pairs of sourcefiles and descriptions of those sourcefiles
+     *
      * @param workflowId the database id for a workflow
-     * @param tag the version of the workflow
-     * @param fileType the type of file we're interested in
+     * @param tag        the version of the workflow
+     * @param fileType   the type of file we're interested in
+     * @param versionDAO
      * @return a map of file paths -> pairs of sourcefiles and descriptions of those sourcefiles
      */
     default Map<String, ImmutablePair<SourceFile, FileDescription>> getSourceFiles(long workflowId, String tag,
-            DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO) {
-        T entry = getDAO().findById(workflowId);
-        checkOptionalAuthRead(user, entry);
+            DescriptorLanguage.FileType fileType, Optional<User> user, FileDAO fileDAO, VersionDAO versionDAO) {
+        try {
+            versionDAO.enableNameFilter(tag);
+            T entry = getDAO().findById(workflowId);
+            checkOptionalAuthRead(user, entry);
 
-        // tighten permissions for hosted tools and workflows
-        if (!user.isPresent() || AuthenticatedResourceInterface.userCannotRead(user.get(), entry)) {
-            if (!entry.getIsPublished()) {
-                if (entry instanceof Tool && ((Tool)entry).getMode() == ToolMode.HOSTED) {
-                    throw new CustomWebApplicationException("Entry not published", HttpStatus.SC_FORBIDDEN);
+            // tighten permissions for hosted tools and workflows
+            if (!user.isPresent() || AuthenticatedResourceInterface.userCannotRead(user.get(), entry)) {
+                if (!entry.getIsPublished()) {
+                    if (entry instanceof Tool && ((Tool)entry).getMode() == ToolMode.HOSTED) {
+                        throw new CustomWebApplicationException("Entry not published", HttpStatus.SC_FORBIDDEN);
+                    }
+                    if (entry instanceof Workflow && ((Workflow)entry).getMode() == WorkflowMode.HOSTED) {
+                        throw new CustomWebApplicationException("Entry not published", HttpStatus.SC_FORBIDDEN);
+                    }
                 }
-                if (entry instanceof Workflow && ((Workflow)entry).getMode() == WorkflowMode.HOSTED) {
-                    throw new CustomWebApplicationException("Entry not published", HttpStatus.SC_FORBIDDEN);
-                }
+                this.filterContainersForHiddenTags(entry);
             }
-            this.filterContainersForHiddenTags(entry);
-        }
-        Version tagInstance = null;
+            Version tagInstance = null;
 
-        Map<String, ImmutablePair<SourceFile, FileDescription>> resultMap = new HashMap<>();
+            Map<String, ImmutablePair<SourceFile, FileDescription>> resultMap = new HashMap<>();
 
-        if (tag == null) {
-            // This is an assumption made for quay tools. Workflows will not have a latest unless it is created by the user,
-            // and would thus make more sense to use master for workflows.
-            tag = "latest";
-        }
-        final String finalTagName = tag;
-        tagInstance = entry.getWorkflowVersions().stream().filter(v -> v.getName().equals(finalTagName)).findFirst().orElse(null);
+            if (tag == null) {
+                // This is an assumption made for quay tools. Workflows will not have a latest unless it is created by the user,
+                // and would thus make more sense to use master for workflows.
+                tag = "latest";
+            }
+            final String finalTagName = tag;
+            tagInstance = entry.getWorkflowVersions().stream().filter(v -> v.getName().equals(finalTagName)).findFirst().orElse(null);
 
-        if (tagInstance == null) {
-            throw new CustomWebApplicationException("Invalid or missing tag " + tag + ".", HttpStatus.SC_BAD_REQUEST);
-        }
+            if (tagInstance == null) {
+                throw new CustomWebApplicationException("Invalid or missing tag " + tag + ".", HttpStatus.SC_BAD_REQUEST);
+            }
 
-        if (tagInstance instanceof WorkflowVersion) {
-            final WorkflowVersion workflowVersion = (WorkflowVersion)tagInstance;
-            List<SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(workflowVersion.getId());
-            List<SourceFile> filteredTypes = sourceFiles.stream()
-                .filter(file -> Objects.equals(file.getType(), fileType)).collect(Collectors.toList());
-            for (SourceFile file : filteredTypes) {
-                if (fileType == DescriptorLanguage.FileType.CWL_TEST_JSON || fileType == DescriptorLanguage.FileType.WDL_TEST_JSON || fileType == DescriptorLanguage.FileType.NEXTFLOW_TEST_PARAMS) {
-                    resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(true)));
-                } else {
-                    // looks like this takes into account a potentially different workflow path for a specific version of a workflow
-                    final String workflowPath = workflowVersion.getWorkflowPath();
-                    final String workflowVersionPath = workflowVersion.getWorkflowPath();
-                    final String actualPath =
-                        workflowVersionPath == null || workflowVersionPath.isEmpty() ? workflowPath : workflowVersionPath;
-                    boolean isPrimary = file.getType() == fileType && file.getPath().equalsIgnoreCase(actualPath);
+            if (tagInstance instanceof WorkflowVersion) {
+                final WorkflowVersion workflowVersion = (WorkflowVersion)tagInstance;
+                List<SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(workflowVersion.getId());
+                List<SourceFile> filteredTypes = sourceFiles.stream()
+                    .filter(file -> Objects.equals(file.getType(), fileType)).collect(Collectors.toList());
+                for (SourceFile file : filteredTypes) {
+                    if (fileType == DescriptorLanguage.FileType.CWL_TEST_JSON || fileType == DescriptorLanguage.FileType.WDL_TEST_JSON || fileType == DescriptorLanguage.FileType.NEXTFLOW_TEST_PARAMS) {
+                        resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(true)));
+                    } else {
+                        // looks like this takes into account a potentially different workflow path for a specific version of a workflow
+                        final String workflowPath = workflowVersion.getWorkflowPath();
+                        final String workflowVersionPath = workflowVersion.getWorkflowPath();
+                        final String actualPath =
+                            workflowVersionPath == null || workflowVersionPath.isEmpty() ? workflowPath : workflowVersionPath;
+                        boolean isPrimary = file.getType() == fileType && file.getPath().equalsIgnoreCase(actualPath);
+                        resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(isPrimary)));
+                    }
+                }
+            } else {
+                final Tool tool = (Tool)entry;
+                final Tag toolTag = (Tag)tagInstance;
+                List<SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(toolTag.getId());
+                List<SourceFile> filteredTypes = sourceFiles.stream().filter(file -> Objects.equals(file.getType(), fileType))
+                    .collect(Collectors.toList());
+                for (SourceFile file : filteredTypes) {
+                    // dockerfile is a special case since there always is only a max of one
+                    if (fileType == DescriptorLanguage.FileType.DOCKERFILE || fileType == DescriptorLanguage.FileType.CWL_TEST_JSON
+                        || fileType == DescriptorLanguage.FileType.WDL_TEST_JSON) {
+                        resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(true)));
+                        continue;
+                    }
+
+                    final String toolPath;
+                    String toolVersionPath;
+                    if (fileType == DescriptorLanguage.FileType.DOCKSTORE_CWL) {
+                        toolPath = tool.getDefaultCwlPath();
+                        toolVersionPath = toolTag.getCwlPath();
+                    } else if (fileType == DescriptorLanguage.FileType.DOCKSTORE_WDL) {
+                        toolPath = tool.getDefaultWdlPath();
+                        toolVersionPath = toolTag.getWdlPath();
+                    } else {
+                        throw new CustomWebApplicationException("Format " + fileType + " not valid", HttpStatus.SC_BAD_REQUEST);
+                    }
+
+                    final String actualPath = (toolVersionPath == null || toolVersionPath.isEmpty()) ? toolPath : toolVersionPath;
+                    boolean isPrimary = file.getType() == fileType && actualPath.equalsIgnoreCase(file.getPath());
                     resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(isPrimary)));
                 }
             }
-        } else {
-            final Tool tool = (Tool)entry;
-            final Tag toolTag = (Tag)tagInstance;
-            List<SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(toolTag.getId());
-            List<SourceFile> filteredTypes = sourceFiles.stream().filter(file -> Objects.equals(file.getType(), fileType))
-                .collect(Collectors.toList());
-            for (SourceFile file : filteredTypes) {
-                // dockerfile is a special case since there always is only a max of one
-                if (fileType == DescriptorLanguage.FileType.DOCKERFILE || fileType == DescriptorLanguage.FileType.CWL_TEST_JSON
-                    || fileType == DescriptorLanguage.FileType.WDL_TEST_JSON) {
-                    resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(true)));
-                    continue;
-                }
-
-                final String toolPath;
-                String toolVersionPath;
-                if (fileType == DescriptorLanguage.FileType.DOCKSTORE_CWL) {
-                    toolPath = tool.getDefaultCwlPath();
-                    toolVersionPath = toolTag.getCwlPath();
-                } else if (fileType == DescriptorLanguage.FileType.DOCKSTORE_WDL) {
-                    toolPath = tool.getDefaultWdlPath();
-                    toolVersionPath = toolTag.getWdlPath();
-                } else {
-                    throw new CustomWebApplicationException("Format " + fileType + " not valid", HttpStatus.SC_BAD_REQUEST);
-                }
-
-                final String actualPath = (toolVersionPath == null || toolVersionPath.isEmpty()) ? toolPath : toolVersionPath;
-                boolean isPrimary = file.getType() == fileType && actualPath.equalsIgnoreCase(file.getPath());
-                resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(isPrimary)));
-            }
+            return resultMap;
+        } finally {
+            versionDAO.disableNameFilter();
         }
-        return resultMap;
     }
 
     @SuppressWarnings("lgtm[java/path-injection]")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -61,6 +61,7 @@ import io.dockstore.webservice.jdbi.TagDAO;
 import io.dockstore.webservice.jdbi.TokenDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import io.dockstore.webservice.jdbi.UserDAO;
+import io.dockstore.webservice.jdbi.VersionDAO;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.swagger.annotations.Api;
@@ -134,6 +135,7 @@ public class DockerRepoResource
     private final LabelDAO labelDAO;
     private final FileDAO fileDAO;
     private final FileFormatDAO fileFormatDAO;
+    private final VersionDAO versionDAO;
     private final HttpClient client;
     private final String bitbucketClientID;
     private final String bitbucketClientSecret;
@@ -154,6 +156,7 @@ public class DockerRepoResource
         this.fileDAO = new FileDAO(sessionFactory);
         this.eventDAO = new EventDAO(sessionFactory);
         this.fileFormatDAO = new FileFormatDAO(sessionFactory);
+        this.versionDAO = new VersionDAO(sessionFactory);
         this.client = client;
 
         this.bitbucketClientID = configuration.getBitbucketClientID();
@@ -882,7 +885,7 @@ public class DockerRepoResource
     public SourceFile dockerfile(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag) {
 
-        return getSourceFile(containerId, tag, DescriptorLanguage.FileType.DOCKERFILE, user, fileDAO);
+        return getSourceFile(containerId, tag, DescriptorLanguage.FileType.DOCKERFILE, user, fileDAO, versionDAO);
     }
 
     // Add for new descriptor types
@@ -897,7 +900,7 @@ public class DockerRepoResource
     public SourceFile primaryDescriptor(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag, @QueryParam("language") String language) {
         final FileType fileType = DescriptorLanguage.getOptionalFileType(language).orElseThrow(() ->  new CustomWebApplicationException("Language not valid", HttpStatus.SC_BAD_REQUEST));
-        return getSourceFile(containerId, tag, fileType, user, fileDAO);
+        return getSourceFile(containerId, tag, fileType, user, fileDAO, versionDAO);
     }
 
     @GET
@@ -912,7 +915,7 @@ public class DockerRepoResource
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
         @PathParam("relative-path") String path, @QueryParam("language") String language) {
         final FileType fileType = DescriptorLanguage.getOptionalFileType(language).orElseThrow(() ->  new CustomWebApplicationException("Language not valid", HttpStatus.SC_BAD_REQUEST));
-        return getSourceFileByPath(containerId, tag, fileType, path, user, fileDAO);
+        return getSourceFileByPath(containerId, tag, fileType, path, user, fileDAO, versionDAO);
     }
 
     @GET
@@ -926,7 +929,7 @@ public class DockerRepoResource
     public List<SourceFile> secondaryDescriptors(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag, @QueryParam("language") DescriptorLanguage language) {
         final FileType fileType = language.getFileType();
-        return getAllSecondaryFiles(containerId, tag, fileType, user, fileDAO);
+        return getAllSecondaryFiles(containerId, tag, fileType, user, fileDAO, versionDAO);
     }
 
     @GET
@@ -941,7 +944,7 @@ public class DockerRepoResource
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
         @ApiParam(value = "Descriptor Type", required = true) @QueryParam("descriptorType") DescriptorLanguage descriptorLanguage) {
         final FileType testParameterType = descriptorLanguage.getTestParamType();
-        return getAllSourceFiles(containerId, tag, testParameterType, user, fileDAO);
+        return getAllSourceFiles(containerId, tag, testParameterType, user, fileDAO, versionDAO);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1127,7 +1127,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId,
         @QueryParam("tag") String tag, @QueryParam("language") String language) {
         final FileType fileType = DescriptorLanguage.getOptionalFileType(language).orElseThrow(() ->  new CustomWebApplicationException("Language not valid", HttpStatus.SC_BAD_REQUEST));
-        return getSourceFile(workflowId, tag, fileType, user, fileDAO);
+        return getSourceFile(workflowId, tag, fileType, user, fileDAO, versionDAO);
     }
 
     @GET
@@ -1142,7 +1142,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag,
         @PathParam("relative-path") String path, @QueryParam("language") DescriptorLanguage language) {
         final FileType fileType = language.getFileType();
-        return getSourceFileByPath(workflowId, tag, fileType, path, user, fileDAO);
+        return getSourceFileByPath(workflowId, tag, fileType, path, user, fileDAO, versionDAO);
     }
 
     @GET
@@ -1156,7 +1156,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     public List<SourceFile> secondaryDescriptors(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth Optional<User> user,
         @ApiParam(value = "Workflow id", required = true) @PathParam("workflowId") Long workflowId, @QueryParam("tag") String tag, @QueryParam("language") DescriptorLanguage language) {
         final FileType fileType = language.getFileType();
-        return getAllSecondaryFiles(workflowId, tag, fileType, user, fileDAO);
+        return getAllSecondaryFiles(workflowId, tag, fileType, user, fileDAO, versionDAO);
     }
 
 
@@ -1175,7 +1175,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         Workflow workflow = workflowDAO.findById(workflowId);
         checkEntry(workflow);
         FileType testParameterType = workflow.getTestParameterType();
-        return getAllSourceFiles(workflowId, version, testParameterType, user, fileDAO);
+        return getAllSourceFiles(workflowId, version, testParameterType, user, fileDAO, versionDAO);
     }
 
     @PUT

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -682,12 +682,12 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
                     // this only works for test parameters associated with tools
                     List<SourceFile> testSourceFiles = new ArrayList<>();
                     try {
-                        testSourceFiles.addAll(toolHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO));
+                        testSourceFiles.addAll(toolHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO, versionDAO));
                     } catch (CustomWebApplicationException e) {
                         LOG.warn("intentionally ignoring failure to get test parameters", e);
                     }
                     try {
-                        testSourceFiles.addAll(workflowHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO));
+                        testSourceFiles.addAll(workflowHelper.getAllSourceFiles(entry.getId(), versionId, type, user, fileDAO, versionDAO));
                     } catch (CustomWebApplicationException e) {
                         LOG.warn("intentionally ignoring failure to get source files", e);
                     }


### PR DESCRIPTION

**Description**
Uses version filter to improve performance of fetching primary and secondary descriptors.

For the problematic endpoints (see ticket), reduces the number of JDBC  statements executed from 807 to 14.

A big chunk of the diff is due to indentation and shifting caused by introducing a try...finally. The other part is by needing to pass around a VersionDAO instance.

**Issue**
#4975

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
