### PR TITLE
Remove unnecessary log messages by default

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
@@ -28,7 +28,6 @@ import javax.validation.ValidatorFactory;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.similarity.LevenshteinDistance;
-import org.jline.utils.Log;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.DumperOptions;

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java
@@ -28,6 +28,7 @@ import javax.validation.ValidatorFactory;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.similarity.LevenshteinDistance;
+import org.jline.utils.Log;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.DumperOptions;
@@ -181,7 +182,9 @@ public final class DockstoreYamlHelper {
             return dockstoreYaml12;
         } catch (UnsupportedOperationException | InvocationTargetException | IllegalAccessException e) {
             final String msg = "Error converting ; " + e.getMessage();
-            LOG.error(msg, e);
+            if (LOG.isDebugEnabled()) {
+                LOG.error(msg, e);
+            }
             throw new DockstoreYamlException(msg);
         }
     }
@@ -223,7 +226,9 @@ public final class DockstoreYamlHelper {
             return yaml.load(content);
         } catch (Exception e) {
             final String exceptionMsg = e.getMessage();
-            LOG.error(ERROR_READING_DOCKSTORE_YML + exceptionMsg, e);
+            if (LOG.isDebugEnabled()) {
+                LOG.error(ERROR_READING_DOCKSTORE_YML + exceptionMsg, e);
+            }
             throw new DockstoreYamlException(exceptionMsg);
         }
     }
@@ -345,7 +350,9 @@ public final class DockstoreYamlHelper {
                         try {
                             fieldClass = Class.forName(className);
                         } catch (ClassNotFoundException ex) {
-                            LOG.error("Could not get the class object for {}", className, ex);
+                            if (LOG.isDebugEnabled()) {
+                                LOG.error("Could not get the class object for {}", className, ex);
+                            }
                             continue;
                         }
                         addNewPropertyClassToQueue(dockstoreYamlPackageName, fieldClass, discoveredClasses, dockstoreYmlPropertiesQueue);


### PR DESCRIPTION
**Description**
[DockstoreYamlHelper.java](https://github.com/dockstore/dockstore/compare/develop...feature/DOCK-2268/remove-stack-trace#diff-83a20218f746824f90f7f608cd685ed5d0b0e0ad71d1c448576b94f0b2c83c38) is generating log messages at the error level [here](https://github.com/dockstore/dockstore/blob/00cccd2a1afc47d51c06a877df003577305afa62/dockstore-common/src/main/java/io/dockstore/common/yaml/DockstoreYamlHelper.java#L226), which is causing the output in the yaml validator in the CLI to be difficult to understand for the end user. For example, it is currently generating the following output,
```
java -jar dockstore-client/target/dockstore-client-1.14.0-SNAPSHOT-shaded.jar yaml validate --path dockstore-client/src/test/resources/YamlVerifyTestDirectory/incorrectly-named-parameter-in-yml
dockstore-client/src/test/resources/YamlVerifyTestDirectory/incorrectly-named-parameter-in-yml/.dockstore.yml is a valid yaml file
15:48:39.882 [main] ERROR io.dockstore.common.yaml.DockstoreYamlHelper - Error reading .dockstore.yml: Cannot create property=tools for JavaBean=io.dockstore.common.yaml.DockstoreYaml12@7e9da981
 in 'string', line 1, column 1:
    version: 1.2
    ^
Cannot create property=publih for JavaBean=io.dockstore.common.yaml.YamlTool@40368a46
 in 'string', line 3, column 6:
      -  subclass: WDL
         ^
Unable to find property 'publih' on class: io.dockstore.common.yaml.YamlTool
 in 'string', line 10, column 14:
         publih: true
                 ^

 in 'string', line 3, column 3:
      -  subclass: WDL
      ^

org.yaml.snakeyaml.constructor.ConstructorException: Cannot create property=tools for JavaBean=io.dockstore.common.yaml.DockstoreYaml12@7e9da981
 in 'string', line 1, column 1:
    version: 1.2
    ^
Cannot create property=publih for JavaBean=io.dockstore.common.yaml.YamlTool@40368a46
 in 'string', line 3, column 6:
      -  subclass: WDL
         ^
Unable to find property 'publih' on class: io.dockstore.common.yaml.YamlTool
 in 'string', line 10, column 14:
         publih: true
                 ^

 in 'string', line 3, column 3:
      -  subclass: WDL
      ^

        at org.yaml.snakeyaml.constructor.Constructor$ConstructMapping.constructJavaBean2ndStep(Constructor.java:321)
        at org.yaml.snakeyaml.constructor.Constructor$ConstructMapping.construct(Constructor.java:207)
        at org.yaml.snakeyaml.constructor.Constructor$ConstructYamlObject.construct(Constructor.java:358)
        at org.yaml.snakeyaml.constructor.BaseConstructor.constructObjectNoCheck(BaseConstructor.java:270)
        at org.yaml.snakeyaml.constructor.BaseConstructor.constructObject(BaseConstructor.java:253)
        at org.yaml.snakeyaml.constructor.BaseConstructor.constructDocument(BaseConstructor.java:207)
        at org.yaml.snakeyaml.constructor.BaseConstructor.getSingleData(BaseConstructor.java:191)
        at org.yaml.snakeyaml.Yaml.loadFromReader(Yaml.java:477)
        at org.yaml.snakeyaml.Yaml.load(Yaml.java:406)
        at io.dockstore.common.yaml.DockstoreYamlHelper.readContent(DockstoreYamlHelper.java:223)
        at io.dockstore.common.yaml.DockstoreYamlHelper.checkForUnknownProperty(DockstoreYamlHelper.java:254)
        at io.dockstore.common.yaml.DockstoreYamlHelper$Version$3.validateDockstoreYamlProperties(DockstoreYamlHelper.java:86)
        at io.dockstore.common.yaml.DockstoreYamlHelper.validateDockstoreYamlProperties(DockstoreYamlHelper.java:240)
        at io.dockstore.client.cli.YamlVerifyUtility.dockstoreValidate(YamlVerifyUtility.java:167)
        at io.dockstore.client.cli.YamlClient.handleCommand(YamlClient.java:73)
        at io.dockstore.client.cli.Client.run(Client.java:734)
        at io.dockstore.client.cli.Client.main(Client.java:633)
Caused by: org.yaml.snakeyaml.constructor.ConstructorException: Cannot create property=publih for JavaBean=io.dockstore.common.yaml.YamlTool@40368a46
 in 'string', line 3, column 6:
      -  subclass: WDL
         ^
Unable to find property 'publih' on class: io.dockstore.common.yaml.YamlTool
 in 'string', line 10, column 14:
         publih: true
                 ^

        at org.yaml.snakeyaml.constructor.Constructor$ConstructMapping.constructJavaBean2ndStep(Constructor.java:321)
        at org.yaml.snakeyaml.constructor.Constructor$ConstructMapping.construct(Constructor.java:207)
        at org.yaml.snakeyaml.constructor.BaseConstructor.constructObjectNoCheck(BaseConstructor.java:270)
        at org.yaml.snakeyaml.constructor.BaseConstructor.constructObject(BaseConstructor.java:253)
        at org.yaml.snakeyaml.constructor.BaseConstructor.constructSequenceStep2(BaseConstructor.java:469)
        at org.yaml.snakeyaml.constructor.BaseConstructor.constructSequence(BaseConstructor.java:435)
        at org.yaml.snakeyaml.constructor.Constructor$ConstructSequence.construct(Constructor.java:560)
        at org.yaml.snakeyaml.constructor.BaseConstructor.constructObjectNoCheck(BaseConstructor.java:270)
        at org.yaml.snakeyaml.constructor.BaseConstructor.constructObject(BaseConstructor.java:253)
        at org.yaml.snakeyaml.constructor.Constructor$ConstructMapping.newInstance(Constructor.java:333)
        at org.yaml.snakeyaml.constructor.Constructor$ConstructMapping.constructJavaBean2ndStep(Constructor.java:298)
        ... 16 common frames omitted
Caused by: org.yaml.snakeyaml.error.YAMLException: Unable to find property 'publih' on class: io.dockstore.common.yaml.YamlTool
        at org.yaml.snakeyaml.introspector.PropertyUtils.getProperty(PropertyUtils.java:155)
        at org.yaml.snakeyaml.introspector.PropertyUtils.getProperty(PropertyUtils.java:145)
        at org.yaml.snakeyaml.constructor.Constructor$ConstructMapping.getProperty(Constructor.java:337)
        at org.yaml.snakeyaml.constructor.Constructor$ConstructMapping.constructJavaBean2ndStep(Constructor.java:261)
        ... 26 common frames omitted
Your .dockstore.yml is invalid:
dockstore-client/src/test/resources/YamlVerifyTestDirectory
```
And this PR will cause it generate output such as this,
```
dockstore-client/src/test/resources/YamlVerifyTestDirectory/incorrectly-named-parameter-in-yml/.dockstore.yml is a valid yaml file
Your .dockstore.yml is invalid:
dockstore-client/src/test/resources/YamlVerifyTestDirectory/incorrectly-named-parameter-in-yml/.dockstore.yml has the following errors:
Unknown property: 'publih'. Did you mean: 'publish'?
```
This is because the log error messages will now only be shown to the end user if debug mode is on.

This PR implemented feedback given in https://github.com/dockstore/dockstore-cli/pull/215.

**Review Instructions**

- [ ] Ensure that the stack trace is displayed when the debug flag is used in the CLI
- [ ] Verify that the stack trace is removed when the debug flag is not used in the CLI
- [ ] Verify that helpful error messages are still given in the CLI

**Issue**
https://github.com/dockstore/dockstore/issues/5186
[DOCK-2268](https://ucsc-cgl.atlassian.net/browse/DOCK-2268)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[DOCK-2268]: https://ucsc-cgl.atlassian.net/browse/DOCK-2268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ