### PR TITLE
Update SEM_VER_STRING to support prereleases (#4981)

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
@@ -14,7 +14,8 @@ import java.util.regex.Pattern;
  */
 public final class PipHelper {
     public static final String DEV_SEM_VER = "development-build";
-    public static final String SEM_VER_STRING = "(^(\\d+)\\.(\\d+)\\.(\\d+)$)|(^" + DEV_SEM_VER + "$)";
+    // Regex copied from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    public static final String SEM_VER_STRING = "(^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$)|(^" + DEV_SEM_VER + "$)";
     public static final Pattern SEM_VER_PATTERN = Pattern.compile(SEM_VER_STRING);
 
     private PipHelper() { }

--- a/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
@@ -15,7 +15,7 @@ import java.util.regex.Pattern;
 public final class PipHelper {
     public static final String DEV_SEM_VER = "development-build";
     // Regex copied from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-    public static final String SEM_VER_STRING = "(^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$)|(^" + DEV_SEM_VER + "$)";
+    public static final String SEM_VER_STRING = "(^(0|[1-9]\\d*+)\\.(0|[1-9]\\d*+)\\.(0|[1-9]\\d*+)(?:-((?:0|[1-9]\\d*+|\\d*+[a-zA-Z-][0-9a-zA-Z-]*+)(?:\\.(?:0|[1-9]\\d*+|\\d*+[a-zA-Z-][0-9a-zA-Z-]*+))*+))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*+))?$)|(^" + DEV_SEM_VER + "$)";
     public static final Pattern SEM_VER_PATTERN = Pattern.compile(SEM_VER_STRING);
 
     private PipHelper() { }

--- a/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/PipHelper.java
@@ -14,7 +14,8 @@ import java.util.regex.Pattern;
  */
 public final class PipHelper {
     public static final String DEV_SEM_VER = "development-build";
-    // Regex copied from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    // Modified regex linked above to mitigate against ReDoS attacks.
     public static final String SEM_VER_STRING = "(^(0|[1-9]\\d*+)\\.(0|[1-9]\\d*+)\\.(0|[1-9]\\d*+)(?:-((?:0|[1-9]\\d*+|\\d*+[a-zA-Z-][0-9a-zA-Z-]*+)(?:\\.(?:0|[1-9]\\d*+|\\d*+[a-zA-Z-][0-9a-zA-Z-]*+))*+))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*+))?$)|(^" + DEV_SEM_VER + "$)";
     public static final Pattern SEM_VER_PATTERN = Pattern.compile(SEM_VER_STRING);
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MetadataIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MetadataIT.java
@@ -1,7 +1,6 @@
 package io.dockstore.client.cli;
 
 import io.dockstore.common.PipHelper;
-import io.dockstore.webservice.resources.MetadataResource;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.ApiResponse;
@@ -39,7 +38,6 @@ public class MetadataIT extends BaseIT {
         return queryParams;
     }
 
-    @Category(MetadataResource.class)
     @Test
     public void testValidClientVersion() {
         String endpoint = "/metadata/runner_dependencies";
@@ -49,7 +47,6 @@ public class MetadataIT extends BaseIT {
         Assert.assertEquals(HttpStatus.OK_200, response.getStatusCode());
     }
 
-    @Category(MetadataResource.class)
     @Test
     public void testPrereleaseClientVersion() {
         String endpoint = "/metadata/runner_dependencies";
@@ -59,7 +56,6 @@ public class MetadataIT extends BaseIT {
         Assert.assertEquals(HttpStatus.OK_200, response.getStatusCode());
     }
 
-    @Category(MetadataResource.class)
     @Test
     public void testDevelopmentSemanticVersion() {
         String endpoint = "/metadata/runner_dependencies";
@@ -69,7 +65,6 @@ public class MetadataIT extends BaseIT {
         Assert.assertEquals(HttpStatus.OK_200, response.getStatusCode());
     }
 
-    @Category(MetadataResource.class)
     @Test
     public void testInvalidClientVersion() {
         String endpoint = "/metadata/runner_dependencies";

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MetadataIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MetadataIT.java
@@ -51,6 +51,16 @@ public class MetadataIT extends BaseIT {
 
     @Category(MetadataResource.class)
     @Test
+    public void testPrereleaseClientVersion() {
+        String endpoint = "/metadata/runner_dependencies";
+        List<Pair> queryParams = this.queryParams();
+        queryParams.addAll(apiClient.parameterToPairs("", "client_version", "1.13.0-alpha.7"));
+        ApiResponse<Object> response = this.get_request(endpoint, queryParams);
+        Assert.assertEquals(HttpStatus.OK_200, response.getStatusCode());
+    }
+
+    @Category(MetadataResource.class)
+    @Test
     public void testDevelopmentSemanticVersion() {
         String endpoint = "/metadata/runner_dependencies";
         List<Pair> queryParams = this.queryParams();

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3212,9 +3212,9 @@ paths:
         name: client_version
         schema:
           type: string
-          pattern: "(^\" + DEV_SEM_VER + \"$)|(^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\\
-            d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\\
-            d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$)"
+          pattern: "(^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\\
+            d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\\
+            +([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$)|(^development-build$)"
       - description: "Python version, only relevant for the cwltool runner"
         in: query
         name: python_version

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3212,7 +3212,9 @@ paths:
         name: client_version
         schema:
           type: string
-          pattern: (^(\d+)\.(\d+)\.(\d+)$)|(^development-build$)
+          pattern: "(^\" + DEV_SEM_VER + \"$)|(^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\\
+            d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\\
+            d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$)"
       - description: "Python version, only relevant for the cwltool runner"
         in: query
         name: python_version


### PR DESCRIPTION
**Description**
Adds support for prerelease / metadata within semvar regex.

**Issue**
 #4981 

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
