### PR TITLE
SEAB-4704: delete entries that are not considered any of the EntryTypes

### DIFF
--- a/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
@@ -280,9 +280,9 @@
         <sql dbms="postgresql">
             DELETE FROM user_entry ue WHERE ue.entryid NOT IN (SELECT id FROM workflow UNION ALL
                                                                SELECT id FROM apptool UNION ALL
-                                                               SELECT id from service UNION ALL
-                                                               SELECT id from tool UNION ALL
-                                                               SELECT id from notebook);
+                                                               SELECT id FROM service UNION ALL
+                                                               SELECT id FROM tool UNION ALL
+                                                               SELECT id FROM notebook);
         </sql>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
@@ -276,4 +276,12 @@
         <addUniqueConstraint columnNames="metricsid" constraintName="uk_metricsid_version_metrics" tableName="version_metrics"/>
         <addForeignKeyConstraint baseColumnNames="metricsid" baseTableName="version_metrics" constraintName="fk_metricsid_version_metrics" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="metrics"/>
     </changeSet>
+    <changeSet id="deleteNonExistentEntries" author="nhyun">
+        <sql dbms="postgresql">
+            DELETE FROM user_entry ue WHERE ue.entryid NOT IN (SELECT id FROM workflow UNION ALL
+                                                               SELECT id FROM apptool UNION ALL
+                                                               SELECT id from service UNION ALL
+                                                               SELECT id from TOOL );
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
@@ -281,7 +281,8 @@
             DELETE FROM user_entry ue WHERE ue.entryid NOT IN (SELECT id FROM workflow UNION ALL
                                                                SELECT id FROM apptool UNION ALL
                                                                SELECT id from service UNION ALL
-                                                               SELECT id from TOOL );
+                                                               SELECT id from tool UNION ALL
+                                                               SELECT id from notebook);
         </sql>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**Description**
Prior to this PR, the SQL query `select count(userid) from user_entry where userid = <redacted>;` would return a higher number than the endpoint
```
curl -s -X 'GET'   'http://localhost:4200/api/users/users/entries'   -H 'accept: application/json'   -H 'Authorization: Bearer <redacted>' | jq '. | length'
```

Upon investigation, the extra entries found in `select count(userid) from user_entry where userid = <redacted>;` are entries that are essentially non-existent where it is not considered an apptool, tool, workflow, or service.

We can get every entry ids of with this issue by :
```
select * from user_entry ue where ue.entryid not in  (select id from workflow union all
select id from apptool union all
select id from service union all
select id from tool );
```

Thus this PR deletes all of these entries from the database leading to an output of 0 when running the query above again.

**Review Instructions**
Verify that the query is correct and deletes all of these entries.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4704

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
