### PR TITLE
DOCK-5245: Replace cwljava with cwlavro

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 367 third-party dependencies.
+Lists of 368 third-party dependencies.
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-slf4j (com.typesafe.akka:akka-slf4j_2.13:2.5.32 - https://akka.io/)
@@ -112,6 +112,7 @@ Lists of 367 third-party dependencies.
      (Cromwell License https://github.com/broadinstitute/cromwell/blob/develop/LICENSE.txt) cromwell-wdl-transforms-shared (org.broadinstitute:cromwell-wdl-transforms-shared_2.13:84 - no url defined)
      (Cromwell License https://github.com/broadinstitute/cromwell/blob/develop/LICENSE.txt) cromwell-wom (org.broadinstitute:cromwell-wom_2.13:84 - no url defined)
      (Apache License, Version 2.0) cwlavro-generated (io.cwl:cwlavro-generated:2.0.4.7 - no url defined)
+     (Apache License, Version 2.0) cwlavro-tools (io.cwl:cwlavro-tools:2.0.4.7 - no url defined)
      (The Apache Software License, Version 2.0) docker-java-api (com.github.docker-java:docker-java-api:3.2.8 - https://github.com/docker-java/docker-java)
      (The Apache Software License, Version 2.0) docker-java-core (com.github.docker-java:docker-java-core:3.2.8 - https://github.com/docker-java/docker-java)
      (The Apache Software License, Version 2.0) docker-java-transport (com.github.docker-java:docker-java-transport:3.2.8 - https://github.com/docker-java/docker-java)

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 369 third-party dependencies.
+Lists of 367 third-party dependencies.
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-slf4j (com.typesafe.akka:akka-slf4j_2.13:2.5.32 - https://akka.io/)
@@ -112,8 +112,6 @@ Lists of 369 third-party dependencies.
      (Cromwell License https://github.com/broadinstitute/cromwell/blob/develop/LICENSE.txt) cromwell-wdl-transforms-shared (org.broadinstitute:cromwell-wdl-transforms-shared_2.13:84 - no url defined)
      (Cromwell License https://github.com/broadinstitute/cromwell/blob/develop/LICENSE.txt) cromwell-wom (org.broadinstitute:cromwell-wom_2.13:84 - no url defined)
      (Apache License, Version 2.0) cwlavro-generated (io.cwl:cwlavro-generated:2.0.4.7 - no url defined)
-     (Apache License, Version 2.0) cwlavro-tools (io.cwl:cwlavro-tools:2.0.4.7 - no url defined)
-     (Apache License, Version 2.0) cwljava (org.w3id.cwl.sdk:cwljava:1.0.0 - no url defined)
      (The Apache Software License, Version 2.0) docker-java-api (com.github.docker-java:docker-java-api:3.2.8 - https://github.com/docker-java/docker-java)
      (The Apache Software License, Version 2.0) docker-java-core (com.github.docker-java:docker-java-core:3.2.8 - https://github.com/docker-java/docker-java)
      (The Apache Software License, Version 2.0) docker-java-transport (com.github.docker-java:docker-java-transport:3.2.8 - https://github.com/docker-java/docker-java)

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 366 third-party dependencies.
+Lists of 369 third-party dependencies.
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-slf4j (com.typesafe.akka:akka-slf4j_2.13:2.5.32 - https://akka.io/)
@@ -9,11 +9,12 @@ Lists of 366 third-party dependencies.
      (Apache License 2.0) Annotations for Metrics (io.dropwizard.metrics:metrics-annotation:4.2.12 - https://metrics.dropwizard.io/metrics-annotation)
      (BSD License) AntLR Parser Generator (antlr:antlr:2.7.7 - http://www.antlr.org/)
      (EPL 2.0) (GPL2 w/ CPE) aopalliance version 1.0 repackaged as a module (org.glassfish.hk2.external:aopalliance-repackaged:2.6.1 - https://github.com/eclipse-ee4j/glassfish-hk2/external/aopalliance-repackaged)
+     (Apache License, Version 2.0) Apache Avro (org.apache.avro:avro:1.9.1 - https://avro.apache.org)
      (Apache License, Version 2.0) Apache Commons BeanUtils (commons-beanutils:commons-beanutils:1.9.4 - https://commons.apache.org/proper/commons-beanutils/)
      (Apache License, Version 2.0) Apache Commons Codec (commons-codec:commons-codec:1.15 - https://commons.apache.org/proper/commons-codec/)
      (Apache License, Version 2.0) Apache Commons Collections (commons-collections:commons-collections:3.2.2 - http://commons.apache.org/collections/)
      (Apache License, Version 2.0) Apache Commons Compress (org.apache.commons:commons-compress:1.21 - https://commons.apache.org/proper/commons-compress/)
-     (Apache License, Version 2.0) Apache Commons Configuration (org.apache.commons:commons-configuration2:2.8.0 - https://commons.apache.org/proper/commons-configuration/)
+     (Apache License, Version 2.0) (The Apache Software License, Version 2.0) Apache Commons Configuration (org.apache.commons:commons-configuration2:2.8.0 - https://commons.apache.org/proper/commons-configuration/)
      (Apache License, Version 2.0) Apache Commons Exec (org.apache.commons:commons-exec:1.3 - http://commons.apache.org/proper/commons-exec/)
      (Apache License, Version 2.0) Apache Commons IO (commons-io:commons-io:2.11.0 - https://commons.apache.org/proper/commons-io/)
      (Apache License, Version 2.0) Apache Commons Lang (org.apache.commons:commons-lang3:3.12.0 - https://commons.apache.org/proper/commons-lang/)
@@ -110,6 +111,8 @@ Lists of 366 third-party dependencies.
      (Cromwell License https://github.com/broadinstitute/cromwell/blob/develop/LICENSE.txt) cromwell-wdl-transforms-new-base (org.broadinstitute:cromwell-wdl-transforms-new-base_2.13:84 - no url defined)
      (Cromwell License https://github.com/broadinstitute/cromwell/blob/develop/LICENSE.txt) cromwell-wdl-transforms-shared (org.broadinstitute:cromwell-wdl-transforms-shared_2.13:84 - no url defined)
      (Cromwell License https://github.com/broadinstitute/cromwell/blob/develop/LICENSE.txt) cromwell-wom (org.broadinstitute:cromwell-wom_2.13:84 - no url defined)
+     (Apache License, Version 2.0) cwlavro-generated (io.cwl:cwlavro-generated:2.0.4.7 - no url defined)
+     (Apache License, Version 2.0) cwlavro-tools (io.cwl:cwlavro-tools:2.0.4.7 - no url defined)
      (Apache License, Version 2.0) cwljava (org.w3id.cwl.sdk:cwljava:1.0.0 - no url defined)
      (The Apache Software License, Version 2.0) docker-java-api (com.github.docker-java:docker-java-api:3.2.8 - https://github.com/docker-java/docker-java)
      (The Apache Software License, Version 2.0) docker-java-core (com.github.docker-java:docker-java-core:3.2.8 - https://github.com/docker-java/docker-java)

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -823,21 +823,6 @@ POM as their parent.
             </dependency>
 
             <!--  cwl management -->
-            <dependency>
-                <groupId>io.cwl</groupId>
-                <artifactId>cwlavro-tools</artifactId>
-                <version>${cwlavro.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.httpcomponents</groupId>
-                        <artifactId>httpclient-osgi</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.httpcomponents</groupId>
-                        <artifactId>httpcore-osgi</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <!-- Used by cwlavro. Even though cwlavro uses 1.21, cwlavro's avro dependency uses 1.20 -->
             <dependency>
                 <groupId>io.cwl</groupId>

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -823,6 +823,21 @@ POM as their parent.
             </dependency>
 
             <!--  cwl management -->
+            <dependency>
+                <groupId>io.cwl</groupId>
+                <artifactId>cwlavro-tools</artifactId>
+                <version>${cwlavro.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpclient-osgi</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpcore-osgi</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
             <!-- Used by cwlavro. Even though cwlavro uses 1.21, cwlavro's avro dependency uses 1.20 -->
             <dependency>
                 <groupId>io.cwl</groupId>

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -63,6 +63,7 @@ POM as their parent.
         <powermock.version>2.0.4</powermock.version>
         <postgresql.version>42.4.1</postgresql.version>
         <mockito.version>3.12.4</mockito.version>
+        <cwlavro.version>2.0.4.7</cwlavro.version>
         <okhttp.version>4.10.0</okhttp.version>
         <slf4j.version>1.7.36</slf4j.version>
         <swagger-ui.version>3.25.0</swagger-ui.version>
@@ -819,6 +820,39 @@ POM as their parent.
                 <groupId>commons-net</groupId>
                 <artifactId>commons-net</artifactId>
                 <version>3.3</version>
+            </dependency>
+
+            <!--  cwl management -->
+            <dependency>
+                <groupId>io.cwl</groupId>
+                <artifactId>cwlavro-tools</artifactId>
+                <version>${cwlavro.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpclient-osgi</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpcore-osgi</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <!-- Used by cwlavro. Even though cwlavro uses 1.21, cwlavro's avro dependency uses 1.20 -->
+            <dependency>
+                <groupId>io.cwl</groupId>
+                <artifactId>cwlavro-generated</artifactId>
+                <version>${cwlavro.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpclient-osgi</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpcore-osgi</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -677,22 +677,6 @@
     </dependency>
     <dependency>
       <groupId>io.cwl</groupId>
-      <artifactId>cwlavro-tools</artifactId>
-      <version>2.0.4.7</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient-osgi</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpcore-osgi</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>io.cwl</groupId>
       <artifactId>cwlavro-generated</artifactId>
       <version>2.0.4.7</version>
       <scope>compile</scope>
@@ -1095,12 +1079,6 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
       <version>2.13.4</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.w3id.cwl.sdk</groupId>
-      <artifactId>cwljava</artifactId>
-      <version>1.0.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -676,6 +676,34 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>io.cwl</groupId>
+      <artifactId>cwlavro-tools</artifactId>
+      <version>2.0.4.7</version>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient-osgi</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore-osgi</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.cwl</groupId>
+      <artifactId>cwlavro-generated</artifactId>
+      <version>2.0.4.7</version>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20180130</version>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -677,6 +677,22 @@
     </dependency>
     <dependency>
       <groupId>io.cwl</groupId>
+      <artifactId>cwlavro-tools</artifactId>
+      <version>2.0.4.7</version>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient-osgi</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore-osgi</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.cwl</groupId>
       <artifactId>cwlavro-generated</artifactId>
       <version>2.0.4.7</version>
       <scope>compile</scope>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -606,6 +606,20 @@
             <artifactId>snakeyaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.cwl</groupId>
+            <artifactId>cwlavro-tools</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.cwl</groupId>
+            <artifactId>cwlavro-generated</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
         </dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -605,6 +605,10 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>
+         <dependency>
+            <groupId>io.cwl</groupId>
+            <artifactId>cwlavro-tools</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.cwl</groupId>
             <artifactId>cwlavro-generated</artifactId>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -607,10 +607,6 @@
         </dependency>
         <dependency>
             <groupId>io.cwl</groupId>
-            <artifactId>cwlavro-tools</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.cwl</groupId>
             <artifactId>cwlavro-generated</artifactId>
             <exclusions>
                 <exclusion>
@@ -1006,11 +1002,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.w3id.cwl.sdk</groupId>
-            <artifactId>cwljava</artifactId>
-            <version>1.0.0</version>
         </dependency>
     </dependencies>
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/AppToolPath.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/AppToolPath.java
@@ -17,7 +17,6 @@ package io.dockstore.webservice.core.database;
 import io.dockstore.common.SourceControl;
 import io.dockstore.webservice.core.AppTool;
 
-
 public class AppToolPath {
     private final AppTool appTool = new AppTool();
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -423,7 +423,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
     }
 
     /**
-     * Convert the hints and requirements in the given map to list format.
+     * Produce a new map in which the the hints and requirements in the given map are converted to list format.
      * @param map map to be converted
      * @param where where a description of the location of this construct in the CWL file (ex: "in workflow step", "at line 13")
      */
@@ -435,7 +435,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
     }
 
     /**
-     * Parse the object to the given class.
+     * Parse a map to an instance of the specified class.
      * @param obj the object to parse
      * @param klass the class to parse to
      * @param description description of the object we are parsing, for error reporting purposes

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -82,6 +82,10 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
     private static final String EXPRESSION_TOOL_TYPE = "expressionTool";
     private static final String OPERATION_TYPE = "operation";
     private static final int CODE_SNIPPET_LENGTH = 50;
+    private static final String COMMAND_LINE_TOOL = "CommandLineTool";
+    private static final String WORKFLOW = "Workflow";
+    private static final String EXPRESSION_TOOL = "ExpressionTool";
+    private static final String OPERATION = "Operation";
 
     @Override
     protected DescriptorLanguage.FileType getFileType() {
@@ -323,7 +327,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
 
             // If the descriptor describes something other than a workflow, wrap and process it as a single-step workflow
             final Object cwlClass = mapping.get("class");
-            if (!"Workflow".equals(cwlClass)) {
+            if (!WORKFLOW.equals(cwlClass)) {
                 mapping = convertToolToSingleStepWorkflow(mapping);
             }
 
@@ -371,7 +375,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
         Map<String, Object> workflow = new HashMap<>();
         workflow.put("cwlVersion", "v1.2");
         workflow.put("id", "_dockstore_wrapper");
-        workflow.put("class", "Workflow");
+        workflow.put("class", WORKFLOW);
         workflow.put("inputs", Map.of());
         workflow.put("outputs", Map.of());
         workflow.put("steps", Map.of("tool", Map.of("run", tool, "in", List.of(), "out", List.of())));
@@ -466,19 +470,19 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
     }
 
     private boolean isWorkflow(Object candidate) {
-        return isProcessWithClass(candidate, "Workflow");
+        return isProcessWithClass(candidate, WORKFLOW);
     }
 
     private boolean isTool(Object candidate) {
-        return isProcessWithClass(candidate, "CommandLineTool");
+        return isProcessWithClass(candidate, COMMAND_LINE_TOOL);
     }
 
     private boolean isExpressionTool(Object candidate) {
-        return isProcessWithClass(candidate, "ExpressionTool");
+        return isProcessWithClass(candidate, EXPRESSION_TOOL);
     }
 
     private boolean isOperation(Object candidate) {
-        return isProcessWithClass(candidate, "Operation");
+        return isProcessWithClass(candidate, OPERATION);
     }
 
     private String getWorkflowStepId(WorkflowStep workflowStep) {
@@ -846,12 +850,12 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
 
     @Override
     public VersionTypeValidation validateWorkflowSet(Set<SourceFile> sourceFiles, String primaryDescriptorFilePath) {
-        return validateProcessSet(sourceFiles, primaryDescriptorFilePath, "workflow", Set.of("Workflow"), "tool", Set.of("CommandLineTool", "ExpressionTool"));
+        return validateProcessSet(sourceFiles, primaryDescriptorFilePath, "workflow", Set.of(WORKFLOW), "tool", Set.of(COMMAND_LINE_TOOL, EXPRESSION_TOOL));
     }
 
     @Override
     public VersionTypeValidation validateToolSet(Set<SourceFile> sourceFiles, String primaryDescriptorFilePath) {
-        return validateProcessSet(sourceFiles, primaryDescriptorFilePath, "tool", Set.of("CommandLineTool", "ExpressionTool"), "workflow", Set.of("Workflow"));
+        return validateProcessSet(sourceFiles, primaryDescriptorFilePath, "tool", Set.of(COMMAND_LINE_TOOL, EXPRESSION_TOOL), "workflow", Set.of(WORKFLOW));
     }
 
     @Override
@@ -1096,7 +1100,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
 
         private boolean isProcess(Map<String, Object> cwl) {
             Object c = cwl.get("class");
-            return "Workflow".equals(c) || "CommandLineTool".equals(c) || "ExpressionTool".equals(c) || "Operation".equals(c);
+            return WORKFLOW.equals(c) || COMMAND_LINE_TOOL.equals(c) || EXPRESSION_TOOL.equals(c) || OPERATION.equals(c);
         }
 
         private String setIdIfAbsent(Map<String, Object> entryCwl) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -342,7 +342,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                         if (outputParameterObj instanceof WorkflowOutputParameter) {
                             WorkflowOutputParameter outputParameter = (WorkflowOutputParameter)outputParameterObj;
                             Object sources = outputParameter.getOutputSource();
-                            processDependencies(endDependencies, sources, NODE_PREFIX, String.valueOf(checkNonNull(workflow.getId())));
+                            processDependencies(endDependencies, sources, NODE_PREFIX);
                         }
                     }
                 }
@@ -458,7 +458,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 if (workflowStep.getIn() != null) {
                     for (WorkflowStepInput stepInput: workflowStep.getIn()) {
                         Object sources = stepInput.getSource();
-                        processDependencies(stepDependencies, sources, NODE_PREFIX, String.valueOf(checkNonNull(workflow.getId())));
+                        processDependencies(stepDependencies, sources, NODE_PREFIX);
                     }
                     if (stepDependencies.size() > 0) {
                         toolInfoMap.computeIfPresent(nodeStepId, (toolId, toolInfo) -> {
@@ -572,19 +572,16 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
      * @param endDependencies list to which the computed dependencies are added
      * @param sourcesObj a single String output source or list of String output sources
      * @param nodePrefix prefix to attach to extracted dependencies
-     * @param workflowId normalized workflow ID
      */
-    private void processDependencies(List<String> endDependencies, Object sourcesObj, String nodePrefix, String workflowId) {
+    private void processDependencies(List<String> endDependencies, Object sourcesObj, String nodePrefix) {
         if (sourcesObj != null) {
             List<String> sources = sourcesObj instanceof String ? List.of((String)sourcesObj) : (List<String>)sourcesObj;
             for (String s: sources) {
-                // If the source ID starts with the workflow ID, strip it off, split at the slashes, and if
-                // there are two or more parts, the dependency (workflow step name/id) is the second-to-last part.
-                if (s.startsWith(workflowId)) {
-                    String[] split = s.substring(workflowId.length()).replaceFirst("^/", "").split("/");
-                    if (split.length >= 2) {
-                        endDependencies.add(nodePrefix + split[split.length - 2].replaceFirst("#", ""));
-                    }
+                // Split at the slashes, and if there are two or more parts, 
+                // the dependency (workflow step name/id) is the second-to-last part.
+                String[] split = s.split("/");
+                if (split.length >= 2) {
+                    endDependencies.add(nodePrefix + split[split.length - 2].replaceFirst("#", ""));
                 }
             }
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -16,7 +16,6 @@
 package io.dockstore.webservice.languages;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -84,7 +83,6 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
     private static final String EXPRESSION_TOOL_TYPE = "expressionTool";
     private static final String OPERATION_TYPE = "operation";
     private static final int CODE_SNIPPET_LENGTH = 50;
-    private static final ObjectMapper MAPPER = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     @Override
     protected DescriptorLanguage.FileType getFileType() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -572,6 +572,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 currentPath = runObj.toString();
 
             } else {
+                LOG.error("Unexpected run object: " + runObj);
                 String message = CWLHandler.CWL_PARSE_SECONDARY_ERROR + "in workflow step " + fullStepId;
                 LOG.error(message);
                 throw new CustomWebApplicationException(message, HttpStatus.SC_UNPROCESSABLE_ENTITY);
@@ -617,6 +618,18 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
         return (Map)list.stream().filter(e -> e instanceof Map && value.equals(((Map)e).get(key))).findFirst().orElse(null);
     }
 
+    private List<String> convertToSourceList(Object obj) {
+        if (obj instanceof List) {
+            return (List<String>)obj;
+        } else if (obj instanceof String) {
+            return List.of((String)obj);
+        } else {
+            String message = CWLHandler.CWL_PARSE_ERROR + "unexpected format of input/output list";
+            LOG.error(message);
+            throw new CustomWebApplicationException(message, HttpStatus.SC_UNPROCESSABLE_ENTITY);
+        }
+    }
+
     /**
      * Computes the dependencies from one or more output sources
      * @param endDependencies list to which the computed dependencies are added
@@ -625,7 +638,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
      */
     private void processDependencies(List<String> endDependencies, Object sourcesObj, String nodePrefix) {
         if (sourcesObj != null) {
-            List<String> sources = sourcesObj instanceof String ? List.of((String)sourcesObj) : (List<String>)sourcesObj;
+            List<String> sources = convertToSourceList(sourcesObj);
             for (String s: sources) {
                 // Split at the slashes, and if there are two or more parts, 
                 // the dependency (workflow step name/id) is the second-to-last part.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -503,10 +503,10 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
             // Process any requirements and/or hints.
             RequirementOrHintState stepRequirementState = addToRequirementOrHintState(requirementState, workflowStep.getRequirements());
             RequirementOrHintState stepHintState = addToRequirementOrHintState(hintState, workflowStep.getHints());
+            String stepDockerPath = getDockerPull(stepRequirementState, stepHintState);
 
             // Process the run object.
             Object runObj = workflowStep.getRun();
-            String stepDockerPath;
             String currentPath;
 
             if (isWorkflow(runObj)) {
@@ -530,7 +530,6 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 currentPath = getDockstoreMetadataHintValue(expressionTool.getHints(), "path");
 
             } else if (isOperation(runObj)) {
-                stepDockerPath = null;
                 stepToType.put(nodeStepId, OPERATION_TYPE);
                 List<Object> operationHints = convertToList(((Map<Object, Object>)runObj).get("hints"), "class");
                 currentPath = getDockstoreMetadataHintValue(operationHints, "path");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -338,12 +338,9 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 List<String> endDependencies = new ArrayList<>();
 
                 if (workflow.getOutputs() != null) {
-                    for (Object outputParameterObj : workflow.getOutputs()) {
-                        if (outputParameterObj instanceof WorkflowOutputParameter) {
-                            WorkflowOutputParameter outputParameter = (WorkflowOutputParameter)outputParameterObj;
-                            Object sources = outputParameter.getOutputSource();
-                            processDependencies(endDependencies, sources, NODE_PREFIX);
-                        }
+                    for (WorkflowOutputParameter outputParameter: workflow.getOutputs()) {
+                        Object sources = outputParameter.getOutputSource();
+                        processDependencies(endDependencies, sources, NODE_PREFIX);
                     }
                 }
 
@@ -381,10 +378,6 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
         return workflow;
     }
 
-    private String className(Object obj) {
-        return obj != null ? obj.getClass().getName() : "null object";
-    }
-
     /**
      * Convert the passed object to list representation.  CWL allows some lists of object to be
      * represented in either of two forms:
@@ -414,7 +407,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
         } else if (listOrIdMap instanceof List) {
             return (List<Object>)listOrIdMap;
         } else if (listOrIdMap == null) {
-            return null;
+            return List.of();
         } else {
             String message = CWL_PARSE_ERROR + "malformed cwl " + where;
             LOG.error(message);
@@ -759,26 +752,6 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
         return getDockerPull(
             addToRequirementOrHintState(requirementState, additonalRequirements),
             addToRequirementOrHintState(hintState, additionalHints));
-    }
-
-    private <T> T deOptionalize(Optional<T> optional) {
-        // The cwljava parser did actually return a null Optional reference, thus necessitating the following if statement
-        if (optional == null) {
-            return null;
-        }
-        return optional.orElse(null);
-    }
-
-    /**
-     * Throw an exception if the specified value is null.
-     * Used to implement a controlled failure when we encounter a value that must be non-null (and should have been verified as such by a previous check), but for whatever reason, is not.
-     */
-    private <T> T checkNonNull(T value) {
-        if (value == null) {
-            LOG.error("During CWL processing, got a null value where a non-null value was required.");
-            throw new CustomWebApplicationException(CWL_PARSE_ERROR + "internal processing error", HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        }
-        return value;
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -504,7 +504,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
                 }
 
             } else if (runObj instanceof String) {
-                // If the run object is a String, it was a file reference which the preprocessor could not expand.
+                // If the run object is a String, it is the name of a file which the preprocessor could not expand.
                 stepToType.put(nodeStepId, "n/a");
                 stepDockerPath = getDockerPull(stepRequirementState, stepHintState);
                 currentPath = (String)runObj;

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -357,7 +357,7 @@ public class CWLHandlerTest {
             Assert.fail("Expected parse error: value of workflow step run field should be a string, workflow, or tool");
         } catch (CustomWebApplicationException e) {
             Assert.assertEquals(HttpStatus.SC_UNPROCESSABLE_ENTITY, e.getResponse().getStatus());
-            assertThat(e.getErrorMessage()).contains(CWLHandler.CWL_PARSE_ERROR);
+            assertThat(e.getErrorMessage()).contains(CWLHandler.CWL_PARSE_SECONDARY_ERROR);
         }
     }
 


### PR DESCRIPTION
**Description**
This PR completely replaces the recently-introduced cwljava code with code that uses cwlAvro.  Rather than revert completely, I used the post-cwljava conversion code as a base, because it was of higher quality.

**Review Instructions**
Fork `github.com/ICGC-TCGA-PanCancer/OxoG-Dockstore-Tools` and manually register the workflow on qa.  Primary descriptor `/oxog_varbam_annotate_wf.cwl`, test file `/test.json`.  Verify that the tools/DAG/etc are the same as the registered version on dockstore.org https://dockstore.org/workflows/github.com/ICGC-TCGA-PanCancer/OxoG-Dockstore-Tools/pcawg-oxog-full-workflow:master.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2281
#5245

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
