### PR TITLE
new constraints for workflow and tool names

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -21,7 +21,6 @@ import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_LIM
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.dockstore.client.cli.BaseIT;
@@ -43,7 +42,6 @@ import io.dockstore.webservice.jdbi.WorkflowDAO;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.persistence.PersistenceException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
@@ -112,13 +110,6 @@ class NotebookIT extends BaseIT {
         assertEquals(1, workflowDAO.findAllPublished(1, Integer.valueOf(PAGINATION_LIMIT), null, null, null).size());
         session.close();
     }
-
-    @Test
-    void testDuplicateNotebookName() {
-        new CreateContent().invoke(false, "Hive");
-        assertThrows(PersistenceException.class, () -> new CreateContent().invoke(false, "hive"));
-        session.close();
-    }
     
     @Test
     void testRegisterSimpleNotebook() {
@@ -178,10 +169,10 @@ class NotebookIT extends BaseIT {
         }
 
         CreateContent invoke() {
-            return invoke(false, null);
+            return invoke(false);
         }
 
-        CreateContent invoke(boolean cleanup, String notebookName) {
+        CreateContent invoke(boolean cleanup) {
             final Transaction transaction = session.beginTransaction();
 
             io.dockstore.webservice.core.Notebook testNotebook = new io.dockstore.webservice.core.Notebook();
@@ -192,7 +183,7 @@ class NotebookIT extends BaseIT {
             testNotebook.setMode(io.dockstore.webservice.core.WorkflowMode.DOCKSTORE_YML);
             testNotebook.setOrganization("hydra");
             testNotebook.setRepository("hydra_repo");
-            testNotebook.setWorkflowName(notebookName);
+            testNotebook.setWorkflowName(null);
             testNotebook.setDefaultWorkflowPath(DOCKSTORE_YML_PATH);
 
             // add all users to all things for now

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookWithSessionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookWithSessionIT.java
@@ -1,0 +1,128 @@
+/*
+ *    Copyright 2023 OICR and UCSC
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.dockstore.webservice;
+
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.dockstore.client.cli.BaseIT;
+import io.dockstore.client.cli.BaseIT.TestStatus;
+import io.dockstore.common.ConfidentialTest;
+import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.common.SourceControl;
+import io.dockstore.webservice.jdbi.NotebookDAO;
+import io.dockstore.webservice.jdbi.UserDAO;
+import javax.persistence.PersistenceException;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.context.internal.ManagedSessionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.stream.SystemErr;
+import uk.org.webcompere.systemstubs.stream.SystemOut;
+import uk.org.webcompere.systemstubs.stream.output.NoopStream;
+
+/**
+ *  Like ServiceWithSessionIT, this particular test does not seem to play well with the other tests in NotebookIT, it manages to "breakthrough" the database reset code.
+ */
+@ExtendWith(SystemStubsExtension.class)
+@ExtendWith(TestStatus.class)
+@Tag(ConfidentialTest.NAME)
+class NotebookWithSessionIT extends BaseIT {
+
+    @SystemStub
+    public final SystemOut systemOutRule = new SystemOut(new NoopStream());
+    @SystemStub
+    public final SystemErr systemErrRule = new SystemErr(new NoopStream());
+
+    private NotebookDAO notebookDAO;
+    private UserDAO userDAO;
+    private Session session;
+
+    @BeforeEach
+    public void setup() {
+        DockstoreWebserviceApplication application = SUPPORT.getApplication();
+        SessionFactory sessionFactory = application.getHibernate().getSessionFactory();
+
+        this.notebookDAO = new NotebookDAO(sessionFactory);
+        this.userDAO = new UserDAO(sessionFactory);
+
+        // non-confidential test database sequences seem messed up and need to be iterated past, but other tests may depend on ids
+        testingPostgres.runUpdateStatement("alter sequence enduser_id_seq increment by 50 restart with 100");
+        testingPostgres.runUpdateStatement("alter sequence token_id_seq increment by 50 restart with 100");
+
+        // used to allow us to use notebookDAO outside of the web service
+        this.session = application.getHibernate().getSessionFactory().openSession();
+        ManagedSessionContext.bind(session);
+    }
+
+    @Test
+    void testDuplicateNotebookName() {
+        new CreateContent().invoke(false, "Hive");
+        assertThrows(PersistenceException.class, () -> new CreateContent().invoke(false, "hive"));
+        session.close();
+    }
+
+    private class CreateContent {
+        private long notebookID;
+
+        long getNotebookID() {
+            return notebookID;
+        }
+
+        CreateContent invoke() {
+            return invoke(false, null);
+        }
+
+        CreateContent invoke(boolean cleanup, String notebookName) {
+            final Transaction transaction = session.beginTransaction();
+
+            io.dockstore.webservice.core.Notebook testNotebook = new io.dockstore.webservice.core.Notebook();
+            testNotebook.setDescription("test notebook");
+            testNotebook.setIsPublished(true);
+            testNotebook.setSourceControl(SourceControl.GITHUB);
+            testNotebook.setDescriptorType(DescriptorLanguage.SERVICE);
+            testNotebook.setMode(io.dockstore.webservice.core.WorkflowMode.DOCKSTORE_YML);
+            testNotebook.setOrganization("hydra");
+            testNotebook.setRepository("hydra_repo");
+            testNotebook.setWorkflowName(notebookName);
+            testNotebook.setDefaultWorkflowPath(DOCKSTORE_YML_PATH);
+
+            // add all users to all things for now
+            for (io.dockstore.webservice.core.User user : userDAO.findAll()) {
+                testNotebook.addUser(user);
+            }
+
+            notebookID = notebookDAO.create(testNotebook);
+
+            assertTrue(notebookID != 0);
+
+            session.flush();
+            transaction.commit();
+            if (cleanup) {
+                session.close();
+            }
+            return this;
+        }
+    }
+}

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -22,7 +22,6 @@ import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -54,7 +53,6 @@ import io.swagger.client.model.StarRequest;
 import io.swagger.client.model.Tool;
 import java.util.List;
 import java.util.Map;
-import javax.persistence.PersistenceException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -135,13 +133,6 @@ class ServiceIT extends BaseIT {
     }
 
     @Test
-    void testDuplicateWorkflowName() {
-        new CreateContent().invoke(false, "Hive");
-        assertThrows(PersistenceException.class, () -> new CreateContent().invoke(false, "hive"));
-        session.close();
-    }
-
-    @Test
     @Disabled("https://github.com/dockstore/dockstore/pull/4720")
     void testTRSOutputOfService() {
         new CreateContent().invoke();
@@ -209,7 +200,7 @@ class ServiceIT extends BaseIT {
      * A service is created and a version is added for a release 1.0
      */
     @Test
-    void testGitHubAppEndpoints() throws Exception {
+    void testGitHubAppEndpoints() {
 
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
         final ApiClient webClient = getWebClient("DockstoreTestUser2", testingPostgres);
@@ -258,7 +249,7 @@ class ServiceIT extends BaseIT {
      * Ensures that you cannot create a service if the given user is not on Dockstore
      */
     @Test
-    void createServiceNoUser() throws Exception {
+    void createServiceNoUser() {
 
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
         final ApiClient webClient = getWebClient("admin@admin.com", testingPostgres);
@@ -284,10 +275,9 @@ class ServiceIT extends BaseIT {
     /**
      * Ensures that a service and workflow can have the same path
      *
-     * @throws Exception
      */
     @Test
-    void testServiceWithSamePathAsWorkflow() throws Exception {
+    void testServiceWithSamePathAsWorkflow() {
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
         final ApiClient webClient = getWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
         WorkflowsApi client = new WorkflowsApi(webClient);
@@ -326,7 +316,7 @@ class ServiceIT extends BaseIT {
      * This tests that you can't add a version that doesn't exist
      */
     @Test
-    void updateServiceIncorrectTag() throws Exception {
+    void updateServiceIncorrectTag() {
 
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
         final ApiClient webClient = getWebClient("admin@admin.com", testingPostgres);
@@ -348,7 +338,7 @@ class ServiceIT extends BaseIT {
      * This tests that you can't add a version with an invalid dockstore.yml or no dockstore.yml
      */
     @Test
-    void updateServiceNoOrInvalidYml() throws Exception {
+    void updateServiceNoOrInvalidYml() {
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
         final ApiClient webClient = getWebClient("admin@admin.com", testingPostgres);
         WorkflowsApi client = new WorkflowsApi(webClient);
@@ -377,7 +367,7 @@ class ServiceIT extends BaseIT {
      * Tests that refresh will only grab the releases
      */
     @Test
-    void updateServiceSync() throws Exception {
+    void updateServiceSync() {
         testingPostgres.runUpdateStatement("update enduser set isadmin = 't' where username = 'DockstoreTestUser2';");
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
         final ApiClient webClient = getWebClient("DockstoreTestUser2", testingPostgres);
@@ -405,7 +395,7 @@ class ServiceIT extends BaseIT {
      * This tests that you cannot create a service from an in invalid GitHub repository
      */
     @Test
-    void createServiceNoGitHubRepo() throws Exception {
+    void createServiceNoGitHubRepo() {
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
         final ApiClient webClient = getWebClient("admin@admin.com", testingPostgres);
         WorkflowsApi client = new WorkflowsApi(webClient);
@@ -440,14 +430,10 @@ class ServiceIT extends BaseIT {
         }
 
         CreateContent invoke() {
-            return invoke(true, null);
+            return invoke(true);
         }
 
         CreateContent invoke(boolean cleanup) {
-            return invoke(cleanup, null);
-        }
-
-        CreateContent invoke(boolean cleanup, String workflowName) {
             final Transaction transaction = session.beginTransaction();
 
             Workflow testWorkflow = new BioWorkflow();
@@ -457,7 +443,6 @@ class ServiceIT extends BaseIT {
             testWorkflow.setDescriptorType(DescriptorLanguage.CWL);
             testWorkflow.setOrganization("shield");
             testWorkflow.setRepository("shield_repo");
-            testWorkflow.setWorkflowName(workflowName);
 
             Service testService = new Service();
             testService.setDescription("test service");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceWithSessionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceWithSessionIT.java
@@ -1,0 +1,170 @@
+/*
+ *    Copyright 2019 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.dockstore.webservice;
+
+import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.dockstore.client.cli.BaseIT;
+import io.dockstore.client.cli.BaseIT.TestStatus;
+import io.dockstore.common.ConfidentialTest;
+import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.common.SourceControl;
+import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.Service;
+import io.dockstore.webservice.core.User;
+import io.dockstore.webservice.core.Workflow;
+import io.dockstore.webservice.core.WorkflowMode;
+import io.dockstore.webservice.jdbi.ServiceDAO;
+import io.dockstore.webservice.jdbi.UserDAO;
+import io.dockstore.webservice.jdbi.WorkflowDAO;
+import java.util.Map;
+import javax.persistence.PersistenceException;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.context.internal.ManagedSessionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.stream.SystemErr;
+import uk.org.webcompere.systemstubs.stream.SystemOut;
+import uk.org.webcompere.systemstubs.stream.output.NoopStream;
+
+/**
+ * @author dyuen
+ */
+@ExtendWith(SystemStubsExtension.class)
+@ExtendWith(TestStatus.class)
+@Tag(ConfidentialTest.NAME)
+class ServiceWithSessionIT extends BaseIT {
+
+    @SystemStub
+    public final SystemOut systemOutRule = new SystemOut(new NoopStream());
+    @SystemStub
+    public final SystemErr systemErrRule = new SystemErr(new NoopStream());
+
+    private WorkflowDAO workflowDAO;
+    private ServiceDAO serviceDAO;
+    private Session session;
+    private UserDAO userDAO;
+
+    @BeforeEach
+    public void setup() {
+        DockstoreWebserviceApplication application = SUPPORT.getApplication();
+        SessionFactory sessionFactory = application.getHibernate().getSessionFactory();
+
+        this.workflowDAO = new WorkflowDAO(sessionFactory);
+        this.serviceDAO = new ServiceDAO(sessionFactory);
+        this.userDAO = new UserDAO(sessionFactory);
+
+        // non-confidential test database sequences seem messed up and need to be iterated past, but other tests may depend on ids
+        testingPostgres.runUpdateStatement("alter sequence enduser_id_seq increment by 50 restart with 100");
+        testingPostgres.runUpdateStatement("alter sequence token_id_seq increment by 50 restart with 100");
+
+        // used to allow us to use tokenDAO outside of the web service
+        this.session = application.getHibernate().getSessionFactory().openSession();
+        ManagedSessionContext.bind(session);
+    }
+
+    @Test
+    void testDuplicateWorkflowName() {
+        new CreateContent().invoke(false, "Hive");
+        assertThrows(PersistenceException.class, () -> new CreateContent().invoke(false, "hive"));
+        session.close();
+    }
+
+    private class CreateContent {
+        private long workflowID;
+        private long serviceID;
+        private long serviceID2;
+
+        long getWorkflowID() {
+            return workflowID;
+        }
+
+        long getServiceID() {
+            return serviceID;
+        }
+
+        long getServiceID2() {
+            return serviceID2;
+        }
+
+        CreateContent invoke(boolean cleanup, String workflowName) {
+            final Transaction transaction = session.beginTransaction();
+
+            Workflow testWorkflow = new BioWorkflow();
+            testWorkflow.setDescription("foo workflow");
+            testWorkflow.setIsPublished(true);
+            testWorkflow.setSourceControl(SourceControl.GITHUB);
+            testWorkflow.setDescriptorType(DescriptorLanguage.CWL);
+            testWorkflow.setOrganization("shield");
+            testWorkflow.setRepository("shield_repo");
+            testWorkflow.setWorkflowName(workflowName);
+
+            Service testService = new Service();
+            testService.setDescription("test service");
+            testService.setIsPublished(true);
+            testService.setSourceControl(SourceControl.GITHUB);
+            testService.setDescriptorType(DescriptorLanguage.SERVICE);
+            testService.setMode(WorkflowMode.DOCKSTORE_YML);
+            testService.setOrganization("hydra");
+            testService.setRepository("hydra_repo");
+            testService.setDefaultWorkflowPath(DOCKSTORE_YML_PATH);
+
+            Service test2Service = new Service();
+            test2Service.setDescription("test service");
+            test2Service.setIsPublished(true);
+            test2Service.setSourceControl(SourceControl.GITHUB);
+            test2Service.setMode(WorkflowMode.DOCKSTORE_YML);
+            test2Service.setDescriptorType(DescriptorLanguage.SERVICE);
+            test2Service.setOrganization("hydra");
+            test2Service.setRepository("hydra_repo2");
+            test2Service.setDefaultWorkflowPath(DOCKSTORE_YML_PATH);
+
+            final Map<DescriptorLanguage.FileType, String> defaultPaths = test2Service.getDefaultPaths();
+            for (DescriptorLanguage.FileType val : DescriptorLanguage.FileType.values()) {
+                defaultPaths.put(val, "path for " + val);
+            }
+            test2Service.setDefaultPaths(defaultPaths);
+
+            // add all users to all things for now
+            for (User user : userDAO.findAll()) {
+                testWorkflow.addUser(user);
+                testService.addUser(user);
+                test2Service.addUser(user);
+            }
+
+            workflowID = workflowDAO.create(testWorkflow);
+            serviceID = serviceDAO.create(testService);
+            serviceID2 = serviceDAO.create(test2Service);
+
+            assertTrue(workflowID != 0 && serviceID != 0);
+
+            session.flush();
+            transaction.commit();
+            if (cleanup) {
+                session.close();
+            }
+            return this;
+        }
+    }
+}

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceWithSessionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceWithSessionIT.java
@@ -49,6 +49,8 @@ import uk.org.webcompere.systemstubs.stream.SystemOut;
 import uk.org.webcompere.systemstubs.stream.output.NoopStream;
 
 /**
+ * This particular test does not seem to play well with the other tests in ServiceIT, it manages to "breakthrough" the database reset code.
+ *
  * @author dyuen
  */
 @ExtendWith(SystemStubsExtension.class)

--- a/dockstore-webservice/src/main/resources/import.sql
+++ b/dockstore-webservice/src/main/resources/import.sql
@@ -23,10 +23,15 @@ COMMENT ON COLUMN workflowversion.dbupdatedate IS 'Remote: When workflow was ref
 CREATE UNIQUE INDEX full_workflow_name ON workflow USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
 CREATE UNIQUE INDEX full_workflow_name_masterlist ON fullworkflowpath USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
 CREATE UNIQUE INDEX full_tool_name ON tool USING btree (registry, namespace, name, toolname) WHERE toolname IS NOT NULL;
+CREATE UNIQUE INDEX case_insensitive_toolname on tool using btree (registry, namespace, name, lower(toolname)) where toolname is not null;
 CREATE UNIQUE INDEX full_apptool_name ON apptool USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
+CREATE UNIQUE INDEX case_insensitive_apptool_toolname on apptool using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null;
 CREATE UNIQUE INDEX full_notebook_name ON notebook USING btree (sourcecontrol, organization, repository, workflowname) WHERE workflowname IS NOT NULL;
+CREATE UNIQUE INDEX case_insensitive_notebook_workflowname on notebook using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null;
 CREATE UNIQUE INDEX partial_workflow_name ON workflow USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
 CREATE UNIQUE INDEX partial_workflow_name_masterlist ON fullworkflowpath USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
+-- see https://github.com/dockstore/dockstore/issues/5287, the id may need to be incremented depending on how often people stumble into this
+CREATE UNIQUE INDEX case_insensitive_workflow_workflowname on workflow using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null and id > 18876;
 CREATE UNIQUE INDEX partial_tool_name ON tool USING btree (registry, namespace, name) WHERE toolname IS NULL;
 CREATE UNIQUE INDEX partial_apptool_name ON apptool USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
 CREATE UNIQUE INDEX partial_notebook_name ON notebook USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;

--- a/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
@@ -276,4 +276,13 @@
         <addUniqueConstraint columnNames="metricsid" constraintName="uk_metricsid_version_metrics" tableName="version_metrics"/>
         <addForeignKeyConstraint baseColumnNames="metricsid" baseTableName="version_metrics" constraintName="fk_metricsid_version_metrics" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="metrics"/>
     </changeSet>
+    <changeSet id="tighten constraint for names" author="dyuen">
+        <sql dbms="postgresql">
+            CREATE UNIQUE INDEX case_insensitive_toolname on tool using btree (registry, namespace, name, lower(toolname)) where toolname is not null;
+            CREATE UNIQUE INDEX case_insensitive_apptool_toolname on apptool using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null;
+            CREATE UNIQUE INDEX case_insensitive_notebook_workflowname on notebook using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null;
+            -- see https://github.com/dockstore/dockstore/issues/5287, the id may need to be incremented depending on how often people stumble into this
+            CREATE UNIQUE INDEX case_insensitive_workflow_workflowname on workflow using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null and id > 18876;
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**Description**
Adds DB constraints for workflow names outlawing names that differ only by capitalization. Note, due to existing violations, we need to exempt current entries. We may need to exempt more when the time comes

**Review Instructions**
Should not be able to add names differing by just capitalization

**Issue**
https://github.com/dockstore/dockstore/issues/5287

**Security**
None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
