### PR TITLE
Move language descriptor versions to different tables

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -442,14 +442,14 @@ class GeneralIT extends GeneralWorkflowBaseIT {
             sourceFiles.forEach(sourceFile -> {
                 if ("/Dockstore.wdl".equals(sourceFile.getAbsolutePath())) {
                     assertEquals(FileType.DOCKSTORE_WDL, sourceFile.getType());
-                    assertEquals(WDLHandler.DEFAULT_WDL_VERSION, sourceFile.getTypeVersion(), "Language version of WDL descriptor with no 'version' field should be default version");
+                    assertEquals(WDLHandler.DEFAULT_WDL_VERSION, sourceFile.getMetadata().getTypeVersion(), "Language version of WDL descriptor with no 'version' field should be default version");
                 } else {
                     assertEquals(FileType.DOCKERFILE, sourceFile.getType());
-                    assertNull(sourceFile.getTypeVersion(), "Docker files should not have a version");
+                    assertNull(sourceFile.getMetadata().getTypeVersion(), "Docker files should not have a version");
                 }
             });
-            assertEquals(1, tag.getDescriptorTypeVersions().size(), "Should only have one language version");
-            assertTrue(tag.getDescriptorTypeVersions().contains(WDLHandler.DEFAULT_WDL_VERSION));
+            assertEquals(1, tag.getVersionMetadata().getDescriptorTypeVersions().size(), "Should only have one language version");
+            assertTrue(tag.getVersionMetadata().getDescriptorTypeVersions().contains(WDLHandler.DEFAULT_WDL_VERSION));
         });
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -1232,9 +1232,9 @@ public class WorkflowIT extends BaseIT {
         List<io.dockstore.openapi.client.model.SourceFile> sourceFiles = workflowsApi.getWorkflowVersionsSourcefiles(workflow.getId(), workflowVersion.getId(), null);
         assertNotNull(sourceFiles);
         assertEquals(1, sourceFiles.size());
-        assertEquals(WDLHandler.DEFAULT_WDL_VERSION, sourceFiles.get(0).getTypeVersion(), "Language version of WDL descriptor without 'version' field should be the default version");
-        assertEquals(1, workflowVersion.getDescriptorTypeVersions().size(), "Should only have one language version");
-        assertTrue(workflowVersion.getDescriptorTypeVersions().contains(WDLHandler.DEFAULT_WDL_VERSION));
+        assertEquals(WDLHandler.DEFAULT_WDL_VERSION, sourceFiles.get(0).getMetadata().getTypeVersion(), "Language version of WDL descriptor without 'version' field should be the default version");
+        assertEquals(1, workflowVersion.getVersionMetadata().getDescriptorTypeVersions().size(), "Should only have one language version");
+        assertTrue(workflowVersion.getVersionMetadata().getDescriptorTypeVersions().contains(WDLHandler.DEFAULT_WDL_VERSION));
 
         // Test WDL workflow with 'version 1.0'
         workflow = workflowsApi.manualRegister(SourceControl.GITHUB.name(), "dockstore-testing/hello-wdl-workflow",
@@ -1247,14 +1247,14 @@ public class WorkflowIT extends BaseIT {
         sourceFiles.forEach(sourceFile -> {
             if ("/Dockstore.wdl".equals(sourceFile.getAbsolutePath())) {
                 assertEquals(FileType.DOCKSTORE_WDL.name(), sourceFile.getType().getValue());
-                assertEquals("1.0", sourceFile.getTypeVersion(), "Language version of WDL descriptor with 'version 1.0' should be 1.0");
+                assertEquals("1.0", sourceFile.getMetadata().getTypeVersion(), "Language version of WDL descriptor with 'version 1.0' should be 1.0");
             } else {
                 assertEquals(FileType.WDL_TEST_JSON.name(), sourceFile.getType().getValue());
-                assertNull(sourceFile.getTypeVersion(), "Test files should not have a version");
+                assertNull(sourceFile.getMetadata().getTypeVersion(), "Test files should not have a version");
             }
         });
-        assertEquals(1, workflowVersion.getDescriptorTypeVersions().size(), "Should only have one language version");
-        assertTrue(workflowVersion.getDescriptorTypeVersions().contains("1.0"));
+        assertEquals(1, workflowVersion.getVersionMetadata().getDescriptorTypeVersions().size(), "Should only have one language version");
+        assertTrue(workflowVersion.getVersionMetadata().getDescriptorTypeVersions().contains("1.0"));
 
         // test that versions coming back from TRS 2.0.1 look sane
         workflowsApi.publish1(workflow.getId(), new io.dockstore.openapi.client.model.PublishRequest().publish(true));
@@ -1273,10 +1273,10 @@ public class WorkflowIT extends BaseIT {
         sourceFiles.forEach(sourceFile -> {
             // This workflow has three descriptor files and no test file
             assertEquals(FileType.DOCKSTORE_WDL.name(), sourceFile.getType().getValue());
-            assertEquals(WDLHandler.DEFAULT_WDL_VERSION, sourceFile.getTypeVersion(), "Language version of WDL descriptors with no 'version' field should be default version");
+            assertEquals(WDLHandler.DEFAULT_WDL_VERSION, sourceFile.getMetadata().getTypeVersion(), "Language version of WDL descriptors with no 'version' field should be default version");
         });
-        assertEquals(1, workflowVersion.getDescriptorTypeVersions().size(), "Should only have one language version");
-        assertTrue(workflowVersion.getDescriptorTypeVersions().contains(WDLHandler.DEFAULT_WDL_VERSION));
+        assertEquals(1, workflowVersion.getVersionMetadata().getDescriptorTypeVersions().size(), "Should only have one language version");
+        assertTrue(workflowVersion.getVersionMetadata().getDescriptorTypeVersions().contains(WDLHandler.DEFAULT_WDL_VERSION));
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1594,14 +1594,14 @@ class WebhookIT extends BaseIT {
         sourceFiles.forEach(sourceFile -> {
             if ("/Dockstore.wdl".equals(sourceFile.getAbsolutePath())) {
                 assertEquals(FileType.DOCKSTORE_WDL.name(), sourceFile.getType().getValue());
-                assertEquals("1.0", sourceFile.getTypeVersion(), "Language version of WDL descriptor with 'version 1.0' should be 1.0");
+                assertEquals("1.0", sourceFile.getMetadata().getTypeVersion(), "Language version of WDL descriptor with 'version 1.0' should be 1.0");
             } else {
                 assertEquals(FileType.DOCKSTORE_YML.name(), sourceFile.getType().getValue());
-                assertNull(sourceFile.getTypeVersion(), ".dockstore.yml should not have a version");
+                assertNull(sourceFile.getMetadata().getTypeVersion(), ".dockstore.yml should not have a version");
             }
         });
-        assertEquals(1, version.getDescriptorTypeVersions().size(), "Should only have one language version");
-        assertTrue(version.getDescriptorTypeVersions().contains("1.0"));
+        assertEquals(1, version.getVersionMetadata().getDescriptorTypeVersions().size(), "Should only have one language version");
+        assertTrue(version.getVersionMetadata().getDescriptorTypeVersions().contains("1.0"));
     }
 
     // Asserts that the workflow metadata is the same as the default version metadata

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -59,6 +59,7 @@ import io.dockstore.webservice.core.OrganizationUser;
 import io.dockstore.webservice.core.ParsedInformation;
 import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.SourceFile;
+import io.dockstore.webservice.core.SourceFileMetadata;
 import io.dockstore.webservice.core.Tag;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.core.Tool;
@@ -204,7 +205,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             Tag.class, Label.class, SourceFile.class, Workflow.class, CollectionOrganization.class, WorkflowVersion.class, FileFormat.class,
             Organization.class, Notification.class, OrganizationUser.class, Event.class, Collection.class, Validation.class, BioWorkflow.class, Service.class, VersionMetadata.class, Image.class, Checksum.class, LambdaEvent.class,
             ParsedInformation.class, EntryVersion.class, DeletedUsername.class, CloudInstance.class, Author.class, OrcidAuthor.class,
-            AppTool.class, Category.class, FullWorkflowPath.class, Notebook.class) {
+            AppTool.class, Category.class, FullWorkflowPath.class, Notebook.class, SourceFileMetadata.class) {
         @Override
         public DataSourceFactory getDataSourceFactory(DockstoreWebserviceConfiguration configuration) {
             return configuration.getDataSourceFactory();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -143,7 +143,7 @@ public class SourceFile implements Comparable<SourceFile> {
     private SourceFileMetadata metadata = new SourceFileMetadata();
 
     public SourceFile() {
-        this.metadata.parent = this;
+        metadata.setParent(this);
     }
 
     public Map<String, VerificationInformation> getVerifiedBySource() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -146,6 +146,33 @@ public class SourceFile implements Comparable<SourceFile> {
         metadata.setParent(this);
     }
 
+    /**
+     * Copy constructor with special handling for metadata field -- copies its values, rather
+     * than the object, so that you don't end up with the metadata field pointing to the wrong
+     * source file.
+     *
+     * Necessitated by the ugly circular reference JPA requires for one-to-one relationship.
+     *
+     * @param otherSourceFile
+     */
+    public SourceFile(final SourceFile otherSourceFile) {
+        this();
+        id = otherSourceFile.id;
+        type = otherSourceFile.type;
+        content = otherSourceFile.content;
+        path = otherSourceFile.path;
+        absolutePath = otherSourceFile.absolutePath;
+        frozen = otherSourceFile.frozen;
+        checksums = otherSourceFile.checksums;
+        dbCreateDate = otherSourceFile.dbCreateDate;
+        dbUpdateDate = otherSourceFile.dbUpdateDate;
+        verifiedBySource = otherSourceFile.verifiedBySource;
+
+        // Special case, we want SourceFileMetadata.parent to be this SourceFile, not otherSourceFile
+        metadata.setTypeVersion(otherSourceFile.getMetadata().getTypeVersion());
+        metadata.setId(otherSourceFile.getId());
+    }
+
     public Map<String, VerificationInformation> getVerifiedBySource() {
         return verifiedBySource;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFileMetadata.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFileMetadata.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.dockstore.webservice.core;
+
+import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "sourcefile_metadata")
+public class SourceFileMetadata {
+
+    @Id
+    @Column(name = "id")
+    private long id;
+
+    @Column(columnDefinition = "TEXT")
+    @ApiModelProperty(value = "The language version for the given descriptor file type")
+    @Schema(description = "The language version for the given descriptor file type")
+    private String typeVersion;
+
+    @MapsId
+    @OneToOne
+    @JoinColumn(name = "id")
+    protected SourceFile parent;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(final long id) {
+        this.id = id;
+    }
+
+    public String getTypeVersion() {
+        return typeVersion;
+    }
+
+    public void setTypeVersion(final String typeVersion) {
+        this.typeVersion = typeVersion;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFileMetadata.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFileMetadata.java
@@ -43,7 +43,7 @@ public class SourceFileMetadata {
     @MapsId
     @OneToOne
     @JoinColumn(name = "id")
-    protected SourceFile parent;
+    private SourceFile parent;
 
     public long getId() {
         return id;
@@ -60,4 +60,9 @@ public class SourceFileMetadata {
     public void setTypeVersion(final String typeVersion) {
         this.typeVersion = typeVersion;
     }
+
+    void setParent(final SourceFile parent) {
+        this.parent = parent;
+    }
+
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.sql.Timestamp;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -38,7 +37,6 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
-import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -221,11 +219,6 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @BatchSize(size = 25)
     private Set<Image> images = new HashSet<>();
 
-    @Column(columnDefinition = "varchar")
-    @Convert(converter = DescriptorTypeVersionConverter.class)
-    @ApiModelProperty(value = "The language versions for the version's descriptor files")
-    private List<String> descriptorTypeVersions = new ArrayList<>();
-
     @JsonIgnore
     @OneToMany(mappedBy = "version", cascade = CascadeType.REMOVE)
     private Set<EntryVersion> entryVersions = new HashSet<>();
@@ -295,7 +288,6 @@ public abstract class Version<T extends Version> implements Comparable<T> {
         referenceType = version.getReferenceType();
         frozen = version.isFrozen();
         commitID = version.getCommitID();
-        descriptorTypeVersions = version.getDescriptorTypeVersions();
         this.setVersionMetadata(version.getVersionMetadata());
     }
 
@@ -600,21 +592,15 @@ public abstract class Version<T extends Version> implements Comparable<T> {
         this.parent = parent;
     }
 
-    public List<String> getDescriptorTypeVersions() {
-        return descriptorTypeVersions;
-    }
-
-    public void setDescriptorTypeVersions(List<String> descriptorTypeVersions) {
-        this.descriptorTypeVersions = descriptorTypeVersions;
-    }
 
     public void setDescriptorTypeVersionsFromSourceFiles(Set<SourceFile> sourceFilesWithDescriptorTypeVersions) {
         List<String> languageVersions = sourceFilesWithDescriptorTypeVersions.stream()
-                .map(SourceFile::getTypeVersion)
+                .map(SourceFile::getMetadata)
+                .map(SourceFileMetadata::getTypeVersion)
                 .filter(Objects::nonNull)
                 .distinct()
                 .collect(Collectors.toList());
-        this.setDescriptorTypeVersions(languageVersions);
+        getVersionMetadata().setDescriptorTypeVersions(languageVersions);
     }
 
     public enum DOIStatus { NOT_REQUESTED, REQUESTED, CREATED

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -128,6 +129,11 @@ public class VersionMetadata {
     @ApiModelProperty()
     private Boolean publicAccessibleTestParameterFile;
 
+    @Column(columnDefinition = "varchar")
+    @Convert(converter = DescriptorTypeVersionConverter.class)
+    @ApiModelProperty(value = "The language versions for the version's descriptor files")
+    private List<String> descriptorTypeVersions = new ArrayList<>();
+
     public long getId() {
         return id;
     }
@@ -168,5 +174,13 @@ public class VersionMetadata {
 
     public void setPublicAccessibleTestParameterFile(Boolean publicAccessibleTestParameterFile) {
         this.publicAccessibleTestParameterFile = publicAccessibleTestParameterFile;
+    }
+
+    public List<String> getDescriptorTypeVersions() {
+        return descriptorTypeVersions;
+    }
+
+    public void setDescriptorTypeVersions(final List<String> descriptorTypeVersions) {
+        this.descriptorTypeVersions = descriptorTypeVersions;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -758,7 +758,7 @@ public abstract class AbstractImageRegistry {
             for (SourceFile newFile : newFiles) {
                 if (Objects.equals(oldFile.getAbsolutePath(), newFile.getAbsolutePath())) {
                     oldFile.setContent(newFile.getContent());
-                    oldFile.setTypeVersion(newFile.getTypeVersion());
+                    oldFile.getMetadata().setTypeVersion(newFile.getMetadata().getTypeVersion());
                     newFiles.remove(newFile);
                     found = true;
                     break;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -574,7 +574,7 @@ public abstract class SourceCodeRepoInterface {
         if (sourceFile != null && sourceFile.getContent() != null) {
             // carry over metadata from plugins
             final Optional<SourceFile> matchingFile = sourceFileSet.stream().filter(f -> f.getPath().equals(sourceFile.getPath())).findFirst();
-            matchingFile.ifPresent(file -> sourceFile.setTypeVersion(file.getTypeVersion()));
+            matchingFile.ifPresent(file -> sourceFile.getMetadata().setTypeVersion(file.getMetadata().getTypeVersion()));
             version.getSourceFiles().add(sourceFile);
         }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -498,7 +498,7 @@ public class ElasticListener implements StateListenerInterface {
 
         // Get a list of unique descriptor type versions with the descriptor type prepended. Ex: 'WDL 1.0'
         return workflowVersions.stream()
-                .map(workflowVersion -> (List<String>)workflowVersion.getDescriptorTypeVersions())
+                .map(workflowVersion -> (List<String>)workflowVersion.getVersionMetadata().getDescriptorTypeVersions())
                 .flatMap(List::stream)
                 .distinct()
                 .map(descriptorTypeVersion -> String.join(" ", language, descriptorTypeVersion))

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -439,16 +439,16 @@ public class ElasticListener implements StateListenerInterface {
     private static Set<Version> cloneWorkflowVersion(final Set<Version> originalWorkflowVersions) {
         Set<Version> detachedVersions = new HashSet<>();
         originalWorkflowVersions.forEach(workflowVersion -> {
-            Version detatchedVersion = workflowVersion.createEmptyVersion();
-            detatchedVersion.setDescriptionAndDescriptionSource(workflowVersion.getDescription(), workflowVersion.getDescriptionSource());
-            detatchedVersion.setInputFileFormats(new TreeSet<>(workflowVersion.getInputFileFormats()));
-            detatchedVersion.setOutputFileFormats(new TreeSet<>(workflowVersion.getOutputFileFormats()));
-            detatchedVersion.setName(workflowVersion.getName());
-            detatchedVersion.setReference(workflowVersion.getReference());
+            Version detachedVersion = workflowVersion.createEmptyVersion();
+            detachedVersion.setDescriptionAndDescriptionSource(workflowVersion.getDescription(), workflowVersion.getDescriptionSource());
+            detachedVersion.setInputFileFormats(new TreeSet<>(workflowVersion.getInputFileFormats()));
+            detachedVersion.setOutputFileFormats(new TreeSet<>(workflowVersion.getOutputFileFormats()));
+            detachedVersion.setName(workflowVersion.getName());
+            detachedVersion.setReference(workflowVersion.getReference());
             SortedSet<SourceFile> sourceFiles = workflowVersion.getSourceFiles();
-            sourceFiles.forEach(sourceFile -> detatchedVersion.addSourceFile(new SourceFile(sourceFile)));
-            detatchedVersion.updateVerified();
-            detachedVersions.add(detatchedVersion);
+            sourceFiles.forEach(sourceFile -> detachedVersion.addSourceFile(SourceFile.copy(sourceFile)));
+            detachedVersion.updateVerified();
+            detachedVersions.add(detachedVersion);
         });
         return detachedVersions;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -18,7 +18,6 @@ package io.dockstore.webservice.helpers.statelisteners;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.gson.Gson;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.core.AppTool;
@@ -447,12 +446,7 @@ public class ElasticListener implements StateListenerInterface {
             detatchedVersion.setName(workflowVersion.getName());
             detatchedVersion.setReference(workflowVersion.getReference());
             SortedSet<SourceFile> sourceFiles = workflowVersion.getSourceFiles();
-            sourceFiles.forEach(sourceFile -> {
-                Gson gson = new Gson();
-                String gsonString = gson.toJson(sourceFile);
-                SourceFile detachedSourceFile = gson.fromJson(gsonString, SourceFile.class);
-                detatchedVersion.addSourceFile(detachedSourceFile);
-            });
+            sourceFiles.forEach(sourceFile -> detatchedVersion.addSourceFile(new SourceFile(sourceFile)));
             detatchedVersion.updateVerified();
             detachedVersions.add(detatchedVersion);
         });

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -209,11 +209,11 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
         for (SourceFile file: sourceFiles) {
             if (file.getType() == DescriptorLanguage.FileType.DOCKSTORE_CWL) {
                 Set<String> fileVersions = getCwlVersionsFromSourceFile(file);
-                file.setTypeVersion(newestVersion(fileVersions));
+                file.getMetadata().setTypeVersion(newestVersion(fileVersions));
                 allVersions.addAll(fileVersions);
             }
         }
-        version.setDescriptorTypeVersions(sortVersionsDescending(allVersions));
+        version.getVersionMetadata().setDescriptorTypeVersions(sortVersionsDescending(allVersions));
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -178,7 +178,7 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
             final SourceFile sourceFile = new SourceFile();
             sourceFile.setPath(entry.getKey());
             sourceFile.setContent(entry.getValue().content());
-            sourceFile.setTypeVersion(entry.getValue().languageVersion());
+            sourceFile.getMetadata().setTypeVersion(entry.getValue().languageVersion());
             if (minimalLanguageInterface.getDescriptorLanguage().isServiceLanguage()) {
                 // TODO: this needs to be more sophisticated
                 sourceFile.setType(DescriptorLanguage.FileType.DOCKSTORE_SERVICE_YML);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -125,7 +125,7 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
         sourceFiles.stream()
             // Exclude config file and test params
             .filter(sourceFile -> sourceFile.getType() == FileType.NEXTFLOW)
-            .forEach(sourceFile -> sourceFile.setTypeVersion(dslVersion));
+            .forEach(sourceFile -> sourceFile.getMetadata().setTypeVersion(dslVersion));
         version.setDescriptorTypeVersionsFromSourceFiles(sourceFiles);
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -135,7 +135,7 @@ public class WDLHandler implements LanguageHandlerInterface {
                 // Set language version for descriptor source files
                 for (SourceFile sourceFile : sourceFiles) {
                     if (sourceFile.getType() == DescriptorLanguage.FileType.DOCKSTORE_WDL) {
-                        sourceFile.setTypeVersion(getLanguageVersion(sourceFile.getAbsolutePath(), sourceFiles).orElse(null));
+                        sourceFile.getMetadata().setTypeVersion(getLanguageVersion(sourceFile.getAbsolutePath(), sourceFiles).orElse(null));
                     }
                 }
                 version.setDescriptorTypeVersionsFromSourceFiles(sourceFiles);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -221,7 +221,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             SourceFile existingFile = existingFileMap.get(fileKey);
             if (existingFileMap.containsKey(fileKey)) {
                 existingFile.setContent(file.getContent());
-                existingFile.setTypeVersion(file.getTypeVersion());
+                existingFile.getMetadata().setTypeVersion(file.getMetadata().getTypeVersion());
             } else {
                 final long fileID = fileDAO.create(file);
                 final SourceFile fileFromDB = fileDAO.findById(fileID);

--- a/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
+++ b/dockstore-webservice/src/main/java/io/swagger/api/impl/ToolsImplCommon.java
@@ -222,7 +222,7 @@ public final class ToolsImplCommon {
                     EnumSet<DescriptorType> set = EnumSet.copyOf(descriptorType);
                     toolVersion.setDescriptorType(Lists.newArrayList(set));
                     // can assume in Dockstore that a single version only has one language
-                    toolVersion.setDescriptorTypeVersion(Map.of(descriptorType.get(0).toString(), Lists.newArrayList(version.getDescriptorTypeVersions())));
+                    toolVersion.setDescriptorTypeVersion(Map.of(descriptorType.get(0).toString(), Lists.newArrayList(version.getVersionMetadata().getDescriptorTypeVersions())));
                 }
                 tool.getVersions().add(toolVersion);
             }

--- a/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
@@ -96,6 +96,9 @@
             </column>
             <column name="typeversion" type="text"/>
         </createTable>
+        <sql dbms="postgresql">
+            insert into sourcefile_metadata (id) select id from sourcefile;
+        </sql>
         <addForeignKeyConstraint baseTableName="sourcefile_metadata" baseColumnNames="id" constraintName="fk_sourcefile_metadata" referencedTableName="sourcefile" referencedColumnNames="id"/>
         <addColumn tableName="version_metadata">
             <column name="descriptortypeversions" type="varchar"/>

--- a/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
@@ -90,13 +90,14 @@
         </sql>
     </changeSet>
     <changeSet author="ktran (generated)" id="addDescriptorTypeVersion">
-        <addColumn tableName="sourcefile">
+        <createTable tableName="sourcefile_metadata">
+            <column autoIncrement="true" name="id" type="BIGSERIAL">
+                <constraints primaryKey="true" primaryKeyName="sourcefile_metadata_pkey"/>
+            </column>
             <column name="typeversion" type="text"/>
-        </addColumn>
-        <addColumn tableName="tag">
-            <column name="descriptortypeversions" type="varchar"/>
-        </addColumn>
-        <addColumn tableName="workflowversion">
+        </createTable>
+        <addForeignKeyConstraint baseTableName="sourcefile_metadata" baseColumnNames="id" constraintName="fk_sourcefile_metadata" referencedTableName="sourcefile" referencedColumnNames="id"/>
+        <addColumn tableName="version_metadata">
             <column name="descriptortypeversions" type="varchar"/>
         </addColumn>
     </changeSet>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -8828,6 +8828,8 @@ components:
         id:
           type: integer
           format: int64
+        metadata:
+          $ref: '#/components/schemas/SourceFileMetadata'
         path:
           type: string
           description: Path to sourcefile relative to its parent
@@ -8856,9 +8858,6 @@ components:
           - DOCKSTORE_IPYNB
           - DOCKSTORE_NOTEBOOK_REES
           - DOCKSTORE_NOTEBOOK_OTHER
-        typeVersion:
-          type: string
-          description: The language version for the given descriptor file type
         verifiedBySource:
           type: object
           additionalProperties:
@@ -8867,6 +8866,17 @@ components:
       - absolutePath
       - path
       - type
+    SourceFileMetadata:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        parent:
+          $ref: '#/components/schemas/SourceFile'
+        typeVersion:
+          type: string
+          description: The language version for the given descriptor file type
     StarRequest:
       type: object
       properties:
@@ -8980,10 +8990,6 @@ components:
           enum:
           - README
           - DESCRIPTOR
-        descriptorTypeVersions:
-          type: array
-          items:
-            type: string
         descriptorTypeVersionsFromSourceFiles:
           type: array
           items:
@@ -9599,10 +9605,6 @@ components:
           enum:
           - README
           - DESCRIPTOR
-        descriptorTypeVersions:
-          type: array
-          items:
-            type: string
         descriptorTypeVersionsFromSourceFiles:
           type: array
           items:
@@ -9698,6 +9700,10 @@ components:
           type: string
           description: "This is a human-readable description of this container and\
             \ what it is trying to accomplish, required GA4GH"
+        descriptorTypeVersions:
+          type: array
+          items:
+            type: string
         id:
           type: integer
           format: int64
@@ -9941,10 +9947,6 @@ components:
           enum:
           - README
           - DESCRIPTOR
-        descriptorTypeVersions:
-          type: array
-          items:
-            type: string
         descriptorTypeVersionsFromSourceFiles:
           type: array
           items:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -7898,6 +7898,8 @@ definitions:
         type: "integer"
         format: "int64"
         description: "Implementation specific ID for the source file in this web service"
+      metadata:
+        $ref: "#/definitions/SourceFileMetadata"
       verifiedBySource:
         type: "object"
         description: "maps from platform to whether an entry successfully ran on it\
@@ -7953,9 +7955,14 @@ definitions:
         description: "The checksum(s) of the sourcefile's content"
         items:
           $ref: "#/definitions/Checksum"
+  SourceFileMetadata:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
       typeVersion:
         type: "string"
-        position: 7
         description: "The language version for the given descriptor file type"
   StarRequest:
     type: "object"
@@ -7974,11 +7981,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/Author"
-      descriptorTypeVersions:
-        type: "array"
-        description: "The language versions for the version's descriptor files"
-        items:
-          type: "string"
       id:
         type: "integer"
         format: "int64"
@@ -8662,11 +8664,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/Author"
-      descriptorTypeVersions:
-        type: "array"
-        description: "The language versions for the version's descriptor files"
-        items:
-          type: "string"
       id:
         type: "integer"
         format: "int64"
@@ -8815,6 +8812,11 @@ definitions:
         type: "string"
         description: "This is a human-readable description of this container and what\
           \ it is trying to accomplish, required GA4GH"
+      descriptorTypeVersions:
+        type: "array"
+        description: "The language versions for the version's descriptor files"
+        items:
+          type: "string"
       id:
         type: "integer"
         format: "int64"
@@ -9097,11 +9099,6 @@ definitions:
         uniqueItems: true
         items:
           $ref: "#/definitions/Author"
-      descriptorTypeVersions:
-        type: "array"
-        description: "The language versions for the version's descriptor files"
-        items:
-          type: "string"
       id:
         type: "integer"
         format: "int64"

--- a/dockstore-webservice/src/test/java/core/WDLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/WDLParseTest.java
@@ -441,8 +441,8 @@ class WDLParseTest {
             assertEquals(1, entry.getAuthor().split(",").length, "incorrect author");
             assertEquals("foobar@foo.com", entry.getEmail(), "incorrect email");
             assertTrue(entry.getDescription().length() > 0, "incorrect description");
-            assertEquals(1, entry.getDescriptorTypeVersions().size());
-            assertEquals("1.0", entry.getDescriptorTypeVersions().get(0));
+            assertEquals(1, entry.getVersionMetadata().getDescriptorTypeVersions().size());
+            assertEquals("1.0", entry.getVersionMetadata().getDescriptorTypeVersions().get(0));
         } catch (Exception e) {
             fail("Should properly parse file and imports.");
         }
@@ -479,29 +479,29 @@ class WDLParseTest {
             LanguageHandlerInterface sInterface = LanguageHandlerFactory.getInterface(DescriptorLanguage.FileType.DOCKSTORE_WDL);
             Version entry = sInterface
                     .parseWorkflowContent(primaryWDL.getAbsolutePath(), FileUtils.readFileToString(primaryWDL, StandardCharsets.UTF_8), sourceFileSet, new WorkflowVersion());
-            assertEquals(1, entry.getDescriptorTypeVersions().size());
-            assertTrue(entry.getDescriptorTypeVersions().contains("1.0"));
+            assertEquals(1, entry.getVersionMetadata().getDescriptorTypeVersions().size());
+            assertTrue(entry.getVersionMetadata().getDescriptorTypeVersions().contains("1.0"));
 
             // Make the primary descriptor version 1.1 so the primary descriptor and imported descriptor have different language versions
             sourceFile.setContent(primaryWDLString.replace("version 1.0", "version 1.1"));
             entry = sInterface
                     .parseWorkflowContent(primaryWDL.getAbsolutePath(), sourceFile.getContent(), sourceFileSet, new WorkflowVersion());
-            assertEquals(2, entry.getDescriptorTypeVersions().size(), "Should have two language versions");
-            assertTrue(entry.getDescriptorTypeVersions().contains("1.0") && entry.getDescriptorTypeVersions().contains("1.1"));
+            assertEquals(2, entry.getVersionMetadata().getDescriptorTypeVersions().size(), "Should have two language versions");
+            assertTrue(entry.getVersionMetadata().getDescriptorTypeVersions().contains("1.0") && entry.getVersionMetadata().getDescriptorTypeVersions().contains("1.1"));
 
             // Add a syntax error to the imported descriptor
             importedFile.setContent(importedWDLString.replace("version 1.0", "version 1.0\n\nimport brokenbrokenbroken"));
             entry = sInterface
                     .parseWorkflowContent(primaryWDL.getAbsolutePath(), sourceFile.getContent(), sourceFileSet, new WorkflowVersion());
-            assertEquals(2, entry.getDescriptorTypeVersions().size(), "Should have two language versions");
-            assertTrue(entry.getDescriptorTypeVersions().contains("1.0") && entry.getDescriptorTypeVersions().contains("1.1"));
+            assertEquals(2, entry.getVersionMetadata().getDescriptorTypeVersions().size(), "Should have two language versions");
+            assertTrue(entry.getVersionMetadata().getDescriptorTypeVersions().contains("1.0") && entry.getVersionMetadata().getDescriptorTypeVersions().contains("1.1"));
 
             // Use an invalid 'version' for the imported file. The imported source file should not have a version set
             importedFile.setContent(importedWDLString.replace("version 1.0", "version 1 0"));
             entry = sInterface
                     .parseWorkflowContent(primaryWDL.getAbsolutePath(), sourceFile.getContent(), sourceFileSet, new WorkflowVersion());
-            assertEquals(1, entry.getDescriptorTypeVersions().size(), "Should have one language version");
-            assertTrue(entry.getDescriptorTypeVersions().contains("1.1"));
+            assertEquals(1, entry.getVersionMetadata().getDescriptorTypeVersions().size(), "Should have one language version");
+            assertTrue(entry.getVersionMetadata().getDescriptorTypeVersions().contains("1.1"));
         } catch (Exception e) {
             fail("Should properly parse language versions.");
         }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
@@ -104,7 +104,9 @@ class ElasticListenerTest {
         throws IllegalAccessException {
         version.setName(name);
         final SourceFile sourceFile = new SourceFile();
-        sourceFile.setPath("/Dockstore.wdl");
+        final String path = "/Dockstore.wdl";
+        sourceFile.setPath(path);
+        sourceFile.setAbsolutePath(path);
         sourceFile.setContent("Doesn't matter");
         version.getSourceFiles().add(sourceFile);
         version.getVersionMetadata().setDescriptorTypeVersions(descriptorTypeVersions);

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
@@ -107,7 +107,7 @@ class ElasticListenerTest {
         sourceFile.setPath("/Dockstore.wdl");
         sourceFile.setContent("Doesn't matter");
         version.getSourceFiles().add(sourceFile);
-        version.setDescriptorTypeVersions(descriptorTypeVersions);
+        version.getVersionMetadata().setDescriptorTypeVersions(descriptorTypeVersions);
         // Id is normally set via Hibernate generator; have to use reflection to set it, alas
         FieldUtils.writeField(version, "id", id, true);
     }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -434,6 +434,7 @@ class CWLHandlerTest {
 
         // Test multiple files containing many versions.
         final Version version = new WorkflowVersion();
+        List.of(manyFile, oneFile, noFile).forEach(sourceFile -> sourceFile.getMetadata().setTypeVersion("bogus"));
         cwlHandler.parseWorkflowContent(manyFile.getPath(), manyFile.getContent(), Set.of(manyFile, oneFile, noFile), version);
         assertEquals(List.of("v1.2", "v1.1", "v1.0"), version.getVersionMetadata().getDescriptorTypeVersions());
         assertEquals("v1.2", manyFile.getMetadata().getTypeVersion());

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -423,7 +423,7 @@ class CWLHandlerTest {
         Mockito.doAnswer(invocation -> {
             versionConsumer.accept((String)invocation.getArgument(0));
             return null;
-        }).when(sourceFile).setTypeVersion(Mockito.any());
+        }).when(sourceFile).getMetadata().setTypeVersion(Mockito.any());
         return sourceFile;
     }
 
@@ -431,7 +431,7 @@ class CWLHandlerTest {
         Mockito.doAnswer(invocation -> {
             versionsConsumer.accept((List<String>)invocation.getArgument(0));
             return null;
-        }).when(version).setDescriptorTypeVersions(Mockito.any());
+        }).when(version).getVersionMetadata().setDescriptorTypeVersions(Mockito.any());
         return version;
     }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -436,9 +436,15 @@ class CWLHandlerTest {
         final Version version = new WorkflowVersion();
         cwlHandler.parseWorkflowContent(manyFile.getPath(), manyFile.getContent(), Set.of(manyFile, oneFile, noFile), version);
         assertEquals(List.of("v1.2", "v1.1", "v1.0"), version.getVersionMetadata().getDescriptorTypeVersions());
+        assertEquals("v1.2", manyFile.getMetadata().getTypeVersion());
+        assertEquals("v1.1", oneFile.getMetadata().getTypeVersion());
+        assertEquals(null, noFile.getMetadata().getTypeVersion());
 
         // Test one file containing no versions.
+        noFile.getMetadata().setTypeVersion(null); // Reset
+        version.getVersionMetadata().setDescriptorTypeVersions(List.of("bogus"));
         cwlHandler.parseWorkflowContent(noFile.getPath(), noFile.getContent(), Set.of(noFile), version);
+        assertEquals(null, noFile.getMetadata().getTypeVersion());
         assertEquals(List.of(), version.getVersionMetadata().getDescriptorTypeVersions());
     }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/NextflowHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/NextflowHandlerTest.java
@@ -106,24 +106,24 @@ class NextflowHandlerTest {
         final Set<SourceFile> sourceFiles = Set.of(mainSourceFile, secondarySourceFile);
 
         nextflowHandler.parseWorkflowContent("/main.nf", config, sourceFiles, version);
-        assertEquals(List.of(DSL_V2), version.getDescriptorTypeVersions());
-        sourceFiles.forEach(sourceFile -> assertEquals(DSL_V2, sourceFile.getTypeVersion()));
+        assertEquals(List.of(DSL_V2), version.getVersionMetadata().getDescriptorTypeVersions());
+        sourceFiles.forEach(sourceFile -> assertEquals(DSL_V2, sourceFile.getMetadata().getTypeVersion()));
 
         mainSourceFile.setContent(mainContent.replace("nextflow.enable.dsl = 2", "nextflow.enable.dsl = 1"));
         nextflowHandler.parseWorkflowContent("/main.nf", config, sourceFiles, version);
-        assertEquals(List.of(DSL_V1), version.getDescriptorTypeVersions());
-        sourceFiles.forEach(sourceFile -> assertEquals(DSL_V1, sourceFile.getTypeVersion()));
+        assertEquals(List.of(DSL_V1), version.getVersionMetadata().getDescriptorTypeVersions());
+        sourceFiles.forEach(sourceFile -> assertEquals(DSL_V1, sourceFile.getMetadata().getTypeVersion()));
 
         // No DSL specified
         mainSourceFile.setContent(mainContent.replace("nextflow.enable.dsl = 2", ""));
         nextflowHandler.parseWorkflowContent("/main.nf", config, sourceFiles, version);
-        assertEquals(List.of(), version.getDescriptorTypeVersions());
-        sourceFiles.forEach(sourceFile -> assertNull(sourceFile.getTypeVersion()));
+        assertEquals(List.of(), version.getVersionMetadata().getDescriptorTypeVersions());
+        sourceFiles.forEach(sourceFile -> assertNull(sourceFile.getMetadata().getTypeVersion()));
 
         // Descriptor referenced by config does not exist
         mainSourceFile.setPath("/notthemain.nf");
         nextflowHandler.parseWorkflowContent("/main.nf", config, sourceFiles, version);
-        assertEquals(List.of(), version.getDescriptorTypeVersions());
-        sourceFiles.forEach(sourceFile -> assertNull(sourceFile.getTypeVersion()));
+        assertEquals(List.of(), version.getVersionMetadata().getDescriptorTypeVersions());
+        sourceFiles.forEach(sourceFile -> assertNull(sourceFile.getMetadata().getTypeVersion()));
     }
 }


### PR DESCRIPTION
**Description**
Moves language descriptor version values to version_metadata (pre-existing) and sourcefile_metadata (new) tables.

We need this because the sourcefile and workflowversion/tag tables have some frozen rows, which means we can't update them with language descriptor versions. See longer discussion starting [here](https://github.com/dockstore/dockstore/issues/5270#issuecomment-1371402573). The purpose of the version_metadata table is to handle exactly this sort of case, updates after version frozen, and now we have the equivalent for source files.

The one-to-one pattern in JPA requires a circular reference, which seems like a bit of anti-pattern to me, but it is what it is. The circular reference between `SourceFile` and `SourceFileMetadata` caused a stack overflow in Gson when trying to deserialize a `SourceFile`, hence the change to ElasticListener to use a copy constructor instead. The copy constructor implementation seems a little hacky; if anybody else has a better idea how to accomplish, I'm all ears. I tried using BeanUtils, but it copied the `SourceFileMetadata.parent` reference, which points to the original SourceFile. Circular references...

Another area for input: The sourcefile_metadata rows will be created on demand, i.e., there will be sourcefile rows without corresponding sourcefile_metadata rows. Is that OK? I noticed that for every workflowversion row, there is a version_metadata row. Is it worth doing that for sourcefile_metadata?

Also, in CWLHandlerTest, moved from mocks to actual SourceFile instances. It was getting tricky with the new nested object in SourceFile and Mockito; I discussed with Steve, and decided to just use SourceFile instead of figuring out the proper mocking.

**Review Instructions**
Should generally be transparent to the end user. Verify that language versioning still works in the UI. After #5270 is implemented and run, verify that frozen versions have the language versions correctly set.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5162

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
