### PR TITLE
add null check, start test split

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/HostedWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/HostedWorkflowIT.java
@@ -23,28 +23,20 @@ import com.google.common.collect.Lists;
 import io.dockstore.client.cli.BaseIT.TestStatus;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
-import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.Registry;
-import io.dockstore.common.SourceControl;
 import io.dockstore.common.WorkflowTest;
+import io.dockstore.openapi.client.ApiClient;
+import io.dockstore.openapi.client.ApiException;
+import io.dockstore.openapi.client.api.ContainersApi;
+import io.dockstore.openapi.client.api.HostedApi;
+import io.dockstore.openapi.client.api.WorkflowsApi;
+import io.dockstore.openapi.client.model.DockstoreTool;
+import io.dockstore.openapi.client.model.Entry;
+import io.dockstore.openapi.client.model.SourceFile;
+import io.dockstore.openapi.client.model.Workflow;
+import io.dockstore.openapi.client.model.WorkflowVersion;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
-import io.dropwizard.testing.ResourceHelpers;
-import io.swagger.client.ApiClient;
-import io.swagger.client.ApiException;
-import io.swagger.client.api.HostedApi;
-import io.swagger.client.api.UsersApi;
-import io.swagger.client.api.WorkflowsApi;
-import io.swagger.client.model.SourceFile;
-import io.swagger.client.model.Workflow;
-import io.swagger.client.model.WorkflowVersion;
-import io.swagger.model.DescriptorType;
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import org.apache.commons.io.FileUtils;
+import io.openapi.model.DescriptorType;
 import org.hibernate.Session;
 import org.hibernate.context.internal.ManagedSessionContext;
 import org.junit.jupiter.api.Assertions;
@@ -63,7 +55,6 @@ import uk.org.webcompere.systemstubs.stream.output.NoopStream;
 @Tag(ConfidentialTest.NAME)
 @Tag(WorkflowTest.NAME)
 class HostedWorkflowIT extends BaseIT {
-    public static final String DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME = "DockstoreTestUser2/hello-dockstore-workflow";
 
     @SystemStub
     public final SystemOut systemOutRule = new SystemOut(new NoopStream());
@@ -86,123 +77,44 @@ class HostedWorkflowIT extends BaseIT {
     public void resetDBBetweenTests() throws Exception {
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
     }
-    @Test
-    void testHostedEditAndDelete() {
-        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
-        WorkflowsApi workflowApi = new WorkflowsApi(webClient);
-        UsersApi usersApi = new UsersApi(webClient);
 
-        Workflow workflow = manualRegisterAndPublish(workflowApi, DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "", "cwl", SourceControl.GITHUB,
-            "/Dockstore.cwl", false);
-
-        // using hosted apis to delete normal workflow should fail
-        HostedApi hostedApi = new HostedApi(webClient);
-        try {
-            hostedApi.deleteHostedWorkflowVersion(workflow.getId(), "v1.0");
-            Assertions.fail("Should throw API exception");
-        } catch (ApiException e) {
-            Assertions.assertTrue(e.getMessage().contains("cannot modify non-hosted entries this way"));
-        }
-
-        // using hosted apis to edit normal workflow should fail
-        try {
-            hostedApi.editHostedWorkflow(workflow.getId(), new ArrayList<>());
-            Assertions.fail("Should throw API exception");
-        } catch (ApiException e) {
-            Assertions.assertTrue(e.getMessage().contains("cannot modify non-hosted entries this way"));
-        }
-    }
 
     @Test
-    void testHiddenAndDefaultVersions() {
-        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
-        WorkflowsApi workflowsApi = new WorkflowsApi(webClient);
+    void testDeleteWithoutDefaultVersion() {
+        final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         HostedApi hostedApi = new HostedApi(webClient);
-        Workflow workflow = workflowsApi.manualRegister("github", DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "/Dockstore.wdl", "", DescriptorLanguage.WDL.toString(), "/test.json");
-
-        workflow = workflowsApi.refresh(workflow.getId(), false);
-        List<WorkflowVersion> workflowVersions = workflow.getWorkflowVersions();
-        WorkflowVersion version = workflowVersions.stream().filter(w -> w.getReference().equals("testBoth")).findFirst().get();
-        version.setHidden(true);
-        workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(version));
-
-        try {
-            workflow = workflowsApi.updateWorkflowDefaultVersion(workflow.getId(), version.getName());
-            Assertions.fail("Shouldn't be able to set the default version to one that is hidden.");
-        } catch (ApiException ex) {
-            Assertions.assertEquals("You can not set the default version to a hidden version.", ex.getMessage());
-        }
-
-        // Set the default version to a non-hidden version
-        version.setHidden(false);
-        workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(version));
-        workflow = workflowsApi.updateWorkflowDefaultVersion(workflow.getId(), version.getName());
-
-        // Should not be able to hide a default version
-        version.setHidden(true);
-        try {
-            workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(version));
-            Assertions.fail("Should not be able to hide a default version");
-        } catch (ApiException ex) {
-            Assertions.assertEquals("You cannot hide the default version.", ex.getMessage());
-        }
+        final WorkflowsApi workflowsApi = new WorkflowsApi(getOpenAPIWebClient(USER_2_USERNAME, testingPostgres));
 
         // Test same for hosted workflows
-        Workflow hostedWorkflow = hostedApi.createHostedWorkflow("awesomeTool", null, CWL.getShortName(), null, null);
+        Workflow hostedWorkflow = hostedApi.createHostedWorkflow(null, "awesomeTool", CWL.getShortName(), null, null);
         SourceFile file = new SourceFile();
         file.setContent("cwlVersion: v1.0\n" + "class: Workflow");
         file.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
         file.setPath("/Dockstore.cwl");
         file.setAbsolutePath("/Dockstore.cwl");
-        hostedWorkflow = hostedApi.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file));
-
+        hostedWorkflow = hostedApi.editHostedWorkflow(Lists.newArrayList(file), hostedWorkflow.getId());
+        file.setContent("cwlVersion: v1.1\n" + "class: Workflow");
+        hostedWorkflow = hostedApi.editHostedWorkflow(Lists.newArrayList(file), hostedWorkflow.getId());
         WorkflowVersion hostedVersion = workflowsApi.getWorkflowVersions(hostedWorkflow.getId()).get(0);
-        hostedVersion.setHidden(true);
-        try {
-            workflowsApi.updateWorkflowVersion(hostedWorkflow.getId(), Collections.singletonList(hostedVersion));
-            Assertions.fail("Shouldn't be able to hide the default version.");
-        } catch (ApiException ex) {
-            Assertions.assertEquals("You cannot hide the default version.", ex.getMessage());
-        }
 
-        file.setContent("""
-            cwlVersion: v1.0
-
-            class: Workflow""");
-        hostedWorkflow = hostedApi.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file));
-        hostedVersion = workflowsApi.getWorkflowVersions(hostedWorkflow.getId()).stream().filter(v -> v.getName().equals("1")).findFirst().get();
-        hostedVersion.setHidden(true);
-        workflowsApi.updateWorkflowVersion(hostedWorkflow.getId(), Collections.singletonList(hostedVersion));
-
-        try {
-            workflowsApi.updateWorkflowDefaultVersion(hostedWorkflow.getId(), hostedVersion.getName());
-            Assertions.fail("Shouldn't be able to set the default version to one that is hidden.");
-        } catch (ApiException ex) {
-            Assertions.assertEquals("You can not set the default version to a hidden version.", ex.getMessage());
-        }
-    }
-
-    @Test
-    void testCreationOfIncorrectHostedWorkflowTypeGarbage() {
-        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
-        HostedApi hostedApi = new HostedApi(webClient);
-        assertThrows(ApiException.class, () -> hostedApi.createHostedWorkflow("name", null, "garbage type", null, null));
-
+        // delete default version via DB
+        testingPostgres.runUpdateStatement("update workflow set actualDefaultVersion = null");
+        hostedApi.deleteHostedWorkflowVersion(hostedWorkflow.getId(), hostedVersion.getName());
     }
 
     @Test
     void testGetEntryByPath() {
-        final io.dockstore.openapi.client.ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
-        io.dockstore.openapi.client.api.HostedApi hostedApi = new io.dockstore.openapi.client.api.HostedApi(webClient);
-        io.dockstore.openapi.client.api.WorkflowsApi workflowsApi = new io.dockstore.openapi.client.api.WorkflowsApi(webClient);
-        io.dockstore.openapi.client.model.Entry foundEntry;
+        final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        HostedApi hostedApi = new HostedApi(webClient);
+        WorkflowsApi workflowsApi = new WorkflowsApi(webClient);
+        Entry foundEntry;
 
         // Find a hosted workflow
-        io.dockstore.openapi.client.model.Workflow workflow = hostedApi.createHostedWorkflow(null, "name", io.openapi.model.DescriptorType.CWL.toString(), null, null);
+        Workflow workflow = hostedApi.createHostedWorkflow(null, "name", DescriptorType.CWL.toString(), null, null);
         try {
             foundEntry = workflowsApi.getEntryByPath("dockstore.org/DockstoreTestUser2/name");
             Assertions.assertEquals(workflow.getId(), foundEntry.getId());
-        } catch (io.dockstore.openapi.client.ApiException e) {
+        } catch (ApiException e) {
             Assertions.fail("Should be able to find the workflow entry with path " + workflow.getFullWorkflowPath());
         }
 
@@ -210,136 +122,75 @@ class HostedWorkflowIT extends BaseIT {
         try {
             workflowsApi.getEntryByPath("workflow/does/not/exist");
             Assertions.fail("Should not be able to find a workflow that doesn't exist.");
-        } catch (io.dockstore.openapi.client.ApiException e) {
+        } catch (ApiException e) {
             Assertions.assertEquals("Entry not found", e.getMessage());
         }
 
         // Find a hosted tool -> simple case where the repo-name has no slashes: 'foo', no tool name
-        io.dockstore.openapi.client.model.DockstoreTool tool = hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo",
-            io.openapi.model.DescriptorType.CWL.toString(), "abcd1234", null);
+        DockstoreTool tool = hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo",
+            DescriptorType.CWL.toString(), "abcd1234", null);
         try {
             foundEntry = workflowsApi.getEntryByPath("public.ecr.aws/abcd1234/foo");
             Assertions.assertEquals(tool.getId(), foundEntry.getId());
-        } catch (io.dockstore.openapi.client.ApiException e) {
+        } catch (ApiException e) {
             Assertions.fail("Should be able to find the tool entry with path " + tool.getToolPath());
         }
 
         // Find a hosted tool -> repo name: 'foo/bar', no tool name
-        tool = hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo/bar", io.openapi.model.DescriptorType.CWL.toString(), "abcd1234", null);
+        tool = hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo/bar", DescriptorType.CWL.toString(), "abcd1234", null);
         try {
             foundEntry = workflowsApi.getEntryByPath("public.ecr.aws/abcd1234/foo/bar");
             Assertions.assertEquals(tool.getId(), foundEntry.getId());
-        } catch (io.dockstore.openapi.client.ApiException e) {
+        } catch (ApiException e) {
             Assertions.fail("Should be able to find the tool entry with path " + tool.getToolPath());
         }
 
         // Find a hosted tool -> repo-name: 'foo/bar', tool name: 'tool-name'
-        tool = hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo/bar", io.openapi.model.DescriptorType.CWL.toString(), "abcd1234", "tool-name");
+        tool = hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo/bar", DescriptorType.CWL.toString(), "abcd1234", "tool-name");
         try {
             foundEntry = workflowsApi.getEntryByPath("public.ecr.aws/abcd1234/foo/bar/tool-name");
             Assertions.assertEquals(tool.getId(), foundEntry.getId());
-        } catch (io.dockstore.openapi.client.ApiException e) {
+        } catch (ApiException e) {
             Assertions.fail("Should be able to find the tool entry with path " + tool.getToolPath());
         }
-    }
-    @Test
-    void testDuplicateHostedWorkflowCreation() {
-        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
-        HostedApi hostedApi = new HostedApi(webClient);
-        hostedApi.createHostedWorkflow("name", null, DescriptorType.CWL.toString(), null, null);
-        assertThrows(ApiException.class, () -> hostedApi.createHostedWorkflow("name", null, DescriptorType.CWL.toString(), null, null), "already exists");
-    }
-
-    @Test
-    void testDuplicateHostedToolCreation() {
-        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
-        HostedApi hostedApi = new HostedApi(webClient);
-        hostedApi.createHostedTool("name", Registry.DOCKER_HUB.getDockerPath(), DescriptorType.CWL.toString(), "namespace", null);
-        assertThrows(ApiException.class, () -> hostedApi.createHostedTool("name", Registry.DOCKER_HUB.getDockerPath(), DescriptorType.CWL.toString(), "namespace", null), "already exists");
     }
 
     @Test
     void testAmazonECRHostedToolCreation() {
-        final io.dockstore.openapi.client.ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
-        io.dockstore.openapi.client.api.HostedApi hostedApi = new io.dockstore.openapi.client.api.HostedApi(webClient);
-        io.dockstore.openapi.client.api.ContainersApi containersApi = new io.dockstore.openapi.client.api.ContainersApi(webClient);
+        final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        HostedApi hostedApi = new HostedApi(webClient);
+        ContainersApi containersApi = new ContainersApi(webClient);
 
         // Create a hosted Amazon ECR tool using a private repository
-        io.dockstore.openapi.client.model.DockstoreTool tool = hostedApi.createHostedTool("test.dkr.ecr.us-east-1.amazonaws.com", "foo", io.openapi.model.DescriptorType.CWL.toString(), "namespace", "bar");
+        DockstoreTool tool = hostedApi.createHostedTool("test.dkr.ecr.us-east-1.amazonaws.com", "foo", DescriptorType.CWL.toString(), "namespace", "bar");
         Assertions.assertNotNull(containersApi.getContainer(tool.getId(), ""));
 
         // Create a hosted Amazon ECR tool using a public repository
-        tool = hostedApi.createHostedTool("public.ecr.aws", "foo", io.openapi.model.DescriptorType.CWL.toString(), "namespace", "bar");
+        tool = hostedApi.createHostedTool("public.ecr.aws", "foo", DescriptorType.CWL.toString(), "namespace", "bar");
         Assertions.assertNotNull(containersApi.getContainer(tool.getId(), ""));
     }
 
     @Test
     void testDuplicateAmazonECRHostedToolCreation() {
-        final io.dockstore.openapi.client.ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
-        io.dockstore.openapi.client.api.HostedApi hostedApi = new io.dockstore.openapi.client.api.HostedApi(webClient);
+        final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        HostedApi hostedApi = new HostedApi(webClient);
         String alreadyExistsMessage = "already exists";
 
         // Simple case: the two tools have the same names and entry names
-        hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo", io.openapi.model.DescriptorType.CWL.toString(), "abcd1234", null);
-        assertThrows(io.dockstore.openapi.client.ApiException.class, () ->  hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo", io.openapi.model.DescriptorType.CWL.toString(), "abcd1234", null), alreadyExistsMessage);
+        hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo", DescriptorType.CWL.toString(), "abcd1234", null);
+        assertThrows(ApiException.class, () ->  hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo", DescriptorType.CWL.toString(), "abcd1234", null), alreadyExistsMessage);
 
         // The two tools have different names and entry names, but the tool paths are the same
         // Scenario 1:
         // Tool 1 has name: 'foo/bar' and no entry name
         // Tool 2 has name: 'foo' and entry name: 'bar'
-        hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo/bar", io.openapi.model.DescriptorType.CWL.toString(), "abcd1234", null);
-        assertThrows(io.dockstore.openapi.client.ApiException.class, () ->   hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo", io.openapi.model.DescriptorType.CWL.toString(), "abcd1234", "bar"), alreadyExistsMessage);
+        hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo/bar", DescriptorType.CWL.toString(), "abcd1234", null);
+        assertThrows(ApiException.class, () ->   hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo", DescriptorType.CWL.toString(), "abcd1234", "bar"), alreadyExistsMessage);
 
         // Scenario 2:
         // Tool 1 has name: 'foo' and entry name: 'bar'
         // Tool 2 has name: 'foo/bar' and no entry name
-        hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo", io.openapi.model.DescriptorType.CWL.toString(), "wxyz6789", "bar");
-        assertThrows(io.dockstore.openapi.client.ApiException.class, () ->   hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo/bar", io.openapi.model.DescriptorType.CWL.toString(), "wxyz6789", null), alreadyExistsMessage);
-    }
-
-    @Test
-    void testHostedWorkflowMetadata() throws IOException {
-        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
-        HostedApi hostedApi = new HostedApi(webClient);
-        Workflow hostedWorkflow = hostedApi.createHostedWorkflow("name", null, DescriptorType.CWL.toString(), null, null);
-        Assertions.assertNotNull(hostedWorkflow.getLastModifiedDate());
-        Assertions.assertNotNull(hostedWorkflow.getLastUpdated());
-
-        // make a couple garbage edits
-        SourceFile source = new SourceFile();
-        source.setPath("/Dockstore.cwl");
-        source.setAbsolutePath("/Dockstore.cwl");
-        source.setContent("cwlVersion: v1.0\nclass: Workflow");
-        source.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
-        SourceFile source1 = new SourceFile();
-        source1.setPath("sorttool.cwl");
-        source1.setContent("foo");
-        source1.setAbsolutePath("/sorttool.cwl");
-        source1.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
-        SourceFile source2 = new SourceFile();
-        source2.setPath("revtool.cwl");
-        source2.setContent("foo");
-        source2.setAbsolutePath("/revtool.cwl");
-        source2.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
-        hostedApi.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(source, source1, source2));
-
-        source.setContent("cwlVersion: v1.0\nclass: Workflow");
-        source1.setContent("food");
-        source2.setContent("food");
-        final Workflow updatedHostedWorkflow = hostedApi
-            .editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(source, source1, source2));
-        Assertions.assertNotNull(updatedHostedWorkflow.getLastModifiedDate());
-        Assertions.assertNotNull(updatedHostedWorkflow.getLastUpdated());
-
-        // note that this workflow contains metadata defined on the inputs to the workflow in the old (pre-map) CWL way that is still valid v1.0 CWL
-        source.setContent(FileUtils
-            .readFileToString(new File(ResourceHelpers.resourceFilePath("hosted_metadata/Dockstore.cwl")), StandardCharsets.UTF_8));
-        source1.setContent(
-            FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("hosted_metadata/sorttool.cwl")), StandardCharsets.UTF_8));
-        source2.setContent(
-            FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("hosted_metadata/revtool.cwl")), StandardCharsets.UTF_8));
-        Workflow workflow = hostedApi.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(source, source1, source2));
-        Assertions.assertFalse(workflow.getInputFileFormats().isEmpty());
-        Assertions.assertFalse(workflow.getOutputFileFormats().isEmpty());
+        hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo", DescriptorType.CWL.toString(), "wxyz6789", "bar");
+        assertThrows(ApiException.class, () ->   hostedApi.createHostedTool(Registry.AMAZON_ECR.getDockerPath(), "foo/bar", DescriptorType.CWL.toString(), "wxyz6789", null), alreadyExistsMessage);
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/HostedWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/HostedWorkflowIT.java
@@ -17,6 +17,7 @@
 package io.dockstore.client.cli;
 
 import static io.dockstore.common.DescriptorLanguage.CWL;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.Lists;
@@ -99,7 +100,9 @@ class HostedWorkflowIT extends BaseIT {
 
         // delete default version via DB
         testingPostgres.runUpdateStatement("update workflow set actualDefaultVersion = null");
-        hostedApi.deleteHostedWorkflowVersion(hostedWorkflow.getId(), hostedVersion.getName());
+        final Entry entry = hostedApi.deleteHostedWorkflowVersion(hostedWorkflow.getId(), hostedVersion.getName());
+        // we're really checking that deleting a workflow version did not result in an exception
+        assertNotNull(entry);
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerHostedWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerHostedWorkflowIT.java
@@ -58,6 +58,7 @@ import uk.org.webcompere.systemstubs.stream.SystemOut;
 import uk.org.webcompere.systemstubs.stream.output.NoopStream;
 
 /**
+ * This tests various operations having to do with hosted workflows.
  * @deprecated uses swagger client, prefer the openapi client in SwaggerWorkflowIT
  */
 @ExtendWith(SystemStubsExtension.class)

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerHostedWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerHostedWorkflowIT.java
@@ -1,0 +1,255 @@
+/*
+ *    Copyright 2022 OICR and UCSC
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.dockstore.client.cli;
+
+import static io.dockstore.common.DescriptorLanguage.CWL;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.common.collect.Lists;
+import io.dockstore.client.cli.BaseIT.TestStatus;
+import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.ConfidentialTest;
+import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.common.Registry;
+import io.dockstore.common.SourceControl;
+import io.dockstore.common.WorkflowTest;
+import io.dockstore.webservice.DockstoreWebserviceApplication;
+import io.dropwizard.testing.ResourceHelpers;
+import io.swagger.client.ApiClient;
+import io.swagger.client.ApiException;
+import io.swagger.client.api.HostedApi;
+import io.swagger.client.api.WorkflowsApi;
+import io.swagger.client.model.SourceFile;
+import io.swagger.client.model.Workflow;
+import io.swagger.client.model.WorkflowVersion;
+import io.swagger.model.DescriptorType;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.hibernate.Session;
+import org.hibernate.context.internal.ManagedSessionContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.stream.SystemErr;
+import uk.org.webcompere.systemstubs.stream.SystemOut;
+import uk.org.webcompere.systemstubs.stream.output.NoopStream;
+
+/**
+ * @deprecated uses swagger client, prefer the openapi client in SwaggerWorkflowIT
+ */
+@ExtendWith(SystemStubsExtension.class)
+@ExtendWith(TestStatus.class)
+@Tag(ConfidentialTest.NAME)
+@Tag(WorkflowTest.NAME)
+@Deprecated
+class SwaggerHostedWorkflowIT extends BaseIT {
+    public static final String DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME = "DockstoreTestUser2/hello-dockstore-workflow";
+
+    @SystemStub
+    public final SystemOut systemOutRule = new SystemOut(new NoopStream());
+    @SystemStub
+    public final SystemErr systemErrRule = new SystemErr(new NoopStream());
+
+
+    @BeforeEach
+    public void setup() {
+        DockstoreWebserviceApplication application = SUPPORT.getApplication();
+
+
+        // used to allow us to use workflowDAO outside of the web service
+        Session session = application.getHibernate().getSessionFactory().openSession();
+        ManagedSessionContext.bind(session);
+
+    }
+    @BeforeEach
+    @Override
+    public void resetDBBetweenTests() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
+    }
+    @Test
+    void testHostedEditAndDelete() {
+        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowApi = new WorkflowsApi(webClient);
+
+        Workflow workflow = manualRegisterAndPublish(workflowApi, DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "", "cwl", SourceControl.GITHUB,
+            "/Dockstore.cwl", false);
+
+        // using hosted apis to delete normal workflow should fail
+        HostedApi hostedApi = new HostedApi(webClient);
+        try {
+            hostedApi.deleteHostedWorkflowVersion(workflow.getId(), "v1.0");
+            Assertions.fail("Should throw API exception");
+        } catch (ApiException e) {
+            Assertions.assertTrue(e.getMessage().contains("cannot modify non-hosted entries this way"));
+        }
+
+        // using hosted apis to edit normal workflow should fail
+        try {
+            hostedApi.editHostedWorkflow(workflow.getId(), new ArrayList<>());
+            Assertions.fail("Should throw API exception");
+        } catch (ApiException e) {
+            Assertions.assertTrue(e.getMessage().contains("cannot modify non-hosted entries this way"));
+        }
+    }
+
+    @Test
+    void testHiddenAndDefaultVersions() {
+        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowsApi = new WorkflowsApi(webClient);
+        HostedApi hostedApi = new HostedApi(webClient);
+        Workflow workflow = workflowsApi.manualRegister("github", DOCKSTORE_TEST_USER_2_HELLO_DOCKSTORE_NAME, "/Dockstore.wdl", "", DescriptorLanguage.WDL.toString(), "/test.json");
+
+        workflow = workflowsApi.refresh(workflow.getId(), false);
+        List<WorkflowVersion> workflowVersions = workflow.getWorkflowVersions();
+        WorkflowVersion version = workflowVersions.stream().filter(w -> w.getReference().equals("testBoth")).findFirst().get();
+        version.setHidden(true);
+        workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(version));
+
+        try {
+            workflow = workflowsApi.updateWorkflowDefaultVersion(workflow.getId(), version.getName());
+            Assertions.fail("Shouldn't be able to set the default version to one that is hidden.");
+        } catch (ApiException ex) {
+            Assertions.assertEquals("You can not set the default version to a hidden version.", ex.getMessage());
+        }
+
+        // Set the default version to a non-hidden version
+        version.setHidden(false);
+        workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(version));
+        workflow = workflowsApi.updateWorkflowDefaultVersion(workflow.getId(), version.getName());
+
+        // Should not be able to hide a default version
+        version.setHidden(true);
+        try {
+            workflowsApi.updateWorkflowVersion(workflow.getId(), Collections.singletonList(version));
+            Assertions.fail("Should not be able to hide a default version");
+        } catch (ApiException ex) {
+            Assertions.assertEquals("You cannot hide the default version.", ex.getMessage());
+        }
+
+        // Test same for hosted workflows
+        Workflow hostedWorkflow = hostedApi.createHostedWorkflow("awesomeTool", null, CWL.getShortName(), null, null);
+        SourceFile file = new SourceFile();
+        file.setContent("cwlVersion: v1.0\n" + "class: Workflow");
+        file.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
+        file.setPath("/Dockstore.cwl");
+        file.setAbsolutePath("/Dockstore.cwl");
+        hostedWorkflow = hostedApi.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file));
+
+        WorkflowVersion hostedVersion = workflowsApi.getWorkflowVersions(hostedWorkflow.getId()).get(0);
+        hostedVersion.setHidden(true);
+        try {
+            workflowsApi.updateWorkflowVersion(hostedWorkflow.getId(), Collections.singletonList(hostedVersion));
+            Assertions.fail("Shouldn't be able to hide the default version.");
+        } catch (ApiException ex) {
+            Assertions.assertEquals("You cannot hide the default version.", ex.getMessage());
+        }
+
+        file.setContent("""
+            cwlVersion: v1.0
+
+            class: Workflow""");
+        hostedWorkflow = hostedApi.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file));
+        hostedVersion = workflowsApi.getWorkflowVersions(hostedWorkflow.getId()).stream().filter(v -> v.getName().equals("1")).findFirst().get();
+        hostedVersion.setHidden(true);
+        workflowsApi.updateWorkflowVersion(hostedWorkflow.getId(), Collections.singletonList(hostedVersion));
+
+        try {
+            workflowsApi.updateWorkflowDefaultVersion(hostedWorkflow.getId(), hostedVersion.getName());
+            Assertions.fail("Shouldn't be able to set the default version to one that is hidden.");
+        } catch (ApiException ex) {
+            Assertions.assertEquals("You can not set the default version to a hidden version.", ex.getMessage());
+        }
+    }
+
+    @Test
+    void testCreationOfIncorrectHostedWorkflowTypeGarbage() {
+        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        HostedApi hostedApi = new HostedApi(webClient);
+        assertThrows(ApiException.class, () -> hostedApi.createHostedWorkflow("name", null, "garbage type", null, null));
+
+    }
+    @Test
+    void testDuplicateHostedWorkflowCreation() {
+        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        HostedApi hostedApi = new HostedApi(webClient);
+        hostedApi.createHostedWorkflow("name", null, DescriptorType.CWL.toString(), null, null);
+        assertThrows(ApiException.class, () -> hostedApi.createHostedWorkflow("name", null, DescriptorType.CWL.toString(), null, null), "already exists");
+    }
+
+    @Test
+    void testDuplicateHostedToolCreation() {
+        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        HostedApi hostedApi = new HostedApi(webClient);
+        hostedApi.createHostedTool("name", Registry.DOCKER_HUB.getDockerPath(), DescriptorType.CWL.toString(), "namespace", null);
+        assertThrows(ApiException.class, () -> hostedApi.createHostedTool("name", Registry.DOCKER_HUB.getDockerPath(), DescriptorType.CWL.toString(), "namespace", null), "already exists");
+    }
+
+    @Test
+    void testHostedWorkflowMetadata() throws IOException {
+        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        HostedApi hostedApi = new HostedApi(webClient);
+        Workflow hostedWorkflow = hostedApi.createHostedWorkflow("name", null, DescriptorType.CWL.toString(), null, null);
+        Assertions.assertNotNull(hostedWorkflow.getLastModifiedDate());
+        Assertions.assertNotNull(hostedWorkflow.getLastUpdated());
+
+        // make a couple garbage edits
+        SourceFile source = new SourceFile();
+        source.setPath("/Dockstore.cwl");
+        source.setAbsolutePath("/Dockstore.cwl");
+        source.setContent("cwlVersion: v1.0\nclass: Workflow");
+        source.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
+        SourceFile source1 = new SourceFile();
+        source1.setPath("sorttool.cwl");
+        source1.setContent("foo");
+        source1.setAbsolutePath("/sorttool.cwl");
+        source1.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
+        SourceFile source2 = new SourceFile();
+        source2.setPath("revtool.cwl");
+        source2.setContent("foo");
+        source2.setAbsolutePath("/revtool.cwl");
+        source2.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
+        hostedApi.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(source, source1, source2));
+
+        source.setContent("cwlVersion: v1.0\nclass: Workflow");
+        source1.setContent("food");
+        source2.setContent("food");
+        final Workflow updatedHostedWorkflow = hostedApi
+            .editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(source, source1, source2));
+        Assertions.assertNotNull(updatedHostedWorkflow.getLastModifiedDate());
+        Assertions.assertNotNull(updatedHostedWorkflow.getLastUpdated());
+
+        // note that this workflow contains metadata defined on the inputs to the workflow in the old (pre-map) CWL way that is still valid v1.0 CWL
+        source.setContent(FileUtils
+            .readFileToString(new File(ResourceHelpers.resourceFilePath("hosted_metadata/Dockstore.cwl")), StandardCharsets.UTF_8));
+        source1.setContent(
+            FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("hosted_metadata/sorttool.cwl")), StandardCharsets.UTF_8));
+        source2.setContent(
+            FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("hosted_metadata/revtool.cwl")), StandardCharsets.UTF_8));
+        Workflow workflow = hostedApi.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(source, source1, source2));
+        Assertions.assertFalse(workflow.getInputFileFormats().isEmpty());
+        Assertions.assertFalse(workflow.getOutputFileFormats().isEmpty());
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -140,8 +140,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
         entry.setTopicSelection(TopicSelection.MANUAL);
         checkForDuplicatePath(entry);
         long l = getEntryDAO().create(entry);
-        T byId = getEntryDAO().findById(l);
-        return byId;
+        return getEntryDAO().findById(l);
     }
 
     protected abstract void checkForDuplicatePath(T entry);
@@ -237,10 +236,9 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
 
         String invalidFileNames = String.join(",", invalidFileNames(version));
         if (!invalidFileNames.isEmpty()) {
-            StringBuilder message = new StringBuilder();
-            message.append("Files must have a name. Unable to save new version due to the following files: ");
-            message.append(invalidFileNames);
-            throw new CustomWebApplicationException(message.toString(), HttpStatus.SC_BAD_REQUEST);
+            String message = "Files must have a name. Unable to save new version due to the following files: "
+                + invalidFileNames;
+            throw new CustomWebApplicationException(message, HttpStatus.SC_BAD_REQUEST);
         }
 
         validatedVersion.setValid(true); // Hosted entry versions must be valid to save
@@ -400,7 +398,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
         }
 
         // If the version that's about to be deleted is the default version, unset it
-        if (entry.getActualDefaultVersion().getName().equals(version)) {
+        if (entry.getActualDefaultVersion() != null && entry.getActualDefaultVersion().getName().equals(version)) {
             Optional<U> max = entry.getWorkflowVersions().stream().filter(v -> !Objects.equals(v.getName(), version))
                     .max(Comparator.comparingLong(ver -> ver.getDate().getTime()));
             entry.setActualDefaultVersion(max.orElse(null));


### PR DESCRIPTION
**Description**
Null check for hosted version deletion, further demo what a split between openapi and swagger tests would look like 

**Review Instructions**
Probably not too essential, delete versions from a hosted workflow is probably enough.
Number of tests executed should remain the same

**Issue**
https://github.com/dockstore/dockstore/issues/4511
Demonstrate https://ucsc-cgl.atlassian.net/browse/SEAB-5066 or https://ucsc-cgl.atlassian.net/browse/SEAB-5067

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
