### PR TITLE
add test and hook up verified to collection endpoint

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -58,8 +58,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 @Category(ConfidentialTest.class)
-public class
-OrganizationIT extends BaseIT {
+public class OrganizationIT extends BaseIT {
     private static final long NONEXISTENT_ID = Long.MAX_VALUE;
 
     private static final StarRequest STAR_REQUEST = getStarRequest(true);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -25,10 +25,12 @@ import io.swagger.client.ApiException;
 import io.swagger.client.api.ContainersApi;
 import io.swagger.client.api.ContainertagsApi;
 import io.swagger.client.api.EntriesApi;
+import io.swagger.client.api.ExtendedGa4GhApi;
 import io.swagger.client.api.OrganizationsApi;
 import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.Collection;
+import io.swagger.client.model.CollectionEntry;
 import io.swagger.client.model.CollectionOrganization;
 import io.swagger.client.model.Event;
 import io.swagger.client.model.Organization;
@@ -56,7 +58,8 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 @Category(ConfidentialTest.class)
-public class OrganizationIT extends BaseIT {
+public class
+OrganizationIT extends BaseIT {
     private static final long NONEXISTENT_ID = Long.MAX_VALUE;
 
     private static final StarRequest STAR_REQUEST = getStarRequest(true);
@@ -1923,7 +1926,11 @@ public class OrganizationIT extends BaseIT {
         workflow = workflowApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
         Assert.assertEquals(2, workflow.getWorkflowVersions().size());
 
-        return (workflow);
+        ExtendedGa4GhApi ga4ghApi = new ExtendedGa4GhApi(webClient);
+        ga4ghApi.toolsIdVersionsVersionIdTypeTestsPost("CWL", "#workflow/github.com/DockstoreTestUser2/gdc-dnaseq-cwl", "test", "/workflows/dnaseq/transform.cwl.json", "platform", "platform version",
+            "dummy metadata", true);
+        workflow = workflowApi.getWorkflow(workflow.getId(), "");
+        return workflow;
     }
 
     private Workflow createWorkflow2() {
@@ -1938,7 +1945,7 @@ public class OrganizationIT extends BaseIT {
         workflowApi.refresh(workflowByPathGithub2.getId(), false);
         workflowApi.publish(workflow2.getId(), CommonTestUtilities.createPublishRequest(true));
 
-        return (workflow2);
+        return workflow2;
     }
 
     /**
@@ -1985,6 +1992,11 @@ public class OrganizationIT extends BaseIT {
         //testing the query is working properly by using GET {organizationId}/collections
         List<Collection> collectionsFromOrganization = organizationsApi.getCollectionsFromOrganization(orgId, null);
         assertEquals(3, (long)collectionsFromOrganization.stream().filter(col -> col.getId().equals(collectionId)).findFirst().get().getWorkflowsLength());
+
+
+        // test whether verified workflow info comes back
+        final Collection collectionByName = organizationsApi.getCollectionByName(organization.getName(), collection.getName());
+        assertTrue(collectionByName.getEntries().stream().anyMatch(CollectionEntry::isVerified));
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/CollectionEntry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/CollectionEntry.java
@@ -26,7 +26,18 @@ public class CollectionEntry implements Serializable {
     @JsonProperty("categories")
     private List<CategorySummary> categorySummaries = new ArrayList<>();
 
+    /**
+     * @param id
+     * @param dbUpdateDate
+     * @param entryTypeString
+     * @param sourceControl
+     * @param organization
+     * @param repository
+     * @param entryName
+     * @deprecated assumes verification is false, but one version may in fact be verified
+     */
     @SuppressWarnings("checkstyle:ParameterNumber")
+    @Deprecated
     public CollectionEntry(long id, Date dbUpdateDate, String entryTypeString, SourceControl sourceControl, String organization, String repository, String entryName)  {
         this(id, dbUpdateDate, entryTypeString, sourceControl, organization, repository, entryName, null, false);
     }
@@ -41,7 +52,19 @@ public class CollectionEntry implements Serializable {
         setVerified(verified);
     }
 
+
+    /**
+     * @param id
+     * @param dbUpdateDate
+     * @param entryTypeString
+     * @param registry
+     * @param organization
+     * @param repository
+     * @param entryName
+     * @deprecated assumes verification is false, but one version may in fact be verified
+     */
     @SuppressWarnings("checkstyle:ParameterNumber")
+    @Deprecated
     public CollectionEntry(long id, Date dbUpdateDate, String entryTypeString, String registry, String organization, String repository, String entryName)  {
         this(id, dbUpdateDate, entryTypeString, registry, organization, repository, entryName, null, false);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
@@ -21,6 +21,7 @@ import io.dockstore.webservice.core.Category;
 import io.dockstore.webservice.helpers.ParamHelper;
 import io.dockstore.webservice.jdbi.CategoryDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
+import io.dockstore.webservice.jdbi.VersionDAO;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -56,7 +57,7 @@ public class CategoryResource implements AuthenticatedResourceInterface {
 
     public CategoryResource(SessionFactory sessionFactory) {
         this.categoryDAO = new CategoryDAO(sessionFactory);
-        this.collectionHelper = new CollectionHelper(sessionFactory, new ToolDAO(sessionFactory));
+        this.collectionHelper = new CollectionHelper(sessionFactory, new ToolDAO(sessionFactory), new VersionDAO(sessionFactory));
 
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionHelper.java
@@ -22,6 +22,7 @@ import io.dockstore.webservice.core.Collection;
 import io.dockstore.webservice.core.CollectionEntry;
 import io.dockstore.webservice.core.Label;
 import io.dockstore.webservice.jdbi.EntryDAO;
+import io.dockstore.webservice.jdbi.VersionDAO;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -37,10 +38,12 @@ class CollectionHelper {
     private static final Logger LOG = LoggerFactory.getLogger(CollectionHelper.class);
     private final SessionFactory sessionFactory;
     private final EntryDAO<?> entryDAO;
+    private final VersionDAO versionDAO;
 
-    CollectionHelper(SessionFactory sessionFactory, EntryDAO<?> entryDAO) {
+    CollectionHelper(SessionFactory sessionFactory, EntryDAO<?> entryDAO, VersionDAO versionDAO) {
         this.sessionFactory = sessionFactory;
         this.entryDAO = entryDAO;
+        this.versionDAO = versionDAO;
     }
 
     public void throwExceptionForNullCollection(Collection collection) {
@@ -85,6 +88,7 @@ class CollectionHelper {
             List<Label> labels = entryDAO.getLabelByEntryId(entry.getId());
             List<String> labelStrings = labels.stream().map(Label::getValue).collect(Collectors.toList());
             entry.setLabels(labelStrings);
+            entry.setVerified(!versionDAO.findEntryVersionsWithVerifiedPlatforms(entry.getId()).isEmpty());
             List<CategorySummary> summaries = entryDAO.findCategorySummariesByEntryId(entry.getId());
             entry.setCategorySummaries(summaries);
             switch (entry.getEntryType()) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -102,7 +102,7 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
         this.userDAO = new UserDAO(sessionFactory);
         this.eventDAO = new EventDAO(sessionFactory);
         this.versionDAO = new VersionDAO(sessionFactory);
-        this.helper = new CollectionHelper(sessionFactory, toolDAO);
+        this.helper = new CollectionHelper(sessionFactory, toolDAO, versionDAO);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -135,7 +135,7 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
         this.versionDAO = versionDAO;
         this.tokenDAO = tokenDAO;
         this.userDAO = userDAO;
-        this.collectionHelper = new CollectionHelper(sessionFactory, toolDAO);
+        this.collectionHelper = new CollectionHelper(sessionFactory, toolDAO, versionDAO);
         discourseUrl = configuration.getDiscourseUrl();
         discourseKey = configuration.getDiscourseKey();
         discourseCategoryId = configuration.getDiscourseCategoryId();


### PR DESCRIPTION
**Description**
Hook up verified status to collection endpoint

For background, the constructors in `CollectionEntry` that are not modified in this PR have two versions, ones which specify specific versions and include verification information, and those that do not specify specific versions and encounter this bug.
Ideally, we would do it inside the queries in Entry that call the EntryCollection constructors but JPQL does not support subqueries outside of some special cases

**Issue**
https://github.com/dockstore/dockstore/issues/4645

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
