### PR TITLE
Always index only one version's source files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,9 @@ services:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      # The value on AWS OpenSearch, which we can't change, without changing instance type
+      # https://docs.aws.amazon.com/opensearch-service/latest/developerguide/limits.html#network-limits
+      - http.max_content_length=10mb
       - xpack.security.enabled=false
       - xpack.monitoring.enabled=false
       - xpack.graph.enabled=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      # The value on AWS OpenSearch, which we can't change, without changing instance type
+      # The max_content_length value on AWS OpenSearch is dependent on instance type
       # https://docs.aws.amazon.com/opensearch-service/latest/developerguide/limits.html#network-limits
       - http.max_content_length=10mb
       - xpack.security.enabled=false

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.dockstore.webservice.helpers.statelisteners;
+
+import static org.junit.Assert.assertTrue;
+
+import io.dockstore.webservice.core.AppTool;
+import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.Entry;
+import io.dockstore.webservice.core.SourceFile;
+import io.dockstore.webservice.core.Tool;
+import io.dockstore.webservice.core.Version;
+import io.dockstore.webservice.core.WorkflowVersion;
+import java.util.List;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ElasticListenerTest {
+
+    private static final String FIRST_VERSION_NAME = "First";
+    private static final String SECOND_VERSION_NAME = "Second";
+    private static final int FIRST_VERSION_ID = 1;
+    private static final int SECOND_VERSION_ID = 2;
+    private WorkflowVersion FIRST_WORKFLOW_VERSION;
+    private WorkflowVersion SECOND_WORKFLOW_VERSION;
+    private BioWorkflow bioWorkflow;
+    private Tool tool;
+    private AppTool appTool;
+
+
+    @Before
+    public void setup() throws IllegalAccessException {
+        bioWorkflow = new BioWorkflow();
+        tool = new Tool();
+        appTool = new AppTool();
+        FIRST_WORKFLOW_VERSION = new WorkflowVersion();
+        SECOND_WORKFLOW_VERSION = new WorkflowVersion();
+        initVersion(FIRST_WORKFLOW_VERSION, FIRST_VERSION_NAME, FIRST_VERSION_ID);
+        initVersion(SECOND_WORKFLOW_VERSION, SECOND_VERSION_NAME,
+            SECOND_VERSION_ID);
+    }
+
+    private void initVersion(final WorkflowVersion version, final String name, final long id)
+        throws IllegalAccessException {
+        version.setName(name);
+        final SourceFile sourceFile = new SourceFile();
+        sourceFile.setPath("/Dockstore.wdl");
+        sourceFile.setContent("Doesn't matter");
+        version.getSourceFiles().add(sourceFile);
+        // Id is normally set via Hibernate generator; have to use reflection to set it, alas
+        FieldUtils.writeField(version, "id", id, true);
+        bioWorkflow.getWorkflowVersions().addAll(List.of(FIRST_WORKFLOW_VERSION,
+            SECOND_WORKFLOW_VERSION));
+    }
+
+    @Test
+    public void testNoValidVersions() {
+        // If there are no valid versions, the latest version id wins out
+        final Entry entry = ElasticListener.removeIrrelevantProperties(bioWorkflow);
+        validateOnlyOneVersionHasSourceFileContent(entry, SECOND_WORKFLOW_VERSION);
+    }
+
+    @Test
+    public void testDefaultVersionSet() {
+        bioWorkflow.setActualDefaultVersion(FIRST_WORKFLOW_VERSION);
+        validateOnlyOneVersionHasSourceFileContent(ElasticListener.removeIrrelevantProperties(bioWorkflow),
+            FIRST_WORKFLOW_VERSION);
+        bioWorkflow.setActualDefaultVersion(SECOND_WORKFLOW_VERSION);
+        validateOnlyOneVersionHasSourceFileContent(ElasticListener.removeIrrelevantProperties(bioWorkflow),
+            SECOND_WORKFLOW_VERSION);
+    }
+
+    @Test
+    public void testValidVersionsNoDefault() {
+        // If only one version is valid, it wins out
+        FIRST_WORKFLOW_VERSION.setValid(true);
+        validateOnlyOneVersionHasSourceFileContent(ElasticListener.removeIrrelevantProperties(bioWorkflow),
+            FIRST_WORKFLOW_VERSION);
+
+        // If more than one version is valid, the highest id wins out
+        SECOND_WORKFLOW_VERSION.setValid(true);
+        validateOnlyOneVersionHasSourceFileContent(ElasticListener.removeIrrelevantProperties(bioWorkflow),
+            SECOND_WORKFLOW_VERSION);
+    }
+
+    private void validateOnlyOneVersionHasSourceFileContent(final Entry entry, final WorkflowVersion version) {
+        entry.getWorkflowVersions().forEach(v -> {
+            final Version v1 = (Version) v;
+            if (v1.getName().equals(version.getName())) {
+                v1.getSourceFiles().forEach(sf -> assertTrue(!((SourceFile)sf).getContent().isEmpty()));
+            } else {
+                v1.getSourceFiles().forEach(sf -> assertTrue(((SourceFile)sf).getContent().isEmpty()));
+            }
+        });
+    }
+
+}

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
@@ -38,12 +38,12 @@ public class ElasticListenerTest {
     private static final String SECOND_VERSION_NAME = "Second";
     private static final int FIRST_VERSION_ID = 1;
     private static final int SECOND_VERSION_ID = 2;
-    private WorkflowVersion FIRST_WORKFLOW_VERSION;
-    private WorkflowVersion SECOND_WORKFLOW_VERSION;
-    private Tag FIRST_TAG;
-    private Tag SECOND_TAG;
-    private WorkflowVersion FIRST_APP_TOOL_VERSION;
-    private WorkflowVersion SECOND_APP_TOOL_VERSION;
+    private WorkflowVersion firstWorkflowVersion;
+    private WorkflowVersion secondWorkflowVersion;
+    private Tag firstTag;
+    private Tag secondTag;
+    private WorkflowVersion firstAppToolVersion;
+    private WorkflowVersion secondAppToolVersion;
     private BioWorkflow bioWorkflow;
     private Tool tool;
     private AppTool appTool;
@@ -53,27 +53,27 @@ public class ElasticListenerTest {
     public void setup() throws IllegalAccessException {
 
         bioWorkflow = new BioWorkflow();
-        FIRST_WORKFLOW_VERSION = new WorkflowVersion();
-        SECOND_WORKFLOW_VERSION = new WorkflowVersion();
-        initVersion(FIRST_WORKFLOW_VERSION, FIRST_VERSION_NAME, FIRST_VERSION_ID);
-        initVersion(SECOND_WORKFLOW_VERSION, SECOND_VERSION_NAME,
+        firstWorkflowVersion = new WorkflowVersion();
+        secondWorkflowVersion = new WorkflowVersion();
+        initVersion(firstWorkflowVersion, FIRST_VERSION_NAME, FIRST_VERSION_ID);
+        initVersion(secondWorkflowVersion, SECOND_VERSION_NAME,
             SECOND_VERSION_ID);
-        bioWorkflow.getWorkflowVersions().addAll(List.of(FIRST_WORKFLOW_VERSION,
-            SECOND_WORKFLOW_VERSION));
+        bioWorkflow.getWorkflowVersions().addAll(List.of(firstWorkflowVersion,
+            secondWorkflowVersion));
 
         tool = new Tool();
-        FIRST_TAG = new Tag();
-        SECOND_TAG = new Tag();
-        initVersion(FIRST_TAG, FIRST_VERSION_NAME, FIRST_VERSION_ID);
-        initVersion(SECOND_TAG, SECOND_VERSION_NAME, SECOND_VERSION_ID);
-        tool.getWorkflowVersions().addAll(List.of(FIRST_TAG, SECOND_TAG));
+        firstTag = new Tag();
+        secondTag = new Tag();
+        initVersion(firstTag, FIRST_VERSION_NAME, FIRST_VERSION_ID);
+        initVersion(secondTag, SECOND_VERSION_NAME, SECOND_VERSION_ID);
+        tool.getWorkflowVersions().addAll(List.of(firstTag, secondTag));
 
         appTool = new AppTool();
-        FIRST_APP_TOOL_VERSION = new WorkflowVersion();
-        SECOND_APP_TOOL_VERSION = new WorkflowVersion();
-        initVersion(FIRST_APP_TOOL_VERSION, FIRST_VERSION_NAME, FIRST_VERSION_ID);
-        initVersion(SECOND_APP_TOOL_VERSION, SECOND_VERSION_NAME, SECOND_VERSION_ID);
-        appTool.getWorkflowVersions().addAll(List.of(FIRST_APP_TOOL_VERSION, SECOND_APP_TOOL_VERSION));
+        firstAppToolVersion = new WorkflowVersion();
+        secondAppToolVersion = new WorkflowVersion();
+        initVersion(firstAppToolVersion, FIRST_VERSION_NAME, FIRST_VERSION_ID);
+        initVersion(secondAppToolVersion, SECOND_VERSION_NAME, SECOND_VERSION_ID);
+        appTool.getWorkflowVersions().addAll(List.of(firstAppToolVersion, secondAppToolVersion));
     }
 
     private void initVersion(final Version version, final String name, final long id)
@@ -103,38 +103,38 @@ public class ElasticListenerTest {
             entry.getWorkflowVersions().clear();
             // Just make sure it doesn't throw an exception
             ElasticListener.removeIrrelevantProperties(entry);
-            });
+        });
     }
 
     @Test
     public void testDefaultVersionSet() {
-        bioWorkflow.setActualDefaultVersion(FIRST_WORKFLOW_VERSION);
+        bioWorkflow.setActualDefaultVersion(firstWorkflowVersion);
         validateOnlyOneVersionHasSourceFileContent(ElasticListener.removeIrrelevantProperties(bioWorkflow),
             FIRST_VERSION_NAME);
-        bioWorkflow.setActualDefaultVersion(SECOND_WORKFLOW_VERSION);
+        bioWorkflow.setActualDefaultVersion(secondWorkflowVersion);
         validateOnlyOneVersionHasSourceFileContent(ElasticListener.removeIrrelevantProperties(bioWorkflow),
             SECOND_VERSION_NAME);
 
-        tool.setActualDefaultVersion(FIRST_TAG);
+        tool.setActualDefaultVersion(firstTag);
         validateOnlyOneVersionHasSourceFileContent(ElasticListener.removeIrrelevantProperties(tool),
             FIRST_VERSION_NAME);
-        tool.setActualDefaultVersion(SECOND_TAG);
+        tool.setActualDefaultVersion(secondTag);
         validateOnlyOneVersionHasSourceFileContent(ElasticListener.removeIrrelevantProperties(tool),
             SECOND_VERSION_NAME);
 
-        appTool.setActualDefaultVersion(FIRST_APP_TOOL_VERSION);
+        appTool.setActualDefaultVersion(firstAppToolVersion);
         validateOnlyOneVersionHasSourceFileContent(ElasticListener.removeIrrelevantProperties(appTool),
             FIRST_VERSION_NAME);
-        appTool.setActualDefaultVersion(SECOND_APP_TOOL_VERSION);
+        appTool.setActualDefaultVersion(secondAppToolVersion);
         validateOnlyOneVersionHasSourceFileContent(ElasticListener.removeIrrelevantProperties(appTool),
             SECOND_VERSION_NAME);
     }
 
     @Test
     public void testValidVersionsNoDefault() {
-        FIRST_WORKFLOW_VERSION.setValid(true);
-        FIRST_TAG.setValid(true);
-        FIRST_APP_TOOL_VERSION.setValid(true);
+        firstWorkflowVersion.setValid(true);
+        firstTag.setValid(true);
+        firstAppToolVersion.setValid(true);
         List.of(bioWorkflow, tool, appTool).stream().forEach(entry -> {
             validateOnlyOneVersionHasSourceFileContent(ElasticListener.removeIrrelevantProperties(entry),
                 FIRST_VERSION_NAME);


### PR DESCRIPTION
**Description**
If the default version for an entry is not set, we were indexing all the source files from all versions. With this fix, we only index the source files from one version.

There were some workflows that were failing to index because all their versions' source files are greater than 10MB, and the ES we've been using in AWS has a 10MB request limit. We are temporarily upgrading to an (expensive) AWS ES instance type that allows 100MB requests, but once this merged, we can scale down ES again.

The version to index when there is no default uses the same logic as the UI, by taking the most recently created valid version (the highest id). The only difference is it does default to the latest version if there is no valid version, which is theoretically possible.

On doing the processing of workflow versions in Java rather than with HQL, which would be a ton more efficient:
* This is a hotfix, I want to limit the scope of the change
* We were already processing the versions in Java
* This code can go months without being executed -- we typically only need to reindex if we change the schema (or this bug), so it's arguable whether it's worth the effort in general.

Also, I think we should just always set the default version -- I'm creating a separate issue for this.

**Issue**
#5154

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ ] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
