### PR TITLE
Feature/restub snapshot

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -20,6 +20,7 @@ import static io.dockstore.webservice.core.Version.CANNOT_FREEZE_VERSIONS_WITH_N
 import static io.dockstore.webservice.helpers.EntryVersionHelper.CANNOT_MODIFY_FROZEN_VERSIONS_THIS_WAY;
 import static io.dockstore.webservice.resources.WorkflowResource.A_WORKFLOW_MUST_BE_UNPUBLISHED_TO_RESTUB;
 import static io.dockstore.webservice.resources.WorkflowResource.A_WORKFLOW_MUST_HAVE_NO_DOI_TO_RESTUB;
+import static io.dockstore.webservice.resources.WorkflowResource.A_WORKFLOW_MUST_HAVE_NO_SNAPSHOT_TO_RESTUB;
 import static io.dockstore.webservice.resources.WorkflowResource.FROZEN_VERSION_REQUIRED;
 import static io.dockstore.webservice.resources.WorkflowResource.NO_ZENDO_USER_TOKEN;
 import static org.junit.Assert.assertEquals;
@@ -1207,6 +1208,14 @@ public class GeneralWorkflowIT extends BaseIT {
             fail("This line should never execute, should not be able to restub workflow with DOI even if it is unpublished");
         } catch (ApiException e) {
             assertTrue(e.getMessage().contains(A_WORKFLOW_MUST_HAVE_NO_DOI_TO_RESTUB));
+        }
+        // don't die horribly when stubbing something with snapshots, explain the error
+        testingPostgres.runUpdateStatement("update workflow set conceptdoi = null");
+        try {
+            workflowsApi.restub(workflowBeforeFreezing.getId());
+            fail("This line should never execute, should not be able to restub workflow with DOI even if it is unpublished");
+        } catch (ApiException e) {
+            assertTrue(e.getMessage().contains(A_WORKFLOW_MUST_HAVE_NO_SNAPSHOT_TO_RESTUB));
         }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -81,7 +81,7 @@ import org.hibernate.annotations.UpdateTimestamp;
             "SELECT new io.dockstore.webservice.core.database.VersionVerifiedPlatform(version.id, KEY(verifiedbysource), verifiedbysource.metadata, verifiedbysource.platformVersion, sourcefiles.path, verifiedbysource.verified) FROM Version version "
                 + "INNER JOIN version.sourceFiles as sourcefiles INNER JOIN sourcefiles.verifiedBySource as verifiedbysource WHERE KEY(verifiedbysource) IS NOT NULL AND "
                 + "version.parent.id = :entryId"),
-    @NamedQuery(name = "io.dockstore.webservice.core.Version.getCountVersionFrozenByEntryID", query = "SELECT Count(v.frozen) FROM Version v WHERE v.parent.id = :id"),
+    @NamedQuery(name = "io.dockstore.webservice.core.Version.getCountVersionFrozenByEntryID", query = "SELECT sum (case when v.frozen = true then 1 else 0 end) FROM Version v WHERE v.parent.id = :id"),
     @NamedQuery(name = "io.dockstore.webservice.core.Version.getCountByEntryId", query = "SELECT Count(v) FROM Version v WHERE v.parent.id = :id")
 })
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -81,6 +81,7 @@ import org.hibernate.annotations.UpdateTimestamp;
             "SELECT new io.dockstore.webservice.core.database.VersionVerifiedPlatform(version.id, KEY(verifiedbysource), verifiedbysource.metadata, verifiedbysource.platformVersion, sourcefiles.path, verifiedbysource.verified) FROM Version version "
                 + "INNER JOIN version.sourceFiles as sourcefiles INNER JOIN sourcefiles.verifiedBySource as verifiedbysource WHERE KEY(verifiedbysource) IS NOT NULL AND "
                 + "version.parent.id = :entryId"),
+    @NamedQuery(name = "io.dockstore.webservice.core.Version.getCountVersionFrozenByEntryID", query = "SELECT Count(v.frozen) FROM Version v WHERE v.parent.id = :id"),
     @NamedQuery(name = "io.dockstore.webservice.core.Version.getCountByEntryId", query = "SELECT Count(v) FROM Version v WHERE v.parent.id = :id")
 })
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
@@ -59,6 +59,12 @@ public class VersionDAO<T extends Version> extends AbstractDAO<T> {
         return (long)query.getSingleResult();
     }
 
+    public long getVersionsFrozen(long entryId) {
+        Query query = namedQuery("io.dockstore.webservice.core.Version.getCountVersionFrozenByEntryID");
+        query.setParameter("id", entryId);
+        return (long) query.getSingleResult();
+    }
+
     public void enableNameFilter(String name) {
         currentSession().enableFilter("versionNameFilter").setParameter("name", name);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
@@ -59,11 +59,14 @@ public class VersionDAO<T extends Version> extends AbstractDAO<T> {
         return (long)query.getSingleResult();
     }
 
-    // Currently not used, but may be useful later for archive/deletion operations
     public long getVersionsFrozen(long entryId) {
         Query query = namedQuery("io.dockstore.webservice.core.Version.getCountVersionFrozenByEntryID");
         query.setParameter("id", entryId);
-        return (long) query.getSingleResult();
+        final Object singleResult = query.getSingleResult();
+        if (singleResult == null) {
+            return 0;
+        }
+        return (long)singleResult;
     }
 
     public void enableNameFilter(String name) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/VersionDAO.java
@@ -59,6 +59,7 @@ public class VersionDAO<T extends Version> extends AbstractDAO<T> {
         return (long)query.getSingleResult();
     }
 
+    // Currently not used, but may be useful later for archive/deletion operations
     public long getVersionsFrozen(long entryId) {
         Query query = namedQuery("io.dockstore.webservice.core.Version.getCountVersionFrozenByEntryID");
         query.setParameter("id", entryId);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -172,6 +172,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     private static final String VERSION_INCLUDE_MESSAGE = "Comma-delimited list of fields to include: " + VERSION_INCLUDE;
     private static final String WORKFLOW_INCLUDE_MESSAGE = "Comma-delimited list of fields to include: " + WORKFLOW_INCLUDE + ", " + VERSION_INCLUDE;
     private static final String SHA_TYPE_FOR_SOURCEFILES = "SHA-1";
+    public static final String A_WORKFLOW_MUST_BE_UNPUBLISHED_TO_RESTUB = "A workflow must be unpublished to restub.";
+    public static final String A_WORKFLOW_MUST_HAVE_NO_SNAPSHOTS_TO_RESTUB = "A workflow must have no snapshots to restub";
 
     private final ToolDAO toolDAO;
     private final LabelDAO labelDAO;
@@ -237,11 +239,13 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         Workflow workflow = workflowDAO.findById(workflowId);
         // Check that workflow is valid to restub
         if (workflow.getIsPublished()) {
-            throw new CustomWebApplicationException("A workflow must be unpublished to restub.", HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(A_WORKFLOW_MUST_BE_UNPUBLISHED_TO_RESTUB, HttpStatus.SC_BAD_REQUEST);
         }
-
         if (workflow.isIsChecker()) {
             throw new CustomWebApplicationException("A checker workflow cannot be restubed.", HttpStatus.SC_BAD_REQUEST);
+        }
+        if (versionDAO.getVersionsFrozen(workflowId) > 0) {
+            throw new CustomWebApplicationException(A_WORKFLOW_MUST_HAVE_NO_SNAPSHOTS_TO_RESTUB, HttpStatus.SC_BAD_REQUEST);
         }
 
         checkNotHosted(workflow);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -174,6 +174,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     private static final String SHA_TYPE_FOR_SOURCEFILES = "SHA-1";
     public static final String A_WORKFLOW_MUST_BE_UNPUBLISHED_TO_RESTUB = "A workflow must be unpublished to restub.";
     public static final String A_WORKFLOW_MUST_HAVE_NO_DOI_TO_RESTUB = "A workflow must have no issued DOIs to restub";
+    public static final String A_WORKFLOW_MUST_HAVE_NO_SNAPSHOT_TO_RESTUB = "A workflow must have no snapshots to restub, you may consider unpublishing";
 
     private final ToolDAO toolDAO;
     private final LabelDAO labelDAO;
@@ -246,6 +247,9 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         }
         if (workflow.getConceptDoi() != null) {
             throw new CustomWebApplicationException(A_WORKFLOW_MUST_HAVE_NO_DOI_TO_RESTUB, HttpStatus.SC_BAD_REQUEST);
+        }
+        if (versionDAO.getVersionsFrozen(workflowId) > 0) {
+            throw new CustomWebApplicationException(A_WORKFLOW_MUST_HAVE_NO_SNAPSHOT_TO_RESTUB, HttpStatus.SC_BAD_REQUEST);
         }
 
         checkNotHosted(workflow);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -238,6 +238,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     public Workflow restub(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth User user,
         @ApiParam(value = "workflow ID", required = true) @PathParam("workflowId") Long workflowId) {
         Workflow workflow = workflowDAO.findById(workflowId);
+        checkEntry(workflow);
         // Check that workflow is valid to restub
         if (workflow.getIsPublished()) {
             throw new CustomWebApplicationException(A_WORKFLOW_MUST_BE_UNPUBLISHED_TO_RESTUB, HttpStatus.SC_BAD_REQUEST);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -173,7 +173,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     private static final String WORKFLOW_INCLUDE_MESSAGE = "Comma-delimited list of fields to include: " + WORKFLOW_INCLUDE + ", " + VERSION_INCLUDE;
     private static final String SHA_TYPE_FOR_SOURCEFILES = "SHA-1";
     public static final String A_WORKFLOW_MUST_BE_UNPUBLISHED_TO_RESTUB = "A workflow must be unpublished to restub.";
-    public static final String A_WORKFLOW_MUST_HAVE_NO_SNAPSHOTS_TO_RESTUB = "A workflow must have no snapshots to restub";
+    public static final String A_WORKFLOW_MUST_HAVE_NO_DOI_TO_RESTUB = "A workflow must have no issued DOIs to restub";
 
     private final ToolDAO toolDAO;
     private final LabelDAO labelDAO;
@@ -244,8 +244,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         if (workflow.isIsChecker()) {
             throw new CustomWebApplicationException("A checker workflow cannot be restubed.", HttpStatus.SC_BAD_REQUEST);
         }
-        if (versionDAO.getVersionsFrozen(workflowId) > 0) {
-            throw new CustomWebApplicationException(A_WORKFLOW_MUST_HAVE_NO_SNAPSHOTS_TO_RESTUB, HttpStatus.SC_BAD_REQUEST);
+        if (workflow.getConceptDoi() != null) {
+            throw new CustomWebApplicationException(A_WORKFLOW_MUST_HAVE_NO_DOI_TO_RESTUB, HttpStatus.SC_BAD_REQUEST);
         }
 
         checkNotHosted(workflow);


### PR DESCRIPTION
**Description**
Add test and then check for re-stubbing workflow with frozen versions 
This will now return a 400 for restubbing:
* a published workflow (need to unpublish first and I think it makes sense to make that a separate operation to make a user double-check) 
* a workflow with frozen versions. 
* a workflow with an issued DOI (once the contents are in zenodo, it feels like the cat is out of the bag at that point though a determined user could delete the entry on Zenodo)

The middle one is a little interesting because once a workflow has frozen versions, I don't think we can actually delete them (without using the superuser) since the parentid column is part of what is frozen. That said, a user could unpublish a workflow with snapshots. 

**Issue**
https://github.com/dockstore/dockstore/issues/4717

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
