### PR TITLE
DOCK-2237: Reimplemented ignored integration test

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1406,6 +1406,7 @@ public class WebhookIT extends BaseIT {
         // Add a CWL version of a workflow with the same name should cause error.
         try {
             workflowClient.handleGitHubRelease("refs/heads/sameWorkflowName-CWL", installationId, workflowDockstoreYmlRepo, BasicIT.USER_2_USERNAME);
+            Assert.fail("should have thrown");
         } catch (io.dockstore.openapi.client.ApiException ex) {
             List<io.dockstore.openapi.client.model.LambdaEvent> events = usersApi.getUserGitHubEvents("0", 10);
             io.dockstore.openapi.client.model.LambdaEvent event = events.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).findFirst().get();

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -75,7 +75,6 @@ import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1394,15 +1394,6 @@ public class WebhookIT extends BaseIT {
         assertTrue((collection.getEntries().stream().anyMatch(entry -> Objects.equals(entry.getId(), appTool.getId()))));
     }
 
-    /*
-     * TODO: reimplement
-     * This test broke when merged from a 1.12 hotfix into 1.13, because the test pushed a .dockstore.yml that
-     * contains two workflows with the same name, and 1.13 checks for duplicate names in .dockstore.yml, and
-     * generates an error about the duplicate names, instead.  To reimplement, we'll need to load a workflow
-     * into the db, then push a branch that updates it, containing a workflow with the same name but different
-     * descriptor language.
-     */
-    @Ignore
     @Test
     public void testDifferentLanguagesWithSameWorkflowName() throws Exception {
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
@@ -1410,34 +1401,20 @@ public class WebhookIT extends BaseIT {
         io.dockstore.openapi.client.api.WorkflowsApi workflowClient = new io.dockstore.openapi.client.api.WorkflowsApi(webClient);
         io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(webClient);
 
+        // Add a WDL version of a workflow should pass.
+        workflowClient.handleGitHubRelease("refs/heads/sameWorkflowName-WDL", installationId, workflowDockstoreYmlRepo, BasicIT.USER_2_USERNAME);
+
+        // Add a CWL version of a workflow with the same name should cause error.
         try {
-            workflowClient.handleGitHubRelease("refs/heads/differentLanguagesWithSameWorkflowName", installationId, workflowDockstoreYmlRepo, BasicIT.USER_2_USERNAME);
-            Assert.fail("should have thrown");
+            workflowClient.handleGitHubRelease("refs/heads/sameWorkflowName-CWL", installationId, workflowDockstoreYmlRepo, BasicIT.USER_2_USERNAME);
         } catch (io.dockstore.openapi.client.ApiException ex) {
-            String message = ex.getMessage().toLowerCase();
+            List<io.dockstore.openapi.client.model.LambdaEvent> events = usersApi.getUserGitHubEvents("0", 10);
+            io.dockstore.openapi.client.model.LambdaEvent event = events.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).findFirst().get();
+            String message = event.getMessage().toLowerCase();
+            System.out.println(message);
             assertTrue(message.contains("descriptor language"));
             assertTrue(message.contains("workflow"));
             assertTrue(message.contains("version"));
-        }
-        
-        // There should be one failure message
-        List<io.dockstore.openapi.client.model.LambdaEvent> events = usersApi.getUserGitHubEvents("0", 10);
-        assertEquals(0, events.stream().filter(lambdaEvent -> lambdaEvent.isSuccess()).count());
-        assertEquals(1, events.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count());
-        io.dockstore.openapi.client.model.LambdaEvent event = events.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).findFirst().get();
-        String message = event.getMessage().toLowerCase();
-        assertTrue(message.contains("descriptor language"));
-        assertTrue(message.contains("workflow"));
-        assertTrue(message.contains("version"));
-
-        // No workflow should have been created.
-        // This will change in 1.13, wherein .dockstore.yml processing changes so that an error in one entry will not roll back the entire update, and a workflow with one version should have been created.
-
-        try {
-            io.dockstore.openapi.client.model.Workflow workflow = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo, WorkflowSubClass.BIOWORKFLOW, "versions,validations");
-            Assert.fail("should have thrown");
-        } catch (io.dockstore.openapi.client.ApiException ex) {
-            assertEquals("Entry not found", ex.getMessage());
         }
     }
     

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1411,7 +1411,6 @@ public class WebhookIT extends BaseIT {
             List<io.dockstore.openapi.client.model.LambdaEvent> events = usersApi.getUserGitHubEvents("0", 10);
             io.dockstore.openapi.client.model.LambdaEvent event = events.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).findFirst().get();
             String message = event.getMessage().toLowerCase();
-            System.out.println(message);
             assertTrue(message.contains("descriptor language"));
             assertTrue(message.contains("workflow"));
             assertTrue(message.contains("version"));


### PR DESCRIPTION
**Description**
Reimplemented the ignored integration test that tests when a user attempts to add "same name" workflows with differing versions

**Review Instructions**
Verify that the new test pass and it checks for multiple workflows with the same name.

**Issue**
https://github.com/dockstore/dockstore/issues/5121

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
