### PR TITLE
check whether a manual tool repo is valid

### DIFF
--- a/.github/workflows/mvnw.yml
+++ b/.github/workflows/mvnw.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11', '17' ]
+        java: [ '11', '17.0.4+8' ]
 
     steps:
       - name: install git secrets

--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ Workflow Language (CWL), WDL (Workflow Description Language), Nextflow, or Galax
 workflows so that they are  machine readable as well as runnable in a variety of environments. While the 
 Dockstore is focused on serving researchers in the biosciences, the combination of Docker + workflow languages can be used by 
 anyone to describe the tools and services in their Docker images in a standardized, machine-readable way.  
-Dockstore is also a leading implementor of the GA4GH API standard for container registries, [TRS](https://www.ga4gh.org/news/tool-registry-service-api-enabling-an-interoperable-library-of-genomics-analysis-tools/).
-
-For the live site see [dockstore.org](https://dockstore.org)
-
-This repo contains the web service and CLI components for Dockstore as well as collecting documentation and 
-the issues for the project as a whole. The usage of this is to enumerate the docker containers 
+Dockstore is also a leading implementor of the GA4GH API standard for container registries, [TRS](https://www.ga4gh.org/news/tool-registry-service-api-enabling-an-interoperable-library-of-genomics-analysis-tools/). The usage of this is to enumerate the docker containers 
 (from quay.io and hopefully docker hub) and the workflows (from github/bitbucket) that are available 
 to users of Dockstore.org.
 
+For the live site see [dockstore.org](https://dockstore.org)
+
+This repo contains the web service component for Dockstore as well as collecting issues for the project as a whole. 
+
 For the related web UI see the [dockstore-ui](https://github.com/dockstore/dockstore-ui2) project.
+For the related CLI see the [cli](https://github.com/dockstore/cli) project.
 
 ## For Dockstore Users
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGeneralWorkflowIT.java
@@ -16,6 +16,7 @@
 
 package io.dockstore.client.cli;
 
+import static io.dockstore.webservice.resources.DockerRepoResource.UNABLE_TO_VERIFY_THAT_YOUR_TOOL_POINTS_AT_A_VALID_SOURCE_CONTROL_REPO;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -45,6 +46,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -308,6 +310,21 @@ public class BitBucketGeneralWorkflowIT extends GeneralWorkflowBaseIT {
         verifyChecksumsAreSaved(updatedTags);
     }
 
+    @Test
+    public void testCannotRegisterGarbageSourceControlFromDockerHub() {
+        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        ContainersApi toolApi = new ContainersApi(webClient);
+        DockstoreTool tool = createManualDockerHubTool(false);
+
+        try {
+            toolApi.registerManual(tool);
+        } catch (ApiException e) {
+            Assert.assertTrue(e.getMessage().contains(UNABLE_TO_VERIFY_THAT_YOUR_TOOL_POINTS_AT_A_VALID_SOURCE_CONTROL_REPO));
+            return;
+        }
+        fail("should fail to register");
+    }
+
     private DockstoreTool registerManualGitHubContainerRegistryToolAndAddTag() {
         final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
         ContainersApi toolApi = new ContainersApi(webClient);
@@ -378,6 +395,11 @@ public class BitBucketGeneralWorkflowIT extends GeneralWorkflowBaseIT {
     }
 
     private DockstoreTool createManualDockerHubTool() {
+        return createManualDockerHubTool(true);
+    }
+
+
+    private DockstoreTool createManualDockerHubTool(boolean validRepo) {
         DockstoreTool tool = new DockstoreTool();
         tool.setMode(DockstoreTool.ModeEnum.MANUAL_IMAGE_PATH);
         tool.setName("dockstore-whalesay-2");
@@ -389,8 +411,12 @@ public class BitBucketGeneralWorkflowIT extends GeneralWorkflowBaseIT {
         tool.setDefaultCWLTestParameterFile("/test.cwl.json");
         tool.setDefaultWDLTestParameterFile("/test.wdl.json");
         tool.setIsPublished(false);
-        // This actually exists: https://bitbucket.org/DockstoreTestUser/dockstore-whalesay-2/src/master/
-        tool.setGitUrl("git@bitbucket.org:DockstoreTestUser/dockstore-whalesay-2.git");
+        if (validRepo) {
+            // This actually exists: https://bitbucket.org/DockstoreTestUser/dockstore-whalesay-2/src/master/
+            tool.setGitUrl("git@bitbucket.org:DockstoreTestUser/dockstore-whalesay-2.git");
+        } else {
+            tool.setGitUrl("git@bitbucket.org:DockstoreTestUser/bewareoftheleopard-2.git");
+        }
         tool.setToolname("alternate");
         tool.setPrivateAccess(false);
         return tool;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGeneralWorkflowIT.java
@@ -46,7 +46,6 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -319,7 +318,7 @@ public class BitBucketGeneralWorkflowIT extends GeneralWorkflowBaseIT {
         try {
             toolApi.registerManual(tool);
         } catch (ApiException e) {
-            Assert.assertTrue(e.getMessage().contains(UNABLE_TO_VERIFY_THAT_YOUR_TOOL_POINTS_AT_A_VALID_SOURCE_CONTROL_REPO));
+            assertTrue(e.getMessage().contains(UNABLE_TO_VERIFY_THAT_YOUR_TOOL_POINTS_AT_A_VALID_SOURCE_CONTROL_REPO));
             return;
         }
         fail("should fail to register");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -20,6 +20,7 @@ import static io.dockstore.common.DescriptorLanguage.CWL;
 import static io.dockstore.webservice.core.SourceFile.SHA_TYPE;
 import static io.dockstore.webservice.core.Version.CANNOT_FREEZE_VERSIONS_WITH_NO_FILES;
 import static io.dockstore.webservice.helpers.EntryVersionHelper.CANNOT_MODIFY_FROZEN_VERSIONS_THIS_WAY;
+import static io.dockstore.webservice.resources.DockerRepoResource.UNABLE_TO_VERIFY_THAT_YOUR_TOOL_POINTS_AT_A_VALID_SOURCE_CONTROL_REPO;
 import static io.openapi.api.impl.ToolsApiServiceImpl.DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -78,6 +79,7 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
 import org.json.JSONObject;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1462,6 +1464,21 @@ public class GeneralIT extends GeneralWorkflowBaseIT {
             "select count(*) from tool where mode = '" + DockstoreTool.ModeEnum.MANUAL_IMAGE_PATH + "' and giturl = '" + gitUrl
                 + "' and name = 'my-md5sum' and namespace = 'dockstoretestuser2' and toolname = 'altname'", long.class);
         assertEquals("The tool should be manual, there are " + count, 1, count);
+    }
+
+    @Test
+    public void testCannotRegisterGarbageSourceControlFromDockerHub() {
+        String gitUrl = "git@github.com:DockstoreTestUser2/bewareoftheleopard.git";
+        ContainersApi toolsApi = setupWebService();
+        DockstoreTool tool = getQuayContainer(gitUrl);
+
+        try {
+            toolsApi.registerManual(tool);
+        } catch (ApiException e) {
+            Assert.assertTrue(e.getMessage().contains(UNABLE_TO_VERIFY_THAT_YOUR_TOOL_POINTS_AT_A_VALID_SOURCE_CONTROL_REPO));
+            return;
+        }
+        fail("should fail to register");
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -79,7 +79,6 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
 import org.json.JSONObject;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1475,7 +1474,7 @@ public class GeneralIT extends GeneralWorkflowBaseIT {
         try {
             toolsApi.registerManual(tool);
         } catch (ApiException e) {
-            Assert.assertTrue(e.getMessage().contains(UNABLE_TO_VERIFY_THAT_YOUR_TOOL_POINTS_AT_A_VALID_SOURCE_CONTROL_REPO));
+            assertTrue(e.getMessage().contains(UNABLE_TO_VERIFY_THAT_YOUR_TOOL_POINTS_AT_A_VALID_SOURCE_CONTROL_REPO));
             return;
         }
         fail("should fail to register");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -310,7 +310,7 @@ public class User implements Principal, Comparable<User>, Serializable {
         } else {
             Token githubToken = githubByUserId.get(0);
             GitHubSourceCodeRepo sourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createSourceCodeRepo(githubToken);
-            sourceCodeRepo.checkSourceCodeValidity();
+            sourceCodeRepo.checkSourceControlTokenValidity();
             sourceCodeRepo.syncUserMetadataFromGitHub(this, Optional.of(tokenDAO));
             return true;
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/BitBucketSourceCodeRepo.java
@@ -377,7 +377,7 @@ public class BitBucketSourceCodeRepo extends SourceCodeRepoInterface {
     }
 
     @Override
-    public boolean checkSourceCodeValidity() {
+    public boolean checkSourceControlTokenValidity() {
         //TODO
         return true;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -364,7 +364,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
     }
 
     @Override
-    public boolean checkSourceCodeValidity() {
+    public boolean checkSourceControlTokenValidity() {
         try {
             GHRateLimit ghRateLimit = github.getRateLimit();
             if (ghRateLimit.getRemaining() == 0) {
@@ -1145,30 +1145,6 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             }
         } catch (IOException ex) {
             LOG.info("Could not find user information for user " + user.getUsername(), ex);
-        }
-    }
-
-    // DO NOT USE THIS FUNCTION ELSEWHERE
-    // This function has no use outside of gathering user's GitHub IDs the first time. This uses the GitHub token of the admin user calling the new, one-time-use endpoint.
-    // This will attempt to get the GitHub profile info (including id) of users we were unable to get by calling the github.getMyself() function above.
-    public void syncUserMetadataFromGitHubByUsername(User user, TokenDAO tokenDAO) {
-        // eGit user object
-        try {
-            if (user.getUserProfiles().get(TokenType.GITHUB_COM.toString()) == null) {
-                throw new CustomWebApplicationException("Could not find GitHub user profile information on Dockstore with username: " + user.getUsername() + "dockstore userid: " + user.getId(), HttpStatus.SC_NOT_FOUND);
-            }
-            GHUser ghUser = github.getUser(user.getUserProfiles().get(TokenType.GITHUB_COM.toString()).username);
-            User.Profile profile = getProfile(user, ghUser);
-            profile.email = ghUser.getEmail();
-
-            // Update token. Username on GitHub could have changed and need to collect the GitHub user id as well
-            Token usersGitHubToken = tokenDAO.findGithubByUserId(user.getId()).get(0);
-            usersGitHubToken.setOnlineProfileId(profile.onlineProfileId);
-            usersGitHubToken.setUsername(profile.username);
-        } catch (IOException ex) {
-            String msg = "Unable to get GitHub user id for Dockstore user " + user.getUsername() + " " + user.getId();
-            LOG.info(msg, ex);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitLabSourceCodeRepo.java
@@ -280,7 +280,7 @@ public class GitLabSourceCodeRepo extends SourceCodeRepoInterface {
     }
 
     @Override
-    public boolean checkSourceCodeValidity() {
+    public boolean checkSourceControlTokenValidity() {
         //TODO
         return true;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
@@ -21,6 +21,7 @@ import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.TokenType;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -68,8 +69,17 @@ public final class SourceCodeRepoFactory {
             throw new CustomWebApplicationException("Sorry, we do not support " + token.getTokenSource() + ".",
                 HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE);
         }
-        repo.checkSourceCodeValidity();
+        repo.checkSourceControlTokenValidity();
         return repo;
+    }
+
+    public static SourceCodeRepoInterface createSourceCodeRepo(String gitUrl, List<Token> tokens) {
+        Token githubToken = Token.extractToken(tokens, TokenType.GITHUB_COM);
+        Token gitlabToken = Token.extractToken(tokens, TokenType.GITLAB_COM);
+        Token bitbucketToken = Token.extractToken(tokens, TokenType.BITBUCKET_ORG);
+        return SourceCodeRepoFactory
+            .createSourceCodeRepo(gitUrl, bitbucketToken == null ? null : bitbucketToken.getContent(),
+                gitlabToken == null ? null : gitlabToken.getContent(), githubToken);
     }
 
     /**
@@ -114,7 +124,7 @@ public final class SourceCodeRepoFactory {
             LOG.info("Do not support: " + source);
             throw new CustomWebApplicationException("Sorry, we do not support " + source + ".", HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE);
         }
-        repo.checkSourceCodeValidity();
+        repo.checkSourceControlTokenValidity();
         return repo;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoFactory.java
@@ -73,6 +73,12 @@ public final class SourceCodeRepoFactory {
         return repo;
     }
 
+    /**
+     * Convenience factory method, extracts tokens from list
+     * @param gitUrl
+     * @param tokens
+     * @return
+     */
     public static SourceCodeRepoInterface createSourceCodeRepo(String gitUrl, List<Token> tokens) {
         Token githubToken = Token.extractToken(tokens, TokenType.GITHUB_COM);
         Token gitlabToken = Token.extractToken(tokens, TokenType.GITLAB_COM);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -174,9 +174,22 @@ public abstract class SourceCodeRepoInterface {
     public abstract Map<String, String> getWorkflowGitUrl2RepositoryId();
 
     /**
-     * Checks to see if a particular source code repository is properly setup for issues like token scope
+     * Checks to see if a particular source code repository is properly setup for issues like token scope.
      */
-    public abstract boolean checkSourceCodeValidity();
+    public abstract boolean checkSourceControlTokenValidity();
+
+    /**
+     * Checks to see if a particular source code repository is real or not.
+     * TODO: assumes real repos have branches, there may be a better way for specific source control types
+     *
+     * @param entry
+     * @return
+     */
+    public boolean checkSourceControlRepoValidity(Entry entry) {
+        final String repositoryId = this.getRepositoryId(entry);
+        final String mainBranch = this.getMainBranch(entry, repositoryId);
+        return mainBranch != null;
+    }
 
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -122,6 +122,7 @@ public class DockerRepoResource
 
     private static final Logger LOG = LoggerFactory.getLogger(DockerRepoResource.class);
     private static final String OPTIONAL_AUTH_MESSAGE = "Does not require authentication for published tools, authentication can be provided for restricted tools";
+    public static final String UNABLE_TO_VERIFY_THAT_YOUR_TOOL_POINTS_AT_A_VALID_SOURCE_CONTROL_REPO = "unable to verify that your tool points at a valid source control repo";
 
     @Context
     private ResourceContext rc;
@@ -555,6 +556,12 @@ public class DockerRepoResource
         // Check if the tool has a valid tool name
         StringInputValidationHelper.checkEntryName(toolParam.getClass(), toolParam.getToolname());
 
+        // check that the repo is valid
+        if (!isGit(toolParam.getGitUrl())) {
+            toolParam.setGitUrl(convertHttpsToSsh(toolParam.getGitUrl()));
+        }
+        this.checkRepoValidity(user, toolParam);
+
         final Set<Tag> workflowVersionsFromParam = Sets.newHashSet(toolParam.getWorkflowVersions());
         toolParam.setWorkflowVersions(Sets.newHashSet());
         // cannot create tool with a transient version hanging on it
@@ -597,10 +604,6 @@ public class DockerRepoResource
         tool.getLabels().clear();
         tool.getLabels().addAll(createdLabels);
 
-        if (!isGit(tool.getGitUrl())) {
-            tool.setGitUrl(convertHttpsToSsh(tool.getGitUrl()));
-        }
-
         // Can't set tool license information here, far too many tests register a tool without a GitHub token
         setToolLicenseInformation(user, tool);
 
@@ -617,18 +620,30 @@ public class DockerRepoResource
      * @param tool The tool to get license information for
      */
     private void setToolLicenseInformation(User user, Tool tool) {
-        // Get user's Git tokens
         List<Token> tokens = tokenDAO.findByUserId(user.getId());
-        Token githubToken = Token.extractToken(tokens, TokenType.GITHUB_COM);
-        Token gitlabToken = Token.extractToken(tokens, TokenType.GITLAB_COM);
-        Token bitbucketToken = Token.extractToken(tokens, TokenType.BITBUCKET_ORG);
-        final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory
-            .createSourceCodeRepo(tool.getGitUrl(), bitbucketToken == null ? null : bitbucketToken.getContent(),
-                gitlabToken == null ? null : gitlabToken.getContent(), githubToken);
+        final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory.createSourceCodeRepo(tool.getGitUrl(), tokens);
+
         if (sourceCodeRepo != null) {
-            sourceCodeRepo.checkSourceCodeValidity();
+            sourceCodeRepo.checkSourceControlTokenValidity();
             String gitRepositoryFromGitUrl = AbstractImageRegistry.getGitRepositoryFromGitUrl(tool.getGitUrl());
             sourceCodeRepo.setLicenseInformation(tool, gitRepositoryFromGitUrl);
+        }
+    }
+
+    /**
+     * Check whether a tool is pointing at a valid repo that the user has access to.
+     * This is a bit silly because it looks like the methods in SourceCodeRepoInterface
+     * mainly check whether the github token is valid, not whether the repo exists
+     *
+     * @param user The user the tool belongs to
+     * @param tool The tool to get license information for
+     */
+    private void checkRepoValidity(User user, Tool tool) {
+        List<Token> tokens = tokenDAO.findByUserId(user.getId());
+        final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory.createSourceCodeRepo(tool.getGitUrl(), tokens);
+        if (sourceCodeRepo == null || !sourceCodeRepo.checkSourceControlRepoValidity(tool)) {
+            throw new CustomWebApplicationException(UNABLE_TO_VERIFY_THAT_YOUR_TOOL_POINTS_AT_A_VALID_SOURCE_CONTROL_REPO,
+                HttpStatus.SC_BAD_REQUEST);
         }
     }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/LanguagePluginHandlerTest.java
@@ -306,7 +306,7 @@ public class LanguagePluginHandlerTest {
         }
 
         @Override
-        public boolean checkSourceCodeValidity() {
+        public boolean checkSourceControlTokenValidity() {
             return false;
         }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
@@ -222,7 +222,7 @@ public class WDLHandlerTest {
         }
 
         @Override
-        public boolean checkSourceCodeValidity() {
+        public boolean checkSourceControlTokenValidity() {
             return false;
         }
 


### PR DESCRIPTION
**Description**
Disallows registration of tools pointing at invalid repositories, kinda similar to https://github.com/dockstore/dockstore/pull/5094 in retrospect.
Also adds tests

**Issue**
https://github.com/dockstore/dockstore/issues/4221

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
