### PR TITLE
Add open data availability to ES index

### DIFF
--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
@@ -19,6 +19,7 @@ package io.dockstore.webservice.helpers.statelisteners;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -207,6 +208,27 @@ class ElasticListenerTest {
         entry = ElasticListener.dockstoreEntryToElasticSearchObject(appTool);
         descriptorTypeVersions = entry.get("descriptor_type_versions");
         assertEquals(0, descriptorTypeVersions.size());
+    }
+
+    @Test
+    public void testOpenData() throws IOException {
+        // Test null getPublicAccessibleTestParameterFile
+        assertNull(firstWorkflowVersion.getVersionMetadata().getPublicAccessibleTestParameterFile());
+        JsonNode entry = ElasticListener.dockstoreEntryToElasticSearchObject(bioWorkflow);
+        JsonNode openDataNode = entry.get("openData");
+        assertFalse(openDataNode.asBoolean());
+
+        // Test false getPublicAccessibleTestParameterFile
+        firstWorkflowVersion.getVersionMetadata().setPublicAccessibleTestParameterFile(Boolean.FALSE);
+        entry = ElasticListener.dockstoreEntryToElasticSearchObject(bioWorkflow);
+        openDataNode = entry.get("openData");
+        assertFalse(openDataNode.asBoolean());
+
+        // Test true getPublicAccessibleTestParameterFile
+        firstWorkflowVersion.getVersionMetadata().setPublicAccessibleTestParameterFile(Boolean.TRUE);
+        entry = ElasticListener.dockstoreEntryToElasticSearchObject(bioWorkflow);
+        openDataNode = entry.get("openData");
+        assertTrue(openDataNode.asBoolean());
     }
 
     private List<String> getDescriptorTypeVersionsFromJsonNode(JsonNode descriptorTypeVersionsJsonNode) {

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
@@ -211,7 +211,7 @@ class ElasticListenerTest {
     }
 
     @Test
-    public void testOpenData() throws IOException {
+    void testOpenData() throws IOException {
         // Test null getPublicAccessibleTestParameterFile
         assertNull(firstWorkflowVersion.getVersionMetadata().getPublicAccessibleTestParameterFile());
         JsonNode entry = ElasticListener.dockstoreEntryToElasticSearchObject(bioWorkflow);


### PR DESCRIPTION
**Description**
Adds the the `publicAccessibleTestParameterFile` value from the VersionMetaData to the ElasticSearch index.

**Review Instructions**
In combination with the upcoming UI PR, verify that there is an "Open Data" facet on the search page.

**Issue**
#5136


**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
