### PR TITLE
Set refresh interval

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
@@ -639,7 +639,7 @@ public class DockstoreWebserviceConfiguration extends Configuration {
         private String user;
         private String password;
         private Integer maxConcurrentSessions;
-        private String refreshInterval = "60s";
+        private String refreshInterval = "1s";
 
         public String getProtocol() {
             return protocol;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
@@ -639,6 +639,7 @@ public class DockstoreWebserviceConfiguration extends Configuration {
         private String user;
         private String password;
         private Integer maxConcurrentSessions;
+        private String refreshInterval = "30s";
 
         public String getProtocol() {
             return protocol;
@@ -685,6 +686,19 @@ public class DockstoreWebserviceConfiguration extends Configuration {
         }
         public Integer getMaxConcurrentSessions() {
             return this.maxConcurrentSessions;
+        }
+
+        /**
+         * ElasticSearch refresh interval, see
+         * https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-high-indices-put-settings.html
+         * I got an error once with 60s, the AWS recommended, so cut it back to 30s
+         */
+        public String getRefreshInterval() {
+            return refreshInterval;
+        }
+
+        public void setRefreshInterval(final String refreshInterval) {
+            this.refreshInterval = refreshInterval;
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
@@ -639,7 +639,7 @@ public class DockstoreWebserviceConfiguration extends Configuration {
         private String user;
         private String password;
         private Integer maxConcurrentSessions;
-        private String refreshInterval = "30s";
+        private String refreshInterval = "60s";
 
         public String getProtocol() {
             return protocol;
@@ -691,7 +691,6 @@ public class DockstoreWebserviceConfiguration extends Configuration {
         /**
          * ElasticSearch refresh interval, see
          * https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-high-indices-put-settings.html
-         * I got an error once with 60s, the AWS recommended, so cut it back to 30s
          */
         public String getRefreshInterval() {
             return refreshInterval;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -235,10 +235,11 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
         // This API is deprecated in 7.15.0; when we upgrade, we'll need to change the code
         // https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-high-indices-put-settings.html
         final UpdateSettingsRequest request = new UpdateSettingsRequest(nameOfIndex);
-        final Builder settingsBuilder = Settings.builder().put(settingKey,
-            config.getEsConfiguration().getRefreshInterval());
+        final String refreshInterval = config.getEsConfiguration().getRefreshInterval();
+        final Builder settingsBuilder = Settings.builder().put(settingKey, refreshInterval);
         request.settings(settingsBuilder);
         client.indices().putSettings(request, RequestOptions.DEFAULT);
+        LOG.info("{} index refresh interval set to {}", nameOfIndex, refreshInterval);
     }
 
     private void indexBatch(List<? extends Entry> published) {


### PR DESCRIPTION
**Description**
Sets the refresh interval for ES indexes. Default is 0. The value is configurable, so we can revert to the existing behavior and/or look for the optimal setting.

We are getting 429 errors, [this page](https://aws.amazon.com/premiumsupport/knowledge-center/opensearch-indexing-performance/) says to set the interval to 60s or more to avoid them.

The theory is when a repo with associated with multiple workflows gets updated, we update the index for every workflow in quick succession (and in prod, we're indexing all versions' source files for some of those workflows). Each of those updates is causing a reindex, more updates are coming in while the reindex is happening, and a big strain results.

Companion PR in dockstore/compose_setup#238

**Review Instructions**
To verify the interval is being set, look for the message "...index refresh interval set to " in the logs after doing a reindex, where value is the ELASTICSEARCH_REFRESH_INTERVAL value.

Other than that, make sure after you push a new workflow that is shows up in ES (after a minute or two). Hopefully notice a reduction in ES alerts in prod.

**Issue**
#5227

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
