### PR TITLE
Tweak new Sourcefile path-related integration test

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ConfigurationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ConfigurationIT.java
@@ -125,7 +125,7 @@ public class ConfigurationIT {
 
     @SuppressWarnings("checkstyle:AvoidEscapedUnicodeCharacters")
     private List<String> getSomeWeirdPaths() {
-        return List.of("\t", "`", "$", "@", "\\", "\u00f1", "\u1200").stream().map(w -> ("/" + w + VANILLA_SOURCEFILE_PATH)).collect(Collectors.toList());
+        return List.of("\t", "`", "$", "@", "\u00f1", "\u1200").stream().map(w -> ("/" + w + VANILLA_SOURCEFILE_PATH)).collect(Collectors.toList());
     }
 
     @Test


### PR DESCRIPTION
**Description**
Oh no, the CircleCI run failed on develop after I merged #5005!

My best theory as to what happened: some component on develop/CircleCI changed so it began to behave differently with one of the weirder SQL queries in the new IT, some time between when I ran the ITs on the final PR commit, and when I merged the PR.  Quick fix is to make the test paths slightly less weird.

Sooner this is merged, the better.  Feel free to squash-and-merge it yourself once you feel it has been adequately vetted.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4269

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
