### PR TITLE
Add language version to search

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -295,6 +295,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
         referenceType = version.getReferenceType();
         frozen = version.isFrozen();
         commitID = version.getCommitID();
+        descriptorTypeVersions = version.getDescriptorTypeVersions();
         this.setVersionMetadata(version.getVersionMetadata());
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -487,7 +487,7 @@ public class ElasticListener implements StateListenerInterface {
     private static List<String> getDistinctDescriptorTypeVersions(Entry entry, Set<? extends Version> workflowVersions) {
         String language;
         if (entry instanceof Tool && ((Tool)entry).getDescriptorType().size() == 1) {
-            // Only set descriptor type versions if there's one descriptor type...WDL tools will be gone soon
+            // Only set descriptor type versions if there's one descriptor type otherwise we can't tell which version belongs to which type without looking at the source files
             language = ((Tool)entry).getDescriptorType().get(0);
         } else if (entry instanceof BioWorkflow || entry instanceof AppTool) {
             language = ((Workflow)entry).getDescriptorType().toString();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
@@ -183,6 +183,9 @@ public class HostedToolResource extends AbstractHostedEntryResource<Tool, Tag, T
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = Tool.class)
     public Tool deleteHostedVersion(User user, Long entryId, String version) {
         Tool tool = super.deleteHostedVersion(user, entryId, version);
+        // Deleting a version can change the descriptor types of the tool
+        List<String> descriptorTypes =  tool.calculateDescriptorType();
+        tool.setDescriptorType(descriptorTypes);
         PublicStateManager.getInstance().handleIndexUpdate(tool, StateManagerMode.UPDATE);
         return tool;
     }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
@@ -17,8 +17,12 @@
 
 package io.dockstore.webservice.helpers.statelisteners;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.common.SourceControl;
 import io.dockstore.webservice.core.AppTool;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Entry;
@@ -26,7 +30,10 @@ import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.core.Tag;
 import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.Version;
+import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowVersion;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.Before;
@@ -53,36 +60,53 @@ public class ElasticListenerTest {
     public void setup() throws IllegalAccessException {
 
         bioWorkflow = new BioWorkflow();
+        initEntry(bioWorkflow);
         firstWorkflowVersion = new WorkflowVersion();
         secondWorkflowVersion = new WorkflowVersion();
-        initVersion(firstWorkflowVersion, FIRST_VERSION_NAME, FIRST_VERSION_ID);
+        initVersion(firstWorkflowVersion, FIRST_VERSION_NAME, FIRST_VERSION_ID, List.of("1.0"));
         initVersion(secondWorkflowVersion, SECOND_VERSION_NAME,
-            SECOND_VERSION_ID);
+            SECOND_VERSION_ID, List.of("1.1"));
         bioWorkflow.getWorkflowVersions().addAll(List.of(firstWorkflowVersion,
             secondWorkflowVersion));
 
         tool = new Tool();
+        initEntry(tool);
         firstTag = new Tag();
         secondTag = new Tag();
-        initVersion(firstTag, FIRST_VERSION_NAME, FIRST_VERSION_ID);
-        initVersion(secondTag, SECOND_VERSION_NAME, SECOND_VERSION_ID);
+        initVersion(firstTag, FIRST_VERSION_NAME, FIRST_VERSION_ID, List.of("1.0"));
+        initVersion(secondTag, SECOND_VERSION_NAME, SECOND_VERSION_ID, List.of("1.0"));
         tool.getWorkflowVersions().addAll(List.of(firstTag, secondTag));
 
         appTool = new AppTool();
+        initEntry(appTool);
         firstAppToolVersion = new WorkflowVersion();
         secondAppToolVersion = new WorkflowVersion();
-        initVersion(firstAppToolVersion, FIRST_VERSION_NAME, FIRST_VERSION_ID);
-        initVersion(secondAppToolVersion, SECOND_VERSION_NAME, SECOND_VERSION_ID);
+        initVersion(firstAppToolVersion, FIRST_VERSION_NAME, FIRST_VERSION_ID, List.of());
+        initVersion(secondAppToolVersion, SECOND_VERSION_NAME, SECOND_VERSION_ID, List.of());
         appTool.getWorkflowVersions().addAll(List.of(firstAppToolVersion, secondAppToolVersion));
     }
 
-    private void initVersion(final Version version, final String name, final long id)
+    private void initEntry(Entry entry) {
+        if (entry instanceof Tool) {
+            Tool toolEntry = (Tool)entry;
+            toolEntry.setDescriptorType(List.of(DescriptorLanguage.WDL.toString()));
+        } else if (entry instanceof Workflow) {
+            Workflow workflowOrAppTool = (Workflow)entry;
+            workflowOrAppTool.setDescriptorType(DescriptorLanguage.WDL);
+            workflowOrAppTool.setSourceControl(SourceControl.GITHUB);
+            workflowOrAppTool.setOrganization("potato");
+            workflowOrAppTool.setRepository("foobar");
+        }
+    }
+
+    private void initVersion(final Version version, final String name, final long id, List<String> descriptorTypeVersions)
         throws IllegalAccessException {
         version.setName(name);
         final SourceFile sourceFile = new SourceFile();
         sourceFile.setPath("/Dockstore.wdl");
         sourceFile.setContent("Doesn't matter");
         version.getSourceFiles().add(sourceFile);
+        version.setDescriptorTypeVersions(descriptorTypeVersions);
         // Id is normally set via Hibernate generator; have to use reflection to set it, alas
         FieldUtils.writeField(version, "id", id, true);
     }
@@ -153,4 +177,40 @@ public class ElasticListenerTest {
         });
     }
 
+    @Test
+    public void testDescriptorTypeVersionsSet() throws IOException {
+        // bioWorkflow has two descriptor type versions
+        JsonNode entry = ElasticListener.dockstoreEntryToElasticSearchObject(bioWorkflow);
+        JsonNode descriptorTypeVersions = entry.get("descriptor_type_versions");
+        assertEquals(2, descriptorTypeVersions.size());
+        List<String> esObjectDescriptorTypeVersions = getDescriptorTypeVersionsFromJsonNode(descriptorTypeVersions);
+        assertTrue(esObjectDescriptorTypeVersions.contains("WDL 1.0") && esObjectDescriptorTypeVersions.contains("WDL 1.1"));
+
+        // tool has one descriptor type version
+        entry = ElasticListener.dockstoreEntryToElasticSearchObject(tool);
+        descriptorTypeVersions = entry.get("descriptor_type_versions");
+        assertEquals(1, descriptorTypeVersions.size());
+        esObjectDescriptorTypeVersions = getDescriptorTypeVersionsFromJsonNode(descriptorTypeVersions);
+        assertTrue(esObjectDescriptorTypeVersions.contains("WDL 1.0"));
+
+        // tool has CWL and WDL
+        tool.setDescriptorType(List.of(DescriptorLanguage.WDL.toString(), DescriptorLanguage.CWL.toString()));
+        assertEquals(2, tool.getDescriptorType().size());
+        entry = ElasticListener.dockstoreEntryToElasticSearchObject(tool);
+        descriptorTypeVersions = entry.get("descriptor_type_versions");
+        assertEquals("Should not have descriptor type versions if there's more than one language", 0, descriptorTypeVersions.size());
+
+        // appTool has one descriptor type version
+        entry = ElasticListener.dockstoreEntryToElasticSearchObject(appTool);
+        descriptorTypeVersions = entry.get("descriptor_type_versions");
+        assertEquals(0, descriptorTypeVersions.size());
+    }
+
+    private List<String> getDescriptorTypeVersionsFromJsonNode(JsonNode descriptorTypeVersionsJsonNode) {
+        List<String> descriptorTypeVersions = new ArrayList<>();
+        for (JsonNode version : descriptorTypeVersionsJsonNode) {
+            descriptorTypeVersions.add(version.textValue());
+        }
+        return descriptorTypeVersions;
+    }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
@@ -17,6 +17,7 @@
 
 package io.dockstore.webservice.helpers.statelisteners;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -198,7 +199,7 @@ class ElasticListenerTest {
         assertEquals(2, tool.getDescriptorType().size());
         entry = ElasticListener.dockstoreEntryToElasticSearchObject(tool);
         descriptorTypeVersions = entry.get("descriptor_type_versions");
-        assertEquals("Should not have descriptor type versions if there's more than one language", 0, descriptorTypeVersions.size());
+        assertEquals(0, descriptorTypeVersions.size(), "Should not have descriptor type versions if there's more than one language");
 
         // appTool has no descriptor type versions
         entry = ElasticListener.dockstoreEntryToElasticSearchObject(appTool);

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
@@ -200,7 +200,7 @@ public class ElasticListenerTest {
         descriptorTypeVersions = entry.get("descriptor_type_versions");
         assertEquals("Should not have descriptor type versions if there's more than one language", 0, descriptorTypeVersions.size());
 
-        // appTool has one descriptor type version
+        // appTool has no descriptor type versions
         entry = ElasticListener.dockstoreEntryToElasticSearchObject(appTool);
         descriptorTypeVersions = entry.get("descriptor_type_versions");
         assertEquals(0, descriptorTypeVersions.size());


### PR DESCRIPTION
**Description**
This PR adds the descriptor type version to search so it can be displayed as a Language Versions facet in the UI. The Language Versions facet allows users to filter for tools/workflows that contain files with the workflow language versions.

View PR https://github.com/dockstore/dockstore-ui2/pull/1673 for the UI changes.

Note that our legacy tools can have more than one descriptor language (CWL & WDL). This PR only adds the language versions to search for legacy tools that have one descriptor language to simplify things and because we plan to get rid of WDL tools and deprecate the legacy tool registration eventually ([docs](https://docs.dockstore.org/en/stable/advanced-topics/dockstore-tools-overhaul.html#future-of-dockstore-tools)). From what I can tell, prod has < 10 legacy tools that are both CWL and WDL.

**Review Instructions**
View the review instructions in the UI PR https://github.com/dockstore/dockstore-ui2/pull/1673

**Issue**
[SEAB-5052](https://ucsc-cgl.atlassian.net/browse/SEAB-5052)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-5052]: https://ucsc-cgl.atlassian.net/browse/SEAB-5052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ