### PR TITLE
Unpublish GH App workflow if it has no versions

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -580,11 +580,18 @@ class WebhookIT extends BaseIT {
         assertEquals(1, workflow.getWorkflowVersions().size(), "should have 1 version after deletion");
         assertNotNull(workflow.getDefaultVersion(), "should have reassigned the default version during deletion");
 
+        // Publish workflow
+        PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
+        client.publish(workflow.getId(), publishRequest);
+        workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", BIOWORKFLOW, "versions");
+        assertTrue(workflow.isIsPublished());
+
         // Delete 2.0 tag, unset default version
         client.handleGitHubBranchDeletion(githubFiltersRepo, BasicIT.USER_2_USERNAME, "refs/tags/2.0", installationId);
         workflow = client.getWorkflowByPath("github.com/" + githubFiltersRepo + "/filternone", BIOWORKFLOW, "versions");
         assertEquals(0, workflow.getWorkflowVersions().size(), "should have 0 versions after deletion");
         assertNull(workflow.getDefaultVersion(), "should have no default version after final version is deleted");
+        assertFalse(workflow.isIsPublished(), "should not be published if it has 0 versions");
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -332,11 +332,9 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             workflow.getWorkflowVersions().removeIf(workflowVersion -> Objects.equals(workflowVersion.getName(), gitReferenceName.get()) && !workflowVersion.isFrozen());
             FileFormatHelper.updateEntryLevelFileFormats(workflow);
 
-            // Delete the workflow if it no longer has any versions
+            // Unpublish the workflow if it was published and no longer has any versions
             if (workflow.getWorkflowVersions().isEmpty()) {
-                PublicStateManager.getInstance().handleIndexUpdate(workflow, StateManagerMode.DELETE);
-                eventDAO.deleteEventByEntryID(workflow.getId());
-                workflowDAO.delete(workflow);
+                workflow.setIsPublished(false);
             }
         });
         LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, username, LambdaEvent.LambdaEventType.DELETE);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -331,6 +331,13 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         workflows.forEach(workflow -> {
             workflow.getWorkflowVersions().removeIf(workflowVersion -> Objects.equals(workflowVersion.getName(), gitReferenceName.get()) && !workflowVersion.isFrozen());
             FileFormatHelper.updateEntryLevelFileFormats(workflow);
+
+            // Delete the workflow if it no longer has any versions
+            if (workflow.getWorkflowVersions().isEmpty()) {
+                PublicStateManager.getInstance().handleIndexUpdate(workflow, StateManagerMode.DELETE);
+                eventDAO.deleteEventByEntryID(workflow.getId());
+                workflowDAO.delete(workflow);
+            }
         });
         LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, username, LambdaEvent.LambdaEventType.DELETE);
         lambdaEventDAO.create(lambdaEvent);


### PR DESCRIPTION
**Description**
While investigating the ticket, I noticed that it's possible for a published GH App workflow to have no versions, which I think we don't want because, normally, you can't publish a workflow with no versions. This PR unpublishes a published GH App workflow if it has no versions. A GH App workflow can get into a state where it has no versions if all the branches/tags that contain a .dockstore.yml that references the workflow are deleted (see more details in the ticket).

**Review Instructions**
View review instructions in PR https://github.com/dockstore/dockstore-ui2/pull/1695

**Issue**
#5138 

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
