### PR TITLE
SEAB-5107: Index notebooks in Elasticsearch

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguageSubclass.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguageSubclass.java
@@ -39,11 +39,14 @@ public enum DescriptorLanguageSubclass {
         this.shortName = shortName;
     }
 
+    public boolean isApplicable() {
+        return this != NOT_APPLICABLE;
+    }
+
     @Override
     public String toString() {
         return shortName;
     }
-
 
     public String getShortName() {
         return shortName;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/ElasticSearchHelperIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/ElasticSearchHelperIT.java
@@ -43,7 +43,9 @@ class ElasticSearchHelperIT extends BaseIT {
         deleteIndex(ElasticListener.TOOLS_INDEX, esClient);
         assertFalse(ElasticSearchHelper.doMappingsExist(), "Should return false if one of the indices are missing its mapping");
         deleteIndex(ElasticListener.WORKFLOWS_INDEX, esClient);
-        assertFalse(ElasticSearchHelper.doMappingsExist(), "Should return false if all indices are missing its mapping");
+        assertFalse(ElasticSearchHelper.doMappingsExist(), "Should return false if two of the indices are missing its mapping");
+        deleteIndex(ElasticListener.NOTEBOOKS_INDEX, esClient);
+        assertFalse(ElasticSearchHelper.doMappingsExist(), "Should return false if all indices are missing their mapping");
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ElasticSearchHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ElasticSearchHelper.java
@@ -3,8 +3,6 @@ package io.dockstore.webservice.helpers;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.helpers.statelisteners.ElasticListener;
 import io.dropwizard.lifecycle.Managed;
-import java.util.Arrays;
-import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
@@ -48,9 +46,8 @@ public final class  ElasticSearchHelper implements Managed {
     public static boolean doMappingsExist() {
         GetMappingsRequest getMappingsRequest = new GetMappingsRequest();
         try {
-            List<String> allIndices =  Arrays.asList(ElasticListener.ALL_INDICES.split(","));
             GetMappingsResponse response = restHighLevelClient.indices().getMapping(getMappingsRequest, RequestOptions.DEFAULT);
-            return response.mappings().keySet().containsAll(allIndices);
+            return response.mappings().keySet().containsAll(ElasticListener.INDEXES);
         } catch (Exception e) {
             LOG.error("Could not get Elasticsearch mappings", e);
             return false;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -82,7 +82,6 @@ public class ElasticListener implements StateListenerInterface {
     public static final String WORKFLOWS_INDEX = "workflows";
     public static final String NOTEBOOKS_INDEX = "notebooks";
     public static final List<String> INDEXES = List.of(TOOLS_INDEX, WORKFLOWS_INDEX, NOTEBOOKS_INDEX);
-    public static final String ALL_INDICES = String.join(",", INDEXES);
     private static final Logger LOGGER = LoggerFactory.getLogger(ElasticListener.class);
     private static final ObjectMapper MAPPER = Jackson.newObjectMapper().addMixIn(Version.class, Version.ElasticSearchMixin.class);
     private static final String MAPPER_ERROR = "Could not convert Dockstore entry to Elasticsearch object";

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -111,8 +111,12 @@ public class ElasticListener implements StateListenerInterface {
         if (entry instanceof BioWorkflow) {
             return WORKFLOWS_INDEX;
         }
-        // #2771 will need to properly create objects/indexes to get services into the index
+        // Services are not currently indexed, see #2771
         return null;
+    }
+
+    private List<Entry> entriesInIndex(List<Entry> entries, String index) {
+        return entries.stream().filter(entry -> Objects.equals(determineIndex(entry), index)).toList();
     }
 
     @Override
@@ -197,13 +201,9 @@ public class ElasticListener implements StateListenerInterface {
     public void bulkUpsert(List<Entry> entries) {
         entries.forEach(this::eagerLoadEntry);
         entries = filterCheckerWorkflows(entries);
-        // #2771 will need to disable this and properly create objects to get services into the index
-        if (entries.isEmpty()) {
-            return;
-        }
-        // for each index, bulk index the corresponding entries.
+        // For each index, bulk index the corresponding entries
         for (String index: INDEXES) {
-            postBulkUpdate(index, entries.stream().filter(entry -> Objects.equals(index, determineIndex(entry))).toList());
+            postBulkUpdate(index, entriesInIndex(entries, index));
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -115,7 +115,7 @@ public class ElasticListener implements StateListenerInterface {
         return null;
     }
 
-    private List<Entry> entriesInIndex(List<Entry> entries, String index) {
+    private List<Entry> entriesByIndex(List<Entry> entries, String index) {
         return entries.stream().filter(entry -> Objects.equals(determineIndex(entry), index)).toList();
     }
 
@@ -203,7 +203,7 @@ public class ElasticListener implements StateListenerInterface {
         entries = filterCheckerWorkflows(entries);
         // For each index, bulk index the corresponding entries
         for (String index: INDEXES) {
-            postBulkUpdate(index, entriesInIndex(entries, index));
+            postBulkUpdate(index, entriesByIndex(entries, index));
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -114,7 +114,7 @@ public class ElasticListener implements StateListenerInterface {
         return null;
     }
 
-    private List<Entry> entriesByIndex(List<Entry> entries, String index) {
+    private List<Entry> filterEntriesByIndex(List<Entry> entries, String index) {
         return entries.stream().filter(entry -> Objects.equals(determineIndex(entry), index)).toList();
     }
 
@@ -202,7 +202,7 @@ public class ElasticListener implements StateListenerInterface {
         entries = filterCheckerWorkflows(entries);
         // For each index, bulk index the corresponding entries
         for (String index: INDEXES) {
-            postBulkUpdate(index, entriesByIndex(entries, index));
+            postBulkUpdate(index, filterEntriesByIndex(entries, index));
         }
     }
 
@@ -401,11 +401,10 @@ public class ElasticListener implements StateListenerInterface {
             detachedEntry = detachWorkflow(detachedAppTool, appTool);
         } else if (entry instanceof Notebook notebook) {
             Notebook detachedNotebook = new Notebook();
-            detachedEntry = detachWorkflow(detachedNotebook, notebook); // TODO ok?
+            detachedEntry = detachWorkflow(detachedNotebook, notebook);
         } else {
             return entry;
         }
-
 
         detachedEntry.setDescription(entry.getDescription());
         detachedEntry.setAuthor(entry.getAuthor());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -482,9 +482,12 @@ public class ElasticListener implements StateListenerInterface {
     private static Workflow detachWorkflow(Workflow detachedWorkflow, Workflow workflow) {
         // These are for facets
         detachedWorkflow.setDescriptorType(workflow.getDescriptorType());
-        detachedWorkflow.setDescriptorTypeSubclass(workflow.getDescriptorTypeSubclass());
         detachedWorkflow.setSourceControl(workflow.getSourceControl());
         detachedWorkflow.setOrganization(workflow.getOrganization());
+        // Set the descriptor type subclass if it has a meaningful value
+        if (workflow.getDescriptorTypeSubclass().isApplicable()) {
+            detachedWorkflow.setDescriptorTypeSubclass(workflow.getDescriptorTypeSubclass());
+        }
 
         // These are for table
         detachedWorkflow.setWorkflowName(workflow.getWorkflowName());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -84,7 +84,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
     private static final String TOOLS_INDEX = ElasticListener.TOOLS_INDEX;
     private static final String WORKFLOWS_INDEX = ElasticListener.WORKFLOWS_INDEX;
     private static final String NOTEBOOKS_INDEX = ElasticListener.NOTEBOOKS_INDEX;
-    private static final String ALL_INDICES = ElasticListener.ALL_INDICES;
+    private static final String COMMA_SEPARATED_INDEXES = String.join(",", ElasticListener.INDEXES);
     private static final int SEARCH_TERM_LIMIT = 256;
     private static final int TOO_MANY_REQUESTS_429 = 429;
     private static final int ELASTICSEARCH_DEFAULT_LIMIT = 15;
@@ -256,14 +256,14 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
                         queryParameters.forEach((key, value) -> parameters.put(key, value.get(0)));
                     }
                     // This should be using the high-level Elasticsearch client instead
-                    Request request = new Request("GET", "/" + ALL_INDICES + "/_search");
+                    Request request = new Request("GET", "/" + COMMA_SEPARATED_INDEXES + "/_search");
                     if (query != null) {
                         request.setJsonEntity(query);
                     }
                     request.addParameters(parameters);
                     org.elasticsearch.client.Response get = restClient.performRequest(request);
                     if (get.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
-                        throw new CustomWebApplicationException("Could not search " + ALL_INDICES + "index",
+                        throw new CustomWebApplicationException("Could not search " + COMMA_SEPARATED_INDEXES + " index",
                             HttpStatus.SC_INTERNAL_SERVER_ERROR);
                     }
                     return Response.ok().entity(get.getEntity().getContent()).build();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -207,10 +207,11 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
         try {
             // FYI. it is real tempting to use a try ... catch with resources to close this client, but it actually permanently messes up the client!
             RestHighLevelClient client = ElasticSearchHelper.restHighLevelClient();
-            // Delete previous indices
-            deleteIndex(client, TOOLS_INDEX);
-            deleteIndex(client, WORKFLOWS_INDEX);
-            deleteIndex(client, NOTEBOOKS_INDEX);
+            // Delete previous indexes
+            deleteIndex(TOOLS_INDEX, client);
+            deleteIndex(WORKFLOWS_INDEX, client);
+            deleteIndex(NOTEBOOKS_INDEX, client);
+            // Create new indexes
             createIndex("queries/mapping_tool.json", TOOLS_INDEX, client);
             createIndex("queries/mapping_workflow.json", WORKFLOWS_INDEX, client);
             createIndex("queries/mapping_notebook.json", NOTEBOOKS_INDEX, client);
@@ -390,7 +391,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
         throw new CustomWebApplicationException("Could not submit verification information", HttpStatus.SC_BAD_REQUEST);
     }
 
-    private void deleteIndex(RestHighLevelClient restClient, String index) {
+    private void deleteIndex(String index, RestHighLevelClient restClient) {
         try {
             DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(index);
             restClient.indices().delete(deleteIndexRequest, RequestOptions.DEFAULT);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -83,6 +83,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
 
     private static final String TOOLS_INDEX = ElasticListener.TOOLS_INDEX;
     private static final String WORKFLOWS_INDEX = ElasticListener.WORKFLOWS_INDEX;
+    private static final String NOTEBOOKS_INDEX = ElasticListener.NOTEBOOKS_INDEX;
     private static final String ALL_INDICES = ElasticListener.ALL_INDICES;
     private static final int SEARCH_TERM_LIMIT = 256;
     private static final int TOO_MANY_REQUESTS_429 = 429;
@@ -184,6 +185,8 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
             LOG.info("Processed {} tools and workflows", totalProcessed);
             totalProcessed += indexDAO(appToolDAO);
             LOG.info("Processed {} tools, workflows, and apptools", totalProcessed);
+            totalProcessed += indexDAO(notebookDAO);
+            LOG.info("Processed {} tools, workflows, apptools, and notebooks", totalProcessed);
         }
         return Response.ok().entity(totalProcessed).build();
     }
@@ -207,8 +210,10 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
             // Delete previous indices
             deleteIndex(client, TOOLS_INDEX);
             deleteIndex(client, WORKFLOWS_INDEX);
+            deleteIndex(client, NOTEBOOKS_INDEX);
             createIndex("queries/mapping_tool.json", TOOLS_INDEX, client);
             createIndex("queries/mapping_workflow.json", WORKFLOWS_INDEX, client);
+            createIndex("queries/mapping_notebook.json", NOTEBOOKS_INDEX, client);
         } catch (IOException | RuntimeException e) {
             LOG.error("Could not clear elastic search index", e);
             throw new CustomWebApplicationException("Search indexing failed", HttpStatus.SC_INTERNAL_SERVER_ERROR);

--- a/dockstore-webservice/src/main/resources/queries/mapping_notebook.json
+++ b/dockstore-webservice/src/main/resources/queries/mapping_notebook.json
@@ -1,0 +1,132 @@
+{
+  "settings": {
+    "index": {
+      "number_of_shards" : 1,
+      "number_of_replicas": 1,
+      "analysis": {
+        "filter": {
+          "english_stop": {
+            "type": "stop",
+            "stopwords": "_english_"
+          },
+          "unique_stem": {
+            "type": "unique",
+            "only_on_same_position": true
+          },
+          "dockstore_stop": {
+            "type": "stop",
+            "stopwords": [ "https", "http", "see", "from", "use", "usage", "more", "can", "reads", "website", "count" ]
+          }
+        },
+        "analyzer": {
+          "didYouMean": {
+            "filter": [
+              "lowercase"
+            ],
+            "char_filter": [
+              "html_strip"
+            ],
+            "type": "custom",
+            "tokenizer": "standard"
+          },
+          "text_analyzer":{
+            "type":"custom",
+            "tokenizer":"standard",
+            "filter": [
+              "lowercase",
+              "english_stop",
+              "dockstore_stop",
+              "keyword_repeat",
+              "unique_stem"
+            ],
+            "char_filter": [
+              "html_strip"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "author": {
+        "type": "keyword",
+        "null_value": ""
+      },
+      "categories": {
+        "properties": {
+          "description": {
+            "type": "text"
+          },
+          "displayName": {
+            "type": "text"
+          },
+          "id": {
+            "type": "long"
+          },
+          "name": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 39
+              }
+            }
+          },
+          "topic": {
+            "type": "text"
+          }
+        }
+      },
+      "defaultVersion": {
+        "type": "keyword"
+      },
+      "description": {
+        "type": "text",
+        "fielddata": true,
+        "index": true,
+        "analyzer": "text_analyzer"
+      },
+      "descriptorType": {
+        "type": "keyword"
+      },
+      "descriptorTypeSubclass": {
+        "type": "keyword"
+      }
+      "email": {
+        "type": "text"
+      },
+      "gitUrl": {
+        "type": "text"
+      },
+      "id": {
+        "type": "long"
+      },
+      "is_published": {
+        "type": "boolean"
+      },
+      "lastUpdated": {
+        "format": "epoch_millis",
+        "type": "date"
+      },
+      "mode": {
+        "type": "text"
+      },
+      "organization": {
+        "type": "keyword"
+      },
+      "path": {
+        "type": "text"
+      },
+      "repository": {
+        "type": "keyword"
+      },
+      "workflowName": {
+        "type": "keyword"
+      },
+      "workflow_path": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/dockstore-webservice/src/main/resources/queries/mapping_notebook.json
+++ b/dockstore-webservice/src/main/resources/queries/mapping_notebook.json
@@ -92,7 +92,7 @@
       },
       "descriptorTypeSubclass": {
         "type": "keyword"
-      }
+      },
       "email": {
         "type": "text"
       },


### PR DESCRIPTION
**Description**
This PR adds support for notebooks to our Elasticsearch (ES) code.  Basically, this meant creating/updating/deleting a new "notebooks" index, which is the same as the "workflows" index except with the addition of a `descriptorTypeSubclass` field, which corresponds to the "programming language" of the notebook.  While I was in there, I did some light refactoring.

Upon inspecting the tests, I realized that after we have implemented a notebook registration mechanism, it'll be much easier to write a good test.  So, I would like to delay the creation of said test until after https://ucsc-cgl.atlassian.net/browse/SEAB-5106 is done (next sprint?).  If this works for everyone, I will write a ticket and link it appropriately so we don't forget about it.

**Review Instructions**
Confirm that an index named "notebooks" has been created on the ES server, and that its structure is reasonable.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5107

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
