### PR TITLE
DOCK-2167: Handle push of conflicting descriptor languages gracefully

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1234,6 +1234,7 @@ public class WebhookIT extends BaseIT {
 
         try {
             io.dockstore.openapi.client.model.Workflow workflow = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo, WorkflowSubClass.BIOWORKFLOW, "versions,validations");
+            Assert.fail("should have thrown");
         } catch (io.dockstore.openapi.client.ApiException ex) {
             assertEquals("Entry not found", ex.getMessage());
         }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1224,15 +1224,18 @@ public class WebhookIT extends BaseIT {
         assertEquals(0, events.stream().filter(lambdaEvent -> lambdaEvent.isSuccess()).count());
         assertEquals(1, events.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count());
         io.dockstore.openapi.client.model.LambdaEvent event = events.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).findFirst().get();
-
-        // There should be one workflow version
-        io.dockstore.openapi.client.model.Workflow workflow = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo, WorkflowSubClass.BIOWORKFLOW, "versions,validations");
-        assertEquals(1, workflow.getWorkflowVersions());
-       
-        // The failure message should contain some words about non-matching descriptor languages, workflows, and versions
         String message = event.getMessage().toLowerCase();
         assertTrue(message.contains("descriptor language"));
         assertTrue(message.contains("workflow"));
         assertTrue(message.contains("version"));
+
+        // No workflow should have been created.
+        // This will change in 1.13, wherein .dockstore.yml processing changes so that an error in one entry will not roll back the entire update, and a workflow with one version should have been created.
+
+        try {
+            io.dockstore.openapi.client.model.Workflow workflow = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo, WorkflowSubClass.BIOWORKFLOW, "versions,validations");
+        } catch (io.dockstore.openapi.client.ApiException ex) {
+            assertEquals("Entry not found", ex.getMessage());
+        }
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1210,7 +1210,7 @@ public class WebhookIT extends BaseIT {
         io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(webClient);
 
         try {
-            workflowClient.handleGitHubRelease(workflowDockstoreYmlRepo, BasicIT.USER_2_USERNAME, "refs/heads/differentLanguagesWithSameWorkflowName", installationId);
+            workflowClient.handleGitHubRelease("refs/heads/differentLanguagesWithSameWorkflowName", installationId, workflowDockstoreYmlRepo, BasicIT.USER_2_USERNAME);
             Assert.fail("should have thrown");
         } catch (io.dockstore.openapi.client.ApiException ex) {
             String message = ex.getMessage().toLowerCase();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -610,11 +610,25 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             }
         }
 
+        if (workflowType == BioWorkflow.class || workflowType == AppTool.class) {
+            checkSameDescriptorLanguage(workflowToUpdate, subclass);
+        }
+
         if (user != null) {
             workflowToUpdate.getUsers().add(user);
         }
 
         return  workflowToUpdate;
+    }
+
+    private void checkSameDescriptorLanguage(Workflow workflow, String subclass) {
+        try {
+            if (workflow.getDescriptorType() != DescriptorLanguage.convertShortStringToEnum(subclass)) {
+                throw new CustomWebApplicationException(String.format("The descriptor language (subclass) of the original workflow ('%s') and all of its versions must be the same.", subclass), HttpStatus.SC_BAD_REQUEST);
+            }
+        } catch (UnsupportedOperationException e) {
+            throw new CustomWebApplicationException(String.format("Unknown descriptor language '%s'", subclass), HttpStatus.SC_BAD_REQUEST);
+        }
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -618,7 +618,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             if (workflowType == Service.class) {
                 checkSame(workflowToUpdate.getDescriptorTypeSubclass(), DescriptorLanguageSubclass.convertShortNameStringToEnum(subclass), "descriptor type subclass", "service");
             } else {
-                checkSame(workflowToUpdate.getDescriptorType(), DescriptorLanguage.convertShortStringToEnum(subclass), "descriptor language (subclass)", workflowToUpdate instanceof AppTool ? "tool" : "workflow");
+                checkSame(workflowToUpdate.getDescriptorType(), DescriptorLanguage.convertShortStringToEnum(subclass), "descriptor language (subclass)", workflowType == AppTool.class ? "tool" : "workflow");
             }
         } catch (UnsupportedOperationException e) {
             throw new CustomWebApplicationException(String.format("Unknown subclass '%s'", subclass), HttpStatus.SC_BAD_REQUEST);
@@ -633,7 +633,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
 
     private <T> void checkSame(T currentValue, T newValue, String valueDescription, String entryDescription) {
         if (!Objects.equals(currentValue, newValue)) {
-            throw new CustomWebApplicationException(String.format("The %s of the original %s ('%s') and all of its versions must be the same.", valueDescription, entryDescription, currentValue), HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(String.format("You can't add a %s version to a %s %s, the %s of all versions must be the same.", newValue, currentValue, entryDescription, valueDescription), HttpStatus.SC_BAD_REQUEST);
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -624,7 +624,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     private void checkSameDescriptorLanguage(Workflow workflow, String subclass) {
         try {
             if (workflow.getDescriptorType() != DescriptorLanguage.convertShortStringToEnum(subclass)) {
-                throw new CustomWebApplicationException(String.format("The descriptor language (subclass) of the original workflow ('%s') and all of its versions must be the same.", subclass), HttpStatus.SC_BAD_REQUEST);
+                throw new CustomWebApplicationException(String.format("The descriptor language (subclass) of the original workflow ('%s') and all of its versions must be the same.", workflow.getDescriptorType().getShortName()), HttpStatus.SC_BAD_REQUEST);
             }
         } catch (UnsupportedOperationException e) {
             throw new CustomWebApplicationException(String.format("Unknown descriptor language '%s'", subclass), HttpStatus.SC_BAD_REQUEST);


### PR DESCRIPTION
**Description**
This PR changes the github apps processing code to gracefully reject a push of a workflow version that has a different descriptor language than the existing workflow.  For example, pushing a CWL version to a WDL workflow.

Should this behavior ever be allowed?  Not sure, but as Charles noted, `Workflow` only stores/returns a single descriptor language.  One could imagine that it might be acceptable to change a workflow's descriptor language if a push overwrote the sole version.  However, would users be ok with the descriptor language of a workflow they used shifting underneath them?  Dunno.

The original ticket suggested that the problem was related to the presence/absence of the `authors` entry in `.dockstore.yml`, but that wasn't true.  Ash had created a CWL workflow, then made some changes to `.dockstore.yml` that later tried to push a WDL version of the same workflow, thus triggering the problem...

When we merge this change with 1.13, we'll need to change the integration test slightly, since 1.13 is more tolerant of errors during `.dockstore.yml` processing.  See the code comments for more details.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2167
#4894

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
