### PR TITLE
Fix collectionsLength for starred organizations

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -1254,6 +1254,19 @@ public class OrganizationIT extends BaseIT {
 
         numberOfCollections = organizationsApi.getCollectionsFromOrganization(organization.getId(), null).size();
         assertEquals(1, numberOfCollections);
+
+        // Test collectionsLength works for starred orgs. https://ucsc-cgl.atlassian.net/browse/SEAB-3136
+        organizationsApi.approveOrganization(organization.getId()); // Can only star approved orgs
+
+        final StarRequest starRequest = new StarRequest();
+        starRequest.star(Boolean.TRUE);
+        organizationsApi.starOrganization(organization.getId(), starRequest);
+
+        final UsersApi usersApi = new UsersApi(webClientUser2);
+        final List<Organization> starredOrganizations = usersApi.getStarredOrganizations();
+        assertEquals(1, starredOrganizations.size());
+        final long starredOrgNumberOfCollections = starredOrganizations.get(0).getCollectionsLength().longValue();
+        assertEquals(1, starredOrgNumberOfCollections);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Organization.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Organization.java
@@ -33,7 +33,6 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
-import javax.persistence.Transient;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
@@ -119,15 +118,16 @@ public class Organization implements Serializable, Aliasable {
     @OrderBy("id")
     private Set<User> starredUsers;
 
+    /**
+     * This should probably be lazy. Until then, note that the <code>getCollectionsLength()</code>
+     * method fetches all collections; to convert this to lazy, the implementation of
+     * <code>getCollectionsLength()</code> should change otherwise they'll be eagerly fetched
+     * anyway.
+     */
     @JsonIgnore
     @OneToMany(mappedBy = "organization")
     @Where(clause = "deleted = false")
     private Set<Collection> collections = new HashSet<>();
-
-    @Transient
-    @JsonSerialize
-    @ApiModelProperty(value = "collectionsLength")
-    private long collectionsLength;
 
     @ElementCollection(targetClass = Alias.class)
     @JoinTable(name = "organization_alias", joinColumns = @JoinColumn(name = "id", columnDefinition = "bigint"), uniqueConstraints = @UniqueConstraint(name = "unique_org_aliases", columnNames = { "alias" }))
@@ -265,12 +265,10 @@ public class Organization implements Serializable, Aliasable {
         this.collections = collections;
     }
 
+    @JsonSerialize
+    @ApiModelProperty(value = "collectionsLength")
     public long getCollectionsLength() {
-        return collectionsLength; 
-    }
-
-    public void setCollectionsLength(long length) {
-        this.collectionsLength = length; 
+        return getCollections().size();
     }
 
     public void addCollection(Collection collection) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
@@ -106,7 +106,6 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
         List<Organization> organizations = organizationDAO.findApprovedSortedByStar();
         organizations.stream().forEach(org -> {
             Hibernate.initialize(org.getAliases());
-            org.setCollectionsLength(org.getCollections().size());
         });
         return organizations;
     }
@@ -255,7 +254,6 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
         @ApiParam(value = "Organization ID.", required = true) @Parameter(description = "Organization ID.", name = "organizationId", in = ParameterIn.PATH, required = true) @PathParam("organizationId") Long id) {
         Organization organization = getOrganizationByIdOptionalAuth(user, id);
         Hibernate.initialize(organization.getAliases());
-        organization.setCollectionsLength(organization.getCollections().size());
         return organization;
     }
 


### PR DESCRIPTION
**Description**
This PR relies on the fact that we don't lazily fetch an organization's collections.
But the existing code already eagerly fetches, so this is no worse, doesn't
generate any additional queries, and on the plus side doesn't force
developers to manually initialize the field.

Note: With a recent-ish snapshot of prod data, 145 JDBC statements are executed to load the Organizations page, which isn't great, but isn't terrible, so I think the lazy switch can wait a bit (it's 145 statements both with and without this fix). 

**Issue**
[SEAB-3136](https://ucsc-cgl.atlassian.net/browse/SEAB-3136)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
