### PR TITLE
SEAB-4880: Include galaxy plugin in webservice docker image

### DIFF
--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -2,6 +2,8 @@ name: Develop Deploy
 
 on:
   push:
+    branches:
+      - hotfix/seab-4880/include-galaxy-plugin-in-webservice-container
       
 jobs:
   build:

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -3,7 +3,7 @@ name: Develop Deploy
 on:
   push:
     branches:
-      - hotfix/seab-4880/include-galaxy-plugin-in-webservice-container
+      - develop
       
 jobs:
   build:

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -2,8 +2,6 @@ name: Develop Deploy
 
 on:
   push:
-    branches:
-      - develop
       
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY dockstore-webservice/target/dockstore-webservice*[^s].jar /home
 RUN mkdir /dockstore_logs && chmod a+rx /dockstore_logs
 
 # Include galaxy language plugin
+RUN apt-get install -y wget
 RUN mkdir -p /root/.dockstore/language-plugins
 RUN wget -P /root/.dockstore/language-plugins https://artifacts.oicr.on.ca/artifactory/collab-release/com/github/galaxyproject/dockstore-galaxy-interface/dockstore-galaxy-interface/0.0.7/dockstore-galaxy-interface-0.0.7.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,28 @@
 FROM eclipse-temurin:17.0.3_7-jdk-focal
 
-# wipe them out, all of them, to reduce CVEs
+# Wipe them out, all of them, to reduce CVEs
 RUN apt-get purge -y -- *python*  && apt-get -y autoremove
 
 # Update the APT cache
-# prepare for Java download
+# Prepare for Java download
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends
-# note locale settings seem redundant, temurin already has en_US.UTF-8 set
+# Note locale settings seem redundant, temurin already has en_US.UTF-8 set
 #    locales \
 #    && apt-get clean \
 #    && rm -rf /var/lib/apt/lists/* \
 #    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 # ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-# copy the jar not ending in 's', to make sure we get don't get the one ending in 'sources'
+# Copy the jar not ending in 's', to make sure we get don't get the one ending in 'sources'
 COPY dockstore-webservice/target/dockstore-webservice*[^s].jar /home
 
 RUN mkdir /dockstore_logs && chmod a+rx /dockstore_logs
+
+# Include galaxy language plugin
+mkdir -p /root/.dockstore/language-plugins
+RUN wget -P /root/.dockstore/language-plugins https://artifacts.oicr.on.ca/artifactory/collab-release/com/github/galaxyproject/dockstore-galaxy-interface/dockstore-galaxy-interface/0.0.7/dockstore-galaxy-interface-0.0.7.jar
 
 CMD ["/home/init_webservice.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,10 @@ COPY dockstore-webservice/target/dockstore-webservice*[^s].jar /home
 RUN mkdir /dockstore_logs && chmod a+rx /dockstore_logs
 
 # Include galaxy language plugin
+ARG galaxy_plugin_version=0.0.7
 RUN apt-get install -y wget
 RUN mkdir -p /root/.dockstore/language-plugins
-RUN wget -P /root/.dockstore/language-plugins https://artifacts.oicr.on.ca/artifactory/collab-release/com/github/galaxyproject/dockstore-galaxy-interface/dockstore-galaxy-interface/0.0.7/dockstore-galaxy-interface-0.0.7.jar
+RUN wget -P /root/.dockstore/language-plugins https://artifacts.oicr.on.ca/artifactory/collab-release/com/github/galaxyproject/dockstore-galaxy-interface/dockstore-galaxy-interface/${galaxy_plugin_version}/dockstore-galaxy-interface-${galaxy_plugin_version}.jar
 
 CMD ["/home/init_webservice.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY dockstore-webservice/target/dockstore-webservice*[^s].jar /home
 RUN mkdir /dockstore_logs && chmod a+rx /dockstore_logs
 
 # Include galaxy language plugin
-mkdir -p /root/.dockstore/language-plugins
+RUN mkdir -p /root/.dockstore/language-plugins
 RUN wget -P /root/.dockstore/language-plugins https://artifacts.oicr.on.ca/artifactory/collab-release/com/github/galaxyproject/dockstore-galaxy-interface/dockstore-galaxy-interface/0.0.7/dockstore-galaxy-interface-0.0.7.jar
 
 CMD ["/home/init_webservice.sh"]


### PR DESCRIPTION
**Description**
This PR includes the Galaxy language plugin in the docker image that is uploaded to quay, by downloading/installing in the `Dockerfile`.  The upshot is that the artifactory dependency is moved to build time, allowing our containers to start if artifactory is down.

This PR has companions in the following repos:
* `dockstore-deploy`: https://github.com/dockstore/dockstore-deploy/pull/635
* `compose_setup`: https://github.com/dockstore/compose_setup/pull/235

Also, some comments are recapitalized to enhance readability.

**Review Instructions**
Confirm that the Galaxy plugin is installed in the appropriate directory of the webservice image, and that the webservice runs and loads the Galaxy plugin.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4880

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
