### PR TITLE
DOCK-2159: Handle duplicate keys in .dockstore.yml parse

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
@@ -30,6 +30,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
@@ -209,25 +211,16 @@ public final class DockstoreYamlHelper {
             safeYaml.load(content);
             Representer representer = new Representer();
             representer.getPropertyUtils().setSkipMissingProperties(skipUnknownProperties);
-            final Yaml yaml = new Yaml(constructor, representer);
+            DumperOptions dumperOptions = new DumperOptions();
+            LoaderOptions loaderOptions = new LoaderOptions();
+            loaderOptions.setAllowDuplicateKeys(false);
+            final Yaml yaml = new Yaml(constructor, representer, dumperOptions, loaderOptions);
             return yaml.load(content);
         } catch (Exception e) {
-            final String exceptionMsg = createExceptionMessage(e);
+            final String exceptionMsg = e.getMessage();
             LOG.error(ERROR_READING_DOCKSTORE_YML + exceptionMsg, e);
             throw new DockstoreYamlException(exceptionMsg);
         }
-    }
-
-    private static String createExceptionMessage(Exception e) {
-        // For yaml ConstructorException, use `getProblem()`, which returns the line number, cause, and snippet.
-        // This is thrown on errors during the initial yaml parse, before validation, such as attempting to parse
-        // non-list information as a list, or create an enum from an input string that does not match any of the
-        // enum's values.  The full exception message contains lots of information about the surrounding context,
-        // formatted in a way that can be confusing and hard to read.
-        if (e instanceof org.yaml.snakeyaml.constructor.ConstructorException) {
-            return ((org.yaml.snakeyaml.constructor.ConstructorException)e).getProblem();
-        }
-        return e.getMessage();
     }
 
     /**

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -272,6 +272,16 @@ public class DockstoreYamlTest {
     }
 
     @Test
+    public void testDuplicateKeys() {
+        try {
+            DockstoreYamlHelper.readDockstoreYaml(DOCKSTORE12_YAML + "\nworkflows: []\n");
+            Assert.fail("Should have thrown because of duplicate key");
+        } catch (DockstoreYamlHelper.DockstoreYamlException ex) {
+            assertTrue("Error message should contain the name of the duplicate key", ex.getMessage().contains("workflows"));
+        }
+    }
+
+    @Test
     public void testDifferentCaseForWorkflowSubclass() throws DockstoreYamlHelper.DockstoreYamlException {
         final DockstoreYaml12 dockstoreYaml12 = DockstoreYamlHelper.readAsDockstoreYaml12(DOCKSTORE12_YAML);
         final List<YamlWorkflow> workflows = dockstoreYaml12.getWorkflows();


### PR DESCRIPTION
**Description**
This PR changes the `.dockstore.yml` parsing code to throw when it encounters duplicate keys.  Prior to this change, the parser would successfully parse YAML containing duplicate keys, blithely assigning the value of a duplicate key to the last duplicate's value.

Relatively recently, we changed the github apps log UI to display error messages in "pre-formatted" form (fixed width font with CR/LF displayed), so I tweaked the code so that the full YAML parser error message, which includes lots of "pre-formatting", is now included, rather than an abbreviation.    For the duplicate key failure in the test, the error message looks like this: 

```
while constructing a mapping
 in 'string', line 1, column 1:
    version: 1.2
    ^
found duplicate key workflows
 in 'string', line 72, column 1:
    workflows: []
    ^
```

In the logs, it will be prefixed with the "error in .dockstore.yml" text.

Long term, we should create a single YAML/JSON parsing method and use it globally, so that all parts of the codebase can benefit from these types of enhancements.  However, that'll take substantially more effort, and, since we're trying to get 1.13 out the door, now is probably not the time.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2159 #4883

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
