### PR TITLE
parallel circleci unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,6 +256,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
     parallelism: 2
     steps: # a collection of executable commands
+      - setup_test
       - checkout
       - restore_cache:
           key: dockstore-web-cache-unit-test-{{ .Environment.DOCKSTORE_CACHE_VERSION }}-segmented

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,7 +301,7 @@ jobs:
             if [ $CIRCLE_NODE_TOTAL != 1 ]
             then
               # check if this is the "first" node
-              if [ CIRCLE_NODE_INDEX == 0 ]
+              if [ $CIRCLE_NODE_INDEX == 0 ]
               then
                 # normal case, continue onwards below
                 echo "Running non-confidential tests as the 0'th node"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,14 +273,14 @@ jobs:
           name: run the actual tests
           command: |            
             if [ $CIRCLE_NODE_TOTAL != 1 ] 
-              then
-                TESTS_TO_RUN=$(cat temp/test-lists/unit/all.txt | circleci tests split --split-by=timings --time-default=0.1s | tr '\n' ',')
-                echo $TESTS_TO_RUN
-                ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Punit-tests,coverage -ntp \
-                -Dtest=$TESTS_TO_RUN -DfailIfNoTests=false | grep  -v "^Running Changeset:"
-              else 
-                ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Punit-tests,coverage -ntp | grep  -v "^Running Changeset:"
-              fi
+            then
+              TESTS_TO_RUN=$(cat temp/test-lists/unit/all.txt | circleci tests split --split-by=timings --time-default=0.1s | tr '\n' ',')
+              echo $TESTS_TO_RUN
+              ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Punit-tests,coverage -ntp \
+              -Dtest=$TESTS_TO_RUN -DfailIfNoTests=false | grep  -v "^Running Changeset:"
+            else 
+              ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Punit-tests,coverage -ntp | grep  -v "^Running Changeset:"
+            fi
             # The piping grep command is a temporary fix to this issue https://github.com/liquibase/liquibase/issues/2396
 
       # store these twice since non-confidential tests also do a clean install
@@ -299,19 +299,16 @@ jobs:
           name: run the non-confidential integration tests
           command: |
             if [ $CIRCLE_NODE_TOTAL != 1 ]
+            then
+              # check if this is the "first" node
+              if [ CIRCLE_NODE_INDEX == 0 ]
               then
-                # check if this is the "first" node
-                if [ CIRCLE_NODE_INDEX == 0 ]
-                  then
-                    # normal case, continue onwards below
-                    echo 0
-                  else
-                    exit 0
-                fi
-              else
                 # normal case, continue onwards below
-                echo 0
+                echo "Running non-confidential tests as the 0'th node"
+              else
+                exit 0
               fi
+            fi
             # Adding all "normal" certs into this local one that has the Hoverfly cert (instead of adding Hoverfly cert to the global one so it doesn't potentially affect other tests)
             /usr/local/jdk-<< pipeline.parameters.java-tag >>/bin/keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore LocalTrustStore -srcstorepass changeit -deststorepass changeit
             export SKIP_SIGNATURE_CHECK=false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,13 +270,45 @@ jobs:
             python3 -V
       - run:
           name: run the actual tests
-          command: ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Punit-tests,coverage -ntp | grep  -v "^Running Changeset:"
+          command: |            
+            if [ $CIRCLE_NODE_TOTAL != 1 ] 
+              then
+                TESTS_TO_RUN=$(cat temp/test-lists/unit/all.txt | circleci tests split --split-by=timings --time-default=0.1s | tr '\n' ',')
+                echo $TESTS_TO_RUN
+                ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Punit-tests,coverage -ntp \
+                -Dtest=$TESTS_TO_RUN -DfailIfNoTests=false | grep  -v "^Running Changeset:"
+              else 
+                ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Punit-tests,coverage -ntp | grep  -v "^Running Changeset:"
+              fi
+            # The piping grep command is a temporary fix to this issue https://github.com/liquibase/liquibase/issues/2396
+
+      # store these twice since non-confidential tests also do a clean install
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/target/.*-reports/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
       - run:
           name: send coverage for unit tests
           command: bash <(curl -s https://codecov.io/bash) -F unit-tests_and_non-confidential-tests || echo "Codecov did not collect coverage reports"
       - run:
           name: run the non-confidential integration tests
           command: |
+            if [ $CIRCLE_NODE_TOTAL != 1 ]
+              then
+                # check if this is the "first" node
+                if [ CIRCLE_NODE_INDEX == 0 ]
+                  then
+                    # normal case, continue onwards below
+                  else
+                    exit 0
+                fi
+              else
+                # normal case, continue onwards below
+              fi
             # Adding all "normal" certs into this local one that has the Hoverfly cert (instead of adding Hoverfly cert to the global one so it doesn't potentially affect other tests)
             /usr/local/jdk-<< pipeline.parameters.java-tag >>/bin/keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore LocalTrustStore -srcstorepass changeit -deststorepass changeit
             export SKIP_SIGNATURE_CHECK=false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,26 +298,26 @@ jobs:
       - run:
           name: run the non-confidential integration tests
           command: |
-            if [ $CIRCLE_NODE_TOTAL != 1 ]
+            if [ $CIRCLE_NODE_TOTAL != 1 ] 
             then
-              # check if this is the "first" node
-              if [ $CIRCLE_NODE_INDEX == 0 ]
-              then
-                # normal case, continue onwards below
-                echo "Running non-confidential tests as the 0'th node"
-              else
-                exit 0
+              TESTS_TO_RUN=$(cat temp/test-lists/IT/all.txt | circleci tests split --split-by=timings --time-default=0.1s | tr '\n' ',')
+              echo $TESTS_TO_RUN
+            
+              # Adding all "normal" certs into this local one that has the Hoverfly cert (instead of adding Hoverfly cert to the global one so it doesn't potentially affect other tests)
+              /usr/local/jdk-<< pipeline.parameters.java-tag >>/bin/keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore LocalTrustStore -srcstorepass changeit -deststorepass changeit
+              export SKIP_SIGNATURE_CHECK=false
+              if [[ -z "${CIRCLE_TAG}" ]]; then
+                # If it is a branch, skip the signature check
+                export SKIP_SIGNATURE_CHECK=true
               fi
+            
+              ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Pnon-confidential-tests,coverage -Djavax.net.ssl.trustStore=../LocalTrustStore \
+              -Dtest=$TESTS_TO_RUN -DfailIfNoTests=false -Djavax.net.ssl.trustStorePassword=changeit  -DskipSignatureCheck=$SKIP_SIGNATURE_CHECK -ntp | grep  -v "^Running Changeset:"         
+            else 
+              ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Pnon-confidential-tests,coverage -Djavax.net.ssl.trustStore=../LocalTrustStore \
+              -Djavax.net.ssl.trustStorePassword=changeit  -DskipSignatureCheck=$SKIP_SIGNATURE_CHECK -ntp | grep  -v "^Running Changeset:"      
             fi
-            # Adding all "normal" certs into this local one that has the Hoverfly cert (instead of adding Hoverfly cert to the global one so it doesn't potentially affect other tests)
-            /usr/local/jdk-<< pipeline.parameters.java-tag >>/bin/keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore LocalTrustStore -srcstorepass changeit -deststorepass changeit
-            export SKIP_SIGNATURE_CHECK=false
-            if [[ -z "${CIRCLE_TAG}" ]]; then
-              # If it is a branch, skip the signature check
-              export SKIP_SIGNATURE_CHECK=true
-            fi
-            ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Pnon-confidential-tests,coverage -Djavax.net.ssl.trustStore=../LocalTrustStore -Djavax.net.ssl.trustStorePassword=changeit  -DskipSignatureCheck=$SKIP_SIGNATURE_CHECK -ntp | grep  -v "^Running Changeset:"
-            # ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Pnon-confidential-tests,coverage -Djavax.net.ssl.trustStore=../LocalTrustStore -Djavax.net.ssl.trustStorePassword=changeit -ntp
+            # The piping grep command is a temporary fix to this issue https://github.com/liquibase/liquibase/issues/2396
       - run:
           name: send coverage for non-confidential integration tests
           command: bash <(curl -s https://codecov.io/bash) -F unit-tests_and_non-confidential-tests || echo "Codecov did not collect coverage reports"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,9 @@ jobs:
             cp dockstore-webservice/src/main/resources/openapi3/openapi.yaml /tmp/artifacts
       - run:
           name: Move cache miss log
-          command: cp /tmp/dockstore-web-cache.misses.log /tmp/artifacts
+          command: | 
+            touch /tmp/dockstore-web-cache.misses.log
+            cp /tmp/dockstore-web-cache.misses.log /tmp/artifacts
       - store_artifacts:
           path: /tmp/artifacts
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,11 +304,13 @@ jobs:
                 if [ CIRCLE_NODE_INDEX == 0 ]
                   then
                     # normal case, continue onwards below
+                    echo 0
                   else
                     exit 0
                 fi
               else
                 # normal case, continue onwards below
+                echo 0
               fi
             # Adding all "normal" certs into this local one that has the Hoverfly cert (instead of adding Hoverfly cert to the global one so it doesn't potentially affect other tests)
             /usr/local/jdk-<< pipeline.parameters.java-tag >>/bin/keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore LocalTrustStore -srcstorepass changeit -deststorepass changeit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,6 +254,7 @@ jobs:
           POSTGRES_DB: postgres
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_PASSWORD: postgres
+    parallelism: 2
     steps: # a collection of executable commands
       - checkout
       - restore_cache:

--- a/scripts/generate-test-lists.sh
+++ b/scripts/generate-test-lists.sh
@@ -33,6 +33,22 @@ function make_file_names_fully_qualified_class_paths {
   sed -i 's+.*java/++g; s+/+.+g; s+\.java$++g' "$FILE_TO_CHANGE"
 }
 
+#####################################
+# Get list of all Unit Tests        #
+#####################################
+
+# Modify prefix for integration tests
+PREFIX="$BASE_PREFIX""/unit"
+mkdir -p "$PREFIX"
+
+
+# Using same wild card patterns the Failsafe Plugin uses
+# https://maven.apache.org/surefire/maven-failsafe-plugin/examples/inclusion-exclusion.html
+find . -name "*Test\.java" -or -name "Test*\.java" -or -name "*TestCase\.java" > "$PREFIX"/all.txt
+
+FILE_TO_CHANGE="$PREFIX"/all.txt
+make_file_names_fully_qualified_class_paths
+
 
 #####################################
 # Get list of all Integration Tests #
@@ -50,6 +66,3 @@ find . -name "*IT\.java" -or -name "IT*\.java" -or -name "*ITCase\.java" > "$PRE
 
 FILE_TO_CHANGE="$PREFIX"/all.txt
 make_file_names_fully_qualified_class_paths
-
-
-


### PR DESCRIPTION
**Description**
Hook up parallelism machinery developed for integration tests to unit tests (gain is a bit less dramatic as described in https://github.com/dockstore/dockstore/pull/4970 but still seems worthwhile). 
Also noticed that Circle CI was not notified about the state of the unit tests (data was being wiped out when running non-confidential integration tests), so hooked that up. 

**Review Instructions**
Probably just look in develop after a week or two and see that the unit tests in circle ci continue to be significantly faster than before. Unit tests should run non-confidential tests only on one of the parallel instances. Also Circle CI should be aware of 464 unit tests up from 14 unit tests (click into the specific job to see tests for just one job) Or 989 vs 545 tests in total

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4969

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
