### PR TITLE
repair dockstore-cli failing nightly build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
                     <version>2.8.2</version>
                     <configuration>
                         <uniqueVersion>false</uniqueVersion>
-                        <deployAtEnd>false</deployAtEnd>
+                        <deployAtEnd>true</deployAtEnd>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
**Description**
Follow-up on cron failing issue. Looks like when some modules fail, the other ones were still getting uploaded putting some modules out-of-sync, breaking the dockstore-cli nightly build 
https://maven.apache.org/plugins/maven-deploy-plugin/deploy-mojo.html#deployatend

On merge, I'll need to delete all existing snapshot deploys so that future ones will be in sync

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4477


- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
