### PR TITLE
SEAB-4499: Optimize integration test database migrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,9 +373,12 @@ commands:
       - run:
           name: Install postgresql client
           command: |
-            sudo rm -rf /var/lib/apt/lists/*
-            sudo apt update
-            sudo apt install -y postgresql-client
+            psql --version
+            sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+            wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+            sudo apt-get update
+            sudo apt-get -y install postgresql-client-13
+            psql --version
   install-git-secrets:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,12 +373,9 @@ commands:
       - run:
           name: Install postgresql client
           command: |
-            psql --version
-            sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-            wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-            sudo apt-get update
-            sudo apt-get -y install postgresql-client-13
-            psql --version
+            sudo rm -rf /var/lib/apt/lists/*
+            sudo apt update
+            sudo apt install -y postgresql-client
   install-git-secrets:
     steps:
       - run:

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -285,11 +285,11 @@ public final class CommonTestUtilities {
     }
 
     private static boolean dumpDatabase(String dumpPath, String dbName, String userName) {
-        return runCommand(String.format("pg_dump %s -F c -U %s -f %s", dbName, userName, dumpPath));
+        return runCommand(String.format("/usr/local/pgsql/bin/pg_dump %s -F c -U %s -f %s", dbName, userName, dumpPath));
     }
 
     private static boolean restoreDatabase(String dumpPath, String dbName, String userName) {
-        return runCommand(String.format("pg_restore -d %s -U %s --clean %s", dbName, userName, dumpPath));
+        return runCommand(String.format("/usr/local/pgsql/bin/pg_restore -d %s -U %s --clean %s", dbName, userName, dumpPath));
     } 
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -255,10 +255,7 @@ public final class CommonTestUtilities {
 
     public static void dropAllAndRunMigration(List<String> migrations, Application<DockstoreWebserviceConfiguration> application,
         String configPath) {
-        dropAll(application, configPath);
-        runMigration(migrations, application, configPath);
 
-        /*
         String dbName = "webservice_test";
         String userName = "dockstore";
 
@@ -267,19 +264,18 @@ public final class CommonTestUtilities {
         String migrationDir = "/tmp/migrations/";
         String migrationPath = migrationDir + migrationHash + ".sql";
 
-        // if (!restoreDatabase(migrationPath, dbName, userName)) {
+        if (!restoreDatabase(migrationPath, dbName, userName)) {
             dropAll(application, configPath);
             runMigration(migrations, application, configPath);
-        //     makeDirectory(migrationDir);
-        //     dumpDatabase(migrationPath, dbName, userName);
-        // }
-        */
+            makeDirectory(migrationDir);
+            dumpDatabase(migrationPath, dbName, userName);
+        }
     }
 
     private static boolean runCommand(String command) {
-        LOG.error("RUNNING COMMAND " + command);
+        LOG.error("Running command: " + command);
         try {
-            return new DefaultExecutor().execute(CommandLine.parse(command)) != 0;
+            return new DefaultExecutor().execute(CommandLine.parse(command)) == 0;
         } catch (IOException e) {
             return false;
         }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -281,15 +281,15 @@ public final class CommonTestUtilities {
     }
 
     private static boolean makeDirectory(String dir) {
-        return runCommand(String.format("docker exec postgres1 mkdir -p %s", dir));
+        return runCommand(String.format("mkdir -p %s", dir));
     }
 
     private static boolean dumpDatabase(String dumpPath, String dbName, String userName) {
-        return runCommand(String.format("docker exec postgres1 pg_dump %s -F c -U %s -f %s", dbName, userName, dumpPath));
+        return runCommand(String.format("pg_dump %s -F c -U %s -f %s", dbName, userName, dumpPath));
     }
 
     private static boolean restoreDatabase(String dumpPath, String dbName, String userName) {
-        return runCommand(String.format("docker exec postgres1 pg_restore -d %s -U %s --clean %s", dbName, userName, dumpPath));
+        return runCommand(String.format("pg_restore -d %s -U %s --clean %s", dbName, userName, dumpPath));
     } 
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -232,9 +232,6 @@ public final class CommonTestUtilities {
 
     public static void runMigration(List<String> migrations, Application<DockstoreWebserviceConfiguration> application,
         String configPath) {
-        String s = migrations.stream().collect(Collectors.joining(","));
-        LOG.error("RUN MIGRATION " + s);
-        LOG.error("HASHCODE  " + s.hashCode());
         try {
             application.run("db", "migrate", configPath, "--include", migrations.stream().collect(Collectors.joining(",")));
         } catch (Exception e) {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -43,7 +43,6 @@ import javax.ws.rs.core.GenericType;
 import org.apache.commons.configuration2.INIConfiguration;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
-import org.apache.commons.exec.ExecuteException;
 import org.apache.commons.exec.Executor;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -256,7 +256,7 @@ public final class CommonTestUtilities {
         String configPath) {
 
         String dbName = "webservice_test";
-        String userName = "dockstore";
+        String userName = "postgres";
 
         String migrationString = migrations.stream().collect(Collectors.joining("'"));
         String migrationHash = Hashing.sha256().hashString(migrationString, StandardCharsets.UTF_8).toString();

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -285,11 +285,11 @@ public final class CommonTestUtilities {
     }
 
     private static boolean dumpDatabase(String dumpPath, String dbName, String userName) {
-        return runCommand(String.format("/usr/local/pgsql/bin/pg_dump %s -F c -U %s -f %s", dbName, userName, dumpPath));
+        return runCommand(String.format("pg_dump %s -F c -U %s -f %s", dbName, userName, dumpPath));
     }
 
     private static boolean restoreDatabase(String dumpPath, String dbName, String userName) {
-        return runCommand(String.format("/usr/local/pgsql/bin/pg_restore -d %s -U %s --clean %s", dbName, userName, dumpPath));
+        return runCommand(String.format("pg_restore -d %s -U %s --clean %s", dbName, userName, dumpPath));
     } 
 
     /**

--- a/dockstore-webservice/src/main/resources/migrations.xml
+++ b/dockstore-webservice/src/main/resources/migrations.xml
@@ -23,9 +23,9 @@
     <include file="migrations.test.confidential1.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.confidential2.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.test.add_test_tools.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.4.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.testworkflow.xml" relativeToChangelogFile="true"/>
-    <include file="migrations.test.add_test_tools.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.5.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.confidential1_1.5.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.test.confidential2_1.5.0.xml" relativeToChangelogFile="true"/>


### PR DESCRIPTION
**Description**
This PR improves the speed, reduces the resource consumption, and improves the code clarity of the integration test database migrations.

The database migrations are used to set the state of the database prior to each test, by calling `application.run` with the `db migrate` command to apply the named changelogs via the `--include` argument.  Previously, in most cases, a given migration was applied by calling `application.run` to apply each constituent changelog, by itself, one by one, successively, in a loop:

https://github.com/dockstore/dockstore/blob/273cd85d5df19491b298111ed36a5e3b15c522ab/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java#L260

Each call to `application.run` incurs significant overhead, so this PR batches and applies the full set of changelogs in a single call to `application.run`.  On my local install, this change reduced the total migration run time by over 50%.  On circleci, it reduced the run time of the migration-intensive test groups by 1-5 minutes each.  Approximately representative runs:
before: https://app.circleci.com/pipelines/github/dockstore/dockstore/8642
after: https://app.circleci.com/pipelines/github/dockstore/dockstore/8663

I moved one of the changelogs in `migrations.xml` to correct the ordering.  Without that change, sometimes changelogs would be skipped when batched, causing the migration to fail.  This problem was not visible when the changelogs were applied one-by-one, because the batches were of size 1 and, thus, had no relative ordering issues.  This problem might explain why the migrations were applied one-by-one in the first place. 
 
I also refactored so that all migrations are applied via the same method, thus facilitating the next change...

To further reduce the run time of the migrations, I investigated different ways to save snapshots of the database resulting from each migration (series of changelogs) and use the snapshot, instead of migrating, when possible.  IMHO, the observed gain from the solution I implemented, which theoretically should be [close to] the fastest of the bunch, was minor and did not outweigh the various cons.  So, I didn't include it in this PR.   The basic scheme was to use `pg_dump` and `pg_restore` to write/read the snapshots, keyed by a hash of the names of the changelogs applied.  If you want to see it, the prototype is still on the branch: https://github.com/dockstore/dockstore/pull/5161/commits/66efa462d04aec30694ae7480b697987e8076594

Another candidate snapshot mechanism was the `CREATE DATABASE newdb TEMPLATE templatedb` statement.  It seemed promising, but the requirement that the templatedb have no connected users (when it is invoked) made it hard to integrate with our tests (as currently architected).

Over time, should our migrations grow signficantly more ponderous, we may want to revisit snapshotting migrated databases...

The next step to improve the run time of the ITs would probably be to split the `unit_test` group.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4499

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
