### PR TITLE
ensure token refresh before checking repo validity

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -639,6 +639,7 @@ public class DockerRepoResource
      * @param tool The tool to get license information for
      */
     private void checkRepoValidity(User user, Tool tool) {
+        refreshBitbucketToken(user.getId());
         List<Token> tokens = tokenDAO.findByUserId(user.getId());
         final SourceCodeRepoInterface sourceCodeRepo = SourceCodeRepoFactory.createSourceCodeRepo(tool.getGitUrl(), tokens);
         if (sourceCodeRepo == null || !sourceCodeRepo.checkSourceControlRepoValidity(tool)) {


### PR DESCRIPTION
**Description**
Ensure that the bitbucket token is refreshed before using it for checking whether a user has access to a repo (this was buried amongst the rate limit failures)
Also turns out our bitbucket tests had one user using another's workflows, so also added permissions on bitbucket (is not visible in this PR)

**Issue**
Follow-up on https://github.com/dockstore/dockstore/commit/2bc18666e6e52b6c71d556b7a7e1b4a64a725a9d


Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
