### PR TITLE
update regression test requirements

### DIFF
--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -11,7 +11,7 @@ if [ "${TESTING_PROFILE}" = "unit-tests" ] || [ "${TESTING_PROFILE}" == "automat
 fi
 
 if [ "${TESTING_PROFILE}" = "regression-integration-tests" ]; then
-    pip3 install -r dockstore-webservice/src/main/resources/requirements/1.7.0/requirements3.txt
+    pip3 install -r dockstore-webservice/src/main/resources/requirements/1.10.0/requirements3.txt
 elif [ "${TESTING_PROFILE}" == "language-parsing-tests" ]; then
     pip3 install -r dockstore-webservice/src/main/resources/requirements/1.10.0/requirements3.txt
 else


### PR DESCRIPTION
**Description**
Looks like regression tests have been failing on release branch. https://app.circleci.com/pipelines/github/dockstore/dockstore?branch=release%2F1.13.0

Possibly due to old requirements file being used and pip changing in some way (:frowning: )

Note regression tests don't actually run since they must be keyed to the name of the release branch. That said, since those tests are completely failing, this should be an improvement. 

**Issue**
n/a

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
