### PR TITLE
SEAB-5104: Add Notebook entity and related stuff

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
@@ -80,7 +80,13 @@ public enum DescriptorLanguage {
         public boolean isRelevantFileType(FileType type) {
             return super.isRelevantFileType(type) || type == FileType.DOCKSTORE_SERVICE_OTHER;
         }
-    };
+    },
+    IPYNB("ipynb", "Jupyter IPYNB notebook", FileType.DOCKSTORE_IPYNB, null, false, false, Set.of("ipynb"), false, false) {
+        @Override
+        public boolean isRelevantFileType(FileType type) {
+            return super.isRelevantFileType(type) || type == FileType.DOCKSTORE_REES || type == FileType.DOCKSTORE_DATA;
+        }
+    }
 
     /**
      * this name is used in the workflow path
@@ -209,6 +215,7 @@ public enum DescriptorLanguage {
         SECONDARY_DESCRIPTOR,
         TEST_FILE,
         CONTAINERFILE,
+        CONFIGURATION_FILE,
         OTHER
     }
 
@@ -244,7 +251,8 @@ public enum DescriptorLanguage {
         DOCKSTORE_YML(FileTypeCategory.OTHER),
         DOCKSTORE_SERVICE_YML(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_SERVICE_TEST_JSON(FileTypeCategory.TEST_FILE), DOCKSTORE_SERVICE_OTHER(FileTypeCategory.OTHER),
         DOCKSTORE_GXFORMAT2(FileTypeCategory.GENERIC_DESCRIPTOR), GXFORMAT2_TEST_FILE(FileTypeCategory.TEST_FILE),
-        DOCKSTORE_SWL(FileTypeCategory.GENERIC_DESCRIPTOR), SWL_TEST_JSON(FileTypeCategory.TEST_FILE);
+        DOCKSTORE_SWL(FileTypeCategory.GENERIC_DESCRIPTOR), SWL_TEST_JSON(FileTypeCategory.TEST_FILE),
+        DOCKSTORE_IPYNB(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_REES(FileTypeCategory.CONFIGURATION_FILE), DOCKSTORE_DATA(FileTypeCategory.OTHER)
         // DOCKSTORE-2428 - demo how to add new workflow language
 
         private final FileTypeCategory category;

--- a/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
@@ -86,7 +86,7 @@ public enum DescriptorLanguage {
         public boolean isRelevantFileType(FileType type) {
             return super.isRelevantFileType(type) || type == FileType.DOCKSTORE_REES || type == FileType.DOCKSTORE_DATA;
         }
-    }
+    };
 
     /**
      * this name is used in the workflow path
@@ -252,7 +252,7 @@ public enum DescriptorLanguage {
         DOCKSTORE_SERVICE_YML(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_SERVICE_TEST_JSON(FileTypeCategory.TEST_FILE), DOCKSTORE_SERVICE_OTHER(FileTypeCategory.OTHER),
         DOCKSTORE_GXFORMAT2(FileTypeCategory.GENERIC_DESCRIPTOR), GXFORMAT2_TEST_FILE(FileTypeCategory.TEST_FILE),
         DOCKSTORE_SWL(FileTypeCategory.GENERIC_DESCRIPTOR), SWL_TEST_JSON(FileTypeCategory.TEST_FILE),
-        DOCKSTORE_IPYNB(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_REES(FileTypeCategory.CONFIGURATION_FILE), DOCKSTORE_DATA(FileTypeCategory.OTHER)
+        DOCKSTORE_IPYNB(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_REES(FileTypeCategory.CONFIGURATION_FILE), DOCKSTORE_DATA(FileTypeCategory.OTHER);
         // DOCKSTORE-2428 - demo how to add new workflow language
 
         private final FileTypeCategory category;

--- a/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
@@ -84,7 +84,7 @@ public enum DescriptorLanguage {
     IPYNB("ipynb", "Jupyter IPYNB notebook", FileType.DOCKSTORE_IPYNB, null, false, false, Set.of("ipynb"), false, false) {
         @Override
         public boolean isRelevantFileType(FileType type) {
-            return super.isRelevantFileType(type) || type == FileType.DOCKSTORE_REES || type == FileType.DOCKSTORE_DATA;
+            return super.isRelevantFileType(type) || type == FileType.DOCKSTORE_NOTEBOOK_REES || type == FileType.DOCKSTORE_NOTEBOOK_OTHER;
         }
     };
 
@@ -252,7 +252,7 @@ public enum DescriptorLanguage {
         DOCKSTORE_SERVICE_YML(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_SERVICE_TEST_JSON(FileTypeCategory.TEST_FILE), DOCKSTORE_SERVICE_OTHER(FileTypeCategory.OTHER),
         DOCKSTORE_GXFORMAT2(FileTypeCategory.GENERIC_DESCRIPTOR), GXFORMAT2_TEST_FILE(FileTypeCategory.TEST_FILE),
         DOCKSTORE_SWL(FileTypeCategory.GENERIC_DESCRIPTOR), SWL_TEST_JSON(FileTypeCategory.TEST_FILE),
-        DOCKSTORE_IPYNB(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_REES(FileTypeCategory.CONFIGURATION_FILE), DOCKSTORE_DATA(FileTypeCategory.OTHER);
+        DOCKSTORE_IPYNB(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_NOTEBOOK_REES(FileTypeCategory.CONFIGURATION_FILE), DOCKSTORE_NOTEBOOK_OTHER(FileTypeCategory.OTHER);
         // DOCKSTORE-2428 - demo how to add new workflow language
 
         private final FileTypeCategory category;

--- a/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguageSubclass.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguageSubclass.java
@@ -26,6 +26,11 @@ public enum DescriptorLanguageSubclass {
     HELM("helm"),
     SWARM("swarm"),
     KUBERNETES("kubernetes"),
+
+    PYTHON("python"),
+    R("r"),
+    JULIA("julia"),
+
     NOT_APPLICABLE("n/a");
 
     private final String shortName;

--- a/dockstore-common/src/main/java/io/dockstore/common/EntryType.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/EntryType.java
@@ -9,7 +9,8 @@ public enum EntryType {
     TOOL("tool"),
     WORKFLOW("workflow"),
     SERVICE("service"),
-    APPTOOL("tool");
+    APPTOOL("tool"),
+    NOTEBOOK("notebook");
 
     private final String term;
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -1,0 +1,113 @@
+/*
+ *    Copyright 2019 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.dockstore.webservice;
+
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
+import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
+import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_LIMIT;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.dockstore.client.cli.BaseIT;
+import io.dockstore.client.cli.BaseIT.TestStatus;
+import io.dockstore.client.cli.BasicIT;
+import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.ConfidentialTest;
+import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.common.SourceControl;
+import io.dockstore.webservice.core.Notebook;
+import io.dockstore.webservice.core.Workflow;
+import io.dockstore.webservice.jdbi.NotebookDAO;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.swagger.api.impl.ToolsImplCommon;
+import io.swagger.client.ApiClient;
+import io.swagger.client.ApiException;
+import io.swagger.client.api.Ga4GhApi;
+import io.swagger.client.api.UsersApi;
+import io.swagger.client.api.WorkflowsApi;
+import io.swagger.client.model.StarRequest;
+import io.swagger.client.model.Tool;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import org.apache.http.HttpStatus;
+import org.glassfish.jersey.client.ClientProperties;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.context.internal.ManagedSessionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.stream.SystemErr;
+import uk.org.webcompere.systemstubs.stream.SystemOut;
+import uk.org.webcompere.systemstubs.stream.output.NoopStream;
+
+@ExtendWith(SystemStubsExtension.class)
+@ExtendWith(TestStatus.class)
+@Tag(ConfidentialTest.NAME)
+class NotebookIT extends BaseIT {
+
+    @SystemStub
+    public final SystemOut systemOutRule = new SystemOut(new NoopStream());
+    @SystemStub
+    public final SystemErr systemErrRule = new SystemErr(new NoopStream());
+
+    private NotebookDAO notebookDAO;
+    private Session session;
+
+    @BeforeEach
+    public void setup() {
+        DockstoreWebserviceApplication application = SUPPORT.getApplication();
+        SessionFactory sessionFactory = application.getHibernate().getSessionFactory();
+
+        this.notebookDAO = new NotebookDAO(sessionFactory);
+        this.workflowDAO = new WorkflowDAO(sessionFactory);
+
+        // non-confidential test database sequences seem messed up and need to be iterated past, but other tests may depend on ids
+        testingPostgres.runUpdateStatement("alter sequence enduser_id_seq increment by 50 restart with 100");
+        testingPostgres.runUpdateStatement("alter sequence token_id_seq increment by 50 restart with 100");
+
+        // used to allow us to use notebookDAO outside of the web service
+        this.session = application.getHibernate().getSessionFactory().openSession();
+        ManagedSessionContext.bind(session);
+    }
+
+    @Test
+    void testNotebookDAO() {
+        CreateContent createContent = new CreateContent().invoke(false);
+        long notebookID = createContent.getNotebookID();
+
+        // might not be right if our test database is larger than PAGINATION_LIMIT
+        final List<Workflow> allPublished = workflowDAO.findAllPublished(0, Integer.valueOf(PAGINATION_LIMIT), null, null, null);
+        assertTrue(allPublished.stream().anyMatch(workflow -> workflow.getId() == notebookId && workflow instanceof Notebook));
+
+        final Notebook byId = notebookDAO.findById(notebookID);
+
+        assertTrue(byId != null);
+        session.close();
+    }
+}

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2019 OICR
+ *    Copyright 2023 OICR and UCSC
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
 package io.dockstore.webservice;
 
 import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -51,6 +51,7 @@ import io.dockstore.webservice.core.FileFormat;
 import io.dockstore.webservice.core.Image;
 import io.dockstore.webservice.core.Label;
 import io.dockstore.webservice.core.LambdaEvent;
+import io.dockstore.webservice.core.Notebook;
 import io.dockstore.webservice.core.Notification;
 import io.dockstore.webservice.core.OrcidAuthor;
 import io.dockstore.webservice.core.Organization;
@@ -203,7 +204,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             Tag.class, Label.class, SourceFile.class, Workflow.class, CollectionOrganization.class, WorkflowVersion.class, FileFormat.class,
             Organization.class, Notification.class, OrganizationUser.class, Event.class, Collection.class, Validation.class, BioWorkflow.class, Service.class, VersionMetadata.class, Image.class, Checksum.class, LambdaEvent.class,
             ParsedInformation.class, EntryVersion.class, DeletedUsername.class, CloudInstance.class, Author.class, OrcidAuthor.class,
-            AppTool.class, Category.class, FullWorkflowPath.class) {
+            AppTool.class, Category.class, FullWorkflowPath.class, Notebook.class) {
         @Override
         public DataSourceFactory getDataSourceFactory(DockstoreWebserviceConfiguration configuration) {
             return configuration.getDataSourceFactory();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -83,6 +83,7 @@ import io.dockstore.webservice.jdbi.BioWorkflowDAO;
 import io.dockstore.webservice.jdbi.DeletedUsernameDAO;
 import io.dockstore.webservice.jdbi.EventDAO;
 import io.dockstore.webservice.jdbi.FileDAO;
+import io.dockstore.webservice.jdbi.NotebookDAO;
 import io.dockstore.webservice.jdbi.ServiceDAO;
 import io.dockstore.webservice.jdbi.TagDAO;
 import io.dockstore.webservice.jdbi.TokenDAO;
@@ -426,6 +427,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         ToolsApiServiceImpl.setBioWorkflowDAO(bioWorkflowDAO);
         ToolsApiServiceImpl.setServiceDAO(serviceDAO);
         ToolsApiServiceImpl.setAppToolDAO(appToolDAO);
+        ToolsApiServiceImpl.setNotebookDAO(notebookDAO);
         ToolsApiServiceImpl.setFileDAO(fileDAO);
         ToolsApiServiceImpl.setVersionDAO(versionDAO);
         ToolsApiServiceImpl.setConfig(configuration);
@@ -435,6 +437,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         ToolsApiExtendedServiceImpl.setToolDAO(toolDAO);
         ToolsApiExtendedServiceImpl.setWorkflowDAO(workflowDAO);
         ToolsApiExtendedServiceImpl.setAppToolDAO(appToolDAO);
+        ToolsApiExtendedServiceImpl.setNotebookDAO(notebookDAO);
         ToolsApiExtendedServiceImpl.setConfig(configuration);
 
         DOIGeneratorFactory.setConfig(configuration);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -351,6 +351,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         final FileDAO fileDAO = new FileDAO(hibernate.getSessionFactory());
         final WorkflowDAO workflowDAO = new WorkflowDAO(hibernate.getSessionFactory());
         final AppToolDAO appToolDAO = new AppToolDAO(hibernate.getSessionFactory());
+        final NotebookDAO notebookDAO = new NotebookDAO(hibernate.getSessionFactory());
         final TagDAO tagDAO = new TagDAO(hibernate.getSessionFactory());
         final EventDAO eventDAO = new EventDAO(hibernate.getSessionFactory());
         final VersionDAO versionDAO = new VersionDAO(hibernate.getSessionFactory());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -82,6 +82,12 @@ public class Event {
     private AppTool apptool;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notebookId", referencedColumnName = "id")
+    @ApiModelProperty(value = "Notebook that the event is acting on.", position = 10)
+    @JsonIgnoreProperties({ "workflowVersions" })
+    private Notebook notebook;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "collectionId", referencedColumnName = "id", columnDefinition = "bigint")
     @ApiModelProperty(value = "Collection that the event is acting on.", position = 5)
     @JsonIgnoreProperties({ "entries" })
@@ -118,6 +124,7 @@ public class Event {
 
     public Event() { }
 
+    /*
     public Event(User user, Organization organization, Collection collection, BioWorkflow workflow, Tool tool, User initiatorUser, EventType type) {
         this.user = user;
         this.organization = organization;
@@ -127,6 +134,7 @@ public class Event {
         this.initiatorUser = initiatorUser;
         this.type = type;
     }
+    */
 
     public long getId() {
         return id;
@@ -249,6 +257,7 @@ public class Event {
         private BioWorkflow bioWorkflow;
         private AppTool appTool;
         private Service service;
+        private Notebook notebook;
         private Collection collection;
         private User initiatorUser;
         private EventType type;
@@ -288,6 +297,11 @@ public class Event {
 
         public Builder withAppTool(AppTool appTool) {
             this.appTool = appTool;
+            return this;
+        }
+
+        public Builder withNotebook(Notebook notebook) {
+            this.notebook = notebook;
             return this;
         }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -124,18 +124,6 @@ public class Event {
 
     public Event() { }
 
-    /*
-    public Event(User user, Organization organization, Collection collection, BioWorkflow workflow, Tool tool, User initiatorUser, EventType type) {
-        this.user = user;
-        this.organization = organization;
-        this.collection = collection;
-        this.workflow = workflow;
-        this.tool = tool;
-        this.initiatorUser = initiatorUser;
-        this.type = type;
-    }
-    */
-
     public long getId() {
         return id;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
@@ -15,13 +15,13 @@ import javax.persistence.Table;
 @Table(name = "notebook")
 
 @NamedQueries({
-    @NamedQuery(name = "io.dockstore.webservice.core.Notebook.findAllPublishedPaths", query = "SELECT new io.dockstore.webservice.core.database.NotebookPath(c.sourceControl, c.organization, c.repository, c.workflowName) from Notebook c where c.isPublished = true"),
+    @NamedQuery(name = "io.dockstore.webservice.core.Notebook.findAllPublishedPaths", query = "SELECT new io.dockstore.webservice.core.database.NotebookPath(n.sourceControl, n.organization, n.repository, n.workflowName) from Notebook n where n.isPublished = true"),
     @NamedQuery(name = "io.dockstore.webservice.core.Notebook.getEntryLiteByUserId", query =
-        "SELECT new io.dockstore.webservice.core.database.EntryLite$EntryLiteNotebook(s.sourceControl, s.organization, s.repository, s.workflowName, s.dbUpdateDate as entryUpdated, MAX(v.dbUpdateDate) as versionUpdated) "
-            + "FROM Notebook s LEFT JOIN s.workflowVersions v "
-            + "WHERE s.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId) "
-            + "GROUP BY s.sourceControl, s.organization, s.repository, s.workflowName, s.dbUpdateDate"),
-    @NamedQuery(name = "io.dockstore.webservice.core.Notebook.getEntriesByUserId", query = "SELECT s FROM Notebook s WHERE s.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)")
+        "SELECT new io.dockstore.webservice.core.database.EntryLite$EntryLiteNotebook(n.sourceControl, n.organization, n.repository, n.workflowName, n.dbUpdateDate as entryUpdated, MAX(v.dbUpdateDate) as versionUpdated) "
+            + "FROM Notebook n LEFT JOIN n.workflowVersions v "
+            + "WHERE n.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId) "
+            + "GROUP BY n.sourceControl, n.organization, n.repository, n.workflowName, n.dbUpdateDate"),
+    @NamedQuery(name = "io.dockstore.webservice.core.Notebook.getEntriesByUserId", query = "SELECT n FROM Notebook n WHERE n.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)")
 })
 
 public class Notebook extends Workflow {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
@@ -22,7 +22,7 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 
-@ApiModel(value = "Notebook", description = "This describes one notebook in the dockstore as a special generate case of a workflow", parent = Workflow.class)
+@ApiModel(value = "Notebook", description = "This describes one notebook in the dockstore as a special degenerate case of a workflow", parent = Workflow.class)
 @Entity
 @Table(name = "notebook")
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
@@ -15,13 +15,16 @@ import javax.persistence.Table;
 @Table(name = "notebook")
 
 @NamedQueries({
-    @NamedQuery(name = "io.dockstore.webservice.core.Notebook.findAllPublishedPaths", query = "SELECT new io.dockstore.webservice.core.database.NotebookPath(n.sourceControl, n.organization, n.repository, n.workflowName) from Notebook n where n.isPublished = true"),
+    @NamedQuery(name = "io.dockstore.webservice.core.Notebook.getEntriesByUserId", query = "SELECT n FROM Notebook n WHERE n.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)"),
     @NamedQuery(name = "io.dockstore.webservice.core.Notebook.getEntryLiteByUserId", query =
         "SELECT new io.dockstore.webservice.core.database.EntryLite$EntryLiteNotebook(n.sourceControl, n.organization, n.repository, n.workflowName, n.dbUpdateDate as entryUpdated, MAX(v.dbUpdateDate) as versionUpdated) "
             + "FROM Notebook n LEFT JOIN n.workflowVersions v "
             + "WHERE n.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId) "
             + "GROUP BY n.sourceControl, n.organization, n.repository, n.workflowName, n.dbUpdateDate"),
-    @NamedQuery(name = "io.dockstore.webservice.core.Notebook.getEntriesByUserId", query = "SELECT n FROM Notebook n WHERE n.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)")
+    @NamedQuery(name = "io.dockstore.webservice.core.Notebook.findAllPublishedPaths", query = "SELECT new io.dockstore.webservice.core.database.NotebookPath(n.sourceControl, n.organization, n.repository, n.workflowName) from Notebook n where n.isPublished = true"),
+    @NamedQuery(name = "io.dockstore.webservice.core.Notebook.findAllPublishedPathsOrderByDbupdatedate",
+            query = "SELECT new io.dockstore.webservice.core.database.RSSNotebookPath(n.sourceControl, n.organization, n.repository, n.workflowName, n.lastUpdated, n.description) "
+                    + "from Notebook n where n.isPublished = true and n.dbUpdateDate is not null ORDER BY n.dbUpdateDate desc")
 })
 
 public class Notebook extends Workflow {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
@@ -1,0 +1,56 @@
+/*
+ * TODO new copyright header
+ */
+package io.dockstore.webservice.core;
+
+import io.dockstore.common.EntryType;
+import io.swagger.annotations.ApiModel;
+import javax.persistence.Entity;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+
+@ApiModel(value = "Notebook", description = "This describes one notebook in the dockstore as a special generate case of a workflow", parent = Workflow.class)
+@Entity
+@Table(name = "notebook")
+
+@NamedQueries({
+    @NamedQuery(name = "io.dockstore.webservice.core.Notebook.findAllPublishedPaths", query = "SELECT new io.dockstore.webservice.core.database.NotebookPath(c.sourceControl, c.organization, c.repository, c.workflowName) from Notebook c where c.isPublished = true"),
+    @NamedQuery(name = "io.dockstore.webservice.core.Notebook.getEntryLiteByUserId", query =
+        "SELECT new io.dockstore.webservice.core.database.EntryLite$EntryLiteNotebook(s.sourceControl, s.organization, s.repository, s.workflowName, s.dbUpdateDate as entryUpdated, MAX(v.dbUpdateDate) as versionUpdated) "
+            + "FROM Notebook s LEFT JOIN s.workflowVersions v "
+            + "WHERE s.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId) "
+            + "GROUP BY s.sourceControl, s.organization, s.repository, s.workflowName, s.dbUpdateDate"),
+    @NamedQuery(name = "io.dockstore.webservice.core.Notebook.getEntriesByUserId", query = "SELECT s FROM Notebook s WHERE s.id in (SELECT ue.id FROM User u INNER JOIN u.entries ue where u.id = :userId)")
+})
+
+public class Notebook extends Workflow {
+
+    @Override
+    public Entry getParentEntry() {
+        return null;
+    }
+
+    public EntryType getEntryType() {
+        return EntryType.NOTEBOOK;
+    }
+
+    @Override
+    public void setParentEntry(Entry parentEntry) {
+        throw new UnsupportedOperationException("cannot add a checker workflow to a Notebook");
+    }
+
+    @Override
+    public boolean isIsChecker() {
+        return false;
+    }
+
+    @Override
+    public void setIsChecker(boolean isChecker) {
+        throw new UnsupportedOperationException("cannot add a checker workflow to a Notebook");
+    }
+
+    public Event.Builder getEventBuilder() {
+        return new Event.Builder().withNotebook(this);
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
@@ -1,6 +1,18 @@
 /*
- * TODO new copyright header
+ * Copyright 2023 OICR, UCSC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package io.dockstore.webservice.core;
 
 import io.dockstore.common.EntryType;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -131,13 +131,13 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
     // this one is annoying since the codegen doesn't seem to pick up @JsonValue in the DescriptorLanguage enum
     @Column(nullable = false)
     @Convert(converter = DescriptorLanguageConverter.class)
-    @ApiModelProperty(value = "This is a descriptor type for the workflow, by default either SMK, CWL, WDL, NFL, or gxformat2 (Defaults to CWL).", required = true, position = 18, allowableValues = "SMK, CWL, WDL, NFL, gxformat2, service")
+    @ApiModelProperty(value = "This is a descriptor type for the workflow, by default either SMK, CWL, WDL, NFL, or gxformat2 (Defaults to CWL).", required = true, position = 18, allowableValues = "SMK, CWL, WDL, NFL, gxformat2, service, ipynb")
     private DescriptorLanguage descriptorType;
 
     // TODO: Change this to LAZY, this is the source of all our problems
     @Column(nullable = false, columnDefinition = "varchar(255) default 'n/a'")
     @Convert(converter = DescriptorLanguageSubclassConverter.class)
-    @ApiModelProperty(value = "This is a descriptor type subclass for the workflow. Currently it is only used for services.", required = true, position = 22)
+    @ApiModelProperty(value = "This is a descriptor type subclass for the workflow. Currently it is only used for services and notebooks.", required = true, position = 22)
     private DescriptorLanguageSubclass descriptorTypeSubclass = DescriptorLanguageSubclass.NOT_APPLICABLE;
 
     @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true, targetEntity = Version.class, mappedBy = "parent")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/EntryLite.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/EntryLite.java
@@ -4,6 +4,7 @@ import io.dockstore.common.EntryType;
 import io.dockstore.common.SourceControl;
 import io.dockstore.webservice.core.AppTool;
 import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.Notebook;
 import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.Tool;
 import java.util.Arrays;
@@ -128,4 +129,29 @@ public abstract class EntryLite {
             return EntryType.APPTOOL;
         }
     }
+
+    public static class EntryLiteNotebook extends EntryLite {
+        private final Notebook notebook = new Notebook();
+
+        public EntryLiteNotebook(final SourceControl sourceControl, final String organization, final String repository, final String workflowName, final Date entryUpdated, final Date versionUpdated) {
+            super(entryUpdated, versionUpdated);
+            this.notebook.setSourceControl(sourceControl);
+            this.notebook.setOrganization(organization);
+            this.notebook.setRepository(repository);
+            this.notebook.setWorkflowName(workflowName);
+
+        }
+
+        @Override
+        public String getEntryPath() {
+            return notebook.getEntryPath();
+        }
+
+        @Override
+        public EntryType getEntryType() {
+            return EntryType.NOTEBOOK;
+        }
+    }
+
+
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/NotebookPath.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/NotebookPath.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 OICR, UCSC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dockstore.webservice.core.database;
+
+import io.dockstore.common.SourceControl;
+import io.dockstore.webservice.core.Notebook;
+
+public class NotebookPath {
+    private final Notebook notebook = new Notebook();
+
+    public NotebookPath(SourceControl sourceControl, String organization, String repository, String notebookName) {
+        this.notebook.setSourceControl(sourceControl);
+        this.notebook.setOrganization(organization);
+        this.notebook.setRepository(repository);
+        this.notebook.setWorkflowName(notebookName);
+    }
+
+    public Notebook getNotebook() {
+        return notebook;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/RSSNotebookPath.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/RSSNotebookPath.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 OICR, UCSC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package io.dockstore.webservice.core.database;
+
+import io.dockstore.common.SourceControl;
+import io.dockstore.webservice.core.Notebook;
+import java.util.Date;
+
+public class RSSNotebookPath {
+    private final Notebook notebook = new Notebook();
+
+    public RSSNotebookPath(SourceControl sourceControl, String organization, String repository, String entryName, Date lastUpdated, String description) {
+        this.notebook.setSourceControl(sourceControl);
+        this.notebook.setOrganization(organization);
+        this.notebook.setRepository(repository);
+        this.notebook.setWorkflowName(entryName);
+        this.notebook.setLastUpdated(lastUpdated);
+        this.notebook.setDescription(description);
+    }
+
+    public Notebook getNotebook() {
+        return notebook;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/RSSNotebookPath.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/database/RSSNotebookPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 OICR, UCSC
+ * Copyright 2023 OICR, UCSC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/NotebookDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/NotebookDAO.java
@@ -16,13 +16,12 @@
 
 package io.dockstore.webservice.jdbi;
 
-import static io.dockstore.webservice.resources.MetadataResource.RSS_ENTRY_LIMIT;
-
+// import static io.dockstore.webservice.resources.MetadataResource.RSS_ENTRY_LIMIT;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.core.Notebook;
 import io.dockstore.webservice.core.SourceControlConverter;
 import io.dockstore.webservice.core.database.NotebookPath;
-import io.dockstore.webservice.core.database.RSSNotebookPath;
+// import io.dockstore.webservice.core.database.RSSNotebookPath;
 import java.util.List;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/NotebookDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/NotebookDAO.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 OICR, UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dockstore.webservice.jdbi;
+
+import static io.dockstore.webservice.resources.MetadataResource.RSS_ENTRY_LIMIT;
+
+import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.webservice.core.Notebook;
+import io.dockstore.webservice.core.SourceControlConverter;
+import io.dockstore.webservice.core.database.NotebookPath;
+import io.dockstore.webservice.core.database.RSSNotebookPath;
+import java.util.List;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import org.hibernate.SessionFactory;
+
+public class NotebookDAO extends EntryDAO<Notebook> {
+    public NotebookDAO(SessionFactory factory) {
+        super(factory);
+    }
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    protected Root<Notebook> generatePredicate(DescriptorLanguage descriptorLanguage, String registry, String organization, String name, String toolname, String description, String author, Boolean checker,
+        CriteriaBuilder cb, CriteriaQuery<?> q) {
+
+        final SourceControlConverter converter = new SourceControlConverter();
+        final Root<Notebook> entryRoot = q.from(Notebook.class);
+
+        Predicate predicate = getWorkflowPredicate(descriptorLanguage, registry, organization, name, toolname, description, author, checker, cb, converter, entryRoot);
+
+        // notebook is never a checker workflow
+        if (checker != null && checker) {
+            predicate = cb.isFalse(cb.literal(true));
+        }
+
+        q.where(predicate);
+        return entryRoot;
+    }
+    public List<NotebookPath> findAllPublishedPaths() {
+        return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Notebook.findAllPublishedPaths"));
+    }
+
+    /*
+    TODO
+    public List<RSSNotebookPath> findAllPublishedPathsOrderByDbupdatedate() {
+        return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Notebook.findAllPublishedPathsOrderByDbupdatedate").setMaxResults(
+                RSS_ENTRY_LIMIT));
+    }
+    */
+
+
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/NotebookDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/NotebookDAO.java
@@ -52,6 +52,7 @@ public class NotebookDAO extends EntryDAO<Notebook> {
         q.where(predicate);
         return entryRoot;
     }
+
     public List<NotebookPath> findAllPublishedPaths() {
         return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Notebook.findAllPublishedPaths"));
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/NotebookDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/NotebookDAO.java
@@ -16,12 +16,13 @@
 
 package io.dockstore.webservice.jdbi;
 
-// import static io.dockstore.webservice.resources.MetadataResource.RSS_ENTRY_LIMIT;
+import static io.dockstore.webservice.resources.MetadataResource.RSS_ENTRY_LIMIT;
+
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.core.Notebook;
 import io.dockstore.webservice.core.SourceControlConverter;
 import io.dockstore.webservice.core.database.NotebookPath;
-// import io.dockstore.webservice.core.database.RSSNotebookPath;
+import io.dockstore.webservice.core.database.RSSNotebookPath;
 import java.util.List;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -55,13 +56,8 @@ public class NotebookDAO extends EntryDAO<Notebook> {
         return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Notebook.findAllPublishedPaths"));
     }
 
-    /*
-    TODO
     public List<RSSNotebookPath> findAllPublishedPathsOrderByDbupdatedate() {
         return list(this.currentSession().getNamedQuery("io.dockstore.webservice.core.Notebook.findAllPublishedPathsOrderByDbupdatedate").setMaxResults(
                 RSS_ENTRY_LIMIT));
     }
-    */
-
-
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -33,6 +33,7 @@ import io.dockstore.webservice.helpers.PublicStateManager;
 import io.dockstore.webservice.helpers.statelisteners.ElasticListener;
 import io.dockstore.webservice.jdbi.AppToolDAO;
 import io.dockstore.webservice.jdbi.EntryDAO;
+import io.dockstore.webservice.jdbi.NotebookDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import io.dockstore.webservice.jdbi.WorkflowDAO;
 import io.openapi.api.impl.ToolsApiServiceImpl;
@@ -90,6 +91,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
     private static ToolDAO toolDAO = null;
     private static WorkflowDAO workflowDAO = null;
     private static AppToolDAO appToolDAO = null;
+    private static NotebookDAO notebookDAO = null;
     private static DockstoreWebserviceConfiguration config = null;
     private static PublicStateManager publicStateManager = null;
     private static Semaphore elasticSearchConcurrencyLimit = null;
@@ -108,6 +110,10 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
 
     public static void setAppToolDAO(AppToolDAO appToolDAO) {
         ToolsApiExtendedServiceImpl.appToolDAO = appToolDAO;
+    }
+
+    public static void setNotebookDAO(NotebookDAO notebookDAO) {
+        ToolsApiExtendedServiceImpl.notebookDAO = notebookDAO;
     }
 
     public static void setConfig(DockstoreWebserviceConfiguration config) {

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -47,6 +47,7 @@ import io.dockstore.webservice.jdbi.AppToolDAO;
 import io.dockstore.webservice.jdbi.BioWorkflowDAO;
 import io.dockstore.webservice.jdbi.EntryDAO;
 import io.dockstore.webservice.jdbi.FileDAO;
+import io.dockstore.webservice.jdbi.NotebookDAO;
 import io.dockstore.webservice.jdbi.ServiceDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import io.dockstore.webservice.jdbi.VersionDAO;
@@ -114,6 +115,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
     private static WorkflowDAO workflowDAO = null;
     private static ServiceDAO serviceDAO = null;
     private static AppToolDAO appToolDAO = null;
+    private static NotebookDAO notebookDAO = null;
     private static FileDAO fileDAO = null;
     private static DockstoreWebserviceConfiguration config = null;
     private static EntryVersionHelper<Tool, Tag, ToolDAO> toolHelper;
@@ -148,6 +150,10 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         ToolsApiServiceImpl.appToolDAO = appToolDAO;
         // TODO; look into this
         //ToolsApiServiceImpl.bioWorkflowHelper = () -> appToolDAO;
+    }
+
+    public static void setNotebookDAO(NotebookDAO notebookDAO) {
+        ToolsApiServiceImpl.notebookDAO = notebookDAO;
     }
 
     public static void setFileDAO(FileDAO fileDAO) {

--- a/dockstore-webservice/src/main/resources/import.sql
+++ b/dockstore-webservice/src/main/resources/import.sql
@@ -24,10 +24,12 @@ CREATE UNIQUE INDEX full_workflow_name ON workflow USING btree (sourcecontrol, o
 CREATE UNIQUE INDEX full_workflow_name_masterlist ON fullworkflowpath USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
 CREATE UNIQUE INDEX full_tool_name ON tool USING btree (registry, namespace, name, toolname) WHERE toolname IS NOT NULL;
 CREATE UNIQUE INDEX full_apptool_name ON apptool USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
+CREATE UNIQUE INDEX full_notebook_name ON notebook USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
 CREATE UNIQUE INDEX partial_workflow_name ON workflow USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
 CREATE UNIQUE INDEX partial_workflow_name_masterlist ON fullworkflowpath USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
 CREATE UNIQUE INDEX partial_tool_name ON tool USING btree (registry, namespace, name) WHERE toolname IS NULL;
 CREATE UNIQUE INDEX partial_apptool_name ON apptool USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
+CREATE UNIQUE INDEX partial_notebook_name ON notebook USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
 CREATE UNIQUE INDEX full_service_name ON service USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
 CREATE UNIQUE INDEX partial_service_name ON service USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
 CREATE UNIQUE INDEX partial_cloud_instance ON cloud_instance USING btree (url) WHERE user_id IS NULL;

--- a/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
@@ -120,7 +120,6 @@
             <column name="lastmodified" type="TIMESTAMP WITHOUT TIME ZONE"/>
             <column name="lastupdated" type="TIMESTAMP WITHOUT TIME ZONE"/>
             <column name="licensename" type="VARCHAR(255)"/>
-            <column name="orcidputcode" type="VARCHAR(255)"/>
             <column name="topicid" type="BIGINT"/>
             <column name="checkerid" type="BIGINT"/>
             <column name="descriptortype" type="VARCHAR(255)">
@@ -144,6 +143,11 @@
             </column>
             <column name="workflowname" type="TEXT"/>
             <column name="actualdefaultversion" type="BIGINT"/>
+            <column name="topicautomatic" type="varchar(150 BYTE)"/>
+            <column name="topicmanual" type="varchar(150 BYTE)"/>
+            <column defaultValue="AUTOMATIC" name="topicselection" type="varchar(32 BYTE)">
+                <constraints nullable="false"/>
+            </column>
         </createTable>
         <addForeignKeyConstraint baseColumnNames="actualdefaultversion" baseTableName="notebook" constraintName="fk_defaultversion_notebook" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="workflowversion"/>
         <addUniqueConstraint columnNames="actualdefaultversion" constraintName="uk_actualdefaultversion_notebook" tableName="notebook"/>

--- a/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
@@ -153,6 +153,22 @@
         <addUniqueConstraint columnNames="actualdefaultversion" constraintName="uk_actualdefaultversion_notebook" tableName="notebook"/>
         <addUniqueConstraint columnNames="checkerid" constraintName="uk_checkerid_notebook" tableName="notebook"/>
         <addForeignKeyConstraint baseColumnNames="checkerid" baseTableName="notebook" constraintName="fk_checkerid_notebook" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="workflow"/>
+        <sql dbms="postgresql">
+            CREATE UNIQUE INDEX if not exists full_notebook_name ON notebook USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
+            CREATE UNIQUE INDEX if not exists partial_notebook_name ON notebook USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
+        </sql>
+        <sql dbms="postgresql">
+            CREATE TRIGGER notebook_path_trigger
+            AFTER INSERT
+            ON notebook
+            FOR EACH ROW
+            EXECUTE PROCEDURE workflow_path_insert_trigger_fnc();
+            CREATE TRIGGER notebook_path_deletion_trigger
+            AFTER DELETE
+            ON notebook
+            FOR EACH ROW
+            EXECUTE PROCEDURE workflow_path_deletion_trigger_fnc();
+        </sql>
     </changeSet>
     <changeSet author="svonworl" id="addNotebookEvents">
         <addColumn tableName="event">

--- a/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
@@ -100,4 +100,60 @@
             <column name="descriptortypeversions" type="varchar"/>
         </addColumn>
     </changeSet>
+    <changeSet author="svonworl" id="addNotebook">
+        <createTable tableName="notebook">
+            <column name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="notebook_pkey"/>
+            </column>
+            <column name="author" type="VARCHAR(255)"/>
+            <column name="conceptdoi" type="VARCHAR(255)"/>
+            <column name="dbcreatedate" type="TIMESTAMP WITHOUT TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="dbupdatedate" type="TIMESTAMP WITHOUT TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="TEXT"/>
+            <column name="email" type="VARCHAR(255)"/>
+            <column name="giturl" type="VARCHAR(255)"/>
+            <column name="ispublished" type="BOOLEAN"/>
+            <column name="lastmodified" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="lastupdated" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="licensename" type="VARCHAR(255)"/>
+            <column name="orcidputcode" type="VARCHAR(255)"/>
+            <column name="topicid" type="BIGINT"/>
+            <column name="checkerid" type="BIGINT"/>
+            <column name="descriptortype" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValue="n/a" name="descriptortypesubclass" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="forumurl" type="VARCHAR(256)"/>
+            <column defaultValue="STUB" name="mode" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="organization" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="repository" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sourcecontrol" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="workflowname" type="TEXT"/>
+            <column name="actualdefaultversion" type="BIGINT"/>
+        </createTable>
+        <addForeignKeyConstraint baseColumnNames="actualdefaultversion" baseTableName="notebook" constraintName="fk_defaultversion_notebook" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="workflowversion"/>
+        <addUniqueConstraint columnNames="actualdefaultversion" constraintName="uk_actualdefaultversion_notebook" tableName="notebook"/>
+        <addUniqueConstraint columnNames="checkerid" constraintName="uk_checkerid_notebook" tableName="notebook"/>
+        <addForeignKeyConstraint baseColumnNames="checkerid" baseTableName="notebook" constraintName="fk_checkerid_notebook" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="workflow"/>
+    </changeSet>
+    <changeSet author="svonworl" id="addNotebookEvents">
+        <addColumn tableName="event">
+            <column name="notebookid" type="int8"/>
+        </addColumn>
+        <addForeignKeyConstraint baseColumnNames="notebookid" baseTableName="event" constraintName="fkNotebookId" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="notebook"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
@@ -141,7 +141,7 @@
             <column name="sourcecontrol" type="TEXT">
                 <constraints nullable="false"/>
             </column>
-            <column name="workflowname" type="TEXT"/>
+            <column name="workflowname" type="VARCHAR(256)"/>
             <column name="actualdefaultversion" type="BIGINT"/>
             <column name="topicautomatic" type="varchar(150 BYTE)"/>
             <column name="topicmanual" type="varchar(150 BYTE)"/>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1831,8 +1831,8 @@ paths:
             - DOCKSTORE_SWL
             - SWL_TEST_JSON
             - DOCKSTORE_IPYNB
-            - DOCKSTORE_REES
-            - DOCKSTORE_DATA
+            - DOCKSTORE_NOTEBOOK_REES
+            - DOCKSTORE_NOTEBOOK_OTHER
       responses:
         default:
           content:
@@ -2330,8 +2330,8 @@ paths:
                   - DOCKSTORE_SWL
                   - SWL_TEST_JSON
                   - DOCKSTORE_IPYNB
-                  - DOCKSTORE_REES
-                  - DOCKSTORE_DATA
+                  - DOCKSTORE_NOTEBOOK_REES
+                  - DOCKSTORE_NOTEBOOK_OTHER
                 uniqueItems: true
           description: default response
       security:
@@ -7346,8 +7346,8 @@ paths:
             - DOCKSTORE_SWL
             - SWL_TEST_JSON
             - DOCKSTORE_IPYNB
-            - DOCKSTORE_REES
-            - DOCKSTORE_DATA
+            - DOCKSTORE_NOTEBOOK_REES
+            - DOCKSTORE_NOTEBOOK_OTHER
       responses:
         default:
           content:
@@ -8854,8 +8854,8 @@ components:
           - DOCKSTORE_SWL
           - SWL_TEST_JSON
           - DOCKSTORE_IPYNB
-          - DOCKSTORE_REES
-          - DOCKSTORE_DATA
+          - DOCKSTORE_NOTEBOOK_REES
+          - DOCKSTORE_NOTEBOOK_OTHER
         typeVersion:
           type: string
           description: The language version for the given descriptor file type
@@ -9564,8 +9564,8 @@ components:
           - DOCKSTORE_SWL
           - SWL_TEST_JSON
           - DOCKSTORE_IPYNB
-          - DOCKSTORE_REES
-          - DOCKSTORE_DATA
+          - DOCKSTORE_NOTEBOOK_REES
+          - DOCKSTORE_NOTEBOOK_OTHER
         valid:
           type: boolean
     VerificationInformation:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -976,6 +976,7 @@ paths:
           - SWL
           - NFL
           - service
+          - ipynb
       - in: query
         name: namespace
         schema:
@@ -1630,6 +1631,7 @@ paths:
           - SWL
           - NFL
           - service
+          - ipynb
       responses:
         default:
           content:
@@ -1828,6 +1830,9 @@ paths:
             - GXFORMAT2_TEST_FILE
             - DOCKSTORE_SWL
             - SWL_TEST_JSON
+            - DOCKSTORE_IPYNB
+            - DOCKSTORE_REES
+            - DOCKSTORE_DATA
       responses:
         default:
           content:
@@ -1907,6 +1912,7 @@ paths:
           - SWL
           - NFL
           - service
+          - ipynb
       responses:
         default:
           content:
@@ -2323,6 +2329,9 @@ paths:
                   - GXFORMAT2_TEST_FILE
                   - DOCKSTORE_SWL
                   - SWL_TEST_JSON
+                  - DOCKSTORE_IPYNB
+                  - DOCKSTORE_REES
+                  - DOCKSTORE_DATA
                 uniqueItems: true
           description: default response
       security:
@@ -5757,6 +5766,7 @@ paths:
           - SWL
           - NFL
           - service
+          - ipynb
       - in: query
         name: namespace
         schema:
@@ -6447,6 +6457,7 @@ paths:
           - SWL
           - NFL
           - service
+          - ipynb
       responses:
         default:
           content:
@@ -6599,6 +6610,7 @@ paths:
           - SWL
           - NFL
           - service
+          - ipynb
       responses:
         default:
           content:
@@ -6634,6 +6646,7 @@ paths:
           - SWL
           - NFL
           - service
+          - ipynb
       responses:
         default:
           content:
@@ -6906,6 +6919,7 @@ paths:
           - SWL
           - NFL
           - service
+          - ipynb
       responses:
         default:
           content:
@@ -7331,6 +7345,9 @@ paths:
             - GXFORMAT2_TEST_FILE
             - DOCKSTORE_SWL
             - SWL_TEST_JSON
+            - DOCKSTORE_IPYNB
+            - DOCKSTORE_REES
+            - DOCKSTORE_DATA
       responses:
         default:
           content:
@@ -8137,6 +8154,7 @@ components:
           - WORKFLOW
           - SERVICE
           - APPTOOL
+          - NOTEBOOK
         lastUpdateDate:
           type: integer
           format: int64
@@ -8383,6 +8401,7 @@ components:
           - SWL
           - NFL
           - service
+          - ipynb
         version:
           type: string
     LanguageParsingRequest:
@@ -8403,6 +8422,7 @@ components:
           - SWL
           - NFL
           - service
+          - ipynb
         descriptorRelativePathInGit:
           type: string
           description: The relative path to the primary descriptor (relative to the
@@ -8660,6 +8680,7 @@ components:
           - SWL
           - NFL
           - service
+          - ipynb
         hasHTTPImports:
           type: boolean
         hasLocalImports:
@@ -8832,6 +8853,9 @@ components:
           - GXFORMAT2_TEST_FILE
           - DOCKSTORE_SWL
           - SWL_TEST_JSON
+          - DOCKSTORE_IPYNB
+          - DOCKSTORE_REES
+          - DOCKSTORE_DATA
         typeVersion:
           type: string
           description: The language version for the given descriptor file type
@@ -9539,6 +9563,9 @@ components:
           - GXFORMAT2_TEST_FILE
           - DOCKSTORE_SWL
           - SWL_TEST_JSON
+          - DOCKSTORE_IPYNB
+          - DOCKSTORE_REES
+          - DOCKSTORE_DATA
         valid:
           type: boolean
     VerificationInformation:
@@ -9749,6 +9776,7 @@ components:
           - SWL
           - NFL
           - service
+          - ipynb
         descriptorTypeSubclass:
           type: string
           enum:
@@ -9756,6 +9784,9 @@ components:
           - helm
           - swarm
           - kubernetes
+          - python
+          - r
+          - julia
           - n/a
         email:
           type: string

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -7928,8 +7928,8 @@ definitions:
         - "DOCKSTORE_SWL"
         - "SWL_TEST_JSON"
         - "DOCKSTORE_IPYNB"
-        - "DOCKSTORE_REES"
-        - "DOCKSTORE_DATA"
+        - "DOCKSTORE_NOTEBOOK_REES"
+        - "DOCKSTORE_NOTEBOOK_OTHER"
       content:
         type: "string"
         position: 2
@@ -8631,8 +8631,8 @@ definitions:
         - "DOCKSTORE_SWL"
         - "SWL_TEST_JSON"
         - "DOCKSTORE_IPYNB"
-        - "DOCKSTORE_REES"
-        - "DOCKSTORE_DATA"
+        - "DOCKSTORE_NOTEBOOK_REES"
+        - "DOCKSTORE_NOTEBOOK_OTHER"
       valid:
         type: "boolean"
         position: 2

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -1355,6 +1355,7 @@ paths:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
+        - "IPYNB"
       - name: "namespace"
         in: "query"
         description: "The Docker namespace (Tools only)"
@@ -2063,6 +2064,7 @@ paths:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
+        - "IPYNB"
       responses:
         200:
           description: "successful operation"
@@ -2254,6 +2256,7 @@ paths:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
+        - "IPYNB"
       responses:
         200:
           description: "successful operation"
@@ -5009,6 +5012,7 @@ paths:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
+        - "IPYNB"
       - name: "namespace"
         in: "query"
         description: "The Docker namespace (Tools only)"
@@ -5720,6 +5724,7 @@ paths:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
+        - "IPYNB"
       responses:
         200:
           description: "successful operation"
@@ -5884,6 +5889,7 @@ paths:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
+        - "IPYNB"
       responses:
         200:
           description: "successful operation"
@@ -6179,6 +6185,7 @@ paths:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
+        - "IPYNB"
       responses:
         200:
           description: "successful operation"
@@ -7243,6 +7250,7 @@ definitions:
         - "WORKFLOW"
         - "SERVICE"
         - "APPTOOL"
+        - "NOTEBOOK"
       lastUpdateDate:
         type: "integer"
         format: "int64"
@@ -7779,6 +7787,7 @@ definitions:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
+        - "IPYNB"
       hasHTTPImports:
         type: "boolean"
       hasLocalImports:
@@ -7918,6 +7927,9 @@ definitions:
         - "GXFORMAT2_TEST_FILE"
         - "DOCKSTORE_SWL"
         - "SWL_TEST_JSON"
+        - "DOCKSTORE_IPYNB"
+        - "DOCKSTORE_REES"
+        - "DOCKSTORE_DATA"
       content:
         type: "string"
         position: 2
@@ -8618,6 +8630,9 @@ definitions:
         - "GXFORMAT2_TEST_FILE"
         - "DOCKSTORE_SWL"
         - "SWL_TEST_JSON"
+        - "DOCKSTORE_IPYNB"
+        - "DOCKSTORE_REES"
+        - "DOCKSTORE_DATA"
       valid:
         type: "boolean"
         position: 2
@@ -9020,6 +9035,7 @@ definitions:
         - "NFL"
         - "gxformat2"
         - "service"
+        - "ipynb"
       workflow_path:
         type: "string"
         position: 19
@@ -9042,12 +9058,15 @@ definitions:
         type: "string"
         position: 22
         description: "This is a descriptor type subclass for the workflow. Currently\
-          \ it is only used for services."
+          \ it is only used for services and notebooks."
         enum:
         - "DOCKER_COMPOSE"
         - "HELM"
         - "SWARM"
         - "KUBERNETES"
+        - "PYTHON"
+        - "R"
+        - "JULIA"
         - "NOT_APPLICABLE"
       full_workflow_path:
         type: "string"


### PR DESCRIPTION
**Description**
This PR adds a `Notebook` entity and and an associated DAO to the webservice, creates the new `notebook` db table, adds a new descriptor language and some subclass and file type values, and modifies related code and entities so that the webservice still builds.

Please keep in mind that this is a first attempt at something that will provide a suitable foundation for the rest of the work.  Given the unknowns, it's probably somewhere in the neighborhood of reasonable, but it definitely embodies some educated guesses.   We can iterate if we discover that we need to make changes/improvements...

My current plan is to try to shoehorn the "format" of the notebook (IPYNB, RStudio, etc) and the programming language used within (Python, R, Julia, etc) into the notions of an entry's descriptor language and descriptor language subclass, respectively.  This may make it easier to reuse various bits of code, as the expense of not being quite as understandable as storing some or all of that info in custom field(s) of the concrete entities.

To that end, we:
* define a new descriptor language `IPYNB`.
* add values for Python, R, and Julia to `DescriptorLanguageSubclass`.
* add new file types `DOCKSTORE_IPYNB` (notebook file), `DOCKSTORE_REES` (REES configuration files), and `DOCKSTORE_DATA` (data and other accompanying files from the repo that the notebook uses).
* add new file type category `CONFIGURATION_FILE` to describe ancillary configuration files such as those specified by REES.
 
We won't support R and Julia initially, but I put them in there to add meaning/context.  I can take them out if we find it objectionable...

The enum value names are likely to change as we do more work, these are a first draft.

I didn't include the notion of Docker kernel image in the definition of a notebook [version] in this PR, due to the feedback from the PI meeting and the fact since it's currently unclear how high we are prioritizing the "on-prem" use case.  We can add it later if we need to.
 
Most of the new code is [intentionally] a pretty straightforward adaptation of existing `AppTool` and `Service` code.

A very rudimentary test, adapted from `ServiceIT`, which slightly exercises the notebook DAO, is included.  We will add more tests as we build the surrounding functionality... 

**Review Instructions**
Check `openapi.yaml` to make sure the new descriptor language values have appeared, that there is a new `notebook` table in the database, and that from the point of view of the end user, nothing has changed.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5104

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
