### PR TITLE
DOCK-2170: Fix tools and DAG generation problem

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -560,20 +560,22 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
 
     /**
      * Computes the dependencies from one or more output sources
-     * @param endDependencies List to which the computed dependencies are added
-     * @param sources a single String output source or List of String output sources
+     * @param endDependencies list to which the computed dependencies are added
+     * @param sourcesObj a single String output source or list of String output sources
      * @param nodePrefix prefix to attach to extracted dependencies
      * @param workflowId normalized workflow ID
      */
     private void processDependencies(List<String> endDependencies, Object sourcesObj, String nodePrefix, String workflowId) {
-        List<String> sources = sourcesObj instanceof String ? List.of((String)sourcesObj) : (List<String>)sourcesObj;
-        for (String s: sources) {
-            // If the source ID starts with the workflow ID, strip it off, split at the slashes, and if
-            // there are two or more parts, the dependency (workflow step name/id) is the second-to-last part.
-            if (s.startsWith(workflowId)) {
-                String[] split = s.substring(workflowId.length()).replaceFirst("^/", "").split("/");
-                if (split.length >= 2) {
-                    endDependencies.add(nodePrefix + split[split.length - 2].replaceFirst("#", ""));
+        if (sourcesObj != null) {
+            List<String> sources = sourcesObj instanceof String ? List.of((String)sourcesObj) : (List<String>)sourcesObj;
+            for (String s: sources) {
+                // If the source ID starts with the workflow ID, strip it off, split at the slashes, and if
+                // there are two or more parts, the dependency (workflow step name/id) is the second-to-last part.
+                if (s.startsWith(workflowId)) {
+                    String[] split = s.substring(workflowId.length()).replaceFirst("^/", "").split("/");
+                    if (split.length >= 2) {
+                        endDependencies.add(nodePrefix + split[split.length - 2].replaceFirst("#", ""));
+                    }
                 }
             }
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -695,7 +695,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
 
     /**
      * Throw an exception if the specified value is null.
-     * Used to implement a controlled failure when a value is guaranteed by a constraint or process to be non-null, but for whatever reason, is not.
+     * Used to implement a controlled failure when we encounter a value that must be non-null (and should have been verified as such by a previous check), but for whatever reason, is not.
      */
     private <T> T checkNonNull(T value) {
         if (value == null) {

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -433,4 +433,22 @@ public class CWLHandlerTest {
         when(sourceFile.getContent()).thenReturn(content);
         return sourceFile;
     }
+
+    /**
+     * Test a workflow with an ID that contains slashes.
+     */
+    @Test
+    public void testWorkflowWithIdThatContainsSlashes() throws IOException {
+        CWLHandler cwlHandler = new CWLHandler();
+
+        final String resourceRoot = "workflow-id-slashes";
+        final SourceFile primaryFile = mockSourceFile(resourceRoot, "/main.cwl");
+        final ToolDAO toolDAO = Mockito.mock(ToolDAO.class);
+
+        String toolTableContent = cwlHandler.getContent(primaryFile.getAbsolutePath(), primaryFile.getContent(), Set.of(mockSourceFile(resourceRoot, "/tool.cwl")), LanguageHandlerInterface.Type.TOOLS, toolDAO).get();
+        Assert.assertTrue("step id should be part of tool table content", toolTableContent.contains("step_name"));
+
+        String dagContent = cwlHandler.getContent(primaryFile.getAbsolutePath(), primaryFile.getContent(), Set.of(), LanguageHandlerInterface.Type.DAG, toolDAO).get();
+        Assert.assertTrue("step id should be part of dag content", dagContent.contains("step_name"));
+    }
 }

--- a/dockstore-webservice/src/test/resources/workflow-id-slashes/main.cwl
+++ b/dockstore-webservice/src/test/resources/workflow-id-slashes/main.cwl
@@ -1,0 +1,12 @@
+cwlVersion: v1.0
+class: Workflow
+inputs: []
+outputs: []
+id: a/workflow/id/that/contains/slashes
+
+steps:
+
+  step_name:
+    run: tool.cwl
+    in: []
+    out: []

--- a/dockstore-webservice/src/test/resources/workflow-id-slashes/tool.cwl
+++ b/dockstore-webservice/src/test/resources/workflow-id-slashes/tool.cwl
@@ -1,0 +1,9 @@
+cwlVersion: v1.0
+class: CommandLineTool
+inputs: []
+outputs: []
+baseCommand: echo
+requirements:
+  - class: DockerRequirement
+    dockerPull: some_image
+


### PR DESCRIPTION
**Description**
This PR fixes some bugs in the CWL "tool list" and DAG generation code.

While testing the previous PR (https://github.com/dockstore/dockstore/pull/5063), Charles found a workflow for which the list of tools and DAG were generated incorrectly:
https://qa.dockstore.org/workflows/github.com/sevenbridges-openworkflows/Broad-Best-Practice-Data-pre-processing-CWL1.0-workflow-GATK-4.1.0.0/GATK_4_1_0_0_data_pre_processing_workflow:master?tab=info

The problem was that the workflow ID included slashes, which messed up the workflow step ID and dependency parsing algorithms.  This PR changes the algorithms to be more robust.

Yes, that one function takes a ridiculous number of arguments, and now, it's even ridiculous-er, because I added an argument. 
 Alas, there's not an obviously-better alternative, unless we rewrite large chunks of the code (which we might if we ever implement multi-level DAG generation).

**Review Instructions**
Clone the repo of the above-mentioned workflow, register the cloned workflow, and confirm that the resulting list of tools and DAG are equivalent to those referenced by the original link.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2170
#4906

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
