### PR TITLE
code coverage improvement

### DIFF
--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -194,7 +194,10 @@
                 <configuration>
                     <!-- nothing to do with the JAVA_TOOL_OPTIONS in .cirleci/config.yml because surefire has its own JVM-->
                     <!-- This plus the .circle/config.yml must add to a bit less than 4GB -->
-                    <argLine>-Xmx4g</argLine>
+                    <argLine>
+                        ${argLine}
+                        -Xmx4g
+                    </argLine>
                     <!-- seems like some form of Jackson fork issue for this module with random order -->
                     <runOrder>filesystem</runOrder>
                 </configuration>

--- a/dockstore-integration-testing/pom.xml
+++ b/dockstore-integration-testing/pom.xml
@@ -28,6 +28,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <argLine></argLine>
     </properties>
 
     <dependencies>
@@ -195,8 +196,8 @@
                     <!-- nothing to do with the JAVA_TOOL_OPTIONS in .cirleci/config.yml because surefire has its own JVM-->
                     <!-- This plus the .circle/config.yml must add to a bit less than 4GB -->
                     <argLine>
-                        ${argLine}
                         -Xmx4g
+                        @{argLine}
                     </argLine>
                     <!-- seems like some form of Jackson fork issue for this module with random order -->
                     <runOrder>filesystem</runOrder>

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
@@ -29,7 +29,10 @@ public class QuayImageRegistryTest {
     /**
      * Normally, we are only able to get 500 tags without using the paginated endpoint.
      * This tests that when there are over 500 tags, we can use the paginated endpoint to retrieve all of them instead.
-     * Using calico/node because it has over 3838 tags
+     * Originally, this used calico/node with 3838 tags but it now has 8960 tags on 2022-12-19
+     * Openshift-release-dev/ocp-release had 6737 on 2022-12-19
+     * Slowing the test to 256.195 seconds.
+     * Pointing the test at some of our repos reduces time to 5 seconds but is less thorough
      */
     @Test
     public void getOver500TagsTest() {
@@ -38,11 +41,11 @@ public class QuayImageRegistryTest {
         QuayImageRegistry quayImageRegistry = new QuayImageRegistry(token);
         Tool tool = new Tool();
         tool.setRegistry("quay.io");
-        tool.setNamespace("calico");
-        tool.setName("node");
+        tool.setNamespace("dockstore");
+        tool.setName("dockstore-webservice");
         List<Tag> tags = quayImageRegistry.getTags(tool);
         int size = tags.size();
-        Assert.assertTrue("Should be able to get more than the default 500 tags", size > 3838);
+        Assert.assertTrue("Should be able to get more than the default 500 tags", size > 500);
         tags.forEach(tag -> {
             Assert.assertTrue("Images should be populated", tag.getImages().size() > 0);
             Assert.assertTrue("things look kinda sane", !tag.getName().isEmpty() && tag.getImages().stream().noneMatch(img -> img.getImageUpdateDate().isEmpty()));
@@ -56,8 +59,8 @@ public class QuayImageRegistryTest {
         Assert.assertEquals("There should be no tags with the same name", size, distinctSize);
 
         // This Quay repo has tags with > 1 manifest per image
-        tool.setNamespace("openshift-release-dev");
-        tool.setName("ocp-release");
+        tool.setNamespace("dockstore");
+        tool.setName("multi_manifest_test");
         tags = quayImageRegistry.getTags(tool);
         Optional<Tag> tagWithMoreThanOneImage = tags.stream().filter(tag -> tag.getImages().size() > 1).findFirst();
         if (tagWithMoreThanOneImage.isEmpty()) {

--- a/openapi-java-client/pom.xml
+++ b/openapi-java-client/pom.xml
@@ -173,7 +173,10 @@
                             <value>conf/log4j.properties</value>
                         </property>
                     </systemProperties>
-                    <argLine>-Xms512m -Xmx1500m</argLine>
+                    <argLine>
+                        ${argLine}
+                        -Xms512m -Xmx1500m
+                    </argLine>
                     <parallel>methods</parallel>
                     <forkMode>pertest</forkMode>
                 </configuration>


### PR DESCRIPTION
**Description**
Accompanies https://github.com/dockstore/dockstore-cli/pull/211 
Also sped up a rather slow unit test 
Found an explanation for why coverage was failing in Java 17, but it also applies to the main repo. Tried it out and it does seem we're missing some minor coverage. 
 
**Review Instructions**
Not much, could spot check some files in the codecov report to indicate that the improved coverage stayed improved. 

**Issue**
https://github.com/dockstore/dockstore-cli/pull/211

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
