### PR TITLE
DOCK-2299: Correctly handle thrown Error during push

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/OpenAPIWebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/OpenAPIWebhookIT.java
@@ -102,5 +102,10 @@ public class OpenAPIWebhookIT extends BaseIT {
             Assert.assertEquals("There should be one event", 1, events.stream().count());
             Assert.assertEquals("There should be no successful events", 0, events.stream().filter(LambdaEvent::isSuccess).count());
         }
+
+        // Try the release again, with no Error, to confirm it succeeds.
+        client.handleGitHubRelease(taggedToolRepo, BasicIT.USER_2_USERNAME, "refs/tags/1.0", installationId);
+        List<LambdaEvent> events = usersApi.getUserGitHubEvents("0", 10);
+        Assert.assertEquals("There should be one successful event", 1, events.stream().filter(LambdaEvent::isSuccess).count());
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/OpenAPIWebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/OpenAPIWebhookIT.java
@@ -5,12 +5,8 @@ import io.dockstore.client.cli.BasicIT;
 import io.dockstore.client.cli.OrganizationIT;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
-import io.dockstore.common.yaml.DockstoreYamlHelper;
-import io.dockstore.openapi.client.model.LambdaEvent;
 import io.dockstore.openapi.client.model.Organization;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
-import java.util.List;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -19,9 +15,6 @@ import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
-import org.mockito.ArgumentMatchers;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 /**
  * Like WebhookIT but with only openapi classes to avoid having to give fully defined classes everywhere
@@ -82,30 +75,5 @@ public class OpenAPIWebhookIT extends BaseIT {
         // uncomment this after DOCK-1890 and delete from WebhookIT
         // Collection collection = organizationsApiAdmin.getCollectionById(registeredOrganization.getId(), createdCollection.getId());
         // assertTrue((collection.getEntries().stream().anyMatch(entry -> Objects.equals(entry.getId(), appTool.getId()))));
-    }
-
-    @Test
-    public void testErrorThrownDuringInRelease() {
-        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
-        final io.dockstore.openapi.client.ApiClient openApiClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
-        io.dockstore.openapi.client.api.WorkflowsApi client = new io.dockstore.openapi.client.api.WorkflowsApi(openApiClient);
-        io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(openApiClient);
-
-        // Mock DockstoreYamlHelper.readAsDockstoreYaml12 to throw an Error, then try a release.
-        // We do this within a try-resource block so that the mock is reverted at the end.
-        try (MockedStatic<DockstoreYamlHelper> helper = Mockito.mockStatic(DockstoreYamlHelper.class)) {
-            helper.when(() -> DockstoreYamlHelper.readAsDockstoreYaml12(ArgumentMatchers.anyString())).thenThrow(new Error("synthesized error"));
-            // Do the release.
-            client.handleGitHubRelease(taggedToolRepo, BasicIT.USER_2_USERNAME, "refs/tags/1.0", installationId);
-            // Confirm that the release failed and was logged correctly.
-            List<LambdaEvent> events = usersApi.getUserGitHubEvents("0", 10);
-            Assert.assertEquals("There should be one event", 1, events.stream().count());
-            Assert.assertEquals("There should be no successful events", 0, events.stream().filter(LambdaEvent::isSuccess).count());
-        }
-
-        // Try the release again, with no Error, to confirm it succeeds.
-        client.handleGitHubRelease(taggedToolRepo, BasicIT.USER_2_USERNAME, "refs/tags/1.0", installationId);
-        List<LambdaEvent> events = usersApi.getUserGitHubEvents("0", 10);
-        Assert.assertEquals("There should be one successful event", 1, events.stream().filter(LambdaEvent::isSuccess).count());
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1616,7 +1616,7 @@ public class WebhookIT extends BaseIT {
         // Attempt to process a repo containing a recursive WDL.  Internally, we use Cromwell to process WDLs.
         // It should throw a StackOverflowError, which will bubble out of the .dockstore.yml processing code.
         try {
-            client.handleGitHubRelease("refs/heads/main", installationId, "svonworl/recursive-wdl", BasicIT.USER_2_USERNAME);
+            client.handleGitHubRelease("refs/heads/main", installationId, "dockstore-testing/recursive-wdl", BasicIT.USER_2_USERNAME);
             Assert.fail("should have thrown");
         } catch (io.dockstore.openapi.client.ApiException ex) {
             // Confirm that the release failed and was logged correctly.

--- a/dockstore-integration-testing/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/dockstore-integration-testing/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/TransactionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/TransactionHelper.java
@@ -124,7 +124,7 @@ public final class TransactionHelper {
         if (thrown != null) {
             LOG.error("operation on session that has thrown", thrown);
             thrown = new RuntimeException("operation on session that has thrown");
-            throw thrown;
+            rethrow(thrown);
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/TransactionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/TransactionHelper.java
@@ -122,9 +122,9 @@ public final class TransactionHelper {
 
     private void check() {
         if (thrown != null) {
-            LOG.error("operation on session that has previously thrown", thrown);
-            thrown = new Error("operation on session that has previously thrown");
-            rethrow(thrown);
+            LOG.error("operation on session that has thrown", thrown);
+            thrown = new RuntimeException("operation on session that has thrown");
+            throw thrown;
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/TransactionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/TransactionHelper.java
@@ -34,7 +34,7 @@ public final class TransactionHelper {
 
     private static final Logger LOG = LoggerFactory.getLogger(TransactionHelper.class);
     private Session session;
-    private RuntimeException thrown;
+    private Throwable thrown;
 
     public TransactionHelper(Session session) {
         this.session = session;
@@ -74,8 +74,8 @@ public final class TransactionHelper {
         check();
         try {
             session.clear();
-        } catch (RuntimeException ex) {
-            handle("clear", ex);
+        } catch (RuntimeException | Error throwable) {
+            handle("clear", throwable);
         }
     }
 
@@ -83,8 +83,8 @@ public final class TransactionHelper {
         check();
         try {
             session.beginTransaction();
-        } catch (RuntimeException ex) {
-            handle("begin", ex);
+        } catch (RuntimeException | Error throwable) {
+            handle("begin", throwable);
         }
     }
 
@@ -95,8 +95,8 @@ public final class TransactionHelper {
             if (isActive(transaction) && transaction.getStatus().canRollback()) {
                 transaction.rollback();
             }
-        } catch (RuntimeException ex) {
-            handle("rollback", ex);
+        } catch (RuntimeException | Error throwable) {
+            handle("rollback", throwable);
         }
     }
 
@@ -107,38 +107,49 @@ public final class TransactionHelper {
             if (isActive(transaction)) {
                 transaction.commit();
             }
-        } catch (RuntimeException ex) {
-            handle("commit", ex);
+        } catch (RuntimeException | Error throwable) {
+            handle("commit", throwable);
         }
     }
 
-    public RuntimeException thrown() {
+    private boolean isActive(Transaction transaction) {
+        return transaction != null && transaction.isActive();
+    }
+
+    public Throwable thrown() {
         return thrown;
     }
 
     private void check() {
         if (thrown != null) {
-            LOG.error("operation on session that has thrown", thrown);
-            thrown = new RuntimeException("operation on session that has thrown");
-            throw thrown;
+            LOG.error("operation on session that has previously thrown", thrown);
+            thrown = new Error("operation on session that has previously thrown");
+            rethrow(thrown);
         }
     }
 
-    private void handle(String operation, RuntimeException ex) {
-        thrown = ex;
-        LOG.error("{} failed", operation, ex);
+    private void handle(String operation, Throwable throwable) {
+        thrown = throwable;
+        LOG.error("{} failed", operation, throwable);
         // To prevent us from interacting with foobared state, the
         // Hibernate docs instruct us to immediately close a session
         // if a previous operation on the session has thrown.
         try {
             session.close();
-        } catch (RuntimeException closeEx) {
-            LOG.error("post-Exception close failed", closeEx);
+        } catch (Throwable closeThrowable) {
+            LOG.error("post-throw close failed", closeThrowable);
         }
-        throw ex;
+        rethrow(throwable);
     }
 
-    private boolean isActive(Transaction transaction) {
-        return transaction != null && transaction.isActive();
+    private void rethrow(Throwable throwable) {
+        if (throwable instanceof RuntimeException) {
+            throw (RuntimeException)throwable;
+        } else if (throwable instanceof Error) {
+            throw (Error)throwable;
+        } else {
+            LOG.error("attempt to rethrow unexpected checked exception", throwable);
+            throw new RuntimeException(throwable);
+        }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -599,7 +599,9 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     }
 
     private String generateMessageFromThrowable(Throwable throwable) {
-        if (throwable instanceof ClassCastException) {
+        if (throwable instanceof Error) {
+            return "Internal processing error: " + throwable.getClass().getSimpleName();
+        } else if (throwable instanceof ClassCastException) {
             // ClassCastException has been seen from WDL parsing wrapper: https://github.com/dockstore/dockstore/issues/4431
             // The message for #4431 is not user-friendly (class wom.callable.MetaValueElement$MetaValueElementBoolean cannot be cast...),
             // so return a generic one.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -599,15 +599,17 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     }
 
     private String generateMessageFromThrowable(Throwable throwable) {
-        // ClassCastException has been seen from WDL parsing wrapper: https://github.com/dockstore/dockstore/issues/4431
-        // The message for #4431 is not user-friendly (class wom.callable.MetaValueElement$MetaValueElementBoolean cannot be cast...),
-        // so return a generic one.
         if (throwable instanceof ClassCastException) {
+            // ClassCastException has been seen from WDL parsing wrapper: https://github.com/dockstore/dockstore/issues/4431
+            // The message for #4431 is not user-friendly (class wom.callable.MetaValueElement$MetaValueElementBoolean cannot be cast...),
+            // so return a generic one.
             return "Could not parse input.";
         } else if (throwable instanceof DockstoreYamlHelper.DockstoreYamlException) {
             return DockstoreYamlHelper.ERROR_READING_DOCKSTORE_YML + throwable.getMessage();
+        } else if (throwable instanceof CustomWebApplicationException) {
+            return ((CustomWebApplicationException)throwable).getErrorMessage();
         } else {
-            return throwable instanceof CustomWebApplicationException ? ((CustomWebApplicationException)throwable).getErrorMessage() : throwable.getMessage();
+            return throwable.getMessage();
         }
     }
 


### PR DESCRIPTION
**Description**
This PR modifies the webservice's GitHub apps push-processing code to more gracefully handle an `Error` thrown by the code within.  Previously, `Exception`s were handled properly, but `Error`s slightly not: pushes resulting in `Error`s were logged as "success"-ful in the GitHub apps logs.  We discovered this problem because Ash created a WDL workflow that referenced itself via a http url, which Cromwell happily imported until overflowing the stack, resulting in a `StackOverflowError`.

The integration test processes a similarly recursive WDL, which it assumes will trigger a `StackOverflowError`.  The test will break if we/Cromwell change that behavior.  I tried another approach wherein `Error` were triggered via mocks, but it didn't work.
 
**Review Instructions**
Fork https://github.com/dockstore-testing/recursive-wdl and register it on both qa and staging.  Check the github apps logs on each.  qa should report that the push failed, and staging should report that the push succeeded.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2299
#5274

**Security**
There may be related issues, I have contacted the appropriate personnel.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
