### PR TITLE
SEAB-5182: modified endpoints to get notebooks

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -97,7 +97,7 @@ class NotebookIT extends BaseIT {
 
         assertEquals(1, notebookDAO.findAllPublishedPaths().size());
         assertEquals(1, notebookDAO.findAllPublishedPathsOrderByDbupdatedate().size());
-
+        assertEquals(1, workflowDAO.findAllPublished(1, Integer.valueOf(PAGINATION_LIMIT), null, null, null).size());
         session.close();
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -54,6 +54,7 @@ import io.dockstore.webservice.helpers.statelisteners.SitemapListener;
 import io.dockstore.webservice.jdbi.AppToolDAO;
 import io.dockstore.webservice.jdbi.BioWorkflowDAO;
 import io.dockstore.webservice.jdbi.CollectionDAO;
+import io.dockstore.webservice.jdbi.NotebookDAO;
 import io.dockstore.webservice.jdbi.OrganizationDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import io.dockstore.webservice.languages.LanguageHandlerFactory;
@@ -141,6 +142,7 @@ public class MetadataResource {
     private final CollectionDAO collectionDAO;
     private final BioWorkflowDAO bioWorkflowDAO;
     private final AppToolDAO appToolDAO;
+    private final NotebookDAO notebookDAO;
     private final DockstoreWebserviceConfiguration config;
     private final SitemapListener sitemapListener;
     private final RSSListener rssListener;
@@ -156,6 +158,7 @@ public class MetadataResource {
         this.config = config;
         this.bioWorkflowDAO = new BioWorkflowDAO(sessionFactory);
         this.appToolDAO = new AppToolDAO(sessionFactory);
+        this.notebookDAO = new NotebookDAO(sessionFactory);
         this.sitemapListener = PublicStateManager.getInstance().getSitemapListener();
         this.rssListener = PublicStateManager.getInstance().getRSSListener();
     }
@@ -185,6 +188,7 @@ public class MetadataResource {
         urls.addAll(getBioWorkflowPaths());
         urls.addAll(getAppToolPaths());
         urls.addAll(getOrganizationAndCollectionPaths());
+        urls.addAll(getNotebookPaths());
         return urls;
     }
 
@@ -216,6 +220,9 @@ public class MetadataResource {
         return appToolDAO.findAllPublishedPaths().stream().map(appToolPath -> createWorkflowURL(appToolPath.getAppTool())).collect(Collectors.toList());
     }
 
+    private List<String> getNotebookPaths() {
+        return notebookDAO.findAllPublishedPaths().stream().map(notebookPath -> createWorkflowURL(notebookPath.getNotebook())).collect(Collectors.toList());
+    }
     private String createOrganizationURL(Organization organization) {
         return MetadataResourceHelper.createOrganizationURL(organization);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -40,7 +40,6 @@ import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Image;
 import io.dockstore.webservice.core.LambdaEvent;
-import io.dockstore.webservice.core.Notebook;
 import io.dockstore.webservice.core.OrcidAuthor;
 import io.dockstore.webservice.core.OrcidAuthorInformation;
 import io.dockstore.webservice.core.Service;
@@ -874,19 +873,11 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     }
 
     private Class<? extends Workflow> getSubClass(WorkflowSubClass subclass) {
-        final Class<? extends Workflow> targetClass;
-        if (subclass == WorkflowSubClass.SERVICE) {
-            targetClass = Service.class;
-        } else if (subclass == WorkflowSubClass.BIOWORKFLOW) {
-            targetClass = BioWorkflow.class;
-        } else if (subclass == WorkflowSubClass.APPTOOL) {
-            targetClass = AppTool.class;
-        } else if (subclass == WorkflowSubClass.NOTEBOOK) {
-            targetClass = Notebook.class;
-        } else {
+        try {
+            return subclass.getTargetClass();
+        } catch (Exception e) {
             throw new CustomWebApplicationException(subclass + " is not a valid subclass.", HttpStatus.SC_BAD_REQUEST);
         }
-        return targetClass;
     }
 
     @SuppressWarnings("checkstyle:MagicNumber")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -40,6 +40,7 @@ import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Entry;
 import io.dockstore.webservice.core.Image;
 import io.dockstore.webservice.core.LambdaEvent;
+import io.dockstore.webservice.core.Notebook;
 import io.dockstore.webservice.core.OrcidAuthor;
 import io.dockstore.webservice.core.OrcidAuthorInformation;
 import io.dockstore.webservice.core.Service;
@@ -880,6 +881,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             targetClass = BioWorkflow.class;
         } else if (subclass == WorkflowSubClass.APPTOOL) {
             targetClass = AppTool.class;
+        } else if (subclass == WorkflowSubClass.NOTEBOOK) {
+            targetClass = Notebook.class;
         } else {
             throw new CustomWebApplicationException(subclass + " is not a valid subclass.", HttpStatus.SC_BAD_REQUEST);
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -873,11 +873,10 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     }
 
     private Class<? extends Workflow> getSubClass(WorkflowSubClass subclass) {
-        try {
-            return subclass.getTargetClass();
-        } catch (Exception e) {
-            throw new CustomWebApplicationException(subclass + " is not a valid subclass.", HttpStatus.SC_BAD_REQUEST);
+        if (subclass == null) {
+            throw new CustomWebApplicationException("Subclass cannot be null", HttpStatus.SC_BAD_REQUEST);
         }
+        return subclass.getTargetClass();
     }
 
     @SuppressWarnings("checkstyle:MagicNumber")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowSubClass.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowSubClass.java
@@ -14,6 +14,10 @@ public enum WorkflowSubClass {
     APPTOOL,
     NOTEBOOK;
 
+    /**
+     * Returns the corresponding workflow class
+     *
+     */
     public Class<? extends Workflow> getTargetClass() {
         switch (this) {
         case APPTOOL:

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowSubClass.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowSubClass.java
@@ -9,27 +9,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(enumAsRef = true)
 public enum WorkflowSubClass {
-    BIOWORKFLOW,
-    SERVICE,
-    APPTOOL,
-    NOTEBOOK;
+    BIOWORKFLOW(BioWorkflow.class),
+    SERVICE(Service.class),
+    APPTOOL(AppTool.class),
+    NOTEBOOK(Notebook.class);
 
-    /**
-     * Returns the corresponding workflow class
-     *
-     */
+    private final Class<? extends Workflow> targetClass;
+
+    WorkflowSubClass(Class<? extends Workflow> targetClass) {
+        this.targetClass = targetClass;
+    }
+
     public Class<? extends Workflow> getTargetClass() {
-        switch (this) {
-        case APPTOOL:
-            return AppTool.class;
-        case BIOWORKFLOW:
-            return BioWorkflow.class;
-        case SERVICE:
-            return Service.class;
-        case NOTEBOOK:
-            return Notebook.class;
-        default:
-            return null;
-        }
+        return targetClass;
     }
 }
+

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowSubClass.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowSubClass.java
@@ -6,5 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public enum WorkflowSubClass {
     BIOWORKFLOW,
     SERVICE,
-    APPTOOL
+    APPTOOL,
+    NOTEBOOK
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowSubClass.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowSubClass.java
@@ -1,5 +1,10 @@
 package io.dockstore.webservice.resources;
 
+import io.dockstore.webservice.core.AppTool;
+import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.Notebook;
+import io.dockstore.webservice.core.Service;
+import io.dockstore.webservice.core.Workflow;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(enumAsRef = true)
@@ -7,5 +12,20 @@ public enum WorkflowSubClass {
     BIOWORKFLOW,
     SERVICE,
     APPTOOL,
-    NOTEBOOK
+    NOTEBOOK;
+
+    public Class<? extends Workflow> getTargetClass() {
+        switch (this) {
+        case APPTOOL:
+            return AppTool.class;
+        case BIOWORKFLOW:
+            return BioWorkflow.class;
+        case SERVICE:
+            return Service.class;
+        case NOTEBOOK:
+            return Notebook.class;
+        default:
+            return null;
+        }
+    }
 }

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -9921,6 +9921,7 @@ components:
       - BIOWORKFLOW
       - SERVICE
       - APPTOOL
+      - NOTEBOOK
     WorkflowVersion:
       type: object
       properties:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -5261,6 +5261,7 @@ paths:
         - "BIOWORKFLOW"
         - "SERVICE"
         - "APPTOOL"
+        - "NOTEBOOK"
       responses:
         200:
           description: "successful operation"
@@ -5292,6 +5293,7 @@ paths:
         - "BIOWORKFLOW"
         - "SERVICE"
         - "APPTOOL"
+        - "NOTEBOOK"
       responses:
         200:
           description: "successful operation"
@@ -5447,6 +5449,7 @@ paths:
         - "BIOWORKFLOW"
         - "SERVICE"
         - "APPTOOL"
+        - "NOTEBOOK"
       - name: "versionName"
         in: "query"
         description: "Version name"
@@ -5546,6 +5549,7 @@ paths:
         - "BIOWORKFLOW"
         - "SERVICE"
         - "APPTOOL"
+        - "NOTEBOOK"
       responses:
         200:
           description: "successful operation"


### PR DESCRIPTION
**Description**
This PR modifies numerous endpoints to include Notebooks. Most notably, it allows notebooks to be included in the `/workflows/published` endpoint such that it can be added onto the sitemap.

**Review Instructions**
Review that the endpoints are correctly modified and notebooks are added properly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5182

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
