### PR TITLE
Feature/seab 5167/fix google token access error

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
@@ -584,7 +584,7 @@ public class Ga4GhTRSAPIWorkflowIT extends BaseIT {
      * @throws URISyntaxException
      */
     @Test
-    void testAuthenticatedUserWithNoOrExpiredGoogleToken() throws URISyntaxException, IOException {
+    public void testAuthenticatedUserWithNoOrExpiredGoogleToken() throws URISyntaxException, IOException {
         // Set configuration to use SAM authorizer
         SUPPORT.getConfiguration().setAuthorizerType("sam");
         ToolsApiServiceImpl.setAuthorizer(PermissionsFactory.createAuthorizer(tokenDAO, SUPPORT.getConfiguration()));

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -262,7 +262,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
     @Override
     public boolean canExamine(User user, Entry entry) {
         return AuthenticatedResourceInterface.super.canExamine(user, entry)
-            || (entry instanceof Workflow && permissionsInterface.canDoAction(user, (Workflow)entry, Role.Action.READ));
+            || (entry instanceof Workflow && AuthenticatedResourceInterface.canDoAction(permissionsInterface, user, entry, Role.Action.READ));
     }
 
     @Override


### PR DESCRIPTION
**Description**
This PR fixes the `Could not get Google access token. Try relinking your Google account` error in the CLI when launching a workflow. This error stems from the invocation of the SAM authorization code when calling certain GA4GHV2 endpoints if the user is authenticated. This is related to the state of the user's Google token (or lack thereof). The error occurs in prod and staging, where we use the SAM authorizer, but not in QA where we use a NoOp authorizer. 

In trying to reproduce the error locally, I noticed a slight difference in behaviour between prod/staging and develop. In develop, we check if the user has a Google token before using the SAM client to check permissions [here](https://github.com/dockstore/dockstore/blob/0ff1f507610a0ddf125b2f3781c0bda3992a846e/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java#L433). However, in prod/staging, [we don't do this Google token check](https://github.com/dockstore/dockstore/blob/1eda35d500e6bf2e4361b18b34e849e4274587d7/dockstore-webservice/src/main/java/io/dockstore/webservice/permissions/sam/SamPermissionsImpl.java#L324). The consequence is that in prod/staging, users who **do not** have a Google access token and users who have an expired Google token will run into this error, while in develop, only users who have an expired Google token will run into this error. 

The error occurs for 4 GA4GHV2 endpoints that call `canExamine`, which eventually invokes the SAM authorization code to determine whether to show hidden versions. In prod, the code throws if the user does not have a  Google token or the token is expired
- GET [/ga4gh/trs/v2/tools/{id}/versions/{version_id}/{type}/descriptor](https://dockstore.org/api/static/swagger-ui/index.html#/GA4GHV20/toolsIdVersionsVersionIdTypeDescriptorGet)
- GET [/ga4gh/trs/v2/tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}](https://dockstore.org/api/static/swagger-ui/index.html#/GA4GHV20/toolsIdVersionsVersionIdTypeDescriptorRelativePathGet)
  - This is the endpoint that the CLI called in the ticket description
- GET [/ga4gh/trs/v2/tools/{id}/versions/{version_id}/{type}/tests](https://dockstore.org/api/static/swagger-ui/index.html#/GA4GHV20/toolsIdVersionsVersionIdTypeTestsGet)
- GET [/ga4gh/trs/v2/tools/{id}/versions/{version_id}/containerfile](https://dockstore.org/api/static/swagger-ui/index.html#/GA4GHV20/toolsIdVersionsVersionIdContainerfileGet)

This PR currently targets develop, but should this be a hot fix instead? **EDIT:** changed it to hotfix

**Review Instructions**
Will have to wait for this to be deployed to staging before reviewing because the SAM authorizer is not used in QA.

- Log into Dockstore and unlink your Google account if you have it linked
- Ensure that your CLI config file is pointed to staging and you provided your Dockstore staging token
- Using the CLI, launch a workflow, like `dockstore workflow launch --entry github.com/GA4GH-DREAM/dockstore-workflow-helloworld/dockstore-workflow-helloworld:1.0.0 --json test.cwl.json`
- The workflow should run successfully and you should not see a `Could not get Google access token. Try relinking your Google account` error

**Issue**
[SEAB-5167](https://ucsc-cgl.atlassian.net/browse/SEAB-5167)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-5167]: https://ucsc-cgl.atlassian.net/browse/SEAB-5167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ