### PR TITLE
add test for regex for weird github references

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -108,6 +108,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
     public static final String GITHUB_ABUSE_LIMIT_REACHED = "GitHub abuse limit reached";
     public static final int GITHUB_MAX_CACHE_AGE_SECONDS = 30; // GitHub's default max-cache age is 60 seconds
+    public static final Pattern GIT_BRANCH_TAG_PATTERN = Pattern.compile("^refs/(tags|heads)/([a-zA-Z0-9\\.\\-_/]+)$");
     private static final Logger LOG = LoggerFactory.getLogger(GitHubSourceCodeRepo.class);
     private final GitHub github;
     private String githubTokenUsername;
@@ -1295,8 +1296,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         GHRepository ghRepository = getRepository(repository);
 
         // Match the github reference (ex. refs/heads/feature/foobar or refs/tags/1.0)
-        Pattern pattern = Pattern.compile("^refs/(tags|heads)/([a-zA-Z0-9]+([./_-]?[a-zA-Z0-9]+)*)$");
-        Matcher matcher = pattern.matcher(gitReference);
+        Matcher matcher = GIT_BRANCH_TAG_PATTERN.matcher(gitReference);
 
         if (!matcher.find()) {
             throw new CustomWebApplicationException("Reference " + gitReference + " is not of the valid form", LAMBDA_FAILURE);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -108,7 +108,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
     public static final String GITHUB_ABUSE_LIMIT_REACHED = "GitHub abuse limit reached";
     public static final int GITHUB_MAX_CACHE_AGE_SECONDS = 30; // GitHub's default max-cache age is 60 seconds
-    public static final Pattern GIT_BRANCH_TAG_PATTERN = Pattern.compile("^refs/(tags|heads)/((?!.*//)(?!.*\\.\\.)[.'\\p{L}\\d\\-_/]+)$");
+    public static final Pattern GIT_BRANCH_TAG_PATTERN = Pattern.compile("^refs/(tags|heads)/((?!.*//)(?!.*\\\\)(?!.*@)(?!.*\\[)(?!.*\\?)(?!.*~)(?!.*\\.\\.)[\\p{Punct}\\p{L}\\d\\-_/]+)$");
     private static final Logger LOG = LoggerFactory.getLogger(GitHubSourceCodeRepo.class);
     private final GitHub github;
     private String githubTokenUsername;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -108,7 +108,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
     public static final String GITHUB_ABUSE_LIMIT_REACHED = "GitHub abuse limit reached";
     public static final int GITHUB_MAX_CACHE_AGE_SECONDS = 30; // GitHub's default max-cache age is 60 seconds
-    public static final Pattern GIT_BRANCH_TAG_PATTERN = Pattern.compile("^refs/(tags|heads)/([a-zA-Z0-9\\.\\-_/]+)$");
+    public static final Pattern GIT_BRANCH_TAG_PATTERN = Pattern.compile("^refs/(tags|heads)/((?!.*//)(?!.*\\.\\.)[.'\\p{L}\\d\\-_/]+)$");
     private static final Logger LOG = LoggerFactory.getLogger(GitHubSourceCodeRepo.class);
     private final GitHub github;
     private String githubTokenUsername;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -108,7 +108,10 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
     public static final String GITHUB_ABUSE_LIMIT_REACHED = "GitHub abuse limit reached";
     public static final int GITHUB_MAX_CACHE_AGE_SECONDS = 30; // GitHub's default max-cache age is 60 seconds
-    public static final Pattern GIT_BRANCH_TAG_PATTERN = Pattern.compile("^refs/(tags|heads)/((?!.*//)(?!.*\\\\)(?!.*@)(?!.*\\[)(?!.*\\?)(?!.*~)(?!.*\\.\\.)[\\p{Punct}\\p{L}\\d\\-_/]+)$");
+    /**
+     * each section that starts with (?!.* is excluding a specific character
+     */
+    public static final Pattern GIT_BRANCH_TAG_PATTERN = Pattern.compile("^refs/(tags|heads)/((?!.*//)(?!.*\\^)(?!.*:)(?!.*\\\\)(?!.*@)(?!.*\\[)(?!.*\\?)(?!.*~)(?!.*\\.\\.)[\\p{Punct}\\p{L}\\d\\-_/]+)$");
     private static final Logger LOG = LoggerFactory.getLogger(GitHubSourceCodeRepo.class);
     private final GitHub github;
     private String githubTokenUsername;

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GitHubHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GitHubHelperTest.java
@@ -45,6 +45,10 @@ class GitHubHelperTest {
         testReferenceString("refs/heads/AshO'Farrell", "heads/AshO'Farrell");
         testReferenceString("refs/heads/Νάξος", "heads/Νάξος");
         testReferenceString("refs/heads/孤独のグルメ", "heads/孤独のグルメ");
+        // plain weird character classes
+        testReferenceString("refs/heads/foo()bar", "heads/foo()bar");
+        testReferenceString("refs/heads/foo{}bar", "heads/foo{}bar");
+
 
         // not sure if the following would make it into github in the first place, but wouldn't hurt to double-check to make sure they don't get into our DB
 
@@ -57,6 +61,7 @@ class GitHubHelperTest {
         assertThrows(IllegalStateException.class, () -> testReferenceString("refs/heads/foo?bar", "heads/_foo_bar"));
         assertThrows(IllegalStateException.class, () -> testReferenceString("refs/heads/foo[bar", "heads/_foo_bar"));
         assertThrows(IllegalStateException.class, () -> testReferenceString("refs/heads/foo~bar", "heads/_foo_bar"));
+        assertThrows(IllegalStateException.class, () -> testReferenceString("refs/heads/foo\\bar", "heads/_foo_bar"));
         assertThrows(IllegalStateException.class, () -> testReferenceString("refs/heads/@{.", "heads/_foo_bar"));
         assertThrows(IllegalStateException.class, () -> testReferenceString("refs/heads/@", "heads/_foo_bar"));
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GitHubHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GitHubHelperTest.java
@@ -1,12 +1,13 @@
 package io.dockstore.webservice.helpers;
 
+import static io.dockstore.webservice.helpers.GitHubSourceCodeRepo.GIT_BRANCH_TAG_PATTERN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import io.dockstore.webservice.CustomWebApplicationException;
+import java.util.regex.Matcher;
 import org.junit.jupiter.api.Test;
 
-// Ignoring for now, see https://ucsc-cgl.atlassian.net/browse/SEAB-1855
 class GitHubHelperTest {
 
     private static final String CODE = "abcdefghijklmnop";
@@ -22,6 +23,30 @@ class GitHubHelperTest {
         } catch (CustomWebApplicationException e) {
             assertEquals("HTTP 400 Bad Request", e.getMessage());
         }
+    }
 
+    @Test
+    void testGitHubBranchTagPattern() {
+        testReferenceString("refs/heads/feature/foobar", "heads/feature/foobar");
+        testReferenceString("refs/tags/1.0", "tags/1.0");
+        testReferenceString("refs/heads/main", "heads/main");
+        testReferenceString("refs/tags/v3.14.1", "tags/v3.14.1");
+        testReferenceString("refs/heads/feature/foo_bar", "heads/feature/foo_bar");
+        testReferenceString("refs/heads/feature/_leadingunderscore", "heads/feature/_leadingunderscore");
+        testReferenceString("refs/heads/foo_bar", "heads/foo_bar");
+        testReferenceString("refs/heads/_foo_bar", "heads/_foo_bar");
+        testReferenceString("refs/heads/foo-bar", "heads/foo-bar");
+        testReferenceString("refs/heads/-foo-bar", "heads/-foo-bar");
+        testReferenceString("refs/heads/foo.bar", "heads/foo.bar");
+        testReferenceString("refs/heads/.foo.bar", "heads/.foo.bar");
+        testReferenceString("refs/heads/_leadingunderscore", "heads/_leadingunderscore");
+    }
+
+    private static void testReferenceString(String gitReference, String expectedString) {
+        Matcher matcher = GIT_BRANCH_TAG_PATTERN.matcher(gitReference);
+        final boolean b = matcher.find();
+        String gitBranchType = matcher.group(1);
+        String gitBranchName = matcher.group(2);
+        assertEquals(expectedString, (gitBranchType + "/" + gitBranchName));
     }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GitHubHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GitHubHelperTest.java
@@ -64,7 +64,12 @@ class GitHubHelperTest {
         assertThrows(IllegalStateException.class, () -> testReferenceString("refs/heads/foo\\bar", "heads/_foo_bar"));
         assertThrows(IllegalStateException.class, () -> testReferenceString("refs/heads/@{.", "heads/_foo_bar"));
         assertThrows(IllegalStateException.class, () -> testReferenceString("refs/heads/@", "heads/_foo_bar"));
+        assertThrows(IllegalStateException.class, () -> testReferenceString("refs/heads/foo:bar", "heads/_foo_bar"));
+        assertThrows(IllegalStateException.class, () -> testReferenceString("refs/heads/foo^bar", "heads/_foo_bar"));
 
+        // ASCII control characters
+        assertThrows(IllegalStateException.class, () -> testReferenceString("refs/heads/foo\tbar", "heads/_foo_bar"));
+        assertThrows(IllegalStateException.class, () -> testReferenceString("refs/heads/foo\nbar", "heads/_foo_bar"));
     }
 
     private void testReferenceString(String gitReference, String expectedString) {


### PR DESCRIPTION
**Description**
Changed regex and tested it with a bunch of annoying + international cases while disallowing control characters like was probably intended. https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names#naming-branches-and-tags should work, https://git-scm.com/docs/git-check-ref-format notes a bunch of cases that should not work

On merge, proposing a ticket to use the same regex for bitbucket, hosted workflows, etc. Probably would be good to limit branch/tag names there too to save us some potential pain. 
https://ucsc-cgl.atlassian.net/browse/SEAB-5256

**Review Instructions**
GitHub apps continues to work as normal is probably enough. Actually try a repo with these crazy branch names for bonus points

**Issue**
https://github.com/dockstore/dockstore/issues/5143
https://github.com/dockstore/dockstore/issues/5141
https://github.com/dockstore/dockstore/issues/4993

**Security**
None known

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
