### PR TITLE
Fix multi-arch Quay images

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -473,7 +473,7 @@ public abstract class AbstractImageRegistry {
         final FileDAO fileDAO, final ToolDAO toolDAO, final FileFormatDAO fileFormatDAO, final EventDAO eventDAO, final User user) {
         // Get all existing tags
         List<Tag> existingTags = new ArrayList<>(tool.getWorkflowVersions());
-        if (tool.getMode() != ToolMode.MANUAL_IMAGE_PATH || tool.getRegistry().equals(Registry.QUAY_IO.getDockerPath())) {
+        if (tool.getMode() != ToolMode.MANUAL_IMAGE_PATH || tool.getRegistry().equals(Registry.QUAY_IO.getDockerPath()) && existingTags.isEmpty()) {
 
             if (newTags == null) {
                 LOG.info(tool.getToolPath() + " : Tags for tool {} did not get updated because new tags were not found",
@@ -723,13 +723,7 @@ public abstract class AbstractImageRegistry {
         // No need to get all tags belonging to the container because image information is only updated for existing tool tags
         for (Tag tag : tool.getWorkflowVersions()) {
             // Determine if the tag is the 'latest' tag
-            LanguageHandlerInterface.DockerSpecifier specifier;
-            if (tag.getName().equals("latest")) {
-                specifier = LanguageHandlerInterface.DockerSpecifier.LATEST;
-            } else {
-                specifier = LanguageHandlerInterface.DockerSpecifier.TAG;
-            }
-
+            LanguageHandlerInterface.DockerSpecifier specifier = getSpecifierFromTagName(tag.getName());
             Set<Image> images = DockerRegistryAPIHelper.getImages(registry, repo, specifier, tag.getName());
             if (images.isEmpty()) {
                 LOG.error("Could not get image and checksum information for {}:{} from {}", repo, tag.getName(), registry.getFriendlyName());
@@ -1038,5 +1032,13 @@ public abstract class AbstractImageRegistry {
         }
 
         return dbToolList;
+    }
+
+    public LanguageHandlerInterface.DockerSpecifier getSpecifierFromTagName(String tagName) {
+        if ("latest".equals(tagName)) {
+            return LanguageHandlerInterface.DockerSpecifier.LATEST;
+        } else {
+            return LanguageHandlerInterface.DockerSpecifier.TAG;
+        }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -473,7 +473,7 @@ public abstract class AbstractImageRegistry {
         final FileDAO fileDAO, final ToolDAO toolDAO, final FileFormatDAO fileFormatDAO, final EventDAO eventDAO, final User user) {
         // Get all existing tags
         List<Tag> existingTags = new ArrayList<>(tool.getWorkflowVersions());
-        if (tool.getMode() != ToolMode.MANUAL_IMAGE_PATH || (tool.getRegistry().equals(Registry.QUAY_IO.getDockerPath()) && existingTags.isEmpty())) {
+        if (tool.getMode() != ToolMode.MANUAL_IMAGE_PATH || tool.getRegistry().equals(Registry.QUAY_IO.getDockerPath())) {
 
             if (newTags == null) {
                 LOG.info(tool.getToolPath() + " : Tags for tool {} did not get updated because new tags were not found",

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/QuayImageRegistry.java
@@ -30,6 +30,7 @@ import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.ToolMode;
 import io.dockstore.webservice.core.docker.DockerManifestList;
+import io.dockstore.webservice.languages.LanguageHandlerInterface;
 import io.swagger.quay.client.ApiClient;
 import io.swagger.quay.client.ApiException;
 import io.swagger.quay.client.Configuration;
@@ -53,10 +54,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -72,6 +75,7 @@ import org.slf4j.LoggerFactory;
 public class QuayImageRegistry extends AbstractImageRegistry {
 
     private static final Logger LOG = LoggerFactory.getLogger(QuayImageRegistry.class);
+    private static final Gson GSON = new Gson();
 
     private final Token quayToken;
     private final BuildApi buildApi;
@@ -81,18 +85,23 @@ public class QuayImageRegistry extends AbstractImageRegistry {
     private final ManifestApi manifestApi;
 
     public QuayImageRegistry(final Token quayToken) {
-        this.quayToken = quayToken;
         ApiClient apiClient = Configuration.getDefaultApiClient();
-        apiClient.addDefaultHeader("Authorization", "Bearer " + quayToken.getContent());
+        this.quayToken = quayToken;
+        if (quayToken != null) {
+            apiClient.addDefaultHeader("Authorization", "Bearer " + quayToken.getContent());
+        }
         this.buildApi = new BuildApi(apiClient);
         this.repositoryApi = new RepositoryApi(apiClient);
         this.userApi = new UserApi(apiClient);
         this.tagApi = new TagApi((apiClient));
         this.manifestApi = new ManifestApi(apiClient);
-
     }
 
-    private List<QuayTag> getAllQuayTags(String repository) throws ApiException {
+    public QuayImageRegistry() {
+        this(null);
+    }
+
+    public List<QuayTag> getAllQuayTags(String repository) throws ApiException {
         List<QuayTag> allQuayTags = new ArrayList<>();
         // Completely arbitrary maxPageSize in the weird event that Quay.io's pagination results in an infinite loop or something
         final int maxPageSize = 100;
@@ -105,6 +114,15 @@ public class QuayImageRegistry extends AbstractImageRegistry {
             }
         }
         return allQuayTags;
+    }
+
+    public Optional<QuayTag> getQuayTag(String repository, String tag) throws ApiException {
+        InlineResponse2002 inlineResponse2002 = tagApi.listRepoTags(repository, null, null, tag, true);
+        List<QuayTag> quayTags = inlineResponse2002.getTags();
+        if (!quayTags.isEmpty()) {
+            return Optional.of(quayTags.get(0));
+        }
+        return Optional.empty();
     }
 
 
@@ -125,22 +143,23 @@ public class QuayImageRegistry extends AbstractImageRegistry {
 
             // Search through the Quay tags for ones that are classified as a manifest list and then use its digest to get the repo's manifest.
             List<QuayTag> cleanedQuayTagList = new ArrayList<>(quayTags);
-            Map<QuayTag, List<Image>> multiImageQuayTags = new HashMap<>();
-            Gson g = new Gson();
-            quayTags.stream().forEach(quayTag -> {
+            Map<QuayTag, Set<Image>> multiImageQuayTags = new HashMap<>();
+            // Process multi-arch images first to clean list of all Quay tags
+            quayTags.forEach(quayTag -> {
                 if (Boolean.TRUE.equals(quayTag.isIsManifestList())) {
                     try {
-                        // Store the collected Image(s) into a map that consists of <Original Manifest List Quay Tag, List<Images>>.
-                        List<Image> images = handleMultiArchQuayTags(tool, quayTag, g, cleanedQuayTagList);
+                        LOG.info(quayToken.getUsername() + " ======================= Getting image for tag {}================================", quayTag.getName());
+                        // Store the collected Image(s) into a map that consists of <Original Manifest List Quay Tag, Set<Images>>.
+                        LanguageHandlerInterface.DockerSpecifier specifier = getSpecifierFromTagName(quayTag.getName());
+                        Set<Image> images = handleMultiArchQuayTags(repo, quayTag, cleanedQuayTagList, specifier);
                         multiImageQuayTags.put(quayTag, images);
                     } catch (ApiException ex) {
                         LOG.info("Unable to handle manifest list for Quay Tag " + quayTag.getName() + " in repo " + repo, ex);
                     }
-
                 }
             });
 
-            for (QuayTag tagItem : quayTags) {
+            for (QuayTag tagItem : cleanedQuayTagList) {
                 try {
                     final Tag tag = convertQuayTagToTag(tagItem, tool, multiImageQuayTags);
                     tags.add(tag);
@@ -157,85 +176,92 @@ public class QuayImageRegistry extends AbstractImageRegistry {
 
     /**
      * For each manifest in the list:
-     * Find the matching Quay tag (using the digest)
-     * Gather and return the associated images
-     * Remove the matching Quay tag from the list so that a Dockstore version is not created based off of it.
+     * <li>Create an image</li>
+     * <li>Check if there's a matching Quay tag in cleanedQuayTagList using the manifest digest. If there's a match, this means that the multi-arch
+     * image was built using the docker manifest method which creates individual images for each architecture.
+     * There would be no match if the multi-arch image was created using the buildx method.</li>
+     * <li>Remove the matching Quay tag from cleanedQuayTagList if it exists because it's already been processed and an image was created for it.
+     * Removing it ensures that a Dockstore version is not created from it.</li>
      *
-     * @param tool a tool from Dockstore
-     * @param quayTag the Quay Tag that is a manifest list
-     * @param g Gson to covert string to JSON
-     * @param cleanedQuayTagList List of Quay Tags that removes Quay tags that are listed in quayTag's manifest list
+     * @param repository a tool from Dockstore
+     * @param quayTag    the Quay Tag that is a manifest list
+     * @param cleanedQuayTagList List of Quay Tags that removes Quay tags that are listed in quayTag's manifest list.
      * @return list of images with arch/os information for the quayTag
      */
-    private List<Image> handleMultiArchQuayTags(Tool tool, QuayTag quayTag, Gson g, List<QuayTag> cleanedQuayTagList) throws ApiException {
-        LOG.info(quayToken.getUsername() + " ======================= Getting image for tag {}================================", quayTag.getName());
+    public Set<Image> handleMultiArchQuayTags(String repository, QuayTag quayTag, List<QuayTag> cleanedQuayTagList, LanguageHandlerInterface.DockerSpecifier specifier) throws ApiException {
         QuayRepoManifest quayRepoManifest;
         DockerManifestList manifestList;
-        List<Image> images = new ArrayList<>();
-        quayRepoManifest = manifestApi.getRepoManifest(quayTag.getManifestDigest(), tool.getNamespace() + '/' + tool.getName());
+        Set<Image> images = new HashSet<>();
+        quayRepoManifest = manifestApi.getRepoManifest(quayTag.getManifestDigest(), repository);
         try {
-            manifestList = g.fromJson(quayRepoManifest.getManifestData(), DockerManifestList.class);
+            manifestList = GSON.fromJson(quayRepoManifest.getManifestData(), DockerManifestList.class);
         } catch (JsonSyntaxException ex) {
-            LOG.info("Unexpected response from Quay while retrieving repo manifest for Quay Tag " + quayTag.getName() + " for tool " + tool.getToolPath(), ex);
+            LOG.info("Unexpected response from Quay while retrieving repo manifest for Quay Tag " + quayTag.getName() + " for repository " + repository, ex);
             return images;
         }
+
         try {
-            Optional<QuayTag> matchingTag = cleanedQuayTagList.stream().filter(tag -> (tag.getManifestDigest().equals(quayRepoManifest.getDigest()))).findFirst();
-            if (matchingTag.isPresent()) {
-                // Create an image for each arch manifest
-                Arrays.stream(manifestList.getManifests()).forEach(manifest -> {
-                    // Find the quay tag that has the same manifest as the current tag we're processing
-                    final String manifestDigest = manifest.getDigest();
-                    final String imageID = matchingTag.get().getImageId();
-                    List<Checksum> checksums = new ArrayList<>();
-                    String[] splitChecksum = manifestDigest.split(":");
-                    checksums.add(new Checksum(splitChecksum[0], splitChecksum[1]));
-                    Image image = new Image(checksums, tool.getNamespace() + '/' + tool.getName(), quayTag.getName(), imageID, Registry.QUAY_IO, manifest.getSize(), quayTag.getLastModified());
-                    image.setArchitecture(manifest.getPlatform().getArchitecture());
-                    image.setOs(manifest.getPlatform().getOs());
-                    images.add(image);
-                });
-                cleanedQuayTagList.remove(matchingTag.get());
-            } else {
-                LOG.info("Unable to find matching Quay tag image information using digest");
-            }
+            // Create an image for each architecture manifest
+            Arrays.stream(manifestList.getManifests()).forEach(manifest -> {
+                final String manifestDigest = manifest.getDigest();
+                final String imageID = quayTag.getImageId();
+                List<Checksum> checksums = new ArrayList<>();
+                String[] splitChecksum = manifestDigest.split(":");
+                checksums.add(new Checksum(splitChecksum[0], splitChecksum[1]));
+                Image image = new Image(checksums, repository, quayTag.getName(), imageID, Registry.QUAY_IO, manifest.getSize(), quayTag.getLastModified());
+                image.setArchitecture(manifest.getPlatform().getArchitecture());
+                image.setOs(manifest.getPlatform().getOs());
+                image.setSpecifier(specifier);
+                images.add(image);
+                // Look through Quay tags to see if this multi arch image was built using the "docker manifest" approach where each architecture has its own tag
+                Optional<QuayTag> singleArchTag = cleanedQuayTagList.stream().filter(tag -> tag.getManifestDigest().equals(manifestDigest)).findFirst();
+                singleArchTag.ifPresent(cleanedQuayTagList::remove); // Remove it because it's already been processed
+            });
         } catch (NullPointerException ex) {
-            LOG.info("Unexpected null response from Quay while retrieving image and checksum info from manifest for Quay Tag " + quayTag.getName() + " for tool " + tool.getToolPath(), ex);
+            LOG.info("Unexpected null response from Quay while retrieving image and checksum info from manifest for Quay Tag " + quayTag.getName() + " for repository " + repository, ex);
         }
         return images;
     }
 
-    private Tag convertQuayTagToTag(QuayTag quayTag, Tool tool, Map<QuayTag, List<Image>> multiImageQuayTags) throws InvocationTargetException, IllegalAccessException {
+    private Tag convertQuayTagToTag(QuayTag quayTag, Tool tool, Map<QuayTag, Set<Image>> multiImageQuayTags) throws InvocationTargetException, IllegalAccessException {
         final Tag tag = new Tag();
         BeanUtils.copyProperties(tag, quayTag);
         // If we were unable to get the list of images from the manifest list, then an empty image list will be added to the tag.
         if (quayTag.isIsManifestList() != null && quayTag.isIsManifestList()) {
-            List<Image> images = multiImageQuayTags.get(quayTag);
+            Set<Image> images = multiImageQuayTags.get(quayTag);
             tag.getImages().addAll(images);
         } else {
-            Optional<Image> tagImage = getImageForTag(tool, tag, quayTag);
-            tagImage.ifPresent(image -> tag.getImages().add(image));
+            LOG.info(quayToken.getUsername() + " ======================= Getting image for tag {}================================", tag.getName());
+            final String repo = tool.getNamespace() + '/' + tool.getName();
+            final LanguageHandlerInterface.DockerSpecifier specifier = getSpecifierFromTagName(quayTag.getName());
+            Image tagImage = getImageForTag(repo, quayTag, specifier);
+            tag.getImages().add(tagImage);
         }
         insertQuayLastModifiedIntoLastBuilt(quayTag, tag);
         return tag;
     }
 
+    /**
+     * Checks if a quay tag is multi-arch by getting its repo manifest. Checking its repo manifest instead of QuayTag ensures that isIsManifestList() is not null
+     * if there's no authentication.
+     * @param quayTag
+     * @param repository
+     * @return
+     */
+    public boolean isMultiArchImage(QuayTag quayTag, String repository) throws ApiException {
+        QuayRepoManifest quayRepoManifest = manifestApi.getRepoManifest(quayTag.getManifestDigest(), repository);
+        return quayRepoManifest.isIsManifestList();
+    }
 
     //TODO: If the repo has a lot of tags, then it needs to be paged through. Can get tag info individually, but then that's more API calls.
-    private Optional<Image> getImageForTag(final Tool tool, final Tag tag, final QuayTag quayTag) {
-        LOG.info(quayToken.getUsername() + " ======================= Getting image for tag {}================================", tag.getName());
-
-        final String repo = tool.getNamespace() + '/' + tool.getName();
-        try {
-            final String manifestDigest = quayTag.getManifestDigest();
-            final String imageID = quayTag.getImageId();
-            List<Checksum> checksums = new ArrayList<>();
-            checksums.add(new Checksum(manifestDigest.split(":")[0], manifestDigest.split(":")[1]));
-            return Optional.of((new Image(checksums, repo, tag.getName(), imageID, Registry.QUAY_IO, quayTag.getSize(), quayTag.getLastModified())));
-        } catch (IndexOutOfBoundsException | NullPointerException ex) {
-            LOG.error("Could not get checksum information for " + repo, ex);
-            return Optional.empty();
-        }
+    public Image getImageForTag(final String repo, final QuayTag quayTag, final LanguageHandlerInterface.DockerSpecifier specifier) {
+        final String manifestDigest = quayTag.getManifestDigest();
+        final String imageID = quayTag.getImageId();
+        List<Checksum> checksums = new ArrayList<>();
+        checksums.add(new Checksum(manifestDigest.split(":")[0], manifestDigest.split(":")[1]));
+        Image image = new Image(checksums, repo, quayTag.getName(), imageID, Registry.QUAY_IO, quayTag.getSize(), quayTag.getLastModified());
+        image.setSpecifier(specifier);
+        return image;
     }
 
     /**
@@ -383,7 +409,7 @@ public class QuayImageRegistry extends AbstractImageRegistry {
                                     String trimmed = splitLine[1].trim();
                                     // strip the brackets
                                     String substring = trimmed.substring(1, trimmed.length() - 1);
-                                    Map<String, String> map = new Gson().fromJson(substring, new TypeToken<Map<String, String>>() {
+                                    Map<String, String> map = GSON.fromJson(substring, new TypeToken<Map<String, String>>() {
                                     }.getType());
                                     gitUrl = "git@github.com:" + map.get("namespace") + "/" + map.get("repo") + ".git";
                                 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -35,13 +35,12 @@ import io.dockstore.webservice.core.dockerhub.Results;
 import io.dockstore.webservice.helpers.AbstractImageRegistry;
 import io.dockstore.webservice.helpers.DAGHelper;
 import io.dockstore.webservice.helpers.DockerRegistryAPIHelper;
+import io.dockstore.webservice.helpers.QuayImageRegistry;
 import io.dockstore.webservice.helpers.SourceCodeRepoInterface;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import io.swagger.quay.client.ApiClient;
 import io.swagger.quay.client.ApiException;
 import io.swagger.quay.client.Configuration;
-import io.swagger.quay.client.api.RepositoryApi;
-import io.swagger.quay.client.model.QuayRepo;
 import io.swagger.quay.client.model.QuayTag;
 import java.io.IOException;
 import java.net.URL;
@@ -807,46 +806,38 @@ public interface LanguageHandlerInterface {
         return imageInfo;
     }
 
+    /**
+     * Get set of images for an image specified by tag or digest. If the image is multi-arch, then there will be more than one image in the set.
+     * @param repo
+     * @param specifierType
+     * @param specifierName
+     * @return
+     */
     default Set<Image> getImageResponseFromQuay(String repo, DockerSpecifier specifierType, String specifierName) {
         Set<Image> quayImages = new HashSet<>();
-        RepositoryApi api = new RepositoryApi(API_CLIENT);
+        QuayImageRegistry quayImageRegistry = new QuayImageRegistry();
         try {
-
-            final QuayRepo quayRepo = api.getRepo(repo, false);
+            Optional<QuayTag> maybeTag;
             if (specifierType == DockerSpecifier.DIGEST) {
-                Map<String, QuayTag> tags = quayRepo.getTags();
-                boolean imageFound = false;
-
-                for (QuayTag tag : tags.values()) {
-                    final String digest = tag.getManifestDigest();
-
-                    // Find image with the specified digest
-                    if (digest.equals(specifierName)) {
-                        final String imageID = tag.getImageId();
-                        final String tagName = tag.getName(); // Tag that's associated with the image specified by digest
-                        List<Checksum> checksums = Collections.singletonList(new Checksum(digest.split(":")[0], digest.split(":")[1]));
-                        Image quayImage = new Image(checksums, repo, tagName, imageID, Registry.QUAY_IO, tag.getSize(), tag.getLastModified());
-                        quayImage.setSpecifier(specifierType);
-                        quayImages.add(quayImage);
-                        imageFound = true;
-                        break;
-                    }
-                }
-                if (!imageFound) {
-                    LOG.error("Unable to find image with digest: {} from Quay in repo {}", specifierName, repo);
-                    return quayImages;
-                }
+                // Look through all tags and find one with matching digest
+                List<QuayTag> tags = quayImageRegistry.getAllQuayTags(repo);
+                maybeTag = tags.stream().filter(quayTag -> quayTag.getManifestDigest().equals(specifierName)).findFirst();
             } else {
-                QuayTag tag = quayRepo.getTags().get(specifierName);
-                if (tag == null) {
-                    LOG.error("Unable to find tag: {} from Quay in repo {}", specifierName, repo);
-                    return quayImages;
-                }
-                final String digest = tag.getManifestDigest();
-                final String imageID = tag.getImageId();
-                List<Checksum> checksums = Collections.singletonList(new Checksum(digest.split(":")[0], digest.split(":")[1]));
-                Image quayImage = new Image(checksums, repo, specifierName, imageID, Registry.QUAY_IO, tag.getSize(), tag.getLastModified());
-                quayImage.setSpecifier(specifierType);
+                // Get specific QuayTag
+                maybeTag = quayImageRegistry.getQuayTag(repo, specifierName);
+            }
+
+            if (maybeTag.isEmpty()) {
+                LOG.error("Unable to find image with specifier {}: {} from Quay in repo {}", specifierType, specifierName, repo);
+                return quayImages;
+            }
+
+            QuayTag tag = maybeTag.get();
+            if (quayImageRegistry.isMultiArchImage(tag, repo)) {
+                List<QuayTag> cleanedQuayTagList = List.of(); // Don't need to keep track of cleaned tags because we're only processing one tag, so use empty list
+                quayImages = quayImageRegistry.handleMultiArchQuayTags(repo, tag, cleanedQuayTagList, specifierType);
+            } else {
+                Image quayImage = quayImageRegistry.getImageForTag(repo, tag, specifierType);
                 quayImages.add(quayImage);
             }
         } catch (ApiException ex) {


### PR DESCRIPTION
**Description**
This PR fixes how we process multi-arch Quay images for tools and adds multi-arch Quay support for workflows and GitHub app tools.

**Background**
There are two ways of creating multi-arch images ([source](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/)):
1) Using `docker manifest`: 
  - Individual images are built and pushed to the registry for **each** architecture. These images are then combined in a manifest list which references each architecture image's digest, and this resulting image is also pushed to the registry.
  - https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags is a repo with multi-arch images built using this method. For each multi-arch image, there are individual images for each architecture.
    - `4.12.0-0.nightly-multi-2022-08-22-190530` is the multi-arch image
    - `4.12.0-0.nightly-multi-2022-08-22-190530-aarch64`, `4.12.0-0.nightly-multi-2022-08-22-190530-s390x`, `4.12.0-0.nightly-multi-2022-08-22-190530-ppc64le`, `4.12.0-0.nightly-multi-2022-08-22-190530-x86_64` are the individual architecture images
    - If curious, copy the tag name of one of the multi-arch images, like `4.12.0-0.nightly-multi-2022-08-22-190530`, and paste it into the search bar on the top right to filter the tags. You will see multiple images show up.
2) Using `docker buildx`
  - This is the simple way to create multi-arch images. Using one `docker buildx` command, the multi-arch image is built without needing to build and push individual images for each architecture.
  - https://quay.io/repository/skopeo/stable?tab=tags is a repo with multi-arch images built using this method. Notice how each multi-arch image does **not** have any images for each architecture. 
    - To check, copy the tag name of one of the multi-arch images, like `v1.9.2`, and paste it into the search bar on the top right to filter the tags. Only one image should show up, which is the multi-arch image.

A previous PR https://github.com/dockstore/dockstore/pull/4753 added multi-arch Quay support for tools. The implementation only considered multi-arch images created using method 1 (`docker manifest`). This PR adds support for multi-arch images created using method 2 (`docker buildx`).

This PR also adds multi-arch Quay support for workflows (regular and GitHub apps) and GitHub app tools. I made several `QuayImageRegistry` methods public and refactored them a bit so that `LanguageHandlerInterface` can re-use them when processing images for workflows and GitHub app tools to reduce duplication.

**Side tangent**
Now that I think about it, we might not be handling multi-arch DockerHub images correctly for tools because those two methods of creating multi-arch images are not unique to Quay. The problematic case is the `docker manifest` multi-arch image. We might be creating a `Tag` for the multi-arch image and also a `Tag` for each individual architecture image. If that's the case, we will need to keep a `cleanDockerHubTagList` like we do for Quay. Will investigate and create a separate ticket if it's an issue.


**Issue**
[SEAB-3928](https://ucsc-cgl.atlassian.net/browse/SEAB-3928)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
