### PR TITLE
allow topic update on hosted

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
@@ -41,6 +41,7 @@ import io.swagger.client.api.ContainertagsApi;
 import io.swagger.client.api.HostedApi;
 import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.DockstoreTool;
+import io.swagger.client.model.DockstoreTool.ModeEnum;
 import io.swagger.client.model.PublishRequest;
 import io.swagger.client.model.SourceFile;
 import io.swagger.client.model.Tag;
@@ -469,6 +470,8 @@ public class CRUDClientIT extends BaseIT {
         DockstoreTool hostedTool = hostedApi
             .createHostedTool("awesomeTool", Registry.QUAY_IO.getDockerPath().toLowerCase(), CWL.getShortName(), "coolNamespace", null);
         DockstoreTool newTool = new DockstoreTool();
+        // need to modify something that does not make sense now but isn't ignored
+        newTool.setMode(ModeEnum.MANUAL_IMAGE_PATH);
         thrown.expect(ApiException.class);
         containersApi.updateContainer(hostedTool.getId(), newTool);
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -558,7 +558,7 @@ public class GeneralIT extends BaseIT {
         final io.dockstore.openapi.client.api.HostedApi hostedApi = new io.dockstore.openapi.client.api.HostedApi(openApiWebClient);
         final io.dockstore.openapi.client.model.Workflow hostedWorkflow = hostedApi.createHostedWorkflow(null, "foo", DescriptorLanguage.WDL.toString(), null, null);
         hostedWorkflow.setTopicManual("new foo");
-        assertSame(hostedWorkflow.getTopicSelection(), io.dockstore.openapi.client.model.Workflow.TopicSelectionEnum.MANUAL);
+        assertSame(io.dockstore.openapi.client.model.Workflow.TopicSelectionEnum.MANUAL, hostedWorkflow.getTopicSelection());
         hostedWorkflow.setTopicSelection(io.dockstore.openapi.client.model.Workflow.TopicSelectionEnum.AUTOMATIC);
         io.dockstore.openapi.client.api.WorkflowsApi workflowsApi = new io.dockstore.openapi.client.api.WorkflowsApi(openApiWebClient);
         final io.dockstore.openapi.client.model.Workflow workflow = workflowsApi.updateWorkflow(hostedWorkflow.getId(), hostedWorkflow);
@@ -574,7 +574,7 @@ public class GeneralIT extends BaseIT {
         final io.dockstore.openapi.client.api.HostedApi hostedApi = new io.dockstore.openapi.client.api.HostedApi(openApiWebClient);
         final io.dockstore.openapi.client.model.DockstoreTool hostedTool = hostedApi.createHostedTool(Registry.QUAY_IO.getDockerPath().toLowerCase(), "foo", DescriptorLanguage.WDL.toString(), null, null);
         hostedTool.setTopicManual("new foo");
-        assertSame(hostedTool.getTopicSelection(), io.dockstore.openapi.client.model.DockstoreTool.TopicSelectionEnum.MANUAL);
+        assertSame(io.dockstore.openapi.client.model.DockstoreTool.TopicSelectionEnum.MANUAL, hostedTool.getTopicSelection());
         hostedTool.setTopicSelection(io.dockstore.openapi.client.model.DockstoreTool.TopicSelectionEnum.AUTOMATIC);
         io.dockstore.openapi.client.api.ContainersApi containersApi = new io.dockstore.openapi.client.api.ContainersApi(openApiWebClient);
         final io.dockstore.openapi.client.model.DockstoreTool dockstoreTool = containersApi.updateContainer(hostedTool.getId(), hostedTool);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -549,6 +550,38 @@ public class GeneralIT extends BaseIT {
         workflowApi.publish(workflow.getId(), publishRequest);
         versionsVerified = user1EntriesApi.getVerifiedPlatforms(workflow.getId());
         assertEquals(1, versionsVerified.size());
+    }
+
+    @Test
+    public void testEditingHostedWorkflowTopics() {
+        final io.dockstore.openapi.client.ApiClient openApiWebClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        final io.dockstore.openapi.client.api.HostedApi hostedApi = new io.dockstore.openapi.client.api.HostedApi(openApiWebClient);
+        final io.dockstore.openapi.client.model.Workflow hostedWorkflow = hostedApi.createHostedWorkflow(null, "foo", DescriptorLanguage.WDL.toString(), null, null);
+        hostedWorkflow.setTopicManual("new foo");
+        assertSame(hostedWorkflow.getTopicSelection(), io.dockstore.openapi.client.model.Workflow.TopicSelectionEnum.MANUAL);
+        hostedWorkflow.setTopicSelection(io.dockstore.openapi.client.model.Workflow.TopicSelectionEnum.AUTOMATIC);
+        io.dockstore.openapi.client.api.WorkflowsApi workflowsApi = new io.dockstore.openapi.client.api.WorkflowsApi(openApiWebClient);
+        final io.dockstore.openapi.client.model.Workflow workflow = workflowsApi.updateWorkflow(hostedWorkflow.getId(), hostedWorkflow);
+        // topic should change
+        assertEquals("new foo", workflow.getTopic());
+        // but should ignore selection change
+        assertEquals(io.dockstore.openapi.client.model.Workflow.TopicSelectionEnum.MANUAL, workflow.getTopicSelection());
+    }
+
+    @Test
+    public void testEditingHostedToolTopics() {
+        final io.dockstore.openapi.client.ApiClient openApiWebClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        final io.dockstore.openapi.client.api.HostedApi hostedApi = new io.dockstore.openapi.client.api.HostedApi(openApiWebClient);
+        final io.dockstore.openapi.client.model.DockstoreTool hostedTool = hostedApi.createHostedTool(Registry.QUAY_IO.getDockerPath().toLowerCase(), "foo", DescriptorLanguage.WDL.toString(), null, null);
+        hostedTool.setTopicManual("new foo");
+        assertSame(hostedTool.getTopicSelection(), io.dockstore.openapi.client.model.DockstoreTool.TopicSelectionEnum.MANUAL);
+        hostedTool.setTopicSelection(io.dockstore.openapi.client.model.DockstoreTool.TopicSelectionEnum.AUTOMATIC);
+        io.dockstore.openapi.client.api.ContainersApi containersApi = new io.dockstore.openapi.client.api.ContainersApi(openApiWebClient);
+        final io.dockstore.openapi.client.model.DockstoreTool dockstoreTool = containersApi.updateContainer(hostedTool.getId(), hostedTool);
+        // topic should change
+        assertEquals("new foo", dockstoreTool.getTopic());
+        // but should ignore selection change
+        assertEquals(io.dockstore.openapi.client.model.DockstoreTool.TopicSelectionEnum.MANUAL, dockstoreTool.getTopicSelection());
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -23,6 +23,7 @@ import static io.dockstore.webservice.resources.WorkflowResource.A_WORKFLOW_MUST
 import static io.dockstore.webservice.resources.WorkflowResource.A_WORKFLOW_MUST_HAVE_NO_SNAPSHOT_TO_RESTUB;
 import static io.dockstore.webservice.resources.WorkflowResource.FROZEN_VERSION_REQUIRED;
 import static io.dockstore.webservice.resources.WorkflowResource.NO_ZENDO_USER_TOKEN;
+import static io.dockstore.webservice.resources.WorkflowResource.YOU_CANNOT_CHANGE_THE_DESCRIPTOR_TYPE_OF_A_FULL_OR_HOSTED_WORKFLOW;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -374,7 +375,7 @@ public class GeneralWorkflowIT extends BaseIT {
         try {
             workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
         } catch (ApiException e) {
-            assertTrue(e.getMessage().contains("You cannot change the descriptor type of a FULL workflow"));
+            assertTrue(e.getMessage().contains(YOU_CANNOT_CHANGE_THE_DESCRIPTOR_TYPE_OF_A_FULL_OR_HOSTED_WORKFLOW));
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -22,6 +22,7 @@ import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.core.Entry;
+import io.dockstore.webservice.core.Entry.TopicSelection;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.ToolMode;
@@ -135,6 +136,8 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
         // Only check type for workflows
         String convertedRegistry = checkRegistry(registry);
         T entry = getEntry(user, convertedRegistry, name, descriptorLanguage, namespace, entryName);
+        // manual workflows should always have a manual topic because there is no source control
+        entry.setTopicSelection(TopicSelection.MANUAL);
         checkForDuplicatePath(entry);
         long l = getEntryDAO().create(entry);
         T byId = getEntryDAO().findById(l);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -394,6 +394,9 @@ public class DockerRepoResource
      */
     private void updateInfo(Tool originalTool, Tool newTool) {
         //TODO this could probably be better handled better, maybe with some Jackson magic?
+        if (!Objects.equals(originalTool.getMode(), newTool.getMode())) {
+            throw new CustomWebApplicationException("You cannot change the mode of a tool.", HttpStatus.SC_BAD_REQUEST);
+        }
 
         // Add descriptor type default paths here
         // ignore path changes for hosted workflows

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -342,7 +342,6 @@ public class DockerRepoResource
         @ApiParam(value = "Tool with updated information", required = true) Tool tool) {
         Tool foundTool = toolDAO.findById(containerId);
         checkNotNullEntry(foundTool);
-        checkNotHosted(foundTool);
         checkCanWrite(user, foundTool);
 
         // Don't need to check for duplicate tool because the tool path can't be updated
@@ -394,14 +393,18 @@ public class DockerRepoResource
      * @param newTool      the new tool from the webservice
      */
     private void updateInfo(Tool originalTool, Tool newTool) {
-        // to do, this could probably be better handled better
+        //TODO this could probably be better handled better, maybe with some Jackson magic?
 
         // Add descriptor type default paths here
-        originalTool.setDefaultCwlPath(newTool.getDefaultCwlPath());
-        originalTool.setDefaultWdlPath(newTool.getDefaultWdlPath());
-        originalTool.setDefaultDockerfilePath(newTool.getDefaultDockerfilePath());
-        originalTool.setDefaultTestCwlParameterFile(newTool.getDefaultTestCwlParameterFile());
-        originalTool.setDefaultTestWdlParameterFile(newTool.getDefaultTestWdlParameterFile());
+        // ignore path changes for hosted workflows
+        if (!Objects.equals(originalTool.getMode(), ToolMode.HOSTED)) {
+            originalTool.setDefaultCwlPath(newTool.getDefaultCwlPath());
+            originalTool.setDefaultWdlPath(newTool.getDefaultWdlPath());
+            originalTool.setDefaultDockerfilePath(newTool.getDefaultDockerfilePath());
+            originalTool.setDefaultTestCwlParameterFile(newTool.getDefaultTestCwlParameterFile());
+            originalTool.setDefaultTestWdlParameterFile(newTool.getDefaultTestWdlParameterFile());
+            originalTool.setGitUrl(newTool.getGitUrl());
+        }
 
         if (newTool.getDefaultVersion() != null) {
             if (!originalTool.checkAndSetDefaultVersion(newTool.getDefaultVersion())) {
@@ -409,10 +412,11 @@ public class DockerRepoResource
             }
         }
 
-        originalTool.setGitUrl(newTool.getGitUrl());
         originalTool.setForumUrl(newTool.getForumUrl());
         originalTool.setTopicManual(newTool.getTopicManual());
-        originalTool.setTopicSelection(newTool.getTopicSelection());
+        if (!Objects.equals(originalTool.getMode(), ToolMode.HOSTED)) {
+            originalTool.setTopicSelection(newTool.getTopicSelection());
+        }
 
         if (originalTool.getMode() == ToolMode.MANUAL_IMAGE_PATH) {
             originalTool.setToolMaintainerEmail(newTool.getToolMaintainerEmail());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -171,10 +171,10 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     private static final String WORKFLOW_INCLUDE = VERSIONS + ", " + ORCID_PUT_CODES + ", " + VERSION_INCLUDE;
     private static final String VERSION_INCLUDE_MESSAGE = "Comma-delimited list of fields to include: " + VERSION_INCLUDE;
     private static final String WORKFLOW_INCLUDE_MESSAGE = "Comma-delimited list of fields to include: " + WORKFLOW_INCLUDE + ", " + VERSION_INCLUDE;
-    private static final String SHA_TYPE_FOR_SOURCEFILES = "SHA-1";
     public static final String A_WORKFLOW_MUST_BE_UNPUBLISHED_TO_RESTUB = "A workflow must be unpublished to restub.";
     public static final String A_WORKFLOW_MUST_HAVE_NO_DOI_TO_RESTUB = "A workflow must have no issued DOIs to restub";
     public static final String A_WORKFLOW_MUST_HAVE_NO_SNAPSHOT_TO_RESTUB = "A workflow must have no snapshots to restub, you may consider unpublishing";
+    public static final String YOU_CANNOT_CHANGE_THE_DESCRIPTOR_TYPE_OF_A_FULL_OR_HOSTED_WORKFLOW = "You cannot change the descriptor type of a FULL or HOSTED workflow.";
 
     private final ToolDAO toolDAO;
     private final LabelDAO labelDAO;
@@ -540,7 +540,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         // If workflow is FULL or HOSTED and descriptor type is being changed throw an error
         if ((Objects.equals(oldWorkflow.getMode(), WorkflowMode.FULL) || Objects.equals(oldWorkflow.getMode(), WorkflowMode.HOSTED)) && !Objects
             .equals(oldWorkflow.getDescriptorType(), newWorkflow.getDescriptorType())) {
-            throw new CustomWebApplicationException("You cannot change the descriptor type of a FULL or HOSTED workflow.", HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(YOU_CANNOT_CHANGE_THE_DESCRIPTOR_TYPE_OF_A_FULL_OR_HOSTED_WORKFLOW, HttpStatus.SC_BAD_REQUEST);
         }
 
         // Only copy workflow type if old workflow is a STUB

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -538,9 +538,9 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     // Used to update workflow manually (not refresh)
     private void updateInfo(Workflow oldWorkflow, Workflow newWorkflow) {
         // If workflow is FULL or HOSTED and descriptor type is being changed throw an error
-        if (Objects.equals(oldWorkflow.getMode(), WorkflowMode.FULL) || Objects.equals(oldWorkflow.getMode(), WorkflowMode.HOSTED) && !Objects
+        if ((Objects.equals(oldWorkflow.getMode(), WorkflowMode.FULL) || Objects.equals(oldWorkflow.getMode(), WorkflowMode.HOSTED)) && !Objects
             .equals(oldWorkflow.getDescriptorType(), newWorkflow.getDescriptorType())) {
-            throw new CustomWebApplicationException("You cannot change the descriptor type of a FULL workflow.", HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException("You cannot change the descriptor type of a FULL or HOSTED workflow.", HttpStatus.SC_BAD_REQUEST);
         }
 
         // Only copy workflow type if old workflow is a STUB

--- a/dockstore-webservice/src/main/resources/migrations.1.13.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.13.0.xml
@@ -81,4 +81,14 @@
         <modifyDataType tableName="apptool" columnName="workflowname" newDataType="varchar(256)"/>
         <modifyDataType tableName="service" columnName="workflowname" newDataType="varchar(256)"/>
     </changeSet>
+    <changeSet author="dyuen" id="hostedtopicmanual">
+        <update tableName="workflow">
+            <column name="topicselection" value ="MANUAL"/>
+            <where>mode= 'HOSTED'</where>
+        </update>
+        <update tableName="tool">
+            <column name="topicselection" value ="MANUAL"/>
+            <where>mode = 'HOSTED'</where>
+        </update>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**Description**
Allows for update of manual topic for hosted workflows while disallowing update of other properties
Also enforces manual topic for hosted workflows (since there is no source control)
Adds test

**Issue**
https://github.com/dockstore/dockstore/issues/4591

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
