### PR TITLE
Update Dockerfile galaxy plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY dockstore-webservice/target/dockstore-webservice*[^s].jar /home
 RUN mkdir /dockstore_logs && chmod a+rx /dockstore_logs
 
 # Include galaxy language plugin
-ARG galaxy_plugin_version=0.0.7
+ARG galaxy_plugin_version=0.0.8
 RUN apt-get install -y wget
 RUN mkdir -p /root/.dockstore/language-plugins
 RUN wget -P /root/.dockstore/language-plugins https://artifacts.oicr.on.ca/artifactory/collab-release/com/github/galaxyproject/dockstore-galaxy-interface/dockstore-galaxy-interface/${galaxy_plugin_version}/dockstore-galaxy-interface-${galaxy_plugin_version}.jar


### PR DESCRIPTION
**Description**
Update to a new version of the Galaxy plugin that handles 
1) 500s on malformed galaxy workflows
2) Parsing to determine whether a workflow is gxformat2 or older

**Review Instructions**
Browse to workflows in linked ticket, see if they throw 500s anymore. (There will be no output, which isn't great but at least no 500)

**Issue**
https://github.com/dockstore/dockstore/issues/5285

**Security**
None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
