### PR TITLE
Feature/fix for paths maybe

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -293,10 +293,11 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
                         resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(true)));
                     } else {
                         // looks like this takes into account a potentially different workflow path for a specific version of a workflow
-                        final String workflowPath = workflowVersion.getWorkflowPath();
+                        final Workflow workflow = (Workflow)entry;
+                        final String workflowPath = workflow.getDefaultWorkflowPath();
                         final String workflowVersionPath = workflowVersion.getWorkflowPath();
                         final String actualPath =
-                            workflowVersionPath == null || workflowVersionPath.isEmpty() ? workflowPath : workflowVersionPath;
+                            workflowVersionPath == null || workflowVersionPath.isEmpty() ? workflowVersionPath : workflowPath;
                         boolean isPrimary = file.getType() == fileType && file.getPath().equalsIgnoreCase(actualPath);
                         resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(isPrimary)));
                     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -297,7 +297,7 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
                         final String workflowPath = workflow.getDefaultWorkflowPath();
                         final String workflowVersionPath = workflowVersion.getWorkflowPath();
                         final String actualPath =
-                            workflowVersionPath == null || workflowVersionPath.isEmpty() ? workflowVersionPath : workflowPath;
+                            workflowVersionPath == null || workflowVersionPath.isEmpty() ? workflowPath : workflowVersionPath;
                         boolean isPrimary = file.getType() == fileType && file.getPath().equalsIgnoreCase(actualPath);
                         resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(isPrimary)));
                     }


### PR DESCRIPTION
**Description**
Looks like source file indexing would always take the workflow version path before. 
Now, if the workflow version path is missing, it will fallback to the default path for the workflow. 
Curious what tests fail and if should "fix" this 

**Issue**
https://github.com/dockstore/dockstore/issues/4740

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
