### PR TITLE
Add a type query parameter to fetch user entries.

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
@@ -35,6 +35,7 @@ import io.dockstore.openapi.client.model.ImageData;
 import io.dockstore.openapi.client.model.ToolVersion;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
+import io.dockstore.webservice.helpers.AppToolHelper;
 import io.dockstore.webservice.jdbi.FileDAO;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
@@ -63,8 +64,6 @@ public class GitHubWorkflowIT extends BaseIT {
     public static final String DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME = "DockstoreTestUser2/hello-dockstore-workflow";
     public static final String DOCKSTORE_TEST_USER2_HELLO_DOCKSTORE_WORKFLOW =
         SourceControl.GITHUB.toString() + "/" + DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME;
-    private final String installationId = "1179416";
-    private final String toolAndWorkflowRepo = "DockstoreTestUser2/test-workflows-and-tools";
     private final String toolAndWorkflowRepoToolPath = "DockstoreTestUser2/test-workflows-and-tools/md5sum";
     private static final String DOCKER_IMAGE_SHA_TYPE_FOR_TRS = "sha-256";
     @Rule
@@ -184,7 +183,7 @@ public class GitHubWorkflowIT extends BaseIT {
                 WorkflowSubClass.BIOWORKFLOW.getValue()).size());
 
         // Create an app tool and publish it
-        workflowApi.handleGitHubRelease(toolAndWorkflowRepo, BasicIT.USER_2_USERNAME, "refs/heads/main", installationId);
+        AppToolHelper.registerAppTool(webClient);
         Workflow appTool = workflowApi.getWorkflowByPath("github.com/" + toolAndWorkflowRepoToolPath, APPTOOL, "versions");
         workflowApi.publish(appTool.getId(), publishRequest);
         assertEquals("There should be 1 app tool published", 1,

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceIT.java
@@ -34,6 +34,7 @@ import io.dockstore.openapi.client.model.PrivilegeRequest;
 import io.dockstore.openapi.client.model.SourceControlOrganization;
 import io.dockstore.openapi.client.model.UserInfo;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
+import io.dockstore.webservice.helpers.AppToolHelper;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.HostedApi;
@@ -42,6 +43,7 @@ import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.Collection;
 import io.swagger.client.model.EntryUpdateTime;
+import io.swagger.client.model.EntryUpdateTime.EntryTypeEnum;
 import io.swagger.client.model.Organization;
 import io.swagger.client.model.OrganizationUpdateTime;
 import io.swagger.client.model.Profile;
@@ -420,6 +422,26 @@ public class UserResourceIT extends BaseIT {
     }
 
 
+    @Test
+    public void testGetUserEntries() {
+        ApiClient client = getWebClient(USER_2_USERNAME, testingPostgres);
+        UsersApi userApi = new UsersApi(client);
+        WorkflowsApi workflowsApi = new WorkflowsApi(client);
+
+        workflowsApi.manualRegister("gitlab", "dockstore.test.user2/dockstore-workflow-md5sum-unified", "/Dockstore.cwl", "", "cwl", "/test.json");
+
+        assertEquals(1, userApi.getUserEntries(10, null, "WORKFLOWS").size());
+        assertEquals(5, userApi.getUserEntries(10, null, null).size());
+        assertEquals(0, userApi.getUserEntries(10, null, "SERVICES").size());
+        assertEquals(4, userApi.getUserEntries(10, null, "TOOLS").size());
+
+        // Add an app tool, which should appear when specifying the TOOLS type
+        AppToolHelper.registerAppTool(client);
+        final List<EntryUpdateTime> tools = userApi.getUserEntries(10, null, "TOOLS");
+        assertEquals(5, tools.size());
+        assertEquals(1L, tools.stream().filter(t -> t.getEntryType() == EntryTypeEnum.APPTOOL).count());
+    }
+
     /**
      * Tests the endpoints used for logged in homepage to retrieve recent entries and organizations
      */
@@ -431,7 +453,7 @@ public class UserResourceIT extends BaseIT {
 
         workflowsApi.manualRegister("gitlab", "dockstore.test.user2/dockstore-workflow-md5sum-unified", "/Dockstore.cwl", "", "cwl", "/test.json");
 
-        List<EntryUpdateTime> entries = userApi.getUserEntries(10, null);
+        List<EntryUpdateTime> entries = userApi.getUserEntries(10, null, null);
         assertFalse(entries.isEmpty());
         assertTrue(entries.stream().anyMatch(e -> e.getPath().contains("gitlab.com/dockstore.test.user2/dockstore-workflow-md5sum-unified")));
         assertTrue(entries.stream().anyMatch(e -> e.getPath().contains("dockstore-workflow-md5sum-unified")));
@@ -444,7 +466,7 @@ public class UserResourceIT extends BaseIT {
         Assert.assertTrue(refreshedWorkflow.getDescription().contains("To demonstrate the checker workflow proposal"));
 
         // Entry should now be at the top
-        entries = userApi.getUserEntries(10, null);
+        entries = userApi.getUserEntries(10, null, null);
         assertEquals("gitlab.com/dockstore.test.user2/dockstore-workflow-md5sum-unified", entries.get(0).getPath());
         assertEquals("dockstore-workflow-md5sum-unified", entries.get(0).getPrettyPath());
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/AppToolHelper.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/AppToolHelper.java
@@ -1,0 +1,21 @@
+package io.dockstore.webservice.helpers;
+
+import io.dockstore.client.cli.BasicIT;
+import io.swagger.client.ApiClient;
+import io.swagger.client.api.WorkflowsApi;
+
+public final class AppToolHelper {
+
+    private AppToolHelper() {
+    }
+
+    private static final String INSTALLATION_ID = "1179416";
+    public static final String TOOL_AND_WORKFLOW_REPO = "DockstoreTestUser2/test-workflows-and-tools";
+
+    public static void registerAppTool(ApiClient webClient) {
+        WorkflowsApi workflowApi = new WorkflowsApi(webClient);
+        workflowApi.handleGitHubRelease(TOOL_AND_WORKFLOW_REPO, BasicIT.USER_2_USERNAME, "refs/heads/main",
+            INSTALLATION_ID);
+
+    }
+}

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/AppToolHelper.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/AppToolHelper.java
@@ -6,11 +6,11 @@ import io.swagger.client.api.WorkflowsApi;
 
 public final class AppToolHelper {
 
+    public static final String INSTALLATION_ID = "1179416";
+    public static final String TOOL_AND_WORKFLOW_REPO = "DockstoreTestUser2/test-workflows-and-tools";
+
     private AppToolHelper() {
     }
-
-    private static final String INSTALLATION_ID = "1179416";
-    public static final String TOOL_AND_WORKFLOW_REPO = "DockstoreTestUser2/test-workflows-and-tools";
 
     public static void registerAppTool(ApiClient webClient) {
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/AppTool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/AppTool.java
@@ -26,7 +26,12 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "apptool")
 @NamedQueries({
-    @NamedQuery(name = "io.dockstore.webservice.core.AppTool.getEntriesByUserId", query = "SELECT a FROM AppTool a WHERE a.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)")
+    @NamedQuery(name = "io.dockstore.webservice.core.AppTool.getEntriesByUserId", query = "SELECT a FROM AppTool a WHERE a.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)"),
+    @NamedQuery(name = "io.dockstore.webservice.core.AppTool.getEntryLiteByUserId", query =
+        "SELECT new io.dockstore.webservice.core.database.EntryLite$EntryLiteAppTool(a.sourceControl, a.organization, a.repository, a.workflowName, a.dbUpdateDate as entryUpdated, MAX(v.dbUpdateDate) as versionUpdated) "
+            + "FROM AppTool a LEFT JOIN a.workflowVersions v "
+            + "WHERE a.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId) "
+            + "GROUP BY a.sourceControl, a.organization, a.repository, a.workflowName, a.dbUpdateDate")
 })
 public class AppTool extends Workflow {
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntrySearchType.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntrySearchType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dockstore.webservice.resources;
+
+public enum EntrySearchType {
+    /**
+     * Includes both legacy tools and app tools
+     */
+    TOOLS,
+    WORKFLOWS,
+    SERVICES
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntrySearchType.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntrySearchType.java
@@ -17,7 +17,7 @@ package io.dockstore.webservice.resources;
 
 public enum EntrySearchType {
     /**
-     * Includes both legacy tools and app tools
+     * Includes both legacy tools and app tools.
      */
     TOOLS,
     WORKFLOWS,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntrySearchType.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntrySearchType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 OICR and UCSC
+ * Copyright 2022 OICR and UCSC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -779,13 +779,21 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(value = "See OpenApi for details")
     public List<EntryUpdateTime> getUserEntries(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
                                                 @Parameter(name = "count", description = "Maximum number of entries to return", in = ParameterIn.QUERY) @QueryParam("count") Integer count,
-                                                @Parameter(name = "filter", description = "Filter paths with matching text", in = ParameterIn.QUERY) @QueryParam("filter") String filter) {
+                                                @Parameter(name = "filter", description = "Filter paths with matching text", in = ParameterIn.QUERY) @QueryParam("filter") String filter,
+                                                @Parameter(name = "type", description = "Type of entry", in = ParameterIn.QUERY) @QueryParam("type") EntrySearchType type) {
         //get entries with only minimal columns from database
         final List<EntryLite> entriesLite = new ArrayList<>();
         final long userId = authUser.getId();
-        entriesLite.addAll(toolDAO.findEntryVersions(userId));
-        entriesLite.addAll(bioWorkflowDAO.findEntryVersions(userId));
-        entriesLite.addAll(serviceDAO.findEntryVersions(userId));
+        if (type == null || type == EntrySearchType.TOOLS) {
+            entriesLite.addAll(toolDAO.findEntryVersions(userId));
+            entriesLite.addAll(appToolDAO.findEntryVersions(userId));
+        }
+        if (type == null || type == EntrySearchType.WORKFLOWS) {
+            entriesLite.addAll(bioWorkflowDAO.findEntryVersions(userId));
+        }
+        if (type == null || type == EntrySearchType.SERVICES) {
+            entriesLite.addAll(serviceDAO.findEntryVersions(userId));
+        }
 
         //cleanup fields for UI: filter(if applicable), sort, and limit by count(if applicable)
         List<EntryUpdateTime> filteredEntries = entriesLite

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -5067,6 +5067,15 @@ paths:
         name: filter
         schema:
           type: string
+      - description: Type of entry
+        in: query
+        name: type
+        schema:
+          type: string
+          enum:
+          - TOOLS
+          - WORKFLOWS
+          - SERVICES
       responses:
         "200":
           content:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -4549,6 +4549,14 @@ paths:
         in: "query"
         required: false
         type: "string"
+      - name: "type"
+        in: "query"
+        required: false
+        type: "string"
+        enum:
+        - "TOOLS"
+        - "WORKFLOWS"
+        - "SERVICES"
       responses:
         200:
           description: "successful operation"


### PR DESCRIPTION
**Description**
Add a type query parameter to fetch user entries. Noticed that the endpoint wasn't returning app tools, fixed that also.

Debated whether to also fix the whole filtering and ordering being done in Java instead of on the database, before deciding against it, at least for now:

* JPA query would have been gnarly; a UNION of 4 queries
* There's [Java logic](https://github.com/dockstore/dockstore/blob/6d891efe366773f6af64163f4f23938ab589406d/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/EntryLite.java#L30) in what an entry path is that varies by type; I didn't want to have to deal with that in JPA.
* The EntryLite objects really are very light, so manipulating them in Java isn't too big of a deal.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4699

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
