### PR TITLE
DOCK-2004:  Flag missing nextflow main script

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -702,7 +702,7 @@ public class WorkflowIT extends BaseIT {
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
         UsersApi usersApi = new UsersApi(webClient);
 
-        Workflow workflowByPathGithub = manualRegisterAndPublish(workflowApi, "svonworl/nextflow-broken", "", "nfl", SourceControl.GITHUB,
+        Workflow workflowByPathGithub = manualRegisterAndPublish(workflowApi, "dockstore-testing/nextflow-broken", "", "nfl", SourceControl.GITHUB,
             "/nextflow.config", false);
 
         // need to set paths properly
@@ -710,15 +710,13 @@ public class WorkflowIT extends BaseIT {
         workflowByPathGithub.setDescriptorType(DescriptorTypeEnum.NFL);
         workflowApi.updateWorkflow(workflowByPathGithub.getId(), workflowByPathGithub);
 
-        workflowByPathGithub = workflowApi.getWorkflowByPath("github.com/svonworl/nextflow-broken", BIOWORKFLOW, null);
+        workflowByPathGithub = workflowApi.getWorkflowByPath("github.com/dockstore-testing/nextflow-broken", BIOWORKFLOW, null);
         final Workflow refreshGithub = workflowApi.refresh(workflowByPathGithub.getId(), false);
 
         WorkflowVersion workflowVersion = refreshGithub.getWorkflowVersions().stream().filter(version -> version.getName().equals("no-main-script")).findFirst().get();
         List<Validation> validations = workflowVersion.getValidations();
 
-        assertEquals("should have one validation", 1, validations.size());
-        assertFalse("validation should not be valid", validations.get(0).isValid());
-        assertTrue("validation should have a descriptive message", validations.get(0).getMessage().contains("not find main script"));
+        assertEquals("should have a descriptive invalid validation", 1, validations.stream().filter(v -> !v.isValid() && v.getMessage() != null && v.getMessage().contains("not find main script")).count());
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -201,17 +201,17 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
     }
 
     private void createValidationForGeneralFailure(Version version, String filepath) {
-        createValidation(version, filepath, "Nextflow config file is malformed or missing, cannot extract metadata", false);
+        createValidation(version, false, filepath, "Nextflow config file is malformed or missing, cannot extract metadata");
     }
 
     private void createValidationForMissingMainScript(Version version, String filepath, String mainScriptName) {
-        createValidation(version, filepath, String.format("Could not find main script file '%s'", mainScriptName), false);
+        createValidation(version, false, filepath, String.format("Could not find main script file '%s'", mainScriptName));
     }
 
-    private void createValidation(Version version, String filepath, String message, boolean success) {
+    private void createValidation(Version version, boolean valid, String filepath, String message) {
         Map<String, String> validationMessageObject = new HashMap<>();
         validationMessageObject.put(filepath, message);
-        version.addOrUpdateValidation(new Validation(DescriptorLanguage.FileType.NEXTFLOW_CONFIG, success, validationMessageObject));
+        version.addOrUpdateValidation(new Validation(DescriptorLanguage.FileType.NEXTFLOW_CONFIG, valid, validationMessageObject));
     }
 
     private void handleNextflowImports(String repositoryId, Version version, SourceCodeRepoInterface sourceCodeRepoInterface,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -401,7 +401,7 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
     }
 
     @Override
-    public Optional<String> getContent(String mainPath, String mainDescriptor, Set<SourceFile> secondarySourceFiles, Type type, ToolDAO dao) {
+    public Optional<String> getContent(String configPath, String configContent, Set<SourceFile> secondarySourceFiles, Type type, ToolDAO dao) {
         String callType = "call"; // This may change later (ex. tool, workflow)
         String toolType = "tool";
 
@@ -414,7 +414,7 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
 
         Configuration configuration;
         try {
-            configuration = NextflowUtilities.grabConfig(mainDescriptor);
+            configuration = NextflowUtilities.grabConfig(configContent);
         } catch (NextflowUtilities.NextflowParsingException e) {
             throw new CustomWebApplicationException(e.getMessage(), HttpStatus.SC_UNPROCESSABLE_ENTITY);
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -205,7 +205,7 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
     }
 
     private void createValidationForMissingMainScript(Version version, String filepath, String mainScriptName) {
-        createValidation(version, filepath, String.format("Could not find main script file %s", mainScriptName), false);
+        createValidation(version, filepath, String.format("Could not find main script file '%s'", mainScriptName), false);
     }
 
     private void createValidation(Version version, String filepath, String message, boolean success) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -463,7 +463,7 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
     }
 
     private Optional<SourceFile> findSourceFileByPath(Set<SourceFile> sourceFiles, String path) {
-        return sourceFiles.stream().filter(sourceFile -> sourceFile.getPath().equals(path)).findFirst();
+        return sourceFiles.stream().filter(sourceFile -> Objects.equals(sourceFile.getPath(), path)).findFirst();
     }
 
     /**


### PR DESCRIPTION
**Description**
This PR changes `NextflowHandler` so that it if a Nextflow workflow version is missing the main script, a `!isValid()` `Validation` containing an explanatory message is created.

While I was in there, I did some refactoring.  Two new helper methods encapsulate a couple of repeated operations, most importantly, a new method `findSourceFileByPath` that selects an element from a set of `SourceFile`s by path.  This refactor makes the calling methods more readable by reducing their length and complexity, self-documenting the operations, and narrowing the range of abstraction (we don't need to decode the meaning of a relatively low-level multi-step streaming expression to understand the surrounding higher-level code).   In general, our codebase would benefit greatly from a similar global refactor, in which we replaced common operations currently implemented with duplicate code (for example, extracting a `Version` from by a list by name) with easy-to-use, easy-to-read, easy-to-understand helper methods.

**Review Instructions**
On qa, register a Nextflow workflow that is missing the main script.  In the Files tab of the resulting workflow version, when you select the file `nextflow.config`, you should see a message, highlighted yellow[ish], that indicates that the main script was missing.  Also, in the Versions tab, the version should not be valid.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2004
#4599

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
