### PR TITLE
DOCK-2058: Gracefully reject relative paths in .dockstore.yml

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/LanguageHandlerHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/LanguageHandlerHelper.java
@@ -15,7 +15,7 @@ public final class LanguageHandlerHelper {
      * Should only be used with workflow imports and not for using
      * untrusted inputs for traversing the filesystem.
      * @param parentPath Absolute path to parent file
-     * @param relativePath Relative path the parent file
+     * @param relativePath Relative path to resolve
      * @return Absolute version of relative path
      */
     public static String unsafeConvertRelativePathToAbsolutePath(String parentPath, String relativePath) {
@@ -24,9 +24,13 @@ public final class LanguageHandlerHelper {
         }
 
         Path workDir = Paths.get(parentPath); // lgtm[java/path-injection]
+        Path workDirRoot = workDir.getRoot();
+        if (workDirRoot == null) {
+            throw new IllegalArgumentException("Expected an absolute path but got a relative path: " + parentPath);
+        }
 
         // If the workDir is the root, leave it. If it is not the root, set workDir to the parent of parentPath
-        workDir = !Objects.equals(parentPath, workDir.getRoot().toString()) ? workDir.getParent() : workDir;
+        workDir = !Objects.equals(parentPath, workDirRoot.toString()) ? workDir.getParent() : workDir;
 
         return workDir.resolve(relativePath).normalize().toString();
     }

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/AbsolutePath.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/AbsolutePath.java
@@ -1,4 +1,19 @@
-// TODO copyright
+/*
+ *    Copyright 2022 OICR and UCSC
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package io.dockstore.common.yaml;
 
 import java.lang.annotation.ElementType;

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/AbsolutePath.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/AbsolutePath.java
@@ -1,0 +1,24 @@
+// TODO copyright
+package io.dockstore.common.yaml;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Defines a validation constraint annotation that verifies that a string is an absolute path.
+ */
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = AbsolutePathValidator.class)
+public @interface AbsolutePath {
+
+    String MUST_BE_AN_ABSOLUTE_PATH = "must be an absolute path";
+
+    String message () default MUST_BE_AN_ABSOLUTE_PATH;
+    Class<?>[] groups () default {};
+    Class<? extends Payload>[] payload () default {};
+}

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/AbsolutePathValidator.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/AbsolutePathValidator.java
@@ -6,7 +6,8 @@ import javax.validation.ConstraintValidatorContext;
 
 /**
  * Validates that a string is an absolute path.
- * Similar to the built-in constraints (such as @Pattern), null is valid.
+ * Similar to the built-in constraints (such as @Pattern), null is valid,
+ * so that this constraint can be applied to optional values.
  */
 public class AbsolutePathValidator implements ConstraintValidator<AbsolutePath, String> {
     @Override

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/AbsolutePathValidator.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/AbsolutePathValidator.java
@@ -1,4 +1,19 @@
-// TODO copyright
+/*
+ *    Copyright 2022 OICR and UCSC
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package io.dockstore.common.yaml;
 
 import javax.validation.ConstraintValidator;

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/AbsolutePathValidator.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/AbsolutePathValidator.java
@@ -1,0 +1,21 @@
+// TODO copyright
+package io.dockstore.common.yaml;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Validates that a string is an absolute path.
+ * Similar to the built-in constraints (such as @Pattern), null is valid.
+ */
+public class AbsolutePathValidator implements ConstraintValidator<AbsolutePath, String> {
+    @Override
+    public void initialize(final AbsolutePath constraintAnnotation) {
+        // Intentionally empty
+    }
+
+    @Override
+    public boolean isValid(final String value, final ConstraintValidatorContext context) {
+        return value == null || value.startsWith("/");
+    }
+}

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
@@ -37,6 +37,7 @@ public class YamlWorkflow implements Workflowish {
     @NotNull
     private String subclass;
     @NotNull
+    @AbsolutePath
     private String primaryDescriptorPath;
 
     /**
@@ -48,11 +49,14 @@ public class YamlWorkflow implements Workflowish {
     // If true, the most recent tag that Dockstore processes from AWS lambda becomes the default version
     private boolean latestTagAsDefault = false;
 
+    @Valid
     private Filters filters = new Filters();
 
+    @Valid
     private List<YamlAuthor> authors = new ArrayList<>();
 
-    private List<String> testParameterFiles = new ArrayList<>();
+    @Valid
+    private List<@NotNull @AbsolutePath String> testParameterFiles = new ArrayList<>();
 
 
     public String getName() {
@@ -90,7 +94,6 @@ public class YamlWorkflow implements Workflowish {
         this.publish = publish;
     }
 
-    @Valid
     public Filters getFilters() {
         return filters;
     }
@@ -99,7 +102,6 @@ public class YamlWorkflow implements Workflowish {
         this.filters = filters;
     }
 
-    @Valid
     public List<YamlAuthor> getAuthors() {
         return authors;
     }

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
@@ -34,10 +34,9 @@ public class YamlWorkflow implements Workflowish {
     public static final String NEW_GALAXY_SUBCLASS = "GALAXY";
 
     private String name;
-    @NotNull
+
     private String subclass;
-    @NotNull
-    @AbsolutePath
+
     private String primaryDescriptorPath;
 
     /**
@@ -49,14 +48,11 @@ public class YamlWorkflow implements Workflowish {
     // If true, the most recent tag that Dockstore processes from AWS lambda becomes the default version
     private boolean latestTagAsDefault = false;
 
-    @Valid
     private Filters filters = new Filters();
 
-    @Valid
     private List<YamlAuthor> authors = new ArrayList<>();
 
-    @Valid
-    private List<@NotNull @AbsolutePath String> testParameterFiles = new ArrayList<>();
+    private List<String> testParameterFiles = new ArrayList<>();
 
 
     public String getName() {
@@ -67,6 +63,7 @@ public class YamlWorkflow implements Workflowish {
         this.name = name;
     }
 
+    @NotNull
     public String getSubclass() {
         if (NEW_GALAXY_SUBCLASS.equalsIgnoreCase(subclass)) {
             return DescriptorLanguage.GXFORMAT2.getShortName();
@@ -78,6 +75,8 @@ public class YamlWorkflow implements Workflowish {
         this.subclass = subclass;
     }
 
+    @NotNull
+    @AbsolutePath
     public String getPrimaryDescriptorPath() {
         return primaryDescriptorPath;
     }
@@ -94,6 +93,7 @@ public class YamlWorkflow implements Workflowish {
         this.publish = publish;
     }
 
+    @Valid
     public Filters getFilters() {
         return filters;
     }
@@ -102,6 +102,7 @@ public class YamlWorkflow implements Workflowish {
         this.filters = filters;
     }
 
+    @Valid
     public List<YamlAuthor> getAuthors() {
         return authors;
     }
@@ -110,7 +111,8 @@ public class YamlWorkflow implements Workflowish {
         this.authors = authors;
     }
 
-    public List<String> getTestParameterFiles() {
+    @Valid
+    public List<@NotNull @AbsolutePath String> getTestParameterFiles() {
         return testParameterFiles;
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1340,4 +1340,16 @@ public class WebhookIT extends BaseIT {
         assertEquals(0, countWorkflows());
         assertEquals(0, countTools());
     }
+
+    @Test
+    public void testMultiEntryRelativeTestFilePath() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
+        final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        WorkflowsApi client = new WorkflowsApi(webClient);
+
+        ApiException ex = shouldThrowLambdaError(() -> client.handleGitHubRelease(multiEntryRepo, BasicIT.USER_2_USERNAME, "refs/heads/relative-test-file-path", installationId));
+        assertTrue(ex.getMessage().toLowerCase().contains("absolute"));
+        assertEquals(0, countWorkflows());
+        assertEquals(0, countTools());
+    }
 }


### PR DESCRIPTION
**Description**
This PR improves the github apps push-processing code to gracefully reject entries with relative primary descriptor or test file paths.

The reported bug was not related to multiple entries, as suggested in the ticket.  Instead, it was triggered during the push of a workflow with a secondary descriptor, when a relative secondary descriptor path was converted to an absolute path.  In the case that the primary descriptor path was relative, `unsafeConvertRelativePathToAbsolutePath` threw an NPE, because `path.getRoot()` returns `null` for a relative path.

This PR makes two changes:
1. Adds a new `@AbsolutePath` constraint annotation to `YamlWorkflow` to validate that the primary descriptor and test file paths are absolute.
2. Modifies `LanguageHandlerHelper.unsafeConvertRelativePathToAbsolutePath` to throw an `IllegalArgumentException` with a usable message when it is passed a relative parent path.  Change #*1* should make the forementioned case much less likely, but as a backup...

To reduce clutter, we should probably move our custom constraint annotation definitions to a subpackage, I recommend we do that later, in #4985.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2058
#4715

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
