### PR TITLE
fix link zip behaviour, and add tests

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceConstants.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceConstants.java
@@ -22,7 +22,7 @@ public final class ResourceConstants {
     public static final String CONTAINERTAGS = "List and modify tags for containers";
     public static final String GA4GHV1 = "A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [1.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/1.0.0) and is considered final (not subject to change)";
     public static final String GA4GH = "A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [2.0.0-beta.2](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0-beta.2) . Integrators are welcome to use these endpoints but they are subject to change based on community input.";
-    public static final String GA4GHV20 = "A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [2.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.1).";
+    public static final String GA4GHV20 = "A curated subset of resources proposed as a common standard for tool repositories. Implements TRS [2.0.1](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.1).";
     public static final String EXTENDEDGA4GH = "Optional experimental extensions of the GA4GH API";
     public static final String TOKENS = "List, modify, refresh, and delete tokens for external services";
     public static final String WORKFLOWS = "List and register workflows in the dockstore (CWL, Nextflow, WDL)";

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -833,8 +833,8 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
 
         // check for incompatible format option and header combination
         boolean zipFormat = "zip".equalsIgnoreCase(format);
-        boolean consumesHeaderJsonOnly = value.getAcceptableMediaTypes().stream().allMatch(mediaType -> mediaType.isCompatible(MediaType.APPLICATION_JSON_TYPE));
-        if (zipFormat && consumesHeaderJsonOnly) {
+        boolean jsonOnly = value.getAcceptableMediaTypes().stream().allMatch(mediaType -> mediaType.equals(MediaType.APPLICATION_JSON_TYPE));
+        if (zipFormat && jsonOnly) {
             return Response.status(Status.BAD_REQUEST).build();
         }
 

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -68,7 +68,7 @@ tags:
 - description: Optional experimental extensions of the GA4GH API
   name: extendedGA4GH
 - description: "A curated subset of resources proposed as a common standard for tool\
-    \ repositories. Implements TRS [2.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.1)."
+    \ repositories. Implements TRS [2.0.1](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.1)."
   name: GA4GHV20
 - description: "A curated subset of resources proposed as a common standard for tool\
     \ repositories. Implements TRS [2.0.0-beta.2](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.0-beta.2)\

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -43,7 +43,7 @@ tags:
     \ and is considered final (not subject to change)"
 - name: "GA4GHV20"
   description: "A curated subset of resources proposed as a common standard for tool\
-    \ repositories. Implements TRS [2.0.0](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.1)."
+    \ repositories. Implements TRS [2.0.1](https://github.com/ga4gh/tool-registry-service-schemas/releases/tag/2.0.1)."
 - name: "hosted"
   description: "Created and modify hosted entries in the dockstore"
 - name: "lambdaEvents"


### PR DESCRIPTION
**Description**
fix link zip behaviour, and add tests
For zip download, the idea is that the headers and query parameter should be both usable. If there is an invalid combination, return a 400. If we use wildcards and do not specify zip format, download as a json. If we specify json in the headers, download a json, etc. 

**Review Instructions**
See issue discussion

**Issue**
https://github.com/dockstore/dockstore/issues/5247

**Security**
none

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
