### PR TITLE
DOCK-2058: Gracefully process relative paths in .dockstore.yml

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/LanguageHandlerHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/LanguageHandlerHelper.java
@@ -15,12 +15,16 @@ public final class LanguageHandlerHelper {
      * Should only be used with workflow imports and not for using
      * untrusted inputs for traversing the filesystem.
      * @param parentPath Absolute path to parent file
-     * @param relativePath Relative path the parent file
+     * @param relativePath Relative path to another file
      * @return Absolute version of relative path
      */
     public static String unsafeConvertRelativePathToAbsolutePath(String parentPath, String relativePath) {
         if (relativePath.startsWith("/")) {
             return relativePath;
+        }
+        // If the parent path isn't absolute, make it so, assuming that it's relative to the root directory.
+        if (!parentPath.startsWith("/")) {
+            parentPath = Paths.get("/").resolve(parentPath).normalize().toString();
         }
 
         Path workDir = Paths.get(parentPath); // lgtm[java/path-injection]
@@ -30,5 +34,4 @@ public final class LanguageHandlerHelper {
 
         return workDir.resolve(relativePath).normalize().toString();
     }
-
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1326,4 +1326,15 @@ public class WebhookIT extends BaseIT {
         // test service and unnamed workflows
         shouldThrowLambdaError(() -> client.handleGitHubRelease(multiEntryRepo, BasicIT.USER_2_USERNAME, "refs/heads/service-and-unnamed-workflow", installationId));
     }
+
+    @Test
+    public void testMultiEntryRelativePrimaryDescriptorPath() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
+        final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        WorkflowsApi client = new WorkflowsApi(webClient);
+
+        client.handleGitHubRelease(multiEntryRepo, BasicIT.USER_2_USERNAME, "refs/heads/relative-primary-descriptor-path", installationId);
+        assertEquals(2, countWorkflows());
+        assertEquals(2, countTools());
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -846,7 +846,10 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                 return null;
             }
             theWf = maybeWorkflow.get();
-            testParameterPaths = theWf.getTestParameterFiles().stream().map(this::convertToAbsolutePath).collect(Collectors.toList());
+            testParameterPaths = theWf.getTestParameterFiles();
+            if (testParameterPaths != null) {
+                testParameterPaths = testParameterPaths.stream().map(this::convertToAbsolutePath).collect(Collectors.toList());
+            }
         } catch (DockstoreYamlHelper.DockstoreYamlException ex) {
             String msg = "Invalid .dockstore.yml: " + ex.getMessage();
             LOG.info(msg, ex);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -26,6 +26,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.DescriptorLanguageSubclass;
+import io.dockstore.common.LanguageHandlerHelper;
 import io.dockstore.common.SourceControl;
 import io.dockstore.common.Utilities;
 import io.dockstore.common.VersionTypeValidation;
@@ -845,7 +846,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
                 return null;
             }
             theWf = maybeWorkflow.get();
-            testParameterPaths = theWf.getTestParameterFiles();
+            testParameterPaths = theWf.getTestParameterFiles().stream().map(this::convertToAbsolutePath).collect(Collectors.toList());
         } catch (DockstoreYamlHelper.DockstoreYamlException ex) {
             String msg = "Invalid .dockstore.yml: " + ex.getMessage();
             LOG.info(msg, ex);
@@ -853,7 +854,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         }
 
         // No need to check for null, has been validated
-        String primaryDescriptorPath = theWf.getPrimaryDescriptorPath();
+        String primaryDescriptorPath = convertToAbsolutePath(theWf.getPrimaryDescriptorPath());
 
         version.setWorkflowPath(primaryDescriptorPath);
 
@@ -918,6 +919,10 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         version.addOrUpdateValidation(dockstoreYmlValidation);
 
         return version;
+    }
+
+    private String convertToAbsolutePath(String path) {
+        return LanguageHandlerHelper.unsafeConvertRelativePathToAbsolutePath("/", path);
     }
 
     /**


### PR DESCRIPTION
**Description**
This PR improves the github apps push-processing code to properly process entries with relative primary descriptor paths.

The reported bug was not related to multiple entries, as suggested in the ticket.  Instead, it was triggered during the push of a workflow with a secondary descriptor, when a relative secondary descriptor path was converted to an absolute path.  In the case that the primary descriptor path was relative, `unsafeConvertRelativePathToAbsolutePath` threw an NPE, because `path.getRoot()` returns `null` for a relative path.

This PR makes two changes:
1. If a relative parent path is passed to `unsafeConvertRelativePathToAbsolutePath`, prior to use, it is converted to a normalized absolute path, relative to '/'.  To accomplish this, we could have called `unsafeConvertRelativePathToAbsolutePath` again, but instead, we employ similar code to the end of the method, to avoid any possibility of infinite recursion.
2. The code that processes `.dockstore.yml` converts any relative paths to absolute paths, relative to '/'. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2058
#4715

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
