### PR TITLE
Feature/user permissions profile page

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -16,6 +16,7 @@
 package io.dockstore.webservice;
 
 import static io.dockstore.client.cli.WorkflowIT.DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME;
+import static io.dockstore.webservice.resources.UserResource.USER_PROFILES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -695,6 +696,25 @@ public class UserResourceIT extends BaseIT {
         } catch (io.dockstore.openapi.client.ApiException ex) {
             assertEquals(HttpStatus.SC_FORBIDDEN, ex.getCode());
         }
+    }
+
+    /**
+     * tests that a normal user can grab the user profile for a different user to support user pages
+     */
+    @Test
+    public void testUserProfiles() {
+        io.dockstore.openapi.client.ApiClient adminWebClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        io.dockstore.openapi.client.api.UsersApi adminApi = new io.dockstore.openapi.client.api.UsersApi(adminWebClient);
+        // The API call updateUserMetadata() should not throw an error and exit if any users' tokens are out of date or absent
+        // Additionally, the API call should go through and sync DockstoreTestUser2's GitHub data
+        adminApi.updateUserMetadata();
+
+        io.dockstore.openapi.client.ApiClient unauthUserWebClient = CommonTestUtilities.getOpenAPIWebClient(false, null, testingPostgres);
+        io.dockstore.openapi.client.api.UsersApi unauthUserApi = new io.dockstore.openapi.client.api.UsersApi(unauthUserWebClient);
+
+
+        final io.dockstore.openapi.client.model.User userProfile = unauthUserApi.listUser(USER_2_USERNAME, USER_PROFILES);
+        assertFalse(userProfile.getUserProfiles().isEmpty());
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -597,7 +597,6 @@ public class UserResourceIT extends BaseIT {
         Profile userProfile = usersApi.getUser().getUserProfiles().get("github.com");
 
         assertNull(userProfile.getName());
-        assertNull(userProfile.getEmail());
         assertNull(userProfile.getAvatarURL());
         assertNull(userProfile.getBio());
         assertNull(userProfile.getLocation());
@@ -609,7 +608,6 @@ public class UserResourceIT extends BaseIT {
         userProfile = usersApi.getUser().getUserProfiles().get("github.com");
 
         assertNull(userProfile.getName());
-        assertEquals("dockstore.test.user2@gmail.com", userProfile.getEmail());
         assertTrue(userProfile.getAvatarURL().endsWith("githubusercontent.com/u/17859829?v=4"));
         assertEquals("I am a test user", userProfile.getBio());
         assertEquals("Toronto", userProfile.getLocation());
@@ -715,6 +713,11 @@ public class UserResourceIT extends BaseIT {
 
         final io.dockstore.openapi.client.model.User userProfile = unauthUserApi.listUser(USER_2_USERNAME, USER_PROFILES);
         assertFalse(userProfile.getUserProfiles().isEmpty());
+
+        // check to see that DB actually had an email in the first place and the test above wasn't true by default
+        final String email = testingPostgres.runSelectStatement(String.format("select email from user_profile  WHERE username = '%s' and token_type = 'github.com'", "DockstoreTestUser2"),
+            String.class);
+        assertFalse(email.isEmpty());
     }
 
     /**
@@ -742,7 +745,6 @@ public class UserResourceIT extends BaseIT {
 
         // DockstoreUser2's profile elements should be initially set to null since the GitHub metadata isn't synced yet
         assertNull(userProfile.getName());
-        assertNull(userProfile.getEmail());
         assertNull(userProfile.getAvatarURL());
         assertNull(userProfile.getLocation());
         assertNull(userProfile.getBio());
@@ -755,7 +757,6 @@ public class UserResourceIT extends BaseIT {
 
         userProfile = userApi.getUser().getUserProfiles().get("github.com");
         assertNull(userProfile.getName());
-        assertEquals("dockstore.test.user2@gmail.com", userProfile.getEmail());
         assertTrue(userProfile.getAvatarURL().endsWith("githubusercontent.com/u/17859829?v=4"));
         assertEquals("Toronto", userProfile.getLocation());
         assertEquals("I am a test user", userProfile.getBio());
@@ -779,7 +780,6 @@ public class UserResourceIT extends BaseIT {
         testingPostgres.runUpdateStatement("DELETE FROM token WHERE tokensource <> 'dockstore'");
 
         assertNull(userProfile.getName());
-        assertNull(userProfile.getEmail());
         assertNull(userProfile.getAvatarURL());
         assertNull(userProfile.getLocation());
         assertNull(userProfile.getBio());
@@ -792,7 +792,6 @@ public class UserResourceIT extends BaseIT {
 
         userProfile = userApi.getUser().getUserProfiles().get("github.com");
         assertNull(userProfile.getName());
-        assertNull(userProfile.getEmail());
         assertNull(userProfile.getAvatarURL());
         assertNull(userProfile.getLocation());
         assertNull(userProfile.getBio());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -564,7 +564,11 @@ public class User implements Principal, Comparable<User>, Serializable {
     public static class Profile implements Serializable {
         @Column(columnDefinition = "text")
         public String name;
+        /**
+         * Only use this for computations inside the webservice.
+         */
         @Column(columnDefinition = "text")
+        @JsonIgnore
         public String email;
         @Column(columnDefinition = "text")
         public String avatarURL;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -145,7 +145,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     private static final Pattern VALID_USERNAME_PATTERN = Pattern.compile("^[a-zA-Z]+[.a-zA-Z0-9-_]*$");
     private static final String CLOUD_INSTANCE_ID_DESCRIPTION = "ID of cloud instance to update/delete";
     private static final String USER_NOT_FOUND_DESCRIPTION = "User not found";
-    private static final String USER_PROFILES = "userProfiles";
+    public static final String USER_PROFILES = "userProfiles";
     private static final String USER_INCLUDE = USER_PROFILES + ", ...";
     private static final String USER_INCLUDE_MESSAGE = "Comma-delimited list of fields to include: " + USER_INCLUDE;
     private final UserDAO userDAO;
@@ -218,19 +218,17 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @Timed
     @UnitOfWork(readOnly = true)
     @Path("/username/{username}")
-    @Operation(operationId = "listUser", description = "Get a user by username.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
+    @Operation(operationId = "listUser", description = "Get a user by username.")
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A user with the specified username", content = @Content(schema = @Schema(implementation = User.class)))
     @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = HttpStatusMessageConstants.BAD_REQUEST)
     @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
     @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
     @ApiOperation(value = "Get a user by username.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
-    public User listUser(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
-            @ApiParam("Username of user to return") @PathParam("username") @NotBlank String username,
+    public User listUser(@ApiParam("Username of user to return") @PathParam("username") @NotBlank String username,
         @Parameter(name = "include", description = USER_INCLUDE_MESSAGE, in = ParameterIn.QUERY) @ApiParam(value = USER_INCLUDE_MESSAGE) @QueryParam("include") String include) {
         @SuppressWarnings("deprecation")
         User user = userDAO.findByUsername(username);
         checkNotNullUser(user);
-        checkUserId(authUser, user.getId());
 
         initializeAdditionalFields(include, user);
         return user;

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -5051,8 +5051,6 @@ paths:
           description: Forbidden
         "404":
           description: User not found
-      security:
-      - BEARER: []
       tags:
       - users
   /users/users/entries:
@@ -8618,8 +8616,6 @@ components:
         bio:
           type: string
         company:
-          type: string
-        email:
           type: string
         link:
           type: string

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -7766,8 +7766,6 @@ definitions:
         type: "string"
       company:
         type: "string"
-      email:
-        type: "string"
       link:
         type: "string"
       location:


### PR DESCRIPTION
**Description**
Proposing simpler counterpart to https://github.com/dockstore/dockstore/pull/4897 (which can be closed if this is accepted)
We don't actually use emails for anything and only return it to the logged in user which is pretty useless. 
Aside from that, the user profile and user classes seem to be devoid of PII. 
What if we only kept emails on the server and allowed the rest of the `User` class to be public?

Needs security review

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4240

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ ] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
