### PR TITLE
Removed Liquibase Changeset Message from Output in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
             python3 -V
       - run:
           name: run the actual tests
-          command: ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Punit-tests,coverage -ntp
+          command: ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Punit-tests,coverage -ntp | grep  -v "^Running Changeset:"
       - run:
           name: send coverage for unit tests
           command: bash <(curl -s https://codecov.io/bash) -F unit-tests_and_non-confidential-tests || echo "Codecov did not collect coverage reports"
@@ -280,7 +280,7 @@ jobs:
               # If it is a branch, skip the signature check
               export SKIP_SIGNATURE_CHECK=true
             fi
-            ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Pnon-confidential-tests,coverage -Djavax.net.ssl.trustStore=../LocalTrustStore -Djavax.net.ssl.trustStorePassword=changeit  -DskipSignatureCheck=$SKIP_SIGNATURE_CHECK -ntp
+            ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Pnon-confidential-tests,coverage -Djavax.net.ssl.trustStore=../LocalTrustStore -Djavax.net.ssl.trustStorePassword=changeit  -DskipSignatureCheck=$SKIP_SIGNATURE_CHECK -ntp | grep  -v "^Running Changeset:"
             # ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Pnon-confidential-tests,coverage -Djavax.net.ssl.trustStore=../LocalTrustStore -Djavax.net.ssl.trustStorePassword=changeit -ntp
       - run:
           name: send coverage for non-confidential integration tests
@@ -466,11 +466,11 @@ commands:
               TESTS_TO_RUN=$(cat temp/test-lists/IT/all.txt | circleci tests split --split-by=timings --time-default=0.1s | tr '\n' ',')
               echo $TESTS_TO_RUN
               ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate -P$TESTING_PROFILE,coverage -ntp \
-              clean verify -Dit.test=$TESTS_TO_RUN -DfailIfNoTests=false
+              clean verify -Dit.test=$TESTS_TO_RUN -DfailIfNoTests=false | grep  -v "^Running Changeset:"
             else 
-              ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -P$TESTING_PROFILE,coverage -ntp 
+              ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -P$TESTING_PROFILE,coverage -ntp | grep  -v "^Running Changeset:"
             fi
-
+          # The piping grep command is a temporary fix to this issue https://github.com/liquibase/liquibase/issues/2396
       - run:
           name: send coverage
           command: bash <(curl -s https://codecov.io/bash) -F ${TESTING_PROFILE//-} || echo "Codecov did not collect coverage reports"


### PR DESCRIPTION
**Description**
An update in liquibase has caused every changeset to be logged to stdout. Including messages such as,
```
Running Changeset: migrations.1.12.0.xml::topicPhaseTwoChanges::gluu (generated)
Running Changeset: migrations.1.12.0.xml::clearCwlToolTableJson::svonworl
Running Changeset: migrations.1.12.0.xml::checksumsForNullContent::coverbeck
Running Changeset: migrations.1.12.0.xml::addAppToolEvents::dyuen (generated)
Running Changeset: migrations.1.12.0.xml::orcidAuthorInfo::ktran (generated)
Running Changeset: migrations.1.13.0.xml::migrateBioToBlogLink::ktran
Running Changeset: migrations.1.13.0.xml::convertUserProfileEmptyStringToNull::ktran
Running Changeset: migrations.1.13.0.xml::add_constraints_to_user_profile::ajandu
```
which is making it difficult to determine the cause of test failures in CirlceCI. This issue has been bought to the attention of liquibase and it looks like they will fix it,

https://github.com/liquibase/liquibase/issues/2396

In the meantime I have made added a `grep` to each command that produces liquibase changeset messages so that they aren't displayed in CircleCI.

This PR should be revisited when https://github.com/liquibase/liquibase/issues/2396 is resolved.

**Issue**
[SEAB-4602](https://ucsc-cgl.atlassian.net/browse/SEAB-4602)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
