### PR TITLE
Fix user-level permission check for workflow version ORCID authors endpoint

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -861,6 +861,8 @@ public class WebhookIT extends BaseIT {
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false);
         final io.dockstore.openapi.client.ApiClient webClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
         io.dockstore.openapi.client.api.WorkflowsApi workflowsApi = new io.dockstore.openapi.client.api.WorkflowsApi(webClient);
+        io.dockstore.openapi.client.ApiClient anonymousWebClient = getAnonymousOpenAPIWebClient();
+        io.dockstore.openapi.client.api.WorkflowsApi anonymousWorkflowsApi = new io.dockstore.openapi.client.api.WorkflowsApi(anonymousWebClient);
         String wdlWorkflowRepoPath = String.format("github.com/%s/%s", authorsRepo, "foobar");
 
         // Workflows containing 1 descriptor author and multiple .dockstore.yml authors.
@@ -878,6 +880,14 @@ public class WebhookIT extends BaseIT {
             hoverfly.simulate(ORCID_SIMULATION_SOURCE);
             List<OrcidAuthorInformation> orcidAuthorInfo = workflowsApi.getWorkflowVersionOrcidAuthors(workflow.getId(), version.getId());
             assertEquals(1, orcidAuthorInfo.size()); // There's 1 OrcidAuthorInfo instead of 2 because only 1 ORCID ID from the version exists on ORCID
+
+            // Publish workflow
+            io.dockstore.openapi.client.model.PublishRequest publishRequest = CommonTestUtilities.createOpenAPIPublishRequest(true);
+            workflowsApi.publish1(workflow.getId(), publishRequest);
+
+            // Check that an unauthenticated user can get the workflow version ORCID authors of a published workflow
+            anonymousWorkflowsApi.getWorkflowVersionOrcidAuthors(workflow.getId(), version.getId());
+            assertEquals(1, orcidAuthorInfo.size());
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -2158,12 +2158,11 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Retrieve ORCID author information for a workflow version", content = @Content(
             mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = OrcidAuthorInformation.class))))
     @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad Request")
-    public Set<OrcidAuthorInformation> getWorkflowVersionOrcidAuthors(@Parameter(hidden = true, name = "user")@Auth User user,
+    public Set<OrcidAuthorInformation> getWorkflowVersionOrcidAuthors(@Parameter(hidden = true, name = "user")@Auth Optional<User> user,
             @Parameter(name = "workflowId", description = "id of the workflow", required = true, in = ParameterIn.PATH)  @PathParam("workflowId") Long workflowId,
             @Parameter(name = "workflowVersionId", description = "id of the workflow version", required = true, in = ParameterIn.PATH) @PathParam("workflowVersionId") Long workflowVersionId) {
         Workflow workflow = workflowDAO.findById(workflowId);
-        checkEntry(workflow);
-        checkCanRead(user, workflow);
+        checkOptionalAuthRead(user, workflow);
 
         WorkflowVersion workflowVersion = this.workflowVersionDAO.findById(workflowVersionId);
         if (workflowVersion == null) {


### PR DESCRIPTION
**Description**
This PR fixes the user-level permission check for the `GET /{workflowId}/workflowVersions/{workflowVersionId}/orcidAuthors` endpoint. The authenticated user is now optional and users should be able to view a version's ORCID authors if the workflow is published.

Note that this hotfix uses `checkOptionalAuthRead` which no longer exists in develop. It was removed in the user-level permission check refactoring PR https://github.com/dockstore/dockstore/pull/4989. When merging the hotfix to develop, we will want to keep the refactored change from develop, which is the equivalent of `checkOptionalAuthRead`: https://github.com/dockstore/dockstore/blob/develop/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java#L2161-L2162. It should work, but in any case, there is a test that checks that unauthenticated users can view ORCID authors for a published workflow.

To get ahead of the merge conflict, once this hotfix PR is merged, I'm gonna cherry pick the fix to a develop feature branch, fix the merge conflict, then create a new PR targeted to develop. (Curious, when the hotfix is merged back to develop, will the merge conflict be skipped because we already cherry picked and fixed it in develop? Or will there still be a merge conflict, but we know to keep the change in develop?)

**Issue**
#4916 

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
