### PR TITLE
SEAB-4837: Fix sourcefile retrieval - SAM - google token bug

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.Ignore;
 
 import com.google.common.collect.Lists;
 import io.dockstore.client.cli.BaseIT;
@@ -72,6 +71,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1255,6 +1255,14 @@ public class WebhookIT extends BaseIT {
         assertTrue((collection.getEntries().stream().anyMatch(entry -> Objects.equals(entry.getId(), appTool.getId()))));
     }
 
+    /*
+     * TODO: reimplement
+     * This test broke when merged from a 1.12 hotfix into 1.13, because the test pushed a .dockstore.yml that
+     * contains two workflows with the same name, and 1.13 checks for duplicate names in .dockstore.yml, and
+     * generates an error about the duplicate names, instead.  To reimplement, we'll need to load a workflow
+     * into the db, then push a branch that updates it, containing a workflow with the same name but different
+     * descriptor language.
+
     @Test
     public void testDifferentLanguagesWithSameWorkflowName() throws Exception {
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
@@ -1292,6 +1300,7 @@ public class WebhookIT extends BaseIT {
             assertEquals("Entry not found", ex.getMessage());
         }
     }
+    */
     
     private long countTools() {
         return countTableRows("apptool");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Ignore;
 
 import com.google.common.collect.Lists;
 import io.dockstore.client.cli.BaseIT;
@@ -1262,7 +1263,8 @@ public class WebhookIT extends BaseIT {
      * generates an error about the duplicate names, instead.  To reimplement, we'll need to load a workflow
      * into the db, then push a branch that updates it, containing a workflow with the same name but different
      * descriptor language.
-
+     */
+    @Ignore
     @Test
     public void testDifferentLanguagesWithSameWorkflowName() throws Exception {
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
@@ -1300,7 +1302,6 @@ public class WebhookIT extends BaseIT {
             assertEquals("Entry not found", ex.getMessage());
         }
     }
-    */
     
     private long countTools() {
         return countTableRows("apptool");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/CustomWebApplicationException.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/CustomWebApplicationException.java
@@ -19,6 +19,7 @@ package io.dockstore.webservice;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.http.HttpStatus;
 
 /**
  * @author xliu
@@ -34,5 +35,11 @@ public class CustomWebApplicationException extends WebApplicationException {
 
     public String getErrorMessage() {
         return errorMessage;
+    }
+
+    public void rethrowIf5xx() {
+        if (getResponse().getStatus() >= HttpStatus.SC_INTERNAL_SERVER_ERROR) {
+            throw this;
+        }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
@@ -321,11 +321,11 @@ public class SamPermissionsImpl implements PermissionsInterface {
 
     @Override
     public boolean canDoAction(User user, Workflow workflow, Role.Action action) {
-        ResourcesApi resourcesApi = getResourcesApi(user);
-        String encodedPath = encodedWorkflowResource(workflow, resourcesApi.getApiClient());
         try {
+            ResourcesApi resourcesApi = getResourcesApi(user);
+            String encodedPath = encodedWorkflowResource(workflow, resourcesApi.getApiClient());
             return resourcesApi.resourceAction(SamConstants.RESOURCE_TYPE, encodedPath, SamConstants.toSamAction(action));
-        } catch (ApiException e) {
+        } catch (ApiException | CustomWebApplicationException e) {
             return false;
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
@@ -321,11 +321,11 @@ public class SamPermissionsImpl implements PermissionsInterface {
 
     @Override
     public boolean canDoAction(User user, Workflow workflow, Role.Action action) {
+        ResourcesApi resourcesApi = getResourcesApi(user);
+        String encodedPath = encodedWorkflowResource(workflow, resourcesApi.getApiClient());
         try {
-            ResourcesApi resourcesApi = getResourcesApi(user);
-            String encodedPath = encodedWorkflowResource(workflow, resourcesApi.getApiClient());
             return resourcesApi.resourceAction(SamConstants.RESOURCE_TYPE, encodedPath, SamConstants.toSamAction(action));
-        } catch (ApiException | CustomWebApplicationException e) {
+        } catch (ApiException e) {
             return false;
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -160,8 +160,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
 
     @Override
     public boolean canWrite(User user, Entry entry) {
-        return EntryVersionHelper.super.canWrite(user, entry)
-            || (entry instanceof Workflow && permissionsInterface.canDoAction(user, (Workflow)entry, Role.Action.WRITE));
+        return EntryVersionHelper.super.canWrite(user, entry) || AuthenticatedResourceInterface.canDoAction(permissionsInterface, user, entry, Role.Action.WRITE);
     }
 
     @PATCH

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
@@ -18,6 +18,9 @@ package io.dockstore.webservice.resources;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.User;
+import io.dockstore.webservice.core.Workflow;
+import io.dockstore.webservice.permissions.PermissionsInterface;
+import io.dockstore.webservice.permissions.Role;
 import java.util.List;
 import java.util.Optional;
 import org.apache.http.HttpStatus;
@@ -197,6 +200,16 @@ public interface AuthenticatedResourceInterface {
     static void throwIf(boolean condition, String message, int status) {
         if (condition) {
             throw new CustomWebApplicationException(message, status);
+        }
+    }
+
+    static boolean canDoAction(PermissionsInterface permissionsInterface, User user, Entry workflow, Role.Action action) {
+        try {
+            return workflow instanceof Workflow && permissionsInterface.canDoAction(user, (Workflow) workflow, action);
+        } catch (CustomWebApplicationException e) {
+            e.rethrowIf5xx();
+            LOG.info("converted CustomWebApplicationException to false response", e);
+            return false;
         }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
@@ -19,6 +19,7 @@ import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
+import io.dockstore.webservice.core.WorkflowMode;
 import io.dockstore.webservice.permissions.PermissionsInterface;
 import io.dockstore.webservice.permissions.Role;
 import java.util.List;
@@ -205,7 +206,10 @@ public interface AuthenticatedResourceInterface {
 
     static boolean canDoAction(PermissionsInterface permissionsInterface, User user, Entry workflow, Role.Action action) {
         try {
-            return workflow instanceof Workflow && permissionsInterface.canDoAction(user, (Workflow) workflow, action);
+            return workflow instanceof Workflow
+                // TODO: Remove this guard when ready to expand sharing to non-hosted workflows. https://github.com/dockstore/dockstore/issues/1593
+                && ((Workflow) workflow).getMode() == WorkflowMode.HOSTED
+                && permissionsInterface.canDoAction(user, (Workflow) workflow, action);
         } catch (CustomWebApplicationException e) {
             e.rethrowIf5xx();
             LOG.info("converted CustomWebApplicationException to false response", e);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -915,8 +915,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
      */
     @Override
     public boolean canExamine(User user, Entry workflow) {
-        return super.canExamine(user, workflow)
-            || (workflow instanceof Workflow && permissionsInterface.canDoAction(user, (Workflow) workflow, Role.Action.READ));
+        return super.canExamine(user, workflow) || AuthenticatedResourceInterface.canDoAction(permissionsInterface, user, workflow, Role.Action.READ);
     }
 
     /**
@@ -926,8 +925,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
      */
     @Override
     public boolean canWrite(User user, Entry workflow) {
-        return super.canWrite(user, workflow)
-            || (workflow instanceof Workflow && permissionsInterface.canDoAction(user, (Workflow) workflow, Role.Action.WRITE));
+        return super.canWrite(user, workflow) || AuthenticatedResourceInterface.canDoAction(permissionsInterface, user, workflow, Role.Action.WRITE);
     }
 
     /**
@@ -938,8 +936,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
      */
     @Override
     public boolean canShare(User user, Entry workflow) {
-        return super.canShare(user, workflow)
-            || (workflow instanceof Workflow && permissionsInterface.canDoAction(user, (Workflow) workflow, Role.Action.SHARE));
+        return super.canShare(user, workflow) || AuthenticatedResourceInterface.canDoAction(permissionsInterface, user, workflow, Role.Action.SHARE);
     }
 
     @GET


### PR DESCRIPTION
**Description**
Fixes a bug which caused sourcefiles to be unretrievable, if the user was logged in, did not own the workflow, and did not have a google token linked.   See ticket for more details.

While I was in there, I added a check which skips the version hiding process (and associated auth calls) for entries that have no hidden versions.  This will improve response time and reduce load on Terra.

Also, disabled an unrelated failing IT, merged from a 1.12 hotfix, which broke due to changed 1.13 semantics.  See code comment for more details.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4837

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
