### PR TITLE
Endpoint to find orgs with GitHub app logs

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -337,6 +337,15 @@ public class WebhookIT extends BaseIT {
             assertEquals("Should fail because user cannot access org.", HttpStatus.SC_UNAUTHORIZED, ex.getCode());
         }
 
+        final List<String> organizationsWithLambdaEvents =
+            lambdaEventsApi.getOrganizationsWithLambdaEvents();
+        assertEquals(1, organizationsWithLambdaEvents.size());
+        assertEquals(BasicIT.USER_2_USERNAME, organizationsWithLambdaEvents.get(0));
+
+        // Fake event that doesn't correspond to an entry
+        testingPostgres.runUpdateStatement("insert into lambdaevent (organization) values ('dockstoretesting');");
+        assertEquals(2, lambdaEventsApi.getOrganizationsWithLambdaEvents().size());
+
         // Try adding version with empty test parameter file (should work)
         client.handleGitHubRelease("refs/heads/emptytestparameter", installationId, workflowRepo, BasicIT.USER_2_USERNAME);
         workflow2 = getFoobar2Workflow(client);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LambdaEvent.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LambdaEvent.java
@@ -36,6 +36,7 @@ import org.hibernate.annotations.UpdateTimestamp;
     @NamedQuery(name = "io.dockstore.webservice.core.LambdaEvent.findByOrganization", query = "SELECT lambdaEvent FROM LambdaEvent lambdaEvent WHERE lambdaEvent.repository like :organization"),
     @NamedQuery(name = "io.dockstore.webservice.core.LambdaEvent.findByUsername", query = "SELECT lambdaEvent FROM LambdaEvent lambdaEvent WHERE lambdaEvent.githubUsername = :username"),
     @NamedQuery(name = "io.dockstore.webservice.core.LambdaEvent.findByUser", query = "SELECT lambdaEvent FROM LambdaEvent lambdaEvent WHERE lambdaEvent.user = :user"),
+    @NamedQuery(name = "io.dockstore.webservice.core.LambdaEvent.findOrganizationsWithEvents", query = "select distinct(lambdaEvent.organization) FROM LambdaEvent lambdaEvent WHERE lambdaEvent.organization in :organizations")
 })
 @SuppressWarnings("checkstyle:magicnumber")
 public class LambdaEvent {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -6,6 +6,7 @@ import io.dockstore.webservice.core.User;
 import io.dropwizard.hibernate.AbstractDAO;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -88,5 +89,16 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
         int primitiveOffset = Integer.parseInt(MoreObjects.firstNonNull(offset, "0"));
         TypedQuery<LambdaEvent> typedQuery = currentSession().createQuery(query).setFirstResult(primitiveOffset).setMaxResults(limit);
         return typedQuery.getResultList();
+    }
+
+    /**
+     * Finds GitHub organizations with events that are in <code>organizations</code>. Does a
+     * case-insensitive lookup.
+     * @param organizations
+     * @return
+     */
+    public List<String> findOrganizationsWithEvents(Set<String> organizations) {
+        return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.LambdaEvent.findOrganizationsWithEvents")
+            .setParameter("organizations", organizations));
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -91,12 +91,6 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
         return typedQuery.getResultList();
     }
 
-    /**
-     * Finds GitHub organizations with events that are in <code>organizations</code>. Does a
-     * case-insensitive lookup.
-     * @param organizations
-     * @return
-     */
     public List<String> findOrganizationsWithEvents(Set<String> organizations) {
         return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.LambdaEvent.findOrganizationsWithEvents")
             .setParameter("organizations", organizations));

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3064,7 +3064,24 @@ paths:
       summary: Get a list of test JSONs
       tags:
       - GA4GHV20
-  /lambdaEvents/{organization}:
+  /lambdaEvents/organizations:
+    get:
+      description: Get all of the user's GitHub organizations that have events.
+      operationId: getOrganizationsWithLambdaEvents
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+          description: default response
+      security:
+      - BEARER: []
+      tags:
+      - lambdaEvents
+  /lambdaEvents/organizations/{organization}:
     get:
       description: Get all of the Lambda Events for the given GitHub organization.
       operationId: getLambdaEventsByOrganization

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -2779,7 +2779,24 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/Event"
-  /lambdaEvents/{organization}:
+  /lambdaEvents/organizations:
+    get:
+      tags:
+      - "lambdaEvents"
+      summary: "See OpenApi for details"
+      description: ""
+      operationId: "getOrganizationsWithLambdaEvents"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+  /lambdaEvents/organizations/{organization}:
     get:
       tags:
       - "lambdaEvents"


### PR DESCRIPTION
**Description**

New web service endpoint to fetch the GitHub org names that the user belongs to, and for which there are lambda events.

There will have to be a UI PR to use the endpoint. And adopt to the moved existing endpoint.

Moved the existing endpoint to make it more RESTful, arguably (now /lambdaEvents/organizations, and /lambdaEvents/organizations/{org} -- it was /lambdaEvents/{organization} before). I could have left it, and introduced an ambigous `/organizations` endpoint, but seemed best to change.

**Issue**
#4845

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
