### PR TITLE
Check if user exists in user endpoints

### DIFF
--- a/dockstore-integration-testing/src/test/resources/dockstore.yml
+++ b/dockstore-integration-testing/src/test/resources/dockstore.yml
@@ -33,7 +33,7 @@ externalConfig:
   scheme: http
   port: 8080
 
-authenticationCachePolicy: maximumSize=10000, expireAfterAccess=10m
+authenticationCachePolicy: maximumSize=10000, expireAfterAccess=10s
 
 server:
   applicationConnectors:

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -261,6 +261,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(nickname = "getUser", value = "Get the logged-in user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
     public User getUser(@ApiParam(hidden = true) @Parameter(hidden = true) @Auth User user) {
         User foundUser = userDAO.findById(user.getId());
+        checkUserExists(foundUser);
         Hibernate.initialize(foundUser.getUserProfiles());
         return foundUser;
     }
@@ -292,6 +293,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(value = "Get additional information about the authenticated user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = ExtendedUserData.class)
     public ExtendedUserData getExtendedUserData(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user) {
         User foundUser = userDAO.findById(user.getId());
+        checkUserExists(foundUser);
         return new ExtendedUserData(foundUser, this.authorizer, userDAO);
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -276,6 +276,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(value = "Get the logged-in user's memberships.", authorizations = {@Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = OrganizationUser.class, responseContainer = "set")
     public Set<OrganizationUser> getUserMemberships(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user) {
         User foundUser = userDAO.findById(user.getId());
+        checkUserExists(foundUser);
         Set<OrganizationUser> organizationUsers = foundUser.getOrganizations();
         organizationUsers.forEach(organizationUser -> Hibernate.initialize(organizationUser.getOrganization()));
         return organizationUsers;
@@ -314,6 +315,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
         restrictUsername(username);
 
         User user = userDAO.findById(authUser.getId());
+        checkUserExists(user);
         if (!new ExtendedUserData(user, this.authorizer, userDAO).canChangeUsername()) {
             throw new CustomWebApplicationException("Cannot change username, user not ready", HttpStatus.SC_BAD_REQUEST);
         }
@@ -372,6 +374,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
             checkUser(authUser, authUser.getId());
             user = userDAO.findById(authUser.getId());
         }
+        checkUserExists(user);
 
         if (!new ExtendedUserData(user, this.authorizer, userDAO).canChangeUsername()) {
             throw new CustomWebApplicationException("Cannot delete user, user not ready for deletion", HttpStatus.SC_BAD_REQUEST);
@@ -740,6 +743,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
                                                             @Parameter(name = "filter", description = "Filter paths with matching text", in = ParameterIn.QUERY) @QueryParam("filter") String filter) {
         final List<OrganizationUpdateTime> organizations = new ArrayList<>();
         final User fetchedUser = this.userDAO.findById(authUser.getId());
+        checkUserExists(fetchedUser);
 
         // Retrieve all organizations and get timestamps
         Set<OrganizationUser> organizationUsers = fetchedUser.getOrganizations();
@@ -806,6 +810,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(value = "Get the authenticated user's starred tools.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Entry.class, responseContainer = "List")
     public Set<Entry> getStarredTools(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user) {
         User u = userDAO.findById(user.getId());
+        checkUserExists(u);
         return u.getStarredEntries().stream().filter(element -> element instanceof Tool || element instanceof AppTool)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
@@ -820,6 +825,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(value = "Get the authenticated user's starred workflows.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Entry.class, responseContainer = "List")
     public Set<Entry> getStarredWorkflows(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user) {
         User u = userDAO.findById(user.getId());
+        checkUserExists(u);
         return u.getStarredEntries().stream().filter(element -> element instanceof BioWorkflow)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
@@ -834,6 +840,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(value = "Get the authenticated user's starred services.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Entry.class, responseContainer = "List")
     public Set<Entry> getStarredServices(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user) {
         User u = userDAO.findById(user.getId());
+        checkUserExists(u);
         return u.getStarredEntries().stream().filter(element -> element instanceof Service)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
@@ -848,6 +855,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(value = "Get the authenticated user's starred organizations.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Organization.class, responseContainer = "List")
     public Set<Organization> getStarredOrganizations(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user) {
         User u = userDAO.findById(user.getId());
+        checkUserExists(u);
         return u.getStarredOrganizations();
     }
 
@@ -901,6 +909,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(value = "Update metadata for logged in user.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
     public User updateLoggedInUserMetadata(@ApiParam(hidden = true)@Parameter(hidden = true, name = "user")@Auth User user, @ApiParam(value = "Token source", allowableValues = "google.com, github.com") @QueryParam("source") TokenType source) {
         User dbuser = userDAO.findById(user.getId());
+        checkUserExists(dbuser);
         if (source.equals(TokenType.GOOGLE_COM)) {
             updateGoogleAccessToken(user.getId());
         }
@@ -917,6 +926,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(value = "Update the user's TOS and privacy policy to the latest versions.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class, hidden = true)
     public User updateAcceptedDocuments(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth User user) {
         User dbUser = userDAO.findById(user.getId());
+        checkUserExists(dbUser);
         TokenResource.acceptTOSAndPrivacyPolicy(dbUser);
         return dbUser;
     }
@@ -975,6 +985,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(value = "Syncs Dockstore account with GitHub App Installations.", authorizations = {@Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Workflow.class, responseContainer = "List")
     public List<Workflow> syncUserWithGitHub(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser) {
         final User user = userDAO.findById(authUser.getId());
+        checkUserExists(user);
         workflowResource.syncEntitiesForUser(user);
         userDAO.clearCache();
         return getStrippedWorkflowsAndServices(userDAO.findById(user.getId()));
@@ -992,6 +1003,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     })
     public List<SourceControlOrganization> getMyGitHubOrgs(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser) {
         final User user = userDAO.findById(authUser.getId());
+        checkUserExists(user);
         Token githubToken = tokenDAO.findGithubByUserId(user.getId()).stream()
                 .filter(token -> token.getTokenSource() == TokenType.GITHUB_COM).findFirst().orElse(null);
         if (githubToken != null) {
@@ -1091,6 +1103,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
             @ApiParam(value = PAGINATION_OFFSET_TEXT) @QueryParam("offset") String offset,
             @ApiParam(value = PAGINATION_LIMIT_TEXT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit) {
         final User user = userDAO.findById(authUser.getId());
+        checkUserExists(user);
         return lambdaEventDAO.findByUser(user, offset, limit);
     }
 


### PR DESCRIPTION
**Description**
Companion PRs:
- compose_setup: https://github.com/dockstore/compose_setup/pull/230
- UI: https://github.com/dockstore/dockstore-ui2/pull/1573

I recommend reviewing the compose_setup PR first, then the UI PR, then this PR for things to make the most sense.

This PR checks if a user exists in user endpoints so a 404 is returned instead of a vague 500. The most important endpoint for this check is the get logged in user endpoint because the UI uses it to check if a user is authenticated when routing. If a deleted user tries to navigate to authenticated pages, it'll return a user not found error in the console, which is more helpful than a 500. I added the check to other user endpoints that retrieve a user from the DB so they're also not returning 500s.

The dockstore.yml used for testing is updated with the new `expireAfterAccess` value of 10 seconds. This has no real effect on the deploy, but since it's a template for setting Dockstore up locally, I updated the property. The one that takes effect during deploy is in the compose_setup PR.

**Issue**
[SEAB-3895](https://ucsc-cgl.atlassian.net/browse/SEAB-3895)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
