### PR TITLE
DOCK-2299: Improve handling of WDL with recursive remote import

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1616,7 +1616,7 @@ public class WebhookIT extends BaseIT {
         io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(openApiClient);
 
         // Attempt to process a repo containing a recursive WDL.  Internally, we use the same libraries that Cromwell does to process WDLs.
-        // The WDL processing code should throw a StackOverflowError, which is remap to a more explanatory CustomWebApplicationException, which will trigger a typical registration failure.
+        // The WDL processing code should throw a StackOverflowError, which is remapped to a more explanatory CustomWebApplicationException, which will trigger a typical registration failure.
         try {
             client.handleGitHubRelease("refs/heads/main", installationId, "dockstore-testing/recursive-wdl", BasicIT.USER_2_USERNAME);
             Assert.fail("should have thrown");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -49,6 +49,7 @@ import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.helpers.AppToolHelper;
 import io.dockstore.webservice.jdbi.AppToolDAO;
 import io.dockstore.webservice.jdbi.FileDAO;
+import io.dockstore.webservice.languages.WDLHandler;
 import io.specto.hoverfly.junit.core.Hoverfly;
 import io.specto.hoverfly.junit.core.HoverflyMode;
 import io.swagger.api.impl.ToolsImplCommon;
@@ -1600,5 +1601,31 @@ public class WebhookIT extends BaseIT {
         assertEquals("Workflow author should equal default version author", defaultVersion.getAuthor(), workflow.getAuthor());
         assertEquals("Workflow email should equal default version email", defaultVersion.getEmail(), workflow.getEmail());
         assertEquals("Workflow description should equal default version description", defaultVersion.getDescription(), workflow.getDescription());
+    }
+
+    /**
+     * Tests that an attempt to register a WDL that contains recursive
+     * remote references will result in failure.
+     * https://ucsc-cgl.atlassian.net/browse/DOCK-2299
+     */
+    @Test
+    public void testRegistrationOfRecursiveWDL() {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
+        final io.dockstore.openapi.client.ApiClient openApiClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        io.dockstore.openapi.client.api.WorkflowsApi client = new io.dockstore.openapi.client.api.WorkflowsApi(openApiClient);
+        io.dockstore.openapi.client.api.UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(openApiClient);
+
+        // Attempt to process a repo containing a recursive WDL.  Internally, we use the same libraries that Cromwell does to process WDLs.
+        // The WDL processing code should throw a StackOverflowError, which is remap to a more explanatory CustomWebApplicationException, which will trigger a typical registration failure.
+        try {
+            client.handleGitHubRelease("refs/heads/main", installationId, "dockstore-testing/recursive-wdl", BasicIT.USER_2_USERNAME);
+            Assert.fail("should have thrown");
+        } catch (io.dockstore.openapi.client.ApiException ex) {
+            // Confirm that the release failed and was logged correctly.
+            List<io.dockstore.openapi.client.model.LambdaEvent> events = usersApi.getUserGitHubEvents("0", 10);
+            Assert.assertEquals("There should be one event", 1, events.stream().count());
+            Assert.assertEquals("There should be no successful events", 0, events.stream().filter(io.dockstore.openapi.client.model.LambdaEvent::isSuccess).count());
+            Assert.assertTrue("Event message should indicate the problem", events.get(0).getMessage().contains(WDLHandler.ERROR_PARSING_WORKFLOW_YOU_MAY_HAVE_A_RECURSIVE_IMPORT));
+        }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -206,6 +206,8 @@ public class WDLHandler implements LanguageHandlerInterface {
                 version.getAuthors().clear();
                 version.getOrcidAuthors().clear();
                 return version;
+            } catch (StackOverflowError error) {
+                throw createStackOverflowThrowable(error);
             }
         } catch (IOException e) {
             throw new CustomWebApplicationException(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
@@ -325,6 +327,8 @@ public class WDLHandler implements LanguageHandlerInterface {
             } catch (Exception e) {
                 LOG.error("Unhandled exception", e);
                 throw new CustomWebApplicationException(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            } catch (StackOverflowError error) {
+                throw createStackOverflowThrowable(error);
             } finally {
                 FileUtils.deleteQuietly(tempMainDescriptor);
             }
@@ -486,6 +490,8 @@ public class WDLHandler implements LanguageHandlerInterface {
             final String exMsg = "Could not process request, " + ex.getMessage();
             LOG.error(exMsg, ex);
             throw new CustomWebApplicationException(exMsg, HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        } catch (StackOverflowError error) {
+            throw createStackOverflowThrowable(error);
         } finally {
             FileUtils.deleteQuietly(tempMainDescriptor);
         }
@@ -623,6 +629,8 @@ public class WDLHandler implements LanguageHandlerInterface {
         } catch (IOException e) {
             LOG.error("Error creating temporary file for descriptor {}", primaryDescriptorPath, e);
             throw new CustomWebApplicationException(e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        } catch (StackOverflowError error) {
+            throw createStackOverflowThrowable(error);
         } finally {
             // Delete the temp directory and its contents
             FileUtils.deleteQuietly(tempDir);
@@ -670,5 +678,9 @@ public class WDLHandler implements LanguageHandlerInterface {
         } else {
             return Optional.empty();
         }
+    }
+
+    private static RuntimeException createStackOverflowThrowable(StackOverflowError error) {
+        throw new CustomWebApplicationException(ERROR_PARSING_WORKFLOW_YOU_MAY_HAVE_A_RECURSIVE_IMPORT, HttpStatus.SC_UNPROCESSABLE_ENTITY);
     }
 }


### PR DESCRIPTION
**Description**
This PR changes `WDLHandler` methods to throw a `CustomWebApplicationException`, rather than a `StackOverflowError`, when they attempt to process a WDL that contains recursive remote references, 

Essentially, there were two options as to where to place the fix:
1. In the `WdlBridge` scala, probably method `getBundle`.
2. As a catch on the `try`s of the various `WDLHandler` methods that use `WdlBridge`.

Amongst other reasons, I picked Option 2 because it makes it easier to change the behavior, for example, to instead let the `Error` propagate up the stack, if we so choose.  Later, we might change the behavior to better conform to our emerging policy on catching errors, see https://ucsc-cgl.atlassian.net/browse/SEAB-5097 for more details.

IMHO, the most correct approach is to manufacture a facsimile of the `StackOverflowError` with an appropriate message ("your WDL is recursive" or whatever), and let it propagate outwards.  The approach in this PR is a stopgap, fine, and works, but we're essentially eating an `Error` and continuing, which I think we'll all eventually agree is wrong [at least conceptually].  However, it's probably not particularly dangerous in this specific case...

**Review Instructions**
Fork https://github.com/dockstore-testing/recursive-wdl and register it on both qa and staging. Check the github apps logs on each. qa should report that the push failed, and staging should report that the push succeeded.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2299
https://github.com/dockstore/dockstore/issues/5274

**Security**
Already discussed.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
