### PR TITLE
DOCK-2256: ORCID identifiers can end with 'X'

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
@@ -68,7 +68,7 @@ public final class ORCIDHelper {
     private static final Logger LOG = LoggerFactory.getLogger(ORCIDHelper.class);
     private static final String ORCID_XML_CONTENT_TYPE = "application/vnd.orcid+xml";
     private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
-    private static final Pattern ORCID_ID_PATTERN = Pattern.compile("\\d{4}-\\d{4}-\\d{4}-\\d{4}"); // ex: 1234-1234-1234-1234
+    private static final Pattern ORCID_ID_PATTERN = Pattern.compile("\\d{4}-\\d{4}-\\d{4}-\\d{3}[X\\d]"); // ex: 1234-1234-1234-1234
 
     private static String baseApiUrl; // baseApiUrl should result in something like "https://api.sandbox.orcid.org/v3.0/" or "https://api.orcid.org/v3.0/"
     private static String baseUrl; // baseUrl should be something like "https://sandbox.orcid.org/" or "https://orcid.org/"

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
@@ -68,6 +68,9 @@ public final class ORCIDHelper {
     private static final Logger LOG = LoggerFactory.getLogger(ORCIDHelper.class);
     private static final String ORCID_XML_CONTENT_TYPE = "application/vnd.orcid+xml";
     private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+    // Valid ORCIDs can end with 'X':
+    // https://support.orcid.org/hc/en-us/articles/360053289173-Why-does-my-ORCID-iD-have-an-X-
+    // Stephen Hawking's ORCID: https://orcid.org/0000-0002-9079-593X
     private static final Pattern ORCID_ID_PATTERN = Pattern.compile("\\d{4}-\\d{4}-\\d{4}-\\d{3}[X\\d]"); // ex: 1234-1234-1234-1234
 
     private static String baseApiUrl; // baseApiUrl should result in something like "https://api.sandbox.orcid.org/v3.0/" or "https://api.orcid.org/v3.0/"

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ORCIDHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ORCIDHelperTest.java
@@ -40,6 +40,9 @@ public class ORCIDHelperTest {
     @Test
     public void testIsValidOrcidId() {
         Assert.assertTrue(ORCIDHelper.isValidOrcidId("1234-1234-1234-1234"));
+        Assert.assertTrue(ORCIDHelper.isValidOrcidId("0000-0002-9079-593X"));
+        Assert.assertFalse(ORCIDHelper.isValidOrcidId("0000-0002-9079-593P"));
+        Assert.assertFalse(ORCIDHelper.isValidOrcidId("0000-0002-9079-59X3"));
         Assert.assertFalse(ORCIDHelper.isValidOrcidId("https://orcid.org/1234-1234-1234-1234"));
         Assert.assertFalse(ORCIDHelper.isValidOrcidId("1-1-1-1"));
         Assert.assertFalse(ORCIDHelper.isValidOrcidId("orcidId"));


### PR DESCRIPTION
**Description**
Per the spec, the last character of an ORCID is a checksum and can be the character 'X' (denoting the value 10):
https://support.orcid.org/hc/en-us/articles/360053289173-Why-does-my-ORCID-iD-have-an-X-
https://orcid.org/0000-0002-9079-593X
This PR adjusts the regexp used for validation, so that all valid ORCIDs are processed.  Hotfix.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2256
#5152

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
