### PR TITLE
Sync GitHub app entry metadata with default version

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -366,7 +366,7 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     }
 
     /**
-     * Currently unused because too many entries do not have a default version set
+     * Syncs entry metadata with default version metadata
      */
     public void syncMetadataWithDefault() {
         T realDefaultVersion = this.getActualDefaultVersion();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -530,6 +530,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
 
                         Workflow workflow = createOrGetWorkflow(workflowType, repository, user, workflowName, subclass, gitHubSourceCodeRepo);
                         WorkflowVersion version = addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion, yamlAuthors);
+                        workflow.syncMetadataWithDefault();
 
                         addValidationsToMessage(workflow, version, messageWriter);
                         publishWorkflowAndLog(workflow, publish, user, repository, gitReference);


### PR DESCRIPTION
**Description**
The metadata for the [workflow in the ticket description](https://staging.dockstore.org/workflows/github.com/broadinstitute/viral-pipelines/kraken2_build:master?tab=info) was not properly synced with the default version's (master) metadata. I looked further into it and found a [workflow version (v2.1.8.0)](https://staging.dockstore.org/workflows/github.com/broadinstitute/viral-pipelines/kraken2_build:v2.1.8.0?tab=info) that did match the entry level description. 

My guess for what happened is:
1) The GitHub app workflow was registered.
2) The user picked master as the default version in the UI, which synced the workflow-level metadata with this default version. The master version's description was the README at that point in time because the [primary descriptor didn't have a description](https://github.com/broadinstitute/viral-pipelines/blob/cda126d0bc653ac0ff062b9816f2375f06ba9c15/pipes/WDL/workflows/kraken2_build.wdl).
3) The master branch was modified so that the [primary descriptor has a description](https://github.com/broadinstitute/viral-pipelines/blob/master/pipes/WDL/workflows/kraken2_build.wdl#L7). The master version's description is now different from the workflow's description. The GitHub release did not sync the workflow metadata with the updated default version metadata.

I also found that although setting `latestTagAsDefault: true` sets the latest tag as the default version, it didn't sync the workflow metadata with the default version either.

This PR syncs the GitHub app entry metadata with the default version's metadata every time there's a GitHub release. This syncing problem only occurs with GitHub app entries from my testing.

**Issue**
#4729 
https://ucsc-cgl.atlassian.net/browse/DOCK-2065

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
