### PR TITLE
Changed version number of hibernate-validator

### DIFF
--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -442,7 +442,7 @@ POM as their parent.
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>6.1.7.Final</version>
+                <version>6.2.3.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate.common</groupId>


### PR DESCRIPTION
**Description**
During this [PR](https://github.com/dockstore/dockstore-cli/pull/165) the version numbers of a few dependencies were changed. This was causing the following problem in this [PR](https://github.com/dockstore/dockstore-cli/pull/161).

```
Dependency convergence error for org.hibernate.validator:hibernate-validator:jar:6.2.3.Final:test paths to dependency are:
+-io.dockstore:dockstore-client:jar:1.13.0-SNAPSHOT
  +-io.dropwizard:dropwizard-testing:jar:2.1.0:test
    +-io.dropwizard:dropwizard-core:jar:2.1.0:test
      +-org.glassfish.jersey.ext:jersey-bean-validation:jar:2.35:test
        +-org.hibernate.validator:hibernate-validator:jar:6.2.3.Final:test
and
+-io.dockstore:dockstore-client:jar:1.13.0-SNAPSHOT
  +-io.dropwizard:dropwizard-testing:jar:2.1.0:test
    +-io.dropwizard:dropwizard-core:jar:2.1.0:test
      +-org.hibernate.validator:hibernate-validator:jar:6.2.3.Final:test
and
+-io.dockstore:dockstore-client:jar:1.13.0-SNAPSHOT
  +-io.dropwizard:dropwizard-testing:jar:2.1.0:test
    +-io.dropwizard:dropwizard-jersey:jar:2.1.0:test
      +-org.hibernate.validator:hibernate-validator:jar:6.2.3.Final:test
and
+-io.dockstore:dockstore-client:jar:1.13.0-SNAPSHOT
  +-io.dropwizard:dropwizard-testing:jar:2.1.0:test
    +-io.dropwizard:dropwizard-validation:jar:2.1.0:test
      +-org.hibernate.validator:hibernate-validator:jar:6.2.3.Final:test
and
+-io.dockstore:dockstore-client:jar:1.13.0-SNAPSHOT
  +-org.hibernate.validator:hibernate-validator:jar:6.1.7.Final:compile

[WARNING] Rule 0: org.apache.maven.plugins.enforcer.DependencyConvergence failed with message:
Failed while enforcing releasability. See above detailed error message.
[WARNING] Rule 3: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for org.hibernate.validator:hibernate-validator:6.1.7.Final paths to dependency are:
+-io.dockstore:dockstore-client:1.13.0-SNAPSHOT
  +-org.hibernate.validator:hibernate-validator:6.1.7.Final
and
+-io.dockstore:dockstore-client:1.13.0-SNAPSHOT
  +-io.dropwizard:dropwizard-testing:2.1.0 [test]
    +-io.dropwizard:dropwizard-core:2.1.0 [test] (managed) <-- io.dropwizard:dropwizard-core:2.1.0 [test]
      +-org.hibernate.validator:hibernate-validator:6.2.3.Final [test] (managed) <-- org.hibernate.validator:hibernate-validator:6.2.3.Final [test]
and
+-io.dockstore:dockstore-client:1.13.0-SNAPSHOT
  +-io.dropwizard:dropwizard-testing:2.1.0 [test]
    +-io.dropwizard:dropwizard-jersey:2.1.0 [test] (managed) <-- io.dropwizard:dropwizard-jersey:2.1.0 [test]
      +-org.hibernate.validator:hibernate-validator:6.2.3.Final [test] (managed) <-- org.hibernate.validator:hibernate-validator:6.2.3.Final [test]
and
+-io.dockstore:dockstore-client:1.13.0-SNAPSHOT
  +-io.dropwizard:dropwizard-testing:2.1.0 [test]
    +-io.dropwizard:dropwizard-validation:2.1.0 [test] (managed) <-- io.dropwizard:dropwizard-validation:2.1.0 [test]
      +-org.hibernate.validator:hibernate-validator:6.2.3.Final [test] (managed) <-- org.hibernate.validator:hibernate-validator:6.2.3.Final [test]
and
+-io.dockstore:dockstore-client:1.13.0-SNAPSHOT
  +-io.dropwizard:dropwizard-testing:2.1.0 [test]
    +-io.dropwizard:dropwizard-core:2.1.0 [test] (managed) <-- io.dropwizard:dropwizard-core:2.1.0 [test]
      +-org.glassfish.jersey.ext:jersey-bean-validation:2.35 [test] (managed) <-- org.glassfish.jersey.ext:jersey-bean-validation:2.35 [test]
        +-org.hibernate.validator:hibernate-validator:6.2.3.Final [test] (managed) <-- org.hibernate.validator:hibernate-validator:6.2.0.Final [test]

```

Updating the version number should correct this problem.

**Issue**
https://github.com/dockstore/dockstore/issues/4838

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
