### PR TITLE
builds with CI friendly versions (#4789)

### DIFF
--- a/.github/collab-mvn-settings.xml
+++ b/.github/collab-mvn-settings.xml
@@ -1,0 +1,9 @@
+<settings>
+  <servers>
+    <server>
+      <id>central</id>
+      <username>dockstore-bot</username>
+      <password>${env.COLLAB_DEPLOY_TOKEN}</password>
+    </server>
+  </servers>
+</settings> 

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/mvnw.yml
+++ b/.github/workflows/mvnw.yml
@@ -1,4 +1,4 @@
-name: Java CI
+name: Regular dockstore build
 
 on: [push]
 

--- a/.github/workflows/validate_openapi.yaml
+++ b/.github/workflows/validate_openapi.yaml
@@ -1,3 +1,5 @@
+name: Validate openapi.yaml
+
 on: [push]
 
 

--- a/README.md
+++ b/README.md
@@ -103,11 +103,15 @@ As an alternative to the following commands, if you do not have Maven installed 
     # instead of
     mvn clean install
 
-If you maven build in the root directory this will build not only the web service but the client tool:
+If you maven build in the root directory this will build all modules:
 
     mvn clean install
     # or
     mvn clean install -Punit-tests
+    
+Consider the following if you need to build a specific version (such as in preparation for creating a tag for a release):
+
+    mvnw clean install  -Dchangelist=.0-beta.5 #or whatever version you need 
     
 If you're running tests on CircleCI (or otherwise have access to the confidential data bundle) Run them via:
 

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -37,7 +37,7 @@ POM as their parent.
 
     <groupId>io.dockstore</groupId>
     <artifactId>bom-internal</artifactId>
-    <version>1.12.0</version>
+    <version>${revision}${changelist}</version>
     <packaging>pom</packaging>
 
     <name>bom-internal</name>
@@ -46,6 +46,11 @@ POM as their parent.
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <!-- the following properties set sane defaults when no revision properties are set from the command-line -->
+        <revision>1.12</revision>
+        <changelist>.0-SNAPSHOT</changelist>
+
         <dropwizard.version>2.0.25</dropwizard.version>
         <dropwizard-annotations.version>4.2.4</dropwizard-annotations.version>
         <elasticsearch-version>7.10.2</elasticsearch-version>
@@ -1220,4 +1225,36 @@ POM as their parent.
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.2.5</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <!-- enable flattening -->
+                    <execution>
+                        <id>flatten</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <!-- ensure proper cleanup -->
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-common</artifactId>
-  <version>1.12.1-SNAPSHOT</version>
+  <version>1.12.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.12.1-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-common</artifactId>

--- a/dockstore-event-consumer/generated/src/main/resources/pom.xml
+++ b/dockstore-event-consumer/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-event-consumer</artifactId>
-  <version>1.12.1-SNAPSHOT</version>
+  <version>1.12.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,13 +30,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.1-SNAPSHOT</version>
+      <version>1.12.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.12.1-SNAPSHOT</version>
+      <version>1.12.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-event-consumer/pom.xml
+++ b/dockstore-event-consumer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.12.1-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -30,12 +30,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.12.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.12.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-integration-testing</artifactId>
-  <version>1.12.1-SNAPSHOT</version>
+  <version>1.12.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -54,13 +54,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.12.1-SNAPSHOT</version>
+      <version>1.12.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.1-SNAPSHOT</version>
+      <version>1.12.0-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.1-SNAPSHOT</version>
+      <version>1.12.0-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>openapi-java-client</artifactId>
-      <version>1.12.1-SNAPSHOT</version>
+      <version>1.12.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
-        <version>1.12.1-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dockstore-integration-testing</artifactId>
@@ -63,12 +63,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-client</artifactId>
-            <version>1.12.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.12.1-SNAPSHOT</version>
+            <version>${project.version}</version>
             <!-- looks like these are excluded because they bring in duplicate liquibase.build.properties -->
             <exclusions>
                 <exclusion>
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.12.1-SNAPSHOT</version>
+            <version>${project.version}</version>
             <!-- looks like these are excluded because they bring in duplicate liquibase.build.properties -->
             <exclusions>
                 <exclusion>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>openapi-java-client</artifactId>
-            <version>1.12.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-language-plugin-parent</artifactId>
-  <version>1.12.1-SNAPSHOT</version>
+  <version>1.12.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.1-SNAPSHOT</version>
+      <version>1.12.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-language-plugin-parent/pom.xml
+++ b/dockstore-language-plugin-parent/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <version>1.12.1-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.12.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.pf4j</groupId>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-webservice</artifactId>
-  <version>1.12.1-SNAPSHOT</version>
+  <version>1.12.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -84,13 +84,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.1-SNAPSHOT</version>
+      <version>1.12.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-language-plugin-parent</artifactId>
-      <version>1.12.1-SNAPSHOT</version>
+      <version>1.12.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
 
     <parent>
-        <version>1.12.1-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -73,12 +73,12 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.12.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-language-plugin-parent</artifactId>
-            <version>1.12.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.zafarkhaja</groupId>
@@ -538,7 +538,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.12.1-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
@@ -1163,9 +1163,6 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <configuration>
-                    <excludeFilterFile>src/main/resources/findbugs-exclude.xml</excludeFilterFile>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -1194,7 +1191,7 @@
                 -->
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                <version>4.4.0</version>
+                <version>4.8.0</version>
                 <configuration>
                     <driver>org.postgresql.Driver</driver>
                     <referenceDriver>org.postgresql.Driver</referenceDriver>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -13,7 +13,7 @@ info:
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
   termsOfService: https://github.com/dockstore/dockstore-ui2/raw/develop/src/assets/docs/Dockstore_Terms_of_Service.pdf
   title: Dockstore API
-  version: 1.12.1-SNAPSHOT
+  version: 1.12.0-SNAPSHOT
 servers:
 - description: Current server when hosted on AWS
   url: /api

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5,7 +5,7 @@ info:
     \ of Docker images and associated metadata such as CWL documents and Dockerfiles\
     \ used to build those images. Explore swagger.json for a Swagger 2.0 description\
     \ of our API and explore openapi.yaml for OpenAPI 3.0 descriptions."
-  version: "1.12.1-SNAPSHOT"
+  version: "1.12.0-SNAPSHOT"
   title: "Dockstore API"
   termsOfService: "TBD"
   contact:

--- a/openapi-java-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>openapi-java-client</artifactId>
-  <version>1.12.1-SNAPSHOT</version>
+  <version>1.12.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.1-SNAPSHOT</version>
+      <version>1.12.0-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/openapi-java-client/pom.xml
+++ b/openapi-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>openapi-java-client</name>
 
     <parent>
-        <version>1.12.1-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -325,7 +325,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.12.1-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>io.dockstore</groupId>
     <artifactId>dockstore</artifactId>
-    <version>1.12.1-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>pom</packaging>
 
     <name>dockstore</name>
@@ -30,6 +30,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.url>scm:git:git@github.com:dockstore/dockstore.git</github.url>
+
+        <!-- the following properties set sane defaults when no revision properties are set from the command-line -->
+        <revision>1.12</revision>
+        <changelist>.0-SNAPSHOT</changelist>
 
         <!--
         The following properties are mostly used in the plugins section
@@ -130,6 +134,7 @@
     </distributionManagement>
 
     <modules>
+        <module>bom-internal</module>
         <module>dockstore-common</module>
         <module>dockstore-language-plugin-parent</module>
         <module>dockstore-webservice</module>
@@ -138,7 +143,6 @@
         <module>dockstore-integration-testing</module>
         <module>dockstore-event-consumer</module>
         <module>reports</module>
-        <module>bom-internal</module>
     </modules>
 
 
@@ -148,7 +152,7 @@
                  <groupId>io.dockstore</groupId>
                  <artifactId>bom-internal</artifactId>
                  <type>pom</type>
-                 <version>1.12.0</version>
+                 <version>${revision}${changelist}</version>
                  <scope>import</scope>
              </dependency>
         </dependencies>
@@ -428,10 +432,10 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>flatten-maven-plugin</artifactId>
-                    <version>1.2.2</version>
+                    <version>1.2.5</version>
                     <configuration>
                         <outputDirectory>${project.basedir}/generated/src/main/resources/</outputDirectory>
-                        <updatePomFile>false</updatePomFile>
+                        <updatePomFile>true</updatePomFile>
                         <!-- snyk is picky about filenames -->
                         <flattenedPomFilename>pom.xml</flattenedPomFilename>
                     </configuration>
@@ -453,6 +457,13 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-scm-plugin</artifactId>
+                    <version>2.0.0-M1</version>
+                    <configuration>
+                        <tag>${revision}${changelist}</tag>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/reports/generated/src/main/resources/pom.xml
+++ b/reports/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>reports</artifactId>
-  <version>1.12.1-SNAPSHOT</version>
+  <version>1.12.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,19 +30,19 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.1-SNAPSHOT</version>
+      <version>1.12.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.12.1-SNAPSHOT</version>
+      <version>1.12.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-integration-testing</artifactId>
-      <version>1.12.1-SNAPSHOT</version>
+      <version>1.12.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>dockstore</artifactId>
         <groupId>io.dockstore</groupId>
-        <version>1.12.1-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,17 +29,17 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.12.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-common</artifactId>
-            <version>1.12.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-integration-testing</artifactId>
-            <version>1.12.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/swagger-java-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-client</artifactId>
-  <version>1.12.1-SNAPSHOT</version>
+  <version>1.12.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.12.1-SNAPSHOT</version>
+      <version>1.12.0-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/swagger-java-client/pom.xml
+++ b/swagger-java-client/pom.xml
@@ -22,7 +22,7 @@
     <name>swagger-java-client</name>
 
     <parent>
-        <version>1.12.1-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
         <groupId>io.dockstore</groupId>
         <artifactId>dockstore</artifactId>
         <relativePath>../pom.xml</relativePath>
@@ -255,7 +255,7 @@
             <!-- used just for ordering since this uses the swagger.json created by dockstore-webservice during the build -->
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-webservice</artifactId>
-            <version>1.12.1-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
**Description**
hotfix version of https://github.com/dockstore/dockstore/pull/4789
Needed because hotfix cherry-picked some of the CI friendly code to complete builds without IAM AWS creds, so we kinda need to see it through to actually complete a release using the manual workflow

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4515


Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
