### PR TITLE
DOCK-2293: Parse CWL language version

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -203,7 +203,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
 
     private void getCwlVersionsFromMap(Set<String> versions, Map<String, Object> map) {
         map.forEach((k, v) -> {
-            if (Objects.equals(k, "cwlVersion") && v instanceof String) { // TODO make sure it's an entry
+            if (Objects.equals(k, "cwlVersion") && v instanceof String) {
                 versions.add(v.toString());
             } else if (v instanceof Map) {
                 getCwlVersionsFromMap(versions, (Map<String, Object>)v);
@@ -216,7 +216,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
     }
 
     private List<String> sortVersionsDescending(Set<String> versions) {
-        return versions.stream().sorted(Comparator.comparing(s -> s + "\uffff").reversed()).collect(Collectors.toList());
+        return versions.stream().sorted(Comparator.comparing((String s) -> s.replace("sbg:", "") + "\uffff").reversed()).collect(Collectors.toList());
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -95,7 +95,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
     /**
      * A regular expression that matches all CWL version strings that we want to register as language versions.
      */
-    private static final String LANGUAGE_VERSION_REGEX = "v[1-9].[0-9][0-9]?";
+    private static final String LANGUAGE_VERSION_REGEX = "v1.[0-9]";
     private static final Pattern LANGUAGE_VERSION_PATTERN = Pattern.compile(LANGUAGE_VERSION_REGEX);
 
     @Override
@@ -256,7 +256,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
 
     /**
      * Create a sort key for the specified version string.
-     * The version string is expected to be in the form 'vR', where R represents a semantic release number.
+     * The version string is expected to be in the form 'vD.D', where D is a decimal number.
      * If it is not, a value representing release '0.0.0' is returned, allowing the sort to proceed.
      */
     private com.github.zafarkhaja.semver.Version convertVersionToSortKey(String version) {
@@ -265,7 +265,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
             LOG.error("Version '{}' does not begin with 'v'", version);
             return errorValue;
         }
-        final String release = version.substring(1);
+        final String release = version.substring(1) + ".0";
         try {
             return com.github.zafarkhaja.semver.Version.valueOf(release);
         } catch (IllegalArgumentException | UnexpectedCharacterException | LexerException | UnexpectedTokenException ex) {

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -495,10 +495,10 @@ public class CWLHandlerTest {
         versionVersions = List.of("bogus");
         final Version version = mockMethodSetDescriptorTypeVersions(Mockito.mock(Version.class), v -> versionVersions = v);
         cwlHandler.parseWorkflowContent(manyFile.getPath(), manyFile.getContent(), Set.of(manyFile, oneFile, noFile), version);
-        Assert.assertEquals("v1.0", manyVersion);
+        Assert.assertEquals("v1.2", manyVersion);
         Assert.assertEquals("v1.1", oneVersion);
         Assert.assertEquals(null, noVersion);
-        Assert.assertEquals(List.of("v1.1", "v1.0", "v1.0.dev4", "draft-3.dev5", "sbg:draft-2"), versionVersions);
+        Assert.assertEquals(List.of("v1.2", "v1.1", "v1.0"), versionVersions);
 
         // Test one file containing no versions.
         noVersion = "bogus";

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -471,7 +471,7 @@ public class CWLHandlerTest {
         return version;
     }
 
-    private static String twoVersion;
+    private static String manyVersion;
     private static String oneVersion;
     private static String noVersion;
     private static List<String> versionVersions;
@@ -484,21 +484,27 @@ public class CWLHandlerTest {
         CWLHandler cwlHandler = new CWLHandler();
 
         final String resourceRoot = "multi-version-cwl";
-        final SourceFile twoFile = mockMethodSetTypeVersion(mockSourceFile(resourceRoot, "/two-version.cwl"), v -> twoVersion = v);
+        final SourceFile manyFile = mockMethodSetTypeVersion(mockSourceFile(resourceRoot, "/many-version.cwl"), v -> manyVersion = v);
         final SourceFile oneFile = mockMethodSetTypeVersion(mockSourceFile(resourceRoot, "/one-version.cwl"), v -> oneVersion = v);
         final SourceFile noFile = mockMethodSetTypeVersion(mockSourceFile(resourceRoot, "/no-version.cwl"), v -> noVersion = v);
 
-        twoVersion = "bogus";
+        // Test multiple files containing many versions.
+        manyVersion = "bogus";
         oneVersion = "bogus";
         noVersion = "bogus";
         versionVersions = List.of("bogus");
-
         final Version version = mockMethodSetDescriptorTypeVersions(Mockito.mock(Version.class), v -> versionVersions = v);
-        cwlHandler.parseWorkflowContent(twoFile.getPath(), twoFile.getContent(), Set.of(twoFile, oneFile, noFile), version);
-
-        Assert.assertEquals("v1.0.dev4", twoVersion);
-        Assert.assertEquals("v1.0", oneVersion);
+        cwlHandler.parseWorkflowContent(manyFile.getPath(), manyFile.getContent(), Set.of(manyFile, oneFile, noFile), version);
+        Assert.assertEquals("v1.0", manyVersion);
+        Assert.assertEquals("v1.1", oneVersion);
         Assert.assertEquals(null, noVersion);
-        Assert.assertEquals(List.of("v1.0", "v1.0.dev4", "sbg:draft-2"), versionVersions);
+        Assert.assertEquals(List.of("v1.1", "v1.0", "v1.0.dev4", "draft-3.dev5", "sbg:draft-2"), versionVersions);
+
+        // Test one file containing no versions.
+        noVersion = "bogus";
+        versionVersions = List.of("bogus");
+        cwlHandler.parseWorkflowContent(noFile.getPath(), noFile.getContent(), Set.of(noFile), version);
+        Assert.assertEquals(null, noVersion);
+        Assert.assertEquals(List.of(), versionVersions);
     }
 }

--- a/dockstore-webservice/src/test/resources/multi-version-cwl/many-version.cwl
+++ b/dockstore-webservice/src/test/resources/multi-version-cwl/many-version.cwl
@@ -34,7 +34,7 @@ steps:
 
   step3:
     run:
-      cwlVersion: "draft-3.dev5"
+      cwlVersion: "v1.2"
       class: CommandLineTool
       inputs: []
       outputs: []

--- a/dockstore-webservice/src/test/resources/multi-version-cwl/many-version.cwl
+++ b/dockstore-webservice/src/test/resources/multi-version-cwl/many-version.cwl
@@ -1,0 +1,59 @@
+cwlVersion: v1.0.dev4
+class: Workflow
+inputs: []
+outputs: []
+id: a/workflow/id/that/contains/slashes
+
+steps:
+
+  step1:
+    run:
+      cwlVersion: "sbg:draft-2"
+      class: CommandLineTool
+      inputs: []
+      outputs: []
+      baseCommand: echo
+      requirements:
+        - class: DockerRequirement
+          dockerPull: some_image
+    in: []
+    out: []
+
+  step2:
+    run:
+      cwlVersion: "v1.0"
+      class: CommandLineTool
+      inputs: []
+      outputs: []
+      baseCommand: echo
+      requirements:
+        - class: DockerRequirement
+          dockerPull: some_image
+    in: []
+    out: []
+
+  step3:
+    run:
+      cwlVersion: "draft-3.dev5"
+      class: CommandLineTool
+      inputs: []
+      outputs: []
+      baseCommand: echo
+      requirements:
+        - class: DockerRequirement
+          dockerPull: some_image
+    in: []
+    out: []
+
+  step4:
+    run:
+      cwlVersion: "draft-3.dev5"
+      class: CommandLineTool
+      inputs: []
+      outputs: []
+      baseCommand: echo
+      requirements:
+        - class: DockerRequirement
+          dockerPull: some_image
+    in: []
+    out: []

--- a/dockstore-webservice/src/test/resources/multi-version-cwl/no-version.cwl
+++ b/dockstore-webservice/src/test/resources/multi-version-cwl/no-version.cwl
@@ -1,0 +1,4 @@
+steps:
+  a:
+    run: tool.cwl
+

--- a/dockstore-webservice/src/test/resources/multi-version-cwl/one-version.cwl
+++ b/dockstore-webservice/src/test/resources/multi-version-cwl/one-version.cwl
@@ -1,0 +1,9 @@
+cwlVersion: v1.1
+class: CommandLineTool
+inputs: []
+outputs: []
+baseCommand: echo
+requirements:
+  - class: DockerRequirement
+    dockerPull: some_image
+


### PR DESCRIPTION
**Description**
This PR enhances `CWLHandler.parseWorkflowContent` so that it examines all CWL SourceFiles for language versions, sets the language version for each `SourceFile`, and sets the list of language versions of the specified `Version`.

**Edit, 9/Jan/2023:**
I've incorporated review feedback.  Per Kathy's WDL implementation, the code has been modified to, for the sake of language version extraction, recognize and save only the CWL versions which match a regex and ignore everything else.  The regex currently matches strings of the form 'vD.E', where `D` is the decimal major version 1 and `E` is the decimal minor version 0-9.  The latter range is intentionally larger than it needs to be so that it doesn't break when `v1.3` etc are released.  Per Denis' suggestion, I incorporated the semver code into the sort key generation method to make it more future-proof.  In that method, to make it more robust regarding future changes, it probably would have been better to move `WDLHandler.enhanceSemanticVersionString` to a shared helper and use it to create the three level version string, rather than tacking on a `.0`.  However, that would've required lots of changes to the tests, and since the tests are being refactored in another PR, it didn't seem like the right time to do it, so I did not. 

The new code in `CWLHandler` is commented well-enough that you can refer to it for more information.  Keep in mind that we're simultaneously dealing with two different concepts of "version" in this PR.  Note that because each CWL SourceFile can have multiple language versions, but the SourceFile object, by design, can only store one version, we can't use the same mechanism as we do for WDL to aggregate the versions.

I've got mixed feelings about the new unit test.  It uses mocking so that we're only testing `CWLHandler` itself, rather than whatever is going on inside of `SourceFile` and `Version`, so it is a true unit test.  However, as a result, parts of it are a bit ugly and hard to follow.  We could simplify the tests by creating normal `SourceFile` and [`Workflow`]`Version` objects, assuming that the getters and setters do reasonable things, and using them to store and check the results.  See `ElasticListenerTest` for an example of the latter approach.

**Review Instructions**
Register a CWL, then view the entry page in the browser.  Select the "Files" tab, then view each sourcefile, and use your browser's developer tools to make sure that the endpoint responses contain the correct language versions.  Check the `Version` responses similarly.

Alternately, if the UI portion of the language version work has been merged, deployed to qa, and allows it, register a CWL and use the UI to verify that the correct values were extracted from the sourcefiles.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2293
#5267

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
