### PR TITLE
fix trs 2.0.1 issues, hook up language version

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
@@ -65,7 +65,9 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.ZipFile;
 import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpStatus;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
@@ -158,6 +160,18 @@ public class Ga4GhTRSAPIWorkflowIT extends BaseIT {
             assertTrue("zip file seems to have a wdl file with stuff in it", zipFile.stream().filter(file -> file.getName().endsWith(".wdl")).findFirst().get().getSize() > 0);
         }
         tempZip.deleteOnExit();
+
+        // test combination of zip only with json return (should fail)
+        try {
+            CommonTestUtilities.getArbitraryURL(
+                "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + refresh.getFullWorkflowPath(), StandardCharsets.UTF_8) + "/versions/" + URLEncoder.encode(GATK_SV_TAG, StandardCharsets.UTF_8)
+                + "/" + DescriptorTypeWithPlain.WDL
+                + "/files?format=zip", new GenericType<>() {
+                }, ownerWebClient, MediaType.APPLICATION_JSON);
+            fail("should have died with bad request");
+        } catch (ApiException e) {
+            assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
+        }
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -33,6 +33,8 @@ import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
 import io.dockstore.common.WorkflowTest;
+import io.dockstore.openapi.client.api.Ga4Ghv20Api;
+import io.dockstore.openapi.client.model.ToolVersion;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.helpers.EntryVersionHelper;
 import io.dockstore.webservice.jdbi.EntryDAO;
@@ -1237,6 +1239,13 @@ public class WorkflowIT extends BaseIT {
         });
         assertEquals("Should only have one language version", 1, workflowVersion.getDescriptorTypeVersions().size());
         assertTrue(workflowVersion.getDescriptorTypeVersions().contains("1.0"));
+
+        // test that versions coming back from TRS 2.0.1 look sane
+        workflowsApi.publish1(workflow.getId(), new io.dockstore.openapi.client.model.PublishRequest().publish(true));
+        final Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(webClient);
+        final ToolVersion toolVersion = ga4Ghv20Api.toolsIdVersionsVersionIdGet("#workflow/github.com/dockstore-testing/hello-wdl-workflow", "master");
+        final Map<String, List<String>> descriptorTypeVersion = toolVersion.getDescriptorTypeVersion();
+        assertTrue(descriptorTypeVersion.containsKey("WDL") && descriptorTypeVersion.get("WDL").contains("1.0"));
 
         // Test WDL workflow with imports
         workflow = workflowsApi.manualRegister("github", "DockstoreTestUser2/nested-wdl", "/Dockstore.wdl", "", "wdl", "/test.json");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -436,9 +436,16 @@ public final class CommonTestUtilities {
         return publishRequest;
     }
 
-    public static <T> T getArbitraryURL(String url, GenericType<T> type, ApiClient client) {
+    public static <T> T getArbitraryURL(String url, GenericType<T> type, ApiClient client, String acceptType) {
         return client
-                .invokeAPI(url, "GET", new ArrayList<>(), null, new HashMap<>(), new HashMap<>(), "application/zip", "application/zip",
-                        new String[] { "BEARER" }, type).getData();
+            .invokeAPI(url, "GET", new ArrayList<>(), null, new HashMap<>(), new HashMap<>(), acceptType, "application/zip",
+                new String[] { "BEARER" }, type).getData();
+    }
+
+    /**
+     * Get an arbitrary URL with the accept type defaulting to "application/zip".
+     */
+    public static <T> T getArbitraryURL(String url, GenericType<T> type, ApiClient client) {
+        return getArbitraryURL(url, type, client, "application/zip");
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/AppToolPath.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/AppToolPath.java
@@ -17,7 +17,6 @@ package io.dockstore.webservice.core.database;
 import io.dockstore.common.SourceControl;
 import io.dockstore.webservice.core.AppTool;
 
-
 public class AppToolPath {
     private final AppTool appTool = new AppTool();
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceConstants.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceConstants.java
@@ -22,7 +22,7 @@ public final class ResourceConstants {
     public static final String CONTAINERTAGS = "List and modify tags for containers";
     public static final String GA4GHV1 = "A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [1.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/1.0.0) and is considered final (not subject to change)";
     public static final String GA4GH = "A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [2.0.0-beta.2](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0-beta.2) . Integrators are welcome to use these endpoints but they are subject to change based on community input.";
-    public static final String GA4GHV20 = "A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [2.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0).";
+    public static final String GA4GHV20 = "A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [2.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.1).";
     public static final String EXTENDEDGA4GH = "Optional experimental extensions of the GA4GH API";
     public static final String TOKENS = "List, modify, refresh, and delete tokens for external services";
     public static final String WORKFLOWS = "List and register workflows in the dockstore (CWL, Nextflow, WDL)";

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -170,7 +170,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
     public Response toolsIdGet(String id, SecurityContext securityContext, ContainerRequestContext value, Optional<User> user) {
 
         // https://github.com/ga4gh/tool-registry-service-schemas/issues/229 (text only doesn't make sense)
-        boolean consumesHeaderTextOnly = value.getAcceptableMediaTypes().stream().allMatch(foo -> foo.isCompatible(MediaType.TEXT_PLAIN_TYPE));
+        boolean consumesHeaderTextOnly = value.getAcceptableMediaTypes().stream().allMatch(foo -> foo.isCompatible(MediaType.TEXT_PLAIN_TYPE) && !foo.isCompatible(MediaType.APPLICATION_JSON_TYPE));
         if (consumesHeaderTextOnly) {
             return Response.status(Status.BAD_REQUEST).build();
         }

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -170,7 +170,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
     public Response toolsIdGet(String id, SecurityContext securityContext, ContainerRequestContext value, Optional<User> user) {
 
         // https://github.com/ga4gh/tool-registry-service-schemas/issues/229 (text only doesn't make sense)
-        boolean consumesHeaderTextOnly = value.getAcceptableMediaTypes().stream().allMatch(foo -> foo.isCompatible(MediaType.TEXT_PLAIN_TYPE) && !foo.isCompatible(MediaType.APPLICATION_JSON_TYPE));
+        boolean consumesHeaderTextOnly = value.getAcceptableMediaTypes().stream().allMatch(mediaType -> mediaType.isCompatible(MediaType.TEXT_PLAIN_TYPE) && !mediaType.isCompatible(MediaType.APPLICATION_JSON_TYPE));
         if (consumesHeaderTextOnly) {
             return Response.status(Status.BAD_REQUEST).build();
         }
@@ -798,7 +798,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         };
     }
 
-    /**W
+    /**
      * Return a matching source file
      *
      * @param sourceFiles      files to look through

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -798,7 +798,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         };
     }
 
-    /**
+    /**W
      * Return a matching source file
      *
      * @param sourceFiles      files to look through
@@ -833,13 +833,13 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
 
         // check for incompatible format option and header combination
         boolean zipFormat = "zip".equalsIgnoreCase(format);
-        boolean consumesHeaderJsonOnly = value.getAcceptableMediaTypes().stream().allMatch(foo -> foo.isCompatible(MediaType.APPLICATION_JSON_TYPE));
+        boolean consumesHeaderJsonOnly = value.getAcceptableMediaTypes().stream().allMatch(mediaType -> mediaType.isCompatible(MediaType.APPLICATION_JSON_TYPE));
         if (zipFormat && consumesHeaderJsonOnly) {
             return Response.status(Status.BAD_REQUEST).build();
         }
 
         // accept header should also work
-        boolean consumesHeaderZipOnly = value.getAcceptableMediaTypes().stream().allMatch(foo -> foo.getType().equals("application") && foo.getSubtype().equals("zip"));
+        boolean consumesHeaderZipOnly = value.getAcceptableMediaTypes().stream().allMatch(mediaType -> mediaType.getType().equals("application") && mediaType.getSubtype().equals("zip"));
 
         ParsedRegistryID parsedID = null;
         try {

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
@@ -222,7 +222,7 @@ public final class ToolsImplCommon {
                     EnumSet<DescriptorType> set = EnumSet.copyOf(descriptorType);
                     toolVersion.setDescriptorType(Lists.newArrayList(set));
                     // can assume in Dockstore that a single version only has one language
-                    toolVersion.setDescriptorTypeVersion(Map.of(set.stream().findFirst().get().toString(), Lists.newArrayList(version.getDescriptorTypeVersions())));
+                    toolVersion.setDescriptorTypeVersion(Map.of(descriptorType.get(0).toString(), Lists.newArrayList(version.getDescriptorTypeVersions())));
                 }
                 tool.getVersions().add(toolVersion);
             }

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -68,7 +68,7 @@ tags:
 - description: Optional experimental extensions of the GA4GH API
   name: extendedGA4GH
 - description: "A curated subset of resources proposed as a common standard for tool\
-    \ repositories. Implements TRS [2.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0)."
+    \ repositories. Implements TRS [2.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.1)."
   name: GA4GHV20
 - description: "A curated subset of resources proposed as a common standard for tool\
     \ repositories. Implements TRS [2.0.0-beta.2](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0-beta.2)\

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -43,7 +43,7 @@ tags:
     \ and is considered final (not subject to change)"
 - name: "GA4GHV20"
   description: "A curated subset of resources proposed as a common standard for tool\
-    \ repositories. Implements TRS [2.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0)."
+    \ repositories. Implements TRS [2.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.1)."
 - name: "hosted"
   description: "Created and modify hosted entries in the dockstore"
 - name: "lambdaEvents"


### PR DESCRIPTION
**Description**
Grab-bag of TRS 2.0.1 implementation issues

**Review Instructions**
See that version on swagger page is 2.0.1, should be able to play with either `format` parameter or `Accept` type with the zip endpoint without 500 error, should see workflow language versions coming back from TRS 

**Issue**
Re-opened https://ucsc-cgl.atlassian.net/browse/SEAB-4857
https://github.com/dockstore/dockstore/issues/5260
https://github.com/dockstore/dockstore/issues/5247

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
