### PR TITLE
Tidy up SAM sharing code

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/InMemoryPermissionsImpl.java
@@ -139,7 +139,7 @@ public class InMemoryPermissionsImpl implements PermissionsInterface {
      * @return
      */
     private List<Permission> getWorkflowPermissions(Workflow workflow) {
-        final List<Permission> dockstoreOwners = PermissionsInterface.getOriginalOwnersForWorkflow(workflow);
+        final List<Permission> dockstoreOwners = getOriginalOwnersForWorkflow(workflow);
         Map<String, Role> permissionMap = resourceToUsersAndRolesMap.get(workflow.getWorkflowPath());
         if (permissionMap == null) {
             return dockstoreOwners;
@@ -205,6 +205,11 @@ public class InMemoryPermissionsImpl implements PermissionsInterface {
             }
             return false;
         });
+    }
+
+    @Override
+    public Optional<String> userIdForSharing(final User user) {
+        return Optional.of(user.getUsername());
     }
 
     private Optional<Role> getRole(User requester, Workflow workflow) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/NoOpPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/NoOpPermissionsImpl.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.http.HttpStatus;
 
 /**
@@ -51,5 +52,10 @@ public class NoOpPermissionsImpl implements PermissionsInterface {
     @Override
     public boolean isSharing(User user) {
         return false;
+    }
+
+    @Override
+    public Optional<String> userIdForSharing(final User user) {
+        return Optional.of(user.getUsername());
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/Permission.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/Permission.java
@@ -6,8 +6,12 @@ import java.util.Objects;
  * Contains an email and the associated {@link Role} for that
  * email.
  * <p>
- * The email is not necessarily a single user; it can be a group of
- * users.
+ * The email value is not necessarily for a single user; it can be an email of a group. In some
+ * implementations of {@link PermissionsInterface}, the value is a Dockstore username, not an email.
+ * We should rename the field, but that modifies the OpenAPI, which requires a new UI build to use
+ * it, and doesn't seem worth it at this point, given that only the
+ * {@link io.dockstore.webservice.permissions.sam.SamPermissionsImpl} implementation is used in
+ * production. The other implementations are for testing only.
  */
 public class Permission {
     private String email;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
@@ -175,8 +175,13 @@ public interface PermissionsInterface {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Returns the user's Google profile email if present, otherwise it returns their username. A bit
+     * of a hack to accomodate both SAM and InMemory implementations of this interface.
+     * @param user
+     * @return
+     */
     static String emailOrUsername(User user) {
-        // This is ugly in order to support both SAM and InMemory authorizers
         final User.Profile profile = user.getUserProfiles().get(TokenType.GOOGLE_COM.toString());
         if (profile != null && profile.email != null) {
             return profile.email;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/PermissionsInterface.java
@@ -17,13 +17,12 @@
 package io.dockstore.webservice.permissions;
 
 import io.dockstore.webservice.CustomWebApplicationException;
-import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
@@ -91,7 +90,7 @@ public interface PermissionsInterface {
         if (!workflow.getUsers().contains(user)) {
             throw new CustomWebApplicationException("Forbidden", HttpStatus.SC_FORBIDDEN);
         }
-        return PermissionsInterface.getOriginalOwnersForWorkflow(workflow);
+        return getOriginalOwnersForWorkflow(workflow);
     }
 
     /**
@@ -139,6 +138,37 @@ public interface PermissionsInterface {
     boolean isSharing(User user);
 
     /**
+     * Returns the userid to use for sharing. The userid will vary by implementation. For SAM
+     * the userid is the user's Google email; the InMemory implementation is the Dockstore username.
+     * If we ever add sharing with GitHub, the username might be the GitHub username, etc.
+     * @param user
+     * @return
+     */
+    Optional<String> userIdForSharing(User user);
+
+    /**
+     * Returns the "original owners" of a workflow as list of {@link Permission}. The original owners
+     * are the <code>workflow.getUsers()</code>, e.g., who created the hosted entry, or members of the
+     * GitHub repo.
+     *
+     * @param workflow
+     * @return
+     */
+    default List<Permission> getOriginalOwnersForWorkflow(Workflow workflow) {
+        return workflow.getUsers().stream()
+            .map(this::userIdForSharing)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .map(email -> {
+                final Permission permission = new Permission();
+                permission.setEmail(email);
+                permission.setRole(Role.OWNER);
+                return permission;
+            })
+            .collect(Collectors.toList());
+    }
+
+    /**
      * Merges two lists of permissions, removing any duplicate users. If there
      * are duplicates, gives precedence to <code>dockstoreOwners</code>.
      *
@@ -152,42 +182,6 @@ public interface PermissionsInterface {
         permissions.addAll(nativePermissions.stream()
                 .filter(p -> !dockstoreOwnerEmails.contains(p.getEmail())).collect(Collectors.toList()));
         return permissions;
-    }
-
-    /**
-     * Returns the "original owners" of a workflow as list of {@link Permission}. The original owners
-     * are the <code>workflow.getUsers()</code>, e.g., who created the hosted entry, or members of the
-     * GitHub repo.
-     *
-     * @param workflow
-     * @return
-     */
-    static List<Permission> getOriginalOwnersForWorkflow(Workflow workflow) {
-        return workflow.getUsers().stream()
-                .map(PermissionsInterface::emailOrUsername)
-                .filter(Objects::nonNull)
-                .map(email -> {
-                    final Permission permission = new Permission();
-                    permission.setEmail(email);
-                    permission.setRole(Role.OWNER);
-                    return permission;
-                })
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * Returns the user's Google profile email if present, otherwise it returns their username. A bit
-     * of a hack to accomodate both SAM and InMemory implementations of this interface.
-     * @param user
-     * @return
-     */
-    static String emailOrUsername(User user) {
-        final User.Profile profile = user.getUserProfiles().get(TokenType.GOOGLE_COM.toString());
-        if (profile != null && profile.email != null) {
-            return profile.email;
-        } else {
-            return user.getUsername();
-        }
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
@@ -308,9 +308,8 @@ public class SamPermissionsImpl implements PermissionsInterface {
             try {
                 final ResourcesApi resourcesApi = getResourcesApi(user);
                 final String encoded = encodedWorkflowResource(workflow, resourcesApi.getApiClient());
-                final List<Permission> samPermissions = accessPolicyResponseEntryToUserPermissions(
+                return accessPolicyResponseEntryToUserPermissions(
                         resourcesApi.listResourcePolicies(SamConstants.RESOURCE_TYPE, encoded));
-                return samPermissions;
             } catch (ApiException e) {
                 final String errorGettingPermissions = "Error getting permissions";
                 LOG.error(errorGettingPermissions, e);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java
@@ -127,8 +127,8 @@ public class SamPermissionsImpl implements PermissionsInterface {
      * access token. Throws a <code>CustomWebApplicationException</code> if unable to get an access
      * token.
      * @param requester
-     * @return
-     * @throws CustomWebApplicationException if unable to get a valid Google access token
+     * @return a resources Swagger API client
+     * @throw CustomWebApplicationException
      */
     ResourcesApi getResourcesApi(User requester) {
         return new ResourcesApi(getApiClient(requester));
@@ -233,8 +233,8 @@ public class SamPermissionsImpl implements PermissionsInterface {
      *
      * @param user the user, who must be an owner of the workflow
      * @param workflow the workflow
-     * @return
-     * @throws CustomWebApplicationException if user is not an owner of the workflow
+     * @return a list of permissions
+     * @throw CustomWebApplicationException
      */
     @Override
     public List<Permission> getPermissionsForWorkflow(User user, Workflow workflow) {
@@ -460,8 +460,8 @@ public class SamPermissionsImpl implements PermissionsInterface {
      * access token. Throws a <code>CustomWebApplicationException</code> if unable to get a valid Google access
      * token, which can occur if the Google refresh token has expired.
      * @param user
-     * @return
-     * @throws CustomWebApplicationException if unable to acquire a valid Google access token
+     * @return a Swagger API client
+     * @throw CustomWebApplicationException
      */
     private ApiClient getApiClient(User user) {
         ApiClient apiClient = new ApiClient() {

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/PermissionsInterfaceTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/PermissionsInterfaceTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.Assert;
 import org.junit.Before;
@@ -87,6 +88,11 @@ public class PermissionsInterfaceTest {
             public boolean isSharing(User user) {
                 return false;
             }
+
+            @Override
+            public Optional<String> userIdForSharing(final User user) {
+                return Optional.of(user.getUsername());
+            }
         };
     }
 
@@ -102,7 +108,7 @@ public class PermissionsInterfaceTest {
         mockedWorkflow = Mockito.mock(Workflow.class);
         when(mockedWorkflow.getUsers()).thenReturn(users);
 
-        Assert.assertEquals(1, PermissionsInterface.getOriginalOwnersForWorkflow(mockedWorkflow).size());
+        Assert.assertEquals(1, permissionsInterface.getOriginalOwnersForWorkflow(mockedWorkflow).size());
     }
 
     @Test

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
@@ -2,6 +2,8 @@ package io.dockstore.webservice.permissions.sam;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -44,7 +46,6 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.http.HttpStatus;
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -144,7 +145,7 @@ public class SamPermissionsImplTest {
         ownerPermission = new Permission();
         ownerPermission.setEmail("jdoe@ucsc.edu");
         ownerPermission.setRole(Role.OWNER);
-        Assert.assertThat(samPermissionsImpl
+        assertThat(samPermissionsImpl
                         .accessPolicyResponseEntryToUserPermissions(Collections.singletonList(ownerPolicy)),
                 CoreMatchers.is(Collections.singletonList(ownerPermission)));
 
@@ -179,10 +180,10 @@ public class SamPermissionsImplTest {
     public void testAccessPolicyResponseEntryToUserPermissions() {
         final List<Permission> permissions = samPermissionsImpl
                 .accessPolicyResponseEntryToUserPermissions(Arrays.asList(ownerPolicy, writerPolicy));
-        Assert.assertEquals(permissions.size(), 2);
+        assertEquals(permissions.size(), 2);
 
-        Assert.assertTrue(permissions.contains(ownerPermission));
-        Assert.assertTrue(permissions.contains(writerPermission));
+        assertTrue(permissions.contains(ownerPermission));
+        assertTrue(permissions.contains(writerPermission));
     }
 
     @Test
@@ -191,11 +192,11 @@ public class SamPermissionsImplTest {
         // the most powerful role.
         final List<Permission> permissions = samPermissionsImpl
                 .removeDuplicateEmails(Arrays.asList(ownerPermission, writerPermission, readerPermission));
-        Assert.assertEquals(
+        assertEquals(
                 permissions.size(), 2);
-        Assert.assertTrue(permissions.contains(ownerPermission));
-        Assert.assertTrue(permissions.contains(writerPermission));
-        Assert.assertFalse(permissions.contains(readerPermission));
+        assertTrue(permissions.contains(ownerPermission));
+        assertTrue(permissions.contains(writerPermission));
+        assertFalse(permissions.contains(readerPermission));
     }
 
     @Test
@@ -203,9 +204,9 @@ public class SamPermissionsImplTest {
         String response = "{\n" + "\"statusCode\": 400,\n" + "\"source\": \"sam\",\n" + "\"causes\": [],\n" + "\"stackTrace\": [],\n"
             + "\"message\": \"jane_doe@yahoo.com not found\"\n" + "}";
         Optional<ErrorReport> errorReport = samPermissionsImpl.readValue(response, ErrorReport.class);
-        Assert.assertEquals(errorReport.get().getMessage(), "jane_doe@yahoo.com not found");
+        assertEquals(errorReport.get().getMessage(), "jane_doe@yahoo.com not found");
 
-        Assert.assertFalse(samPermissionsImpl.readValue((String)null, ErrorReport.class).isPresent());
+        assertFalse(samPermissionsImpl.readValue((String)null, ErrorReport.class).isPresent());
     }
 
     @Test
@@ -222,13 +223,13 @@ public class SamPermissionsImplTest {
         when(resourcesApiMock.listResourcesAndPolicies(SamConstants.RESOURCE_TYPE)).thenReturn(Arrays.asList(reader, owner, writer));
         final Map<Role, List<String>> sharedWithUser = samPermissionsImpl.workflowsSharedWithUser(
             janeDoeUserMock);
-        Assert.assertEquals(3, sharedWithUser.size());
+        assertEquals(3, sharedWithUser.size());
         final List<String> ownerWorkflows = sharedWithUser.get(Role.OWNER);
-        Assert.assertEquals(GOO_WORKFLOW_NAME, ownerWorkflows.get(0));
+        assertEquals(GOO_WORKFLOW_NAME, ownerWorkflows.get(0));
         final List<String> readerWorkflows = sharedWithUser.get(Role.READER);
-        Assert.assertEquals(FOO_WORKFLOW_NAME, readerWorkflows.get(0));
+        assertEquals(FOO_WORKFLOW_NAME, readerWorkflows.get(0));
         final List<String> writerWorkflows = sharedWithUser.get(Role.WRITER);
-        Assert.assertEquals(DOCKSTORE_ORG_WORKFLOW_NAME, writerWorkflows.get(0));
+        assertEquals(DOCKSTORE_ORG_WORKFLOW_NAME, writerWorkflows.get(0));
     }
 
     @Test
@@ -239,9 +240,9 @@ public class SamPermissionsImplTest {
 
         Workflow fooWorkflow = Mockito.mock(Workflow.class);
         when(fooWorkflow.getWorkflowPath()).thenReturn(FOO_WORKFLOW_NAME, GOO_WORKFLOW_NAME);
-        Assert.assertTrue(samPermissionsImpl.canDoAction(janeDoeUserMock, fooWorkflow, Role.Action.READ));
+        assertTrue(samPermissionsImpl.canDoAction(janeDoeUserMock, fooWorkflow, Role.Action.READ));
         Workflow gooWorkflow = Mockito.mock(Workflow.class);
-        Assert.assertFalse(samPermissionsImpl.canDoAction(janeDoeUserMock, gooWorkflow, Role.Action.READ));
+        assertFalse(samPermissionsImpl.canDoAction(janeDoeUserMock, gooWorkflow, Role.Action.READ));
     }
 
     @Test
@@ -251,10 +252,10 @@ public class SamPermissionsImplTest {
         when(samPermissionsImpl.getResourcesApi(janeDoeUserMock)).thenReturn(resourcesApiMock);
 
         when(workflowInstance.getWorkflowPath()).thenReturn(FOO_WORKFLOW_NAME);
-        Assert.assertTrue(samPermissionsImpl.canDoAction(janeDoeUserMock, workflowInstance, Role.Action.WRITE));
+        assertTrue(samPermissionsImpl.canDoAction(janeDoeUserMock, workflowInstance, Role.Action.WRITE));
         Workflow gooWorkflow = Mockito.mock(Workflow.class);
         when(gooWorkflow.getWorkflowPath()).thenReturn(GOO_WORKFLOW_NAME);
-        Assert.assertFalse(samPermissionsImpl.canDoAction(janeDoeUserMock, gooWorkflow, Role.Action.WRITE));
+        assertFalse(samPermissionsImpl.canDoAction(janeDoeUserMock, gooWorkflow, Role.Action.WRITE));
     }
 
     @Test
@@ -265,7 +266,7 @@ public class SamPermissionsImplTest {
         permission.setEmail(JOHN_SMITH_GMAIL_COM);
         permission.setRole(Role.READER);
         List<Permission> permissions = samPermissionsImpl.setPermission(janeDoeUserMock, workflowInstance, permission);
-        Assert.assertEquals(permissions.size(), 1);
+        assertEquals(permissions.size(), 1);
     }
 
     @Test
@@ -297,7 +298,7 @@ public class SamPermissionsImplTest {
                 setupInitializePermissionsMocks(SamConstants.WORKFLOW_PREFIX + FOO_WORKFLOW_NAME);
                 final List<Permission> permissions = samPermissionsImpl.setPermission(
                     janeDoeUserMock, workflowInstance, permission);
-                Assert.assertEquals(permissions.size(), 1);
+                assertEquals(permissions.size(), 1);
             } catch (CustomWebApplicationException ex) {
                 fail("setPermissions threw Exception");
             }
@@ -336,7 +337,7 @@ public class SamPermissionsImplTest {
                     Collections.singletonList(readerAccessPolicyResponseEntry), Collections.EMPTY_LIST);
         final List<Permission> permissions = samPermissionsImpl.getPermissionsForWorkflow(
             janeDoeUserMock, workflowInstance);
-        Assert.assertEquals(permissions.size(), 1);
+        assertEquals(permissions.size(), 1);
         try {
             samPermissionsImpl.removePermission(janeDoeUserMock, workflowInstance, JOHN_SMITH_GMAIL_COM, Role.READER);
         } catch (CustomWebApplicationException e) {
@@ -350,7 +351,7 @@ public class SamPermissionsImplTest {
         when(resourcesApiMock.listResourcesAndPolicies(SamConstants.RESOURCE_TYPE)).thenThrow(new ApiException(HttpStatus.SC_UNAUTHORIZED, "Unauthorized"));
         final Map<Role, List<String>> sharedWithUser = samPermissionsImpl.workflowsSharedWithUser(
             janeDoeUserMock);
-        Assert.assertEquals(0, sharedWithUser.size());
+        assertEquals(0, sharedWithUser.size());
     }
 
     @Test
@@ -359,7 +360,7 @@ public class SamPermissionsImplTest {
         when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, resourceId, SamConstants.toSamAction(Role.Action.SHARE)))
                 .thenReturn(Boolean.TRUE);
         final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(janeDoeUserMock, workflowInstance);
-        Assert.assertEquals(Role.Action.values().length, actions.size()); // Owner can perform all actions
+        assertEquals(Role.Action.values().length, actions.size()); // Owner can perform all actions
     }
 
     @Test
@@ -371,8 +372,8 @@ public class SamPermissionsImplTest {
                 .thenReturn(Boolean.TRUE);
         when(johnSmithUserMock.getTemporaryCredential()).thenReturn("whatever");
         final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(johnSmithUserMock, workflowInstance);
-        Assert.assertEquals(2, actions.size());
-        Assert.assertTrue(actions.contains(Role.Action.WRITE) && actions.contains(Role.Action.READ));
+        assertEquals(2, actions.size());
+        assertTrue(actions.contains(Role.Action.WRITE) && actions.contains(Role.Action.READ));
     }
 
     @Test
@@ -386,8 +387,8 @@ public class SamPermissionsImplTest {
                 .thenReturn(Boolean.TRUE);
         final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(
             johnSmithUserMock, workflowInstance);
-        Assert.assertEquals(1, actions.size());
-        Assert.assertTrue(actions.contains(Role.Action.READ));
+        assertEquals(1, actions.size());
+        assertTrue(actions.contains(Role.Action.READ));
     }
 
     @Test
@@ -395,7 +396,7 @@ public class SamPermissionsImplTest {
         when(workflowInstance.getUsers()).thenReturn(new HashSet<>(Collections.singletonList(
             janeDoeUserMock)));
         final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(janeDoeUserMock, workflowInstance);
-        Assert.assertEquals(Role.Action.values().length, actions.size()); // Owner can perform all actions
+        assertEquals(Role.Action.values().length, actions.size()); // Owner can perform all actions
     }
 
     /**
@@ -432,14 +433,14 @@ public class SamPermissionsImplTest {
         // Should be 1 workflow, with the writer role, because writer > reader
         final Map<Role, List<String>> sharedWithUser = samPermissionsImpl.workflowsSharedWithUser(
             janeDoeUserMock);
-        Assert.assertEquals(1, sharedWithUser.size());
-        Assert.assertEquals(Role.WRITER, sharedWithUser.entrySet().iterator().next().getKey());
+        assertEquals(1, sharedWithUser.size());
+        assertEquals(Role.WRITER, sharedWithUser.entrySet().iterator().next().getKey());
 
         // Verify it works the same if the SAM API returns the policies in a different order.
         final Map<Role, List<String>> sharedWithUser2 = samPermissionsImpl.workflowsSharedWithUser(
             janeDoeUserMock);
-        Assert.assertEquals(1, sharedWithUser2.size());
-        Assert.assertEquals(Role.WRITER, sharedWithUser2.entrySet().iterator().next().getKey());
+        assertEquals(1, sharedWithUser2.size());
+        assertEquals(Role.WRITER, sharedWithUser2.entrySet().iterator().next().getKey());
     }
 
     @Test
@@ -456,7 +457,7 @@ public class SamPermissionsImplTest {
     public void testIsSharingNotInSam() throws ApiException {
         when(resourcesApiMock.listResourcesAndPolicies(SamConstants.RESOURCE_TYPE))
                 .thenThrow(new ApiException(HttpStatus.SC_UNAUTHORIZED, "Unauthorized"));
-        Assert.assertFalse(samPermissionsImpl.isSharing(janeDoeUserMock));
+        assertFalse(samPermissionsImpl.isSharing(janeDoeUserMock));
     }
 
     @Test
@@ -472,10 +473,10 @@ public class SamPermissionsImplTest {
                 .thenReturn(Collections.singletonList(owner)) // case 3
                 .thenReturn(Collections.singletonList(owner)); // case 4
         // Case 1: No resources are shared
-        Assert.assertFalse(samPermissionsImpl.isSharing(janeDoeUserMock));
+        assertFalse(samPermissionsImpl.isSharing(janeDoeUserMock));
 
         // Case 2: Being shared with, but not sharing
-        Assert.assertFalse(samPermissionsImpl.isSharing(janeDoeUserMock));
+        assertFalse(samPermissionsImpl.isSharing(janeDoeUserMock));
 
         // Case 3: Is owner, but not shared with anybody
         AccessPolicyResponseEntry onlyOwner = new AccessPolicyResponseEntry();
@@ -484,11 +485,11 @@ public class SamPermissionsImplTest {
         onlyOwner.getPolicy().getMemberEmails().add(JANE_DOE_GMAIL_COM);
         when(resourcesApiMock.listResourcePolicies(SamConstants.RESOURCE_TYPE, resourceId))
                 .thenReturn(Collections.singletonList(onlyOwner));
-        Assert.assertFalse(samPermissionsImpl.isSharing(janeDoeUserMock));
+        assertFalse(samPermissionsImpl.isSharing(janeDoeUserMock));
 
         // Case 4: Is owner, and is being shared
         onlyOwner.getPolicy().getMemberEmails().add("jdoe@ucsc.edu");
-        Assert.assertTrue(samPermissionsImpl.isSharing(janeDoeUserMock));
+        assertTrue(samPermissionsImpl.isSharing(janeDoeUserMock));
     }
 
     @Test
@@ -574,7 +575,7 @@ public class SamPermissionsImplTest {
                 janeDoeUserMock, workflowInstance, new Permission("johndoe@example.com", Role.WRITER));
             fail("Expected setPermission to throw exception");
         } catch (CustomWebApplicationException ex) {
-            Assert.assertTrue(ex.getMessage().contains(" 409 "));
+            assertTrue(ex.getMessage().contains(" 409 "));
         }
     }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
@@ -1,5 +1,7 @@
 package io.dockstore.webservice.permissions.sam;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -15,6 +17,7 @@ import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.TokenType;
 import io.dockstore.webservice.core.User;
+import io.dockstore.webservice.core.User.Profile;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.jdbi.TokenDAO;
 import io.dockstore.webservice.permissions.Permission;
@@ -36,6 +39,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.apache.http.HttpStatus;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
@@ -57,6 +61,7 @@ public class SamPermissionsImplTest {
     private static final String GOO_WORKFLOW_NAME = "goo";
     private static final String DOCKSTORE_ORG_WORKFLOW_NAME = "dockstore.org/john/myworkflow";
     private static final String JANE_DOE_GMAIL_COM = "jane.doe@gmail.com";
+    private static final String JOHN_SMITH_GMAIL_COM = "john.smith@gmail.com";
     private static final String JANE_DOE_GITHUB_ID = "jdoe";
     @Rule
     public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
@@ -73,9 +78,16 @@ public class SamPermissionsImplTest {
     private AccessPolicyResponseEntry ownerPolicy;
     private AccessPolicyResponseEntry writerPolicy;
     private SamPermissionsImpl samPermissionsImpl;
-    private User userMock = Mockito.mock(User.class);
+    private User janeDoeUserMock = Mockito.mock(User.class);
+    private User johnSmithUserMock = Mockito.mock(User.class);
     private User noGoogleUser = Mockito.mock(User.class);
+    /**
+     * A workflow mock with <code>janeDoeUserMock</code> as its user
+     */
     private ResourcesApi resourcesApiMock;
+    /**
+     * A workflow that has one user at start, <code>janeDoeUserMock</code>.
+     */
     private Workflow workflowInstance;
     private Permission ownerPermission;
     private Permission writerPermission;
@@ -95,31 +107,37 @@ public class SamPermissionsImplTest {
         writerPolicy.setPolicyName(SamConstants.WRITE_POLICY);
         AccessPolicyMembership writerMembership = new AccessPolicyMembership();
         writerMembership.setRoles(Collections.singletonList(SamConstants.WRITE_POLICY));
-        writerMembership.setMemberEmails(Collections.singletonList(JANE_DOE_GMAIL_COM));
+        writerMembership.setMemberEmails(Collections.singletonList(JOHN_SMITH_GMAIL_COM));
         writerPolicy.setPolicy(writerMembership);
 
         AccessPolicyResponseEntry readerPolicy = new AccessPolicyResponseEntry();
         readerPolicy.setPolicyName(SamConstants.READ_POLICY);
         AccessPolicyMembership readerMembership = new AccessPolicyMembership();
         readerMembership.setRoles(Collections.singletonList(SamConstants.READ_POLICY));
-        readerMembership.setMemberEmails(Collections.singletonList(JANE_DOE_GMAIL_COM));
+        readerMembership.setMemberEmails(Collections.singletonList(JOHN_SMITH_GMAIL_COM));
         readerPolicy.setPolicy(readerMembership);
 
         TokenDAO tokenDAO = Mockito.mock(TokenDAO.class);
         DockstoreWebserviceConfiguration configMock = Mockito.mock(DockstoreWebserviceConfiguration.class);
         when(configMock.getSamConfiguration()).thenReturn(new DockstoreWebserviceConfiguration.SamConfiguration());
         samPermissionsImpl = Mockito.spy(new SamPermissionsImpl(tokenDAO, configMock));
-        doReturn(Optional.of("my token")).when(samPermissionsImpl).googleAccessToken(userMock);
-        doReturn(Mockito.mock(Token.class)).when(samPermissionsImpl).googleToken(userMock);
+        doReturn(Optional.of("my token")).when(samPermissionsImpl).googleAccessToken(
+            janeDoeUserMock);
+        doReturn(Mockito.mock(Token.class)).when(samPermissionsImpl).googleToken(janeDoeUserMock);
+        doReturn(Optional.of("my token")).when(samPermissionsImpl).googleAccessToken(
+            johnSmithUserMock);
+        doReturn(Mockito.mock(Token.class)).when(samPermissionsImpl).googleToken(johnSmithUserMock);
         resourcesApiMock = Mockito.mock(ResourcesApi.class);
         ApiClient apiClient = Mockito.mock(ApiClient.class);
         when(apiClient.escapeString(ArgumentMatchers.anyString()))
                 .thenAnswer(invocation -> invocation.getArgument(0));
         when(resourcesApiMock.getApiClient()).thenReturn(apiClient);
-        when(samPermissionsImpl.getResourcesApi(userMock)).thenReturn(resourcesApiMock);
+        when(samPermissionsImpl.getResourcesApi(janeDoeUserMock)).thenReturn(resourcesApiMock);
+        when(samPermissionsImpl.getResourcesApi(johnSmithUserMock)).thenReturn(resourcesApiMock);
 
         workflowInstance = Mockito.mock(Workflow.class);
         when(workflowInstance.getWorkflowPath()).thenReturn("foo");
+        when(workflowInstance.getUsers()).thenReturn(Set.of(janeDoeUserMock));
 
         ownerPermission = new Permission();
         ownerPermission.setEmail("jdoe@ucsc.edu");
@@ -129,11 +147,11 @@ public class SamPermissionsImplTest {
                 CoreMatchers.is(Collections.singletonList(ownerPermission)));
 
         writerPermission = new Permission();
-        writerPermission.setEmail(JANE_DOE_GMAIL_COM);
+        writerPermission.setEmail(JOHN_SMITH_GMAIL_COM);
         writerPermission.setRole(Role.WRITER);
 
         readerPermission = new Permission();
-        readerPermission.setEmail(JANE_DOE_GMAIL_COM);
+        readerPermission.setEmail(JOHN_SMITH_GMAIL_COM);
         readerPermission.setRole(Role.READER);
 
         AccessPolicyMembership readerAccessPolicyMembership = new AccessPolicyMembership();
@@ -147,7 +165,12 @@ public class SamPermissionsImplTest {
         profile.email = JANE_DOE_GMAIL_COM;
         final Map<String, User.Profile> map = new HashMap<>();
         map.put(TokenType.GOOGLE_COM.toString(), profile);
-        when(userMock.getUserProfiles()).thenReturn(map);
+        when(janeDoeUserMock.getUserProfiles()).thenReturn(map);
+
+        final Profile johnSmithUserProfile = new Profile();
+        johnSmithUserProfile.email = JOHN_SMITH_GMAIL_COM;
+        when(johnSmithUserMock.getUserProfiles())
+            .thenReturn(Map.of(TokenType.GOOGLE_COM.toString(), johnSmithUserProfile));
     }
 
     @Test
@@ -195,7 +218,8 @@ public class SamPermissionsImplTest {
         writer.setResourceId(SamConstants.ENCODED_WORKFLOW_PREFIX + URLEncoder.encode(DOCKSTORE_ORG_WORKFLOW_NAME, StandardCharsets.UTF_8));
         writer.setAccessPolicyName(SamConstants.WRITE_POLICY);
         when(resourcesApiMock.listResourcesAndPolicies(SamConstants.RESOURCE_TYPE)).thenReturn(Arrays.asList(reader, owner, writer));
-        final Map<Role, List<String>> sharedWithUser = samPermissionsImpl.workflowsSharedWithUser(userMock);
+        final Map<Role, List<String>> sharedWithUser = samPermissionsImpl.workflowsSharedWithUser(
+            janeDoeUserMock);
         Assert.assertEquals(3, sharedWithUser.size());
         final List<String> ownerWorkflows = sharedWithUser.get(Role.OWNER);
         Assert.assertEquals(GOO_WORKFLOW_NAME, ownerWorkflows.get(0));
@@ -209,26 +233,26 @@ public class SamPermissionsImplTest {
     public void testCanRead() throws ApiException {
         when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, SamConstants.WORKFLOW_PREFIX + FOO_WORKFLOW_NAME, Role.Action.READ.toString())).thenReturn(Boolean.TRUE);
         when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, SamConstants.WORKFLOW_PREFIX + GOO_WORKFLOW_NAME, Role.Action.READ.toString())).thenReturn(Boolean.FALSE);
-        when(samPermissionsImpl.getResourcesApi(userMock)).thenReturn(resourcesApiMock);
+        when(samPermissionsImpl.getResourcesApi(janeDoeUserMock)).thenReturn(resourcesApiMock);
 
         Workflow fooWorkflow = Mockito.mock(Workflow.class);
         when(fooWorkflow.getWorkflowPath()).thenReturn(FOO_WORKFLOW_NAME, GOO_WORKFLOW_NAME);
-        Assert.assertTrue(samPermissionsImpl.canDoAction(userMock, fooWorkflow, Role.Action.READ));
+        Assert.assertTrue(samPermissionsImpl.canDoAction(janeDoeUserMock, fooWorkflow, Role.Action.READ));
         Workflow gooWorkflow = Mockito.mock(Workflow.class);
-        Assert.assertFalse(samPermissionsImpl.canDoAction(userMock, gooWorkflow, Role.Action.READ));
+        Assert.assertFalse(samPermissionsImpl.canDoAction(janeDoeUserMock, gooWorkflow, Role.Action.READ));
     }
 
     @Test
     public void testCanWrite() throws ApiException {
         when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, SamConstants.WORKFLOW_PREFIX + FOO_WORKFLOW_NAME, Role.Action.WRITE.toString())).thenReturn(Boolean.TRUE);
         when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, SamConstants.WORKFLOW_PREFIX + GOO_WORKFLOW_NAME, Role.Action.WRITE.toString())).thenReturn(Boolean.FALSE);
-        when(samPermissionsImpl.getResourcesApi(userMock)).thenReturn(resourcesApiMock);
+        when(samPermissionsImpl.getResourcesApi(janeDoeUserMock)).thenReturn(resourcesApiMock);
 
         when(workflowInstance.getWorkflowPath()).thenReturn(FOO_WORKFLOW_NAME);
-        Assert.assertTrue(samPermissionsImpl.canDoAction(userMock, workflowInstance, Role.Action.WRITE));
+        Assert.assertTrue(samPermissionsImpl.canDoAction(janeDoeUserMock, workflowInstance, Role.Action.WRITE));
         Workflow gooWorkflow = Mockito.mock(Workflow.class);
         when(gooWorkflow.getWorkflowPath()).thenReturn(GOO_WORKFLOW_NAME);
-        Assert.assertFalse(samPermissionsImpl.canDoAction(userMock, gooWorkflow, Role.Action.WRITE));
+        Assert.assertFalse(samPermissionsImpl.canDoAction(janeDoeUserMock, gooWorkflow, Role.Action.WRITE));
     }
 
     @Test
@@ -236,9 +260,9 @@ public class SamPermissionsImplTest {
         when(resourcesApiMock.listResourcePolicies(SamConstants.RESOURCE_TYPE, SamConstants.WORKFLOW_PREFIX + FOO_WORKFLOW_NAME))
                 .thenReturn(Collections.emptyList(), Collections.singletonList(readerAccessPolicyResponseEntry));
         Permission permission = new Permission();
-        permission.setEmail(JANE_DOE_GMAIL_COM);
+        permission.setEmail(JOHN_SMITH_GMAIL_COM);
         permission.setRole(Role.READER);
-        List<Permission> permissions = samPermissionsImpl.setPermission(userMock, workflowInstance, permission);
+        List<Permission> permissions = samPermissionsImpl.setPermission(janeDoeUserMock, workflowInstance, permission);
         Assert.assertEquals(permissions.size(), 1);
     }
 
@@ -250,10 +274,10 @@ public class SamPermissionsImplTest {
             permission.setEmail("jdoe@example.com");
             permission.setRole(Role.WRITER);
             thrown.expect(CustomWebApplicationException.class);
-            samPermissionsImpl.setPermission(userMock, workflowInstance, permission);
-            Assert.fail("setPermissions did not throw Exception");
+            samPermissionsImpl.setPermission(janeDoeUserMock, workflowInstance, permission);
+            fail("setPermissions did not throw Exception");
         } catch (ApiException e) {
-            Assert.fail();
+            fail();
             e.printStackTrace();
         }
     }
@@ -262,20 +286,21 @@ public class SamPermissionsImplTest {
     public void setPermissionTest2() {
         try {
             final Permission permission = new Permission();
-            permission.setEmail(JANE_DOE_GMAIL_COM);
+            permission.setEmail(JOHN_SMITH_GMAIL_COM);
             permission.setRole(Role.READER);
             when(resourcesApiMock.listResourcePolicies(SamConstants.RESOURCE_TYPE, SamConstants.WORKFLOW_PREFIX + FOO_WORKFLOW_NAME))
                     .thenThrow(new ApiException(404, "Not Found"))
                     .thenReturn(Collections.singletonList(readerAccessPolicyResponseEntry));
             try {
                 setupInitializePermissionsMocks(SamConstants.WORKFLOW_PREFIX + FOO_WORKFLOW_NAME);
-                final List<Permission> permissions = samPermissionsImpl.setPermission(userMock, workflowInstance, permission);
+                final List<Permission> permissions = samPermissionsImpl.setPermission(
+                    janeDoeUserMock, workflowInstance, permission);
                 Assert.assertEquals(permissions.size(), 1);
             } catch (CustomWebApplicationException ex) {
-                Assert.fail("setPermissions threw Exception");
+                fail("setPermissions threw Exception");
             }
         } catch (ApiException e) {
-            Assert.fail();
+            fail();
             e.printStackTrace();
         }
     }
@@ -288,16 +313,16 @@ public class SamPermissionsImplTest {
      */
     @Test
     public void setPermissionRemovesExistingPermission() throws ApiException {
-        final Permission localReaderPermission = new Permission(JANE_DOE_GMAIL_COM, Role.READER);
+        final Permission localReaderPermission = new Permission(JOHN_SMITH_GMAIL_COM, Role.READER);
         final String encodedPath = SamConstants.WORKFLOW_PREFIX + FOO_WORKFLOW_NAME;
         when(resourcesApiMock.listResourcePolicies(SamConstants.RESOURCE_TYPE, encodedPath))
                 .thenReturn(Collections.singletonList(writerPolicy));
         setupInitializePermissionsMocks(encodedPath);
         doNothing().when(resourcesApiMock)
-                .removeUserFromPolicy(SamConstants.RESOURCE_TYPE, encodedPath, SamConstants.WRITE_POLICY, JANE_DOE_GMAIL_COM);
-        samPermissionsImpl.setPermission(userMock, workflowInstance, localReaderPermission);
+                .removeUserFromPolicy(SamConstants.RESOURCE_TYPE, encodedPath, SamConstants.READ_POLICY, JOHN_SMITH_GMAIL_COM);
+        samPermissionsImpl.setPermission(janeDoeUserMock, workflowInstance, localReaderPermission);
         verify(resourcesApiMock, times(1))
-                .removeUserFromPolicy(SamConstants.RESOURCE_TYPE, encodedPath, SamConstants.WRITE_POLICY, JANE_DOE_GMAIL_COM);
+                .removeUserFromPolicy(SamConstants.RESOURCE_TYPE, encodedPath, SamConstants.WRITE_POLICY, JOHN_SMITH_GMAIL_COM);
     }
 
 
@@ -307,12 +332,13 @@ public class SamPermissionsImplTest {
         when(resourcesApiMock.listResourcePolicies(SamConstants.RESOURCE_TYPE, SamConstants.WORKFLOW_PREFIX  + FOO_WORKFLOW_NAME))
                 .thenReturn(Collections.singletonList(readerAccessPolicyResponseEntry),
                     Collections.singletonList(readerAccessPolicyResponseEntry), Collections.EMPTY_LIST);
-        final List<Permission> permissions = samPermissionsImpl.getPermissionsForWorkflow(userMock, workflowInstance);
+        final List<Permission> permissions = samPermissionsImpl.getPermissionsForWorkflow(
+            janeDoeUserMock, workflowInstance);
         Assert.assertEquals(permissions.size(), 1);
         try {
-            samPermissionsImpl.removePermission(userMock, workflowInstance, JANE_DOE_GMAIL_COM, Role.READER);
+            samPermissionsImpl.removePermission(janeDoeUserMock, workflowInstance, JOHN_SMITH_GMAIL_COM, Role.READER);
         } catch (CustomWebApplicationException e) {
-            Assert.fail();
+            fail();
         }
     }
 
@@ -320,7 +346,8 @@ public class SamPermissionsImplTest {
     public void userNotInSamReturnsEmptyMap() throws ApiException {
         // https://github.com/dockstore/dockstore/issues/1597
         when(resourcesApiMock.listResourcesAndPolicies(SamConstants.RESOURCE_TYPE)).thenThrow(new ApiException(HttpStatus.SC_UNAUTHORIZED, "Unauthorized"));
-        final Map<Role, List<String>> sharedWithUser = samPermissionsImpl.workflowsSharedWithUser(userMock);
+        final Map<Role, List<String>> sharedWithUser = samPermissionsImpl.workflowsSharedWithUser(
+            janeDoeUserMock);
         Assert.assertEquals(0, sharedWithUser.size());
     }
 
@@ -329,7 +356,7 @@ public class SamPermissionsImplTest {
         final String resourceId = SamConstants.WORKFLOW_PREFIX + FOO_WORKFLOW_NAME;
         when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, resourceId, SamConstants.toSamAction(Role.Action.SHARE)))
                 .thenReturn(Boolean.TRUE);
-        final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(userMock, workflowInstance);
+        final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(janeDoeUserMock, workflowInstance);
         Assert.assertEquals(Role.Action.values().length, actions.size()); // Owner can perform all actions
     }
 
@@ -340,7 +367,8 @@ public class SamPermissionsImplTest {
                 .thenReturn(Boolean.FALSE);
         when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, resourceId, SamConstants.toSamAction(Role.Action.WRITE)))
                 .thenReturn(Boolean.TRUE);
-        final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(userMock, workflowInstance);
+        when(johnSmithUserMock.getTemporaryCredential()).thenReturn("whatever");
+        final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(johnSmithUserMock, workflowInstance);
         Assert.assertEquals(2, actions.size());
         Assert.assertTrue(actions.contains(Role.Action.WRITE) && actions.contains(Role.Action.READ));
     }
@@ -354,15 +382,17 @@ public class SamPermissionsImplTest {
                 .thenReturn(Boolean.FALSE);
         when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, resourceId, SamConstants.toSamAction(Role.Action.READ)))
                 .thenReturn(Boolean.TRUE);
-        final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(userMock, workflowInstance);
+        final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(
+            johnSmithUserMock, workflowInstance);
         Assert.assertEquals(1, actions.size());
         Assert.assertTrue(actions.contains(Role.Action.READ));
     }
 
     @Test
     public void testDockstoreOwnerNoSamPermissions() {
-        when(workflowInstance.getUsers()).thenReturn(new HashSet<>(Collections.singletonList(userMock)));
-        final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(userMock, workflowInstance);
+        when(workflowInstance.getUsers()).thenReturn(new HashSet<>(Collections.singletonList(
+            janeDoeUserMock)));
+        final List<Role.Action> actions = samPermissionsImpl.getActionsForWorkflow(janeDoeUserMock, workflowInstance);
         Assert.assertEquals(Role.Action.values().length, actions.size()); // Owner can perform all actions
     }
 
@@ -380,7 +410,7 @@ public class SamPermissionsImplTest {
         when(resourcesApiMock.resourceAction(SamConstants.RESOURCE_TYPE, resourceId, SamConstants.toSamAction(Role.Action.WRITE)))
                 .thenReturn(Boolean.FALSE);
         thrown.expect(CustomWebApplicationException.class);
-        samPermissionsImpl.getPermissionsForWorkflow(userMock, workflowInstance);
+        samPermissionsImpl.getPermissionsForWorkflow(janeDoeUserMock, workflowInstance);
     }
 
     @Test
@@ -398,20 +428,23 @@ public class SamPermissionsImplTest {
                 .thenReturn(Arrays.asList(writer, reader));
 
         // Should be 1 workflow, with the writer role, because writer > reader
-        final Map<Role, List<String>> sharedWithUser = samPermissionsImpl.workflowsSharedWithUser(userMock);
+        final Map<Role, List<String>> sharedWithUser = samPermissionsImpl.workflowsSharedWithUser(
+            janeDoeUserMock);
         Assert.assertEquals(1, sharedWithUser.size());
         Assert.assertEquals(Role.WRITER, sharedWithUser.entrySet().iterator().next().getKey());
 
         // Verify it works the same if the SAM API returns the policies in a different order.
-        final Map<Role, List<String>> sharedWithUser2 = samPermissionsImpl.workflowsSharedWithUser(userMock);
+        final Map<Role, List<String>> sharedWithUser2 = samPermissionsImpl.workflowsSharedWithUser(
+            janeDoeUserMock);
         Assert.assertEquals(1, sharedWithUser.size());
         Assert.assertEquals(Role.WRITER, sharedWithUser.entrySet().iterator().next().getKey());
     }
 
     @Test
     public void testNotOriginalOwnerWithEmailNotUsername() {
-        when(userMock.getUsername()).thenReturn(JANE_DOE_GITHUB_ID);
-        when(workflowInstance.getUsers()).thenReturn(new HashSet<>(Collections.singletonList(userMock)));
+        when(janeDoeUserMock.getUsername()).thenReturn(JANE_DOE_GITHUB_ID);
+        when(workflowInstance.getUsers()).thenReturn(new HashSet<>(Collections.singletonList(
+            janeDoeUserMock)));
         thrown.expect(CustomWebApplicationException.class);
         samPermissionsImpl.checkEmailNotOriginalOwner(JANE_DOE_GMAIL_COM, workflowInstance);
         samPermissionsImpl.checkEmailNotOriginalOwner("johndoe@example.com", workflowInstance);
@@ -421,7 +454,7 @@ public class SamPermissionsImplTest {
     public void testIsSharingNotInSam() throws ApiException {
         when(resourcesApiMock.listResourcesAndPolicies(SamConstants.RESOURCE_TYPE))
                 .thenThrow(new ApiException(HttpStatus.SC_UNAUTHORIZED, "Unauthorized"));
-        Assert.assertFalse(samPermissionsImpl.isSharing(userMock));
+        Assert.assertFalse(samPermissionsImpl.isSharing(janeDoeUserMock));
     }
 
     @Test
@@ -437,10 +470,10 @@ public class SamPermissionsImplTest {
                 .thenReturn(Collections.singletonList(owner)) // case 3
                 .thenReturn(Collections.singletonList(owner)); // case 4
         // Case 1: No resources are shared
-        Assert.assertFalse(samPermissionsImpl.isSharing(userMock));
+        Assert.assertFalse(samPermissionsImpl.isSharing(janeDoeUserMock));
 
         // Case 2: Being shared with, but not sharing
-        Assert.assertFalse(samPermissionsImpl.isSharing(userMock));
+        Assert.assertFalse(samPermissionsImpl.isSharing(janeDoeUserMock));
 
         // Case 3: Is owner, but not shared with anybody
         AccessPolicyResponseEntry onlyOwner = new AccessPolicyResponseEntry();
@@ -449,11 +482,11 @@ public class SamPermissionsImplTest {
         onlyOwner.getPolicy().getMemberEmails().add(JANE_DOE_GMAIL_COM);
         when(resourcesApiMock.listResourcePolicies(SamConstants.RESOURCE_TYPE, resourceId))
                 .thenReturn(Collections.singletonList(onlyOwner));
-        Assert.assertFalse(samPermissionsImpl.isSharing(userMock));
+        Assert.assertFalse(samPermissionsImpl.isSharing(janeDoeUserMock));
 
         // Case 4: Is owner, and is being shared
         onlyOwner.getPolicy().getMemberEmails().add("jdoe@ucsc.edu");
-        Assert.assertTrue(samPermissionsImpl.isSharing(userMock));
+        Assert.assertTrue(samPermissionsImpl.isSharing(janeDoeUserMock));
     }
 
     @Test
@@ -474,13 +507,13 @@ public class SamPermissionsImplTest {
                 .thenReturn(Collections.singletonList(owner)); // case 5
 
         // Case 1. User has Google token, but is not in SAM
-        samPermissionsImpl.selfDestruct(userMock);
+        samPermissionsImpl.selfDestruct(janeDoeUserMock);
 
         // Case 2. User has Google token, in SAM, has no resources
-        samPermissionsImpl.selfDestruct(userMock);
+        samPermissionsImpl.selfDestruct(janeDoeUserMock);
 
         // Case 3. User is not owner, but has workflows shared with
-        samPermissionsImpl.selfDestruct(userMock);
+        samPermissionsImpl.selfDestruct(janeDoeUserMock);
 
         // Case 4. User is owner, but is not sharing with anybody
         AccessPolicyResponseEntry onlyOwner = new AccessPolicyResponseEntry();
@@ -489,12 +522,12 @@ public class SamPermissionsImplTest {
         onlyOwner.getPolicy().getMemberEmails().add(JANE_DOE_GMAIL_COM);
         when(resourcesApiMock.listResourcePolicies(SamConstants.RESOURCE_TYPE, resourceId))
                 .thenReturn(Collections.singletonList(onlyOwner));
-        samPermissionsImpl.selfDestruct(userMock);
+        samPermissionsImpl.selfDestruct(janeDoeUserMock);
 
         // Case 5. User is owner and has shared
         onlyOwner.getPolicy().getMemberEmails().add("jdoe@ucsc.edu");
         thrown.expect(CustomWebApplicationException.class);
-        samPermissionsImpl.selfDestruct(userMock);
+        samPermissionsImpl.selfDestruct(janeDoeUserMock);
 
     }
 
@@ -512,19 +545,22 @@ public class SamPermissionsImplTest {
      */
     @Test
     public void testSetPermissionWhenResourceCreatedWithoutAllPolicies() throws ApiException {
-        when(workflowInstance.getUsers()).thenReturn(new HashSet<>(Collections.singletonList(userMock)));
+        when(workflowInstance.getUsers()).thenReturn(new HashSet<>(Collections.singletonList(
+            janeDoeUserMock)));
         final String resourceId = SamConstants.ENCODED_WORKFLOW_PREFIX + FOO_WORKFLOW_NAME;
         ResourceAndAccessPolicy owner = resourceAndAccessPolicyHelper(SamConstants.OWNER_POLICY);
         when(resourcesApiMock.listResourcesAndPolicies(SamConstants.RESOURCE_TYPE))
                 .thenReturn(Collections.singletonList(owner));
         setupInitializePermissionsMocks(resourceId);
-        samPermissionsImpl.setPermission(userMock, workflowInstance, new Permission("johndoe@example.com", Role.WRITER));
+        samPermissionsImpl.setPermission(
+            janeDoeUserMock, workflowInstance, new Permission("johndoe@example.com", Role.WRITER));
         verify(resourcesApiMock, times(1)).overwritePolicy(eq(SamConstants.RESOURCE_TYPE), anyString(), eq(SamConstants.WRITE_POLICY), any());
     }
 
     @Test
     public void testSamPolicyOwnedbyAnother() throws ApiException {
-        when(workflowInstance.getUsers()).thenReturn(new HashSet<>(Collections.singletonList(userMock)));
+        when(workflowInstance.getUsers()).thenReturn(new HashSet<>(Collections.singletonList(
+            janeDoeUserMock)));
         final String resourceId = SamConstants.WORKFLOW_PREFIX + FOO_WORKFLOW_NAME;
         when(resourcesApiMock.listResourcePolicies(SamConstants.RESOURCE_TYPE, resourceId))
                 .thenThrow(new ApiException(HttpStatus.SC_NOT_FOUND, "")); // If you don't have permissions, you get a 404
@@ -532,8 +568,9 @@ public class SamPermissionsImplTest {
                 .when(resourcesApiMock)
                 .createResourceWithDefaults(SamConstants.RESOURCE_TYPE, resourceId);
         try {
-            samPermissionsImpl.setPermission(userMock, workflowInstance, new Permission("johndoe@example.com", Role.WRITER));
-            Assert.fail("Expected setPermission to throw exception");
+            samPermissionsImpl.setPermission(
+                janeDoeUserMock, workflowInstance, new Permission("johndoe@example.com", Role.WRITER));
+            fail("Expected setPermission to throw exception");
         } catch (CustomWebApplicationException ex) {
             Assert.assertTrue(ex.getMessage().contains(" 409 "));
         }
@@ -541,13 +578,34 @@ public class SamPermissionsImplTest {
 
     @Test
     public void testAddingOwnerDoesNotCreateSecondOwnerPolicy() throws ApiException { //https://github.com/dockstore/dockstore/issues/1805
-        when(workflowInstance.getUsers()).thenReturn(new HashSet<>(Collections.singletonList(userMock)));
-        final String resourceId = SamConstants.ENCODED_WORKFLOW_PREFIX + FOO_WORKFLOW_NAME;
+        when(workflowInstance.getUsers()).thenReturn(new HashSet<>(Collections.singletonList(
+            janeDoeUserMock)));
         ResourceAndAccessPolicy owner = resourceAndAccessPolicyHelper(SamConstants.OWNER_POLICY);
         when(resourcesApiMock.listResourcesAndPolicies(SamConstants.RESOURCE_TYPE))
                 .thenReturn(Collections.singletonList(owner));
-        samPermissionsImpl.setPermission(userMock, workflowInstance, new Permission("johndoe@example.com", Role.OWNER));
+        samPermissionsImpl.setPermission(
+            janeDoeUserMock, workflowInstance, new Permission("johndoe@example.com", Role.OWNER));
         verify(resourcesApiMock, times(0)).overwritePolicy(eq(SamConstants.RESOURCE_TYPE), anyString(), eq(SamConstants.OWNER_POLICY), any());
+    }
+
+    @Test
+    public void testOwnerCanGetPermissions() {
+        final List<Permission> permissions =
+            samPermissionsImpl.getPermissionsForWorkflow(janeDoeUserMock, workflowInstance);
+        assertEquals(1, permissions.size());
+        final Permission permission = permissions.get(0);
+        assertEquals(JANE_DOE_GMAIL_COM, permission.getEmail());
+        assertEquals(Role.OWNER, permission.getRole());
+    }
+
+    @Test
+    public void testNonOwnerCannotGetPermissions() {
+        try {
+            samPermissionsImpl.getPermissionsForWorkflow(johnSmithUserMock, workflowInstance);
+            fail("Non-owner shouldn't be able to get permissions");
+        } catch (CustomWebApplicationException e) {
+            assertEquals("Forbidden", e.getErrorMessage());
+        }
     }
 
     private void setupInitializePermissionsMocks(String encodedPath) {
@@ -555,7 +613,7 @@ public class SamPermissionsImplTest {
             doNothing().when(resourcesApiMock).createResourceWithDefaults(anyString(), anyString());
             doNothing().when(resourcesApiMock).overwritePolicy(anyString(), anyString(), anyString(), any());
         } catch (ApiException e) {
-            Assert.fail();
+            fail();
         }
     }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
@@ -436,8 +436,8 @@ public class SamPermissionsImplTest {
         // Verify it works the same if the SAM API returns the policies in a different order.
         final Map<Role, List<String>> sharedWithUser2 = samPermissionsImpl.workflowsSharedWithUser(
             janeDoeUserMock);
-        Assert.assertEquals(1, sharedWithUser.size());
-        Assert.assertEquals(Role.WRITER, sharedWithUser.entrySet().iterator().next().getKey());
+        Assert.assertEquals(1, sharedWithUser2.size());
+        Assert.assertEquals(Role.WRITER, sharedWithUser2.entrySet().iterator().next().getKey());
     }
 
     @Test


### PR DESCRIPTION
**Description**
If the user is not registered in SAM, some endpoints no longer throw a CustomWebApplicationException.

* Check for both 401 and 403 responses to see if a user is registered in SAM. See [SAM code](https://github.com/broadinstitute/sam/blob/1c3c1a3f3e973895de9ba08e6c755edbb04632db/src/main/scala/org/broadinstitute/dsde/workbench/sam/api/SamUserDirectives.scala#L31-L30). In general, read-only operations do not throw CustomWebApplicationExceptions.
* JavaDoc methods that can throw a CustomWebApplicationException
* Many unit tests were wrong, letting a non-owner change permissions (it worked because responses were mocked).
* In working on the previous item, noticed a bug, which made the PR more complicated: A user registered with SAM could see all the Dockstore users (owners) of a workflow. This PR addresses that.

**Issue**
[SEAB-4848](https://ucsc-cgl.atlassian.net/browse/SEAB-4848)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
