### PR TITLE
Don't terminate indexing after an indexing failure

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -128,7 +128,8 @@ public class Tool extends Entry<Tool, Tag> {
     @ApiModelProperty(value = "Is the docker image private or not.", required = true, position = 21)
     private boolean privateAccess = false;
 
-    @Column(columnDefinition = "Text")
+    @Column
+    @Size(max = StringInputValidationHelper.ENTRY_NAME_LENGTH_LIMIT)
     @ApiModelProperty(value = "This is the tool name of the container, when not-present this will function just like 0.1 dockstore"
             + "when present, this can be used to distinguish between two containers based on the same image, but associated with different "
             + "CWL and Dockerfile documents. i.e. two containers with the same registry+namespace+name but different toolnames "
@@ -357,7 +358,6 @@ public class Tool extends Entry<Tool, Tag> {
     }
 
     @JsonProperty
-    @Size(max = StringInputValidationHelper.ENTRY_NAME_LENGTH_LIMIT)
     public String getToolname() {
         return toolname;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.EntryType;
 import io.dockstore.common.Registry;
+import io.dockstore.webservice.helpers.StringInputValidationHelper;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -356,6 +357,7 @@ public class Tool extends Entry<Tool, Tag> {
     }
 
     @JsonProperty
+    @Size(max = StringInputValidationHelper.ENTRY_NAME_LENGTH_LIMIT)
     public String getToolname() {
         return toolname;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -128,7 +128,7 @@ public class Tool extends Entry<Tool, Tag> {
     @ApiModelProperty(value = "Is the docker image private or not.", required = true, position = 21)
     private boolean privateAccess = false;
 
-    @Column
+    @Column(columnDefinition = "varchar(256)")
     @Size(max = StringInputValidationHelper.ENTRY_NAME_LENGTH_LIMIT)
     @ApiModelProperty(value = "This is the tool name of the container, when not-present this will function just like 0.1 dockstore"
             + "when present, this can be used to distinguish between two containers based on the same image, but associated with different "

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -102,7 +102,7 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
     @ApiModelProperty(value = "This indicates what mode this is in which informs how we do things like refresh, dockstore specific", required = true, position = 13)
     private WorkflowMode mode = WorkflowMode.STUB;
 
-    @Column
+    @Column(columnDefinition = "varchar(256)")
     @ApiModelProperty(value = "This is the name of the workflow, not needed when only one workflow in a repo", position = 14)
     @Size(max = StringInputValidationHelper.ENTRY_NAME_LENGTH_LIMIT)
     private String workflowName;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.DescriptorLanguageSubclass;
 import io.dockstore.common.SourceControl;
+import io.dockstore.webservice.helpers.StringInputValidationHelper;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.Hidden;
@@ -103,6 +104,7 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
 
     @Column(columnDefinition = "text")
     @ApiModelProperty(value = "This is the name of the workflow, not needed when only one workflow in a repo", position = 14)
+    @Size(max = StringInputValidationHelper.ENTRY_NAME_LENGTH_LIMIT)
     private String workflowName;
 
     @Column(nullable = false)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -102,7 +102,7 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
     @ApiModelProperty(value = "This indicates what mode this is in which informs how we do things like refresh, dockstore specific", required = true, position = 13)
     private WorkflowMode mode = WorkflowMode.STUB;
 
-    @Column(columnDefinition = "text")
+    @Column
     @ApiModelProperty(value = "This is the name of the workflow, not needed when only one workflow in a repo", position = 14)
     @Size(max = StringInputValidationHelper.ENTRY_NAME_LENGTH_LIMIT)
     private String workflowName;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -210,8 +210,10 @@ public class ElasticListener implements StateListenerInterface {
                         if (bulkItemResponse.isFailed()) {
                             final Failure failure = bulkItemResponse.getFailure();
                             final Throwable throwable = failure.getCause().getCause();
-                            LOGGER.error("Item {} in bulk [{}] executed with failure, for entry with id {}",
+                            final String message = String.format(
+                                "Item %s in bulk [%s] executed with failure, for entry with id %s",
                                 bulkItemResponse.getItemId(), executionId, failure.getId());
+                            LOGGER.error(message, throwable);
                         }
                     }
                 } else {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -193,7 +193,6 @@ public class ElasticListener implements StateListenerInterface {
     }
 
     private void postBulkUpdate(String index, List<Entry> entries) {
-        final ArrayList<Throwable> afterBulkFailures = new ArrayList<>(); // Store information about failures encountered by the BulkProcessor.Listener
         BulkProcessor.Listener listener = new BulkProcessor.Listener() {
             @Override
             public void beforeBulk(long executionId, BulkRequest request) {
@@ -213,7 +212,6 @@ public class ElasticListener implements StateListenerInterface {
                             final Throwable throwable = failure.getCause().getCause();
                             LOGGER.error("Item {} in bulk [{}] executed with failure, for entry with id {}",
                                 bulkItemResponse.getItemId(), executionId, failure.getId());
-                            afterBulkFailures.add(throwable);
                         }
                     }
                 } else {
@@ -226,7 +224,6 @@ public class ElasticListener implements StateListenerInterface {
             public void afterBulk(long executionId, BulkRequest request,
                     Throwable failure) {
                 LOGGER.error("Failed to execute bulk", failure);
-                afterBulkFailures.add(failure);
             }
         };
 

--- a/dockstore-webservice/src/main/resources/migrations.1.13.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.13.0.xml
@@ -63,4 +63,19 @@
             ALTER TABLE user_profile ADD CONSTRAINT non_blank_link CHECK (CASE WHEN link IS NOT NULL then character_length(link) > 0 END);
         </sql>
     </changeSet>
+    <changeSet id="max_workflowname_and_toolname" author="coverbeck">
+        <!-- 256 is from StringInputValidationHelper.ENTRY_NAME_LENGTH_LIMIT.
+             If truncating, add numbers using a sequence to ensure workflowname uniqueness within a sourcecontrol, organization, repository;
+             otherwise a uniqueness constraint will cause a failure.
+        -->
+        <sql dbms="postgresql">
+            create sequence max_workflowname_and_toolname;
+            update workflow set workflowname = concat(left(workflowname, 254), nextval('max_workflowname_and_toolname')) where length(workflowname) > 256;
+            update tool set toolname = concat(left(toolname, 254), nextVal('max_workflowname_and_toolname')) where length(toolname) > 256;
+            update service set workflowname = concat(left(workflowname, 254), nextval('max_workflowname_and_toolname')) where length(workflowname) > 256;
+            drop sequence max_workflowname_and_toolname;
+        </sql>
+        <modifyDataType tableName="workflow" columnName="workflowname" newDataType="varchar(256)"/>
+        <modifyDataType tableName="tool" columnName="toolname" newDataType="varchar(256)"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.13.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.13.0.xml
@@ -73,9 +73,12 @@
             update workflow set workflowname = concat(left(workflowname, 254), nextval('max_workflowname_and_toolname')) where length(workflowname) > 256;
             update tool set toolname = concat(left(toolname, 254), nextVal('max_workflowname_and_toolname')) where length(toolname) > 256;
             update service set workflowname = concat(left(workflowname, 254), nextval('max_workflowname_and_toolname')) where length(workflowname) > 256;
+            update apptool set workflowname = concat(left(workflowname, 254), nextval('max_workflowname_and_toolname')) where length(workflowname) > 256;
             drop sequence max_workflowname_and_toolname;
         </sql>
         <modifyDataType tableName="workflow" columnName="workflowname" newDataType="varchar(256)"/>
         <modifyDataType tableName="tool" columnName="toolname" newDataType="varchar(256)"/>
+        <modifyDataType tableName="apptool" columnName="workflowname" newDataType="varchar(256)"/>
+        <modifyDataType tableName="service" columnName="workflowname" newDataType="varchar(256)"/>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3212,9 +3212,9 @@ paths:
         name: client_version
         schema:
           type: string
-          pattern: "(^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\\
-            d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\\
-            +([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$)|(^development-build$)"
+          pattern: "(^(0|[1-9]\\d*+)\\.(0|[1-9]\\d*+)\\.(0|[1-9]\\d*+)(?:-((?:0|[1-9]\\\
+            d*+|\\d*+[a-zA-Z-][0-9a-zA-Z-]*+)(?:\\.(?:0|[1-9]\\d*+|\\d*+[a-zA-Z-][0-9a-zA-Z-]*+))*+))?(?:\\\
+            +([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*+))?$)|(^development-build$)"
       - description: "Python version, only relevant for the cwltool runner"
         in: query
         name: python_version
@@ -7838,6 +7838,8 @@ components:
           type: string
         toolname:
           type: string
+          maxLength: 256
+          minLength: 0
         topic:
           type: string
         topicAutomatic:
@@ -9737,6 +9739,8 @@ components:
           uniqueItems: true
         workflowName:
           type: string
+          maxLength: 256
+          minLength: 0
         workflowVersions:
           type: array
           items:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3212,9 +3212,9 @@ paths:
         name: client_version
         schema:
           type: string
-          pattern: "(^(0|[1-9]\\d*+)\\.(0|[1-9]\\d*+)\\.(0|[1-9]\\d*+)(?:-((?:0|[1-9]\\\
-            d*+|\\d*+[a-zA-Z-][0-9a-zA-Z-]*+)(?:\\.(?:0|[1-9]\\d*+|\\d*+[a-zA-Z-][0-9a-zA-Z-]*+))*+))?(?:\\\
-            +([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*+))?$)|(^development-build$)"
+          pattern: "(^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\\
+            d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\\
+            +([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$)|(^development-build$)"
       - description: "Python version, only relevant for the cwltool runner"
         in: query
         name: python_version

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -6997,6 +6997,8 @@ definitions:
           \ entries in the dockstore registry/namespace/name/tool, different options\
           \ to edit tags, and only the same insofar as they would \"docker pull\"\
           \ the same image, required: GA4GH"
+        minLength: 0
+        maxLength: 256
       namespace:
         type: "string"
         position: 23
@@ -8937,6 +8939,8 @@ definitions:
         position: 14
         description: "This is the name of the workflow, not needed when only one workflow\
           \ in a repo"
+        minLength: 0
+        maxLength: 256
       input_file_formats:
         type: "array"
         position: 15


### PR DESCRIPTION

**Description**
If there is an error indexing any items, continue the indexing operation instead of terminating it.

Also, when logging the indexing error, log the the problematic entry's id to help track it down.

***Background***

One entry is failing to index on dev because its workflowname property length is > 75K. Elasticsearch, Lucene really, has a 32K limit on a term, see [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html) (look at the bottom of the page). This particular workflowname is so long for PEN testing purposes.

This is the simple fix. A more complex fix could be some combination of these -- push back if you think it's worth it (I don't, but can be convinced):

1. Enforce a max length on workflowname and other properties that end up being indexed.
2. Truncate strings greater than 32K before indexing them.
3. The index API response should be the number of items that were actually indexed, not the number attempted to index. 
4. Variant of above, instead of only returning a number with items indexed, return a JSON object, with fields for number of items indexed, number of items not indexed, maybe something else as well, etc.
5. The index API response should be a 5xx not a 2xx.
6. Create a CloudWatch alarm for when we fail to index an entry


**Issue**
[SEAB-4596](https://ucsc-cgl.atlassian.net/browse/SEAB-4596)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
