### PR TITLE
Improved Github app handling for logs

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -30,7 +30,6 @@ import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
 import io.dockstore.openapi.client.model.PrivilegeRequest;
-import io.dockstore.openapi.client.model.SourceControlOrganization;
 import io.dockstore.openapi.client.model.UserInfo;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
 import io.dockstore.webservice.resources.WorkflowResource;
@@ -618,13 +617,11 @@ public class UserResourceIT extends BaseIT {
 
         io.dockstore.openapi.client.ApiClient userWebClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         io.dockstore.openapi.client.api.UsersApi userApi = new io.dockstore.openapi.client.api.UsersApi(userWebClient);
-        List<SourceControlOrganization> myGitHubOrgs = userApi.getMyGitHubOrgs();
-        assertTrue(!myGitHubOrgs.isEmpty() && myGitHubOrgs.stream().anyMatch(org -> org.getName().equals("dockstoretesting")));
         // Delete all of the tokens (except for Dockstore tokens) for every user
         testingPostgres.runUpdateStatement("UPDATE token set content = 'foo' WHERE tokensource <> 'dockstore'");
 
         try {
-            userApi.getMyGitHubOrgs();
+            userApi.getUserOrganizations("github.com");
         } catch (io.dockstore.openapi.client.ApiException e) {
             assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
             return;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -23,7 +23,6 @@ import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.Entry;
-import io.dockstore.webservice.core.SourceControlOrganization;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
@@ -47,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.GenericType;
 import org.apache.commons.lang3.StringUtils;
@@ -204,7 +204,7 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
     }
 
     @Override
-    public List<SourceControlOrganization> getOrganizations() {
+    public Set<String> getOrganizations() {
         throw new UnsupportedOperationException("apps not supported for bitbucket yet");
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.GenericType;
 import org.apache.commons.lang3.StringUtils;
@@ -202,12 +201,6 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
         }
         return file;
     }
-
-    @Override
-    public Set<String> getOrganizations() {
-        throw new UnsupportedOperationException("apps not supported for bitbucket yet");
-    }
-
     @Override
     public void updateReferenceType(String repositoryId, Version version) {
         if (version.getReferenceType() != Version.ReferenceType.UNSET) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -324,15 +324,19 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
     /**
      * Returns the set of organizations as well as the personal account the user has some level of
-     * access to.
+     * access to. Overrides the base implementation for performance, avoiding use of
+     * RepositoryListFilter.MEMBER -- although performance tests results are mixed.
      *
      * @return
      */
+    @Override
     public Set<String> getOrganizations() {
         try {
             // The organizations of individual repos the user has been granted access to
+            final Collection<String> inlineMe =
+                getWorkflowGitUrl2RepositoryId(RepositoryListFilter.MEMBER).values();
             final Set<String> orgsViaRepoMembership =
-                getWorkflowGitUrl2RepositoryId(RepositoryListFilter.MEMBER).values().stream()
+                inlineMe.stream()
                     .map(fullRepoName -> fullRepoName.split("/")[0])
                     .collect(Collectors.toSet());
             // The user's account, e.g., coverbeck

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -325,7 +325,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     /**
      * Returns the set of organizations as well as the personal account the user has some level of
      * access to. Overrides the base implementation for performance, avoiding use of
-     * RepositoryListFilter.MEMBER -- although performance tests results are mixed.
+     * RepositoryListFilter.ALL -- although performance tests results are mixed.
      *
      * @return
      */

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -292,12 +292,12 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
      * @return
      */
     public Map<String, String> getRepositoriesWithMemberAccess() {
-        return getWorkflowGitUrl2RepositoryId(RepositoryListFilter.MEMBER);
+        return gitSshUrlToOrgSlashRepositoryMap(RepositoryListFilter.MEMBER);
     }
 
     @Override
     public Map<String, String> getWorkflowGitUrl2RepositoryId() {
-        return getWorkflowGitUrl2RepositoryId(RepositoryListFilter.ALL);
+        return gitSshUrlToOrgSlashRepositoryMap(RepositoryListFilter.ALL);
     }
 
     /**
@@ -306,7 +306,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
      * @param filter
      * @return
      */
-    private Map<String, String> getWorkflowGitUrl2RepositoryId(RepositoryListFilter filter) {
+    private Map<String, String> gitSshUrlToOrgSlashRepositoryMap(RepositoryListFilter filter) {
         Map<String, String> reposByGitURl = new HashMap<>();
         try {
             // The filter RepositoryListFilter.ALL includes:
@@ -333,10 +333,8 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     public Set<String> getOrganizations() {
         try {
             // The organizations of individual repos the user has been granted access to
-            final Collection<String> inlineMe =
-                getWorkflowGitUrl2RepositoryId(RepositoryListFilter.MEMBER).values();
             final Set<String> orgsViaRepoMembership =
-                inlineMe.stream()
+                gitSshUrlToOrgSlashRepositoryMap(RepositoryListFilter.MEMBER).values().stream()
                     .map(fullRepoName -> fullRepoName.split("/")[0])
                     .collect(Collectors.toSet());
             // The user's account, e.g., coverbeck

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -41,7 +41,6 @@ import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.LicenseInformation;
 import io.dockstore.webservice.core.Service;
-import io.dockstore.webservice.core.SourceControlOrganization;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.TokenType;
@@ -60,6 +59,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -71,6 +71,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import okhttp3.OkHttpClient;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -85,6 +86,7 @@ import org.kohsuke.github.GHContent;
 import org.kohsuke.github.GHEmail;
 import org.kohsuke.github.GHFileNotFoundException;
 import org.kohsuke.github.GHMyself;
+import org.kohsuke.github.GHMyself.RepositoryListFilter;
 import org.kohsuke.github.GHRateLimit;
 import org.kohsuke.github.GHRef;
 import org.kohsuke.github.GHRepository;
@@ -164,6 +166,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         }
         return readFileFromRepo(fileName, reference, repo);
     }
+
 
     @Override
     public List<String> listFiles(String repositoryId, String pathToDirectory, String reference) {
@@ -282,18 +285,37 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         return null;
     }
 
+    /**
+     * Returns a map of repositories of which the user is a member. These are individual repositories
+     * to which the user has explicitly been granted access, and does not include repositories the
+     * user has access to via organization or account membership.
+     * @return
+     */
+    public Map<String, String> getRepositoriesWithMemberAccess() {
+        return getWorkflowGitUrl2RepositoryId(RepositoryListFilter.MEMBER);
+    }
+
     @Override
     public Map<String, String> getWorkflowGitUrl2RepositoryId() {
+        return getWorkflowGitUrl2RepositoryId(RepositoryListFilter.ALL);
+    }
+
+    /**
+     * The method can be slow, especially with filter set to <code>RepositoryListFilter.ALL</code>. Try not to
+     * invoke it with <code>RepositoryListFilter.ALL</code>. But you may have to.
+     * @param filter
+     * @return
+     */
+    private Map<String, String> getWorkflowGitUrl2RepositoryId(RepositoryListFilter filter) {
         Map<String, String> reposByGitURl = new HashMap<>();
         try {
-            // TODO: This code should be optimized. Ex. Only grab repositories from a specific org if refreshing by org.
-            // The filter all includes:
+            // The filter RepositoryListFilter.ALL includes:
             // * All repositories I own
             // * All repositories I am a contributor on
             // * All repositories from organizations I belong to
 
-            final int pageSize = 30;
-            github.getMyself().listRepositories(pageSize, GHMyself.RepositoryListFilter.ALL).forEach((GHRepository r) -> reposByGitURl.put(r.getSshUrl(), r.getFullName()));
+            final int pageSize = 100;
+            github.getMyself().listRepositories(pageSize, filter).forEach((GHRepository r) -> reposByGitURl.put(r.getSshUrl(), r.getFullName()));
             return reposByGitURl;
         } catch (IOException e) {
             return this.handleGetWorkflowGitUrl2RepositoryIdError(e);
@@ -301,19 +323,24 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     }
 
     /**
-     * Get a list of all the orgs a user has access to
-     * Based on the ALL repository filter, since getAllOrganizations() does not return personal user accounts.
+     * Returns the set of organizations as well as the personal account the user has some level of
+     * access to.
+     *
      * @return
      */
-    public Set<String> getMyOrganizations() {
+    public Set<String> getOrganizations() {
         try {
-            final int pageSize = 100;
-            return github.getMyself()
-                .listRepositories(pageSize, GHMyself.RepositoryListFilter.ALL)
-                .asList()
-                .stream()
-                .map((GHRepository repository) -> repository.getFullName().split("/")[0])
-                .collect(Collectors.toSet());
+            // The organizations of individual repos the user has been granted access to
+            final Set<String> orgsViaRepoMembership =
+                getWorkflowGitUrl2RepositoryId(RepositoryListFilter.MEMBER).values().stream()
+                    .map(fullRepoName -> fullRepoName.split("/")[0])
+                    .collect(Collectors.toSet());
+            // The user's account, e.g., coverbeck
+            final Set<String> account = Set.of(githubTokenUsername);
+            // The organizations that the user is a member of
+            final Set<String> orgMemberships = github.getMyOrganizations().keySet();
+            return Stream.of(orgsViaRepoMembership, account, orgMemberships)
+                .flatMap(Collection::stream).collect(Collectors.toSet());
         } catch (IOException e) {
             LOG.error("could not find organizations due to ", e);
             throw new CustomWebApplicationException("could not read organizations from github, please re-link your github token", HttpStatus.SC_INTERNAL_SERVER_ERROR);
@@ -321,23 +348,13 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     }
 
     /**
-     * Determine if the specified organization is one that github considers the user has "access" to.
-     * Incorporates some optimizations for the common cases, and falls back to getMyOrganizations()
+     * Determine if the specified organization is one that the user belongs to, including the user's
+     * own account. Does NOT check for organizations where the user has only been granted access
+     * to specific repos within an org.
      */
     public boolean isOneOfMyOrganizations(String organization) {
         try {
-            // The following statements could be condensed into a single OR conditional, but it would be hard to comment, and you would have to grok the short-circuiting to understand it...
-            // The user can always access their own account.
-            if (organization.equals(githubTokenUsername)) {
-                return true;
-            }
-            // Check the list of organizations that github says the user can "access".
-            // Note that getAllOrganizations() only returns organizations, not personal user accounts.
-            if (github.getMyself().getAllOrganizations().stream().anyMatch(org -> org.getLogin().equals(organization))) {
-                return true;
-            }
-            // getMyOrganizations() should enumerate the other possibilities.
-            return getMyOrganizations().contains(organization);
+            return organization.equals(githubTokenUsername) || github.getMyOrganizations().keySet().contains(organization);
         } catch (IOException e) {
             LOG.error("could not determine organization accessibility due to ", e);
             throw new CustomWebApplicationException("could not determine organization accessibility on github, please re-link your github token", HttpStatus.SC_INTERNAL_SERVER_ERROR);
@@ -1046,17 +1063,6 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     @Override
     public SourceFile getSourceFile(String path, String id, String branch, DescriptorLanguage.FileType type) {
         throw new UnsupportedOperationException("not implemented/needed for github");
-    }
-
-    @Override
-    public List<SourceControlOrganization> getOrganizations() {
-        try {
-            return github.getMyOrganizations().entrySet().stream()
-                    .map(o -> new SourceControlOrganization(o.getValue().getId(), o.getKey())).collect(Collectors.toList());
-        } catch (IOException e) {
-            LOG.info(githubTokenUsername + ": Cannot retrieve their organizations", e);
-        }
-        return new ArrayList<>();
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.gitlab.api.GitlabAPI;
 import org.gitlab.api.TokenType;
@@ -278,11 +277,6 @@ public class GitLabSourceCodeRepo extends SourceCodeRepoInterface {
             LOG.info("could not find " + path + " at " + e.getMessage());
         }
         return null;
-    }
-
-    @Override
-    public Set<String> getOrganizations() {
-        throw new UnsupportedOperationException("apps not supported for gitlab yet");
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
@@ -22,7 +22,6 @@ import com.google.common.collect.Lists;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
 import io.dockstore.webservice.core.Entry;
-import io.dockstore.webservice.core.SourceControlOrganization;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
@@ -36,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.gitlab.api.GitlabAPI;
 import org.gitlab.api.TokenType;
@@ -281,7 +281,7 @@ public class GitLabSourceCodeRepo extends SourceCodeRepoInterface {
     }
 
     @Override
-    public List<SourceControlOrganization> getOrganizations() {
+    public Set<String> getOrganizations() {
         throw new UnsupportedOperationException("apps not supported for gitlab yet");
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -738,11 +738,11 @@ public abstract class SourceCodeRepoInterface {
     }
 
     /**
-     * Gets organizations that the user is a member of. Currently only implemented by
-     * <code>GitHubSourceCodeRepo</code>; other implementations throw
-     * <code>UnsupportedOperationException</code>.
-     *
+     * Returns
      * @return
      */
-    public abstract Set<String> getOrganizations();
+    public Set<String> getOrganizations() {
+        return getWorkflowGitUrl2RepositoryId().values().stream()
+            .map(repository -> repository.split("/")[0]).collect(Collectors.toSet());
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -30,7 +30,6 @@ import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.DescriptionSource;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Service;
-import io.dockstore.webservice.core.SourceControlOrganization;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Tag;
 import io.dockstore.webservice.core.Tool;
@@ -739,8 +738,11 @@ public abstract class SourceCodeRepoInterface {
     }
 
     /**
-     * Gets organizations for the current user
+     * Gets organizations that the user is a member of. Currently only implemented by
+     * <code>GitHubSourceCodeRepo</code>; other implementations throw
+     * <code>UnsupportedOperationException</code>.
+     *
      * @return
      */
-    public abstract List<SourceControlOrganization> getOrganizations();
+    public abstract Set<String> getOrganizations();
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -6,6 +6,7 @@ import io.dockstore.webservice.core.User;
 import io.dropwizard.hibernate.AbstractDAO;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -73,13 +74,23 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
         return typedQuery.getResultList();
     }
 
-    public List<LambdaEvent> findByOrganization(String organization, String offset, Integer limit) {
+    /**
+     * Returns a list of lambda events for an organization. If <code>repositories</code> is not
+     * empty, it further filters down to the specified repos within the organization.
+     * @param organization
+     * @param offset
+     * @param limit
+     * @param repositories
+     * @return
+     */
+    public List<LambdaEvent> findByOrganization(String organization, String offset, Integer limit, Optional<List<String>> repositories) {
         CriteriaBuilder cb = currentSession().getCriteriaBuilder();
         CriteriaQuery<LambdaEvent> query = criteriaQuery();
         Root<LambdaEvent> event = query.from(LambdaEvent.class);
 
         List<Predicate> predicates = new ArrayList<>();
         predicates.add(cb.equal(event.get("organization"), organization));
+        repositories.ifPresent(repos -> predicates.add(event.get("repository").in(repos)));
         query.orderBy(cb.desc(event.get("id")));
         query.where(predicates.toArray(new Predicate[]{}));
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -98,7 +98,7 @@ public class LambdaEventResource {
 
     /**
      * Returns a list of repository names, e.g, "dockstore-ui2" for org/repo of "dockstore/dockstore-ui2"
-     * that the user has been granted specific access to in <code>organization</code>
+     * that the user has been granted specific access to in the <code>organization</code>
      * @param organization
      * @param sourceCodeRepoInterface
      * @return

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -24,6 +24,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -59,21 +62,57 @@ public class LambdaEventResource {
             @ApiParam(value = "organization", required = true) @PathParam("organization") String organization,
             @ApiParam(value = PAGINATION_OFFSET_TEXT) @QueryParam("offset") @DefaultValue("0") String offset,
             @ApiParam(value = PAGINATION_LIMIT_TEXT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit) {
-        User authUser = userDAO.findById(user.getId());
-        List<Token> githubTokens = tokenDAO.findGithubByUserId(authUser.getId());
+        final User authUser = userDAO.findById(user.getId());
+        final List<Token> githubTokens = tokenDAO.findGithubByUserId(authUser.getId());
         if (githubTokens.isEmpty()) {
             throw new CustomWebApplicationException("You do not have GitHub connected to your account.", HttpStatus.SC_BAD_REQUEST);
         }
-        Token githubToken = githubTokens.get(0);
-
-        // If the organization isn't the user's github account, check github to see if we have access to the organization.
-        if (!organization.equals(githubToken.getUsername())) {
-            GitHubSourceCodeRepo sourceCodeRepoInterface = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(githubToken);
-            if (!sourceCodeRepoInterface.isOneOfMyOrganizations(organization)) {
-                throw new CustomWebApplicationException("You do not have access to the GitHub organization '" + organization + "'", HttpStatus.SC_UNAUTHORIZED);
-            }
-        }
-
-        return lambdaEventDAO.findByOrganization(organization, offset, limit);
+        final Token githubToken = githubTokens.get(0);
+        final Optional<List<String>> authorizedRepos = authorizedRepos(organization, githubToken);
+        return lambdaEventDAO.findByOrganization(organization, offset, limit, authorizedRepos);
     }
+
+    /**
+     * Returns an Optional list of the repositories in the organization the user has access to. If
+     * the user is an organziation member hand has access to all repositories in the organization,
+     * returns an <code>Optional.empty()</code>.
+     * If the user has no access to the organization or any of its repos, throws a 401 CustomWebApplicationException.
+     *
+     * @param organization
+     * @param gitHubToken
+     * @return
+     */
+    private Optional<List<String>> authorizedRepos(String organization, Token gitHubToken) {
+        final GitHubSourceCodeRepo sourceCodeRepoInterface = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(gitHubToken);
+        if (!sourceCodeRepoInterface.isOneOfMyOrganizations(organization)) {
+            final List<String> gitHubOrgRepos = organizationRepositories(organization, sourceCodeRepoInterface);
+            if (gitHubOrgRepos.isEmpty()) {
+                throw new CustomWebApplicationException(
+                    "You do not have access to the GitHub organization '" + organization + "'",
+                    HttpStatus.SC_UNAUTHORIZED);
+            }
+            return Optional.of(gitHubOrgRepos);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Returns a list of repository names, e.g, "dockstore-ui2" for org/repo of "dockstore/dockstore-ui2"
+     * that the user has been granted specific access to in <code>organization</code>
+     * @param organization
+     * @param sourceCodeRepoInterface
+     * @return
+     */
+    private List<String> organizationRepositories(String organization, GitHubSourceCodeRepo sourceCodeRepoInterface) {
+        final Map<String, String> repositoriesWithMemberAccess =
+            sourceCodeRepoInterface.getRepositoriesWithMemberAccess();
+        // Example values are org/repo, e.g., "dockstore/dockstore", "dockstore/dockstore-ui2", etc.
+        final List<String> gitHubOrgRepos = repositoriesWithMemberAccess.values().stream()
+            .filter(fullname -> fullname.startsWith(organization + "/"))
+            .map(fullname -> fullname.split("/")[1])
+            .collect(Collectors.toList());
+        return gitHubOrgRepos;
+    }
+
 }
+

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -74,7 +74,7 @@ public class LambdaEventResource {
 
     /**
      * Returns an Optional list of the repositories in the organization the user has access to. If
-     * the user is an organziation member hand has access to all repositories in the organization,
+     * the user is an organization member and has access to all repositories in the organization,
      * returns an <code>Optional.empty()</code>.
      * If the user has no access to the organization or any of its repos, throws a 401 CustomWebApplicationException.
      *

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -48,7 +48,6 @@ import io.dockstore.webservice.core.Organization;
 import io.dockstore.webservice.core.OrganizationUpdateTime;
 import io.dockstore.webservice.core.OrganizationUser;
 import io.dockstore.webservice.core.Service;
-import io.dockstore.webservice.core.SourceControlOrganization;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.TokenViews;
@@ -92,7 +91,6 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.sql.Timestamp;
@@ -991,28 +989,6 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
         return getStrippedWorkflowsAndServices(userDAO.findById(user.getId()));
     }
 
-    @GET
-    @Timed
-    @UnitOfWork
-    @Path("/github/organizations")
-    @Operation(operationId = "getMyGitHubOrgs", description = "Gets GitHub organizations for current user.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = HttpStatus.SC_OK
-            + "", description = "Descriptions of Github organizations (including but not limited to id, names)", content = @Content(array = @ArraySchema(schema = @Schema(implementation = SourceControlOrganization.class)))),
-        @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = HttpStatusMessageConstants.BAD_REQUEST)
-    })
-    public List<SourceControlOrganization> getMyGitHubOrgs(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser) {
-        final User user = userDAO.findById(authUser.getId());
-        checkNotNullUser(user);
-        Token githubToken = tokenDAO.findGithubByUserId(user.getId()).stream()
-                .filter(token -> token.getTokenSource() == TokenType.GITHUB_COM).findFirst().orElse(null);
-        if (githubToken != null) {
-            SourceCodeRepoInterface sourceCodeRepo =  SourceCodeRepoFactory.createSourceCodeRepo(githubToken);
-            return sourceCodeRepo.getOrganizations();
-        }
-        return Lists.newArrayList();
-    }
-
     @PATCH
     @Timed
     @UnitOfWork
@@ -1133,8 +1109,11 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(value = "See OpenApi for details")
     public Set<String> getUserOrganizations(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
                                             @Parameter(name = "gitRegistry", description = "Git registry", required = true, in = ParameterIn.PATH) @PathParam("gitRegistry") SourceControl gitRegistry) {
-        Map<String, String> repositoryUrlToName = getGitRepositoryMap(authUser, gitRegistry);
-        return repositoryUrlToName.values().stream().map(repository -> repository.split("/")[0]).collect(Collectors.toSet());
+        SourceCodeRepoInterface sourceCodeRepo = createSourceCodeRepo(authUser, gitRegistry, tokenDAO, client, bitbucketClientID, bitbucketClientSecret);
+        if (sourceCodeRepo == null) {
+            return Set.of();
+        }
+        return Set.copyOf(sourceCodeRepo.getOrganizations());
     }
 
     @GET

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -1109,11 +1109,13 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(value = "See OpenApi for details")
     public Set<String> getUserOrganizations(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
                                             @Parameter(name = "gitRegistry", description = "Git registry", required = true, in = ParameterIn.PATH) @PathParam("gitRegistry") SourceControl gitRegistry) {
+
         SourceCodeRepoInterface sourceCodeRepo = createSourceCodeRepo(authUser, gitRegistry, tokenDAO, client, bitbucketClientID, bitbucketClientSecret);
         if (sourceCodeRepo == null) {
             return Set.of();
+        } else {
+            return sourceCodeRepo.getOrganizations();
         }
-        return Set.copyOf(sourceCodeRepo.getOrganizations());
     }
 
     @GET

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -4577,26 +4577,6 @@ paths:
       - BEARER: []
       tags:
       - users
-  /users/github/organizations:
-    get:
-      description: Gets GitHub organizations for current user.
-      operationId: getMyGitHubOrgs
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/SourceControlOrganization'
-          description: "Descriptions of Github organizations (including but not limited\
-            \ to id, names)"
-        "400":
-          description: Bad request
-      security:
-      - BEARER: []
-      tags:
-      - users
   /users/github/sync:
     post:
       description: Syncs Dockstore account with GitHub App Installations.
@@ -8719,14 +8699,6 @@ components:
         friendlyName:
           type: string
         value:
-          type: string
-    SourceControlOrganization:
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int64
-        name:
           type: string
     SourceFile:
       type: object

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4088,22 +4088,6 @@ paths:
             type: "array"
             items:
               $ref: "#/definitions/LambdaEvent"
-  /users/github/organizations:
-    get:
-      tags:
-      - "users"
-      operationId: "getMyGitHubOrgs"
-      produces:
-      - "application/json"
-      parameters: []
-      responses:
-        200:
-          description: "successful operation"
-          headers: {}
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/SourceControlOrganization"
   /users/github/sync:
     post:
       tags:
@@ -7843,17 +7827,6 @@ definitions:
         type: "string"
       value:
         type: "string"
-  SourceControlOrganization:
-    type: "object"
-    properties:
-      id:
-        type: "integer"
-        format: "int64"
-        description: "Id for the organization e.g. 1"
-      name:
-        type: "string"
-        description: "Name of the organization e.g. dockstore"
-    description: "This describes a source control organization"
   SourceFile:
     type: "object"
     required:

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
@@ -11,7 +11,6 @@ import io.dockstore.language.MinimalLanguageInterface;
 import io.dockstore.language.RecommendedLanguageInterface;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.Entry;
-import io.dockstore.webservice.core.SourceControlOrganization;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
@@ -338,7 +337,7 @@ public class LanguagePluginHandlerTest {
         }
 
         @Override
-        public List<SourceControlOrganization> getOrganizations() {
+        public Set<String> getOrganizations() {
             return null;
         }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
@@ -337,11 +337,6 @@ public class LanguagePluginHandlerTest {
         }
 
         @Override
-        public Set<String> getOrganizations() {
-            return null;
-        }
-
-        @Override
         public void updateReferenceType(String repositoryId, Version version) {
 
         }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
@@ -253,11 +253,6 @@ public class WDLHandlerTest {
         }
 
         @Override
-        public Set<String> getOrganizations() {
-            return null;
-        }
-
-        @Override
         public void updateReferenceType(String repositoryId, Version version) {
 
         }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
@@ -9,7 +9,6 @@ import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Entry;
-import io.dockstore.webservice.core.SourceControlOrganization;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.Version;
@@ -254,7 +253,7 @@ public class WDLHandlerTest {
         }
 
         @Override
-        public List<SourceControlOrganization> getOrganizations() {
+        public Set<String> getOrganizations() {
             return null;
         }
 


### PR DESCRIPTION
**Description**
1. Attempts to improve performance of fetching GitHub orgs, which the UI uses to display orgs with logs.
2. Only allows users to view logs for their repos within an org.

***Background***
In GitHub, a user can be added to an org, or they can be added to specific repos within the org, but not the org itself. We tended to blur the two together. You also have your personal user account, which is not an org.

***Performance***
Use RepositoryListFilter.MEMBER to fetch repos. It should only return repos you have been added to. We were using RepositoryListFilter.ALL to fetch repos, which included repos you had access to because you belonged to the org. Fewer repos in the response, should be faster. Get the orgs you belong to separately.

Seemed a bit faster with curl; results not as clear via Java (but not worse).

***Logs viewing***
* Before, if you could view any repo in an org, you could view the logs for all repos in the org. Now you can only see logs for repos you have permissions to.

**Issue**
* [SEAB-4304](https://ucsc-cgl.atlassian.net/browse/SEAB-4304)
* Improved performance for #4845 

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
