### PR TITLE
deal with n/a author searching

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -315,6 +315,8 @@ public class ElasticListener implements StateListenerInterface {
         Set<String> verifiedPlatforms = getVerifiedPlatforms(workflowVersions);
         Entry detachedEntry = removeIrrelevantProperties(entry);
         JsonNode jsonNode = MAPPER.readTree(MAPPER.writeValueAsString(detachedEntry));
+        // add number of starred users to allow sorting in the UI
+        ((ObjectNode)jsonNode).put("stars_count", (long) entry.getStarredUsers().size());
         ((ObjectNode)jsonNode).put("verified", verified);
         ((ObjectNode)jsonNode).put("verified_platforms", MAPPER.valueToTree(verifiedPlatforms));
         addCategoriesJson(jsonNode, entry);

--- a/dockstore-webservice/src/main/resources/queries/mapping_tool.json
+++ b/dockstore-webservice/src/main/resources/queries/mapping_tool.json
@@ -50,7 +50,8 @@
   "mappings": {
     "properties": {
       "author": {
-        "type": "keyword"
+        "type": "keyword",
+        "null_value": ""
       },
       "categories": {
         "properties": {

--- a/dockstore-webservice/src/main/resources/queries/mapping_workflow.json
+++ b/dockstore-webservice/src/main/resources/queries/mapping_workflow.json
@@ -50,7 +50,8 @@
   "mappings": {
     "properties": {
       "author": {
-        "type": "keyword"
+        "type": "keyword",
+        "null_value": ""
       },
       "categories": {
         "properties": {


### PR DESCRIPTION
**Description**
Elasticsearch was simply not indexing null authors which would make the results confusing. 
https://www.elastic.co/guide/en/elasticsearch/reference/current/null-value.html

BTW, this really boosts the counts for "n/a" as an author :wink: 

Also pulled in the fix for sorting from hotfix to make it less confusing when debugging

**Issue**
https://github.com/dockstore/dockstore/issues/4324

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
