### PR TITLE
SEAB-5242: Improve MuteForSuccessfulTests extension

### DIFF
--- a/dockstore-common/src/test/java/io/dockstore/common/MuteForSuccessfulTests.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/MuteForSuccessfulTests.java
@@ -26,8 +26,7 @@ import uk.org.webcompere.systemstubs.stream.SystemStreamBase;
  * Implements a Junit 5 extension that will print the captured output
  * from any SystemStubs "stream" test fields (any field with a type that
  * is a subclass of SystemStreamBase, such as SystemOut and SystemErr)
- * to stdout for any failed test.  The "stream" test fields should be
- * public to ensure that the extension can access them.
+ * to stdout for any failed test.
  *
  * Note that the default behavior, without this extension, is for
  * SystemOut/SystemErr to capture the output, but not print it.
@@ -36,20 +35,30 @@ public class MuteForSuccessfulTests implements TestWatcher {
 
     @Override
     public void testFailed(ExtensionContext context, Throwable cause) {
+
         try {
+            // Get the object that represents the failed test.
             Object test = context.getRequiredTestInstance();
-            // Iterate over the fields of the test object.
-            for (Field field: test.getClass().getDeclaredFields()) {
-                // Skip any field that doesn't extend SystemStreamBase,
-                // thus avoiding a potential security/access exception on an irrelevant private field.
-                if (SystemStreamBase.class.isAssignableFrom(field.getType())) {
-                    // Extract the "stream" field value.
-                    if (field.get(test) instanceof SystemStreamBase stream) {
-                        // Get the captured text and output it.
-                        String text = stream.getText();
-                        if (text != null) {
-                            System.out.print(text);
-                            System.out.flush();
+
+            // Climb the class hierarchy, starting at the leaf subclass.
+            for (Class<?> klass = test.getClass(); klass != null; klass = klass.getSuperclass()) {
+
+                // Iterate over the declared fields of the class.
+                for (Field field: klass.getDeclaredFields()) {
+
+                    // Skip any fields that do not extend SystemStreamBase.
+                    if (SystemStreamBase.class.isAssignableFrom(field.getType())) {
+
+                        // Extract the value of the "stream" field from the test object.
+                        field.trySetAccessible();
+                        if (field.get(test) instanceof SystemStreamBase stream) {
+
+                            // Get the captured text and output it.
+                            String text = stream.getText();
+                            if (text != null) {
+                                System.out.print(text);
+                                System.out.flush();
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
**Description**
This PR enhances our recently-created `MuteForSuccessfulTests` Junit 5 extension to find (and output, on failure) all SystemStub streams that are declared anywhere in the class or parent classes of the failed test object.  For example, the new extension will now properly handle some of the GA4GH integration tests, which extend a class that contains the SystemStub streams. The code now uses the non-deprecated access acquisition method `trySetAccessible`, which allows the `SystemOut` and `SystemErr` fields to be private (if desired).

I tested with the following tests, which are not included in the PR itself (because they fail (on purpose)):

```
package io.dockstore.client.cli;

import io.dockstore.common.MuteForSuccessfulTests;
import org.junit.jupiter.api.Test;
import org.junit.jupiter.api.extension.ExtendWith;
import uk.org.webcompere.systemstubs.jupiter.SystemStub;
import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
import uk.org.webcompere.systemstubs.stream.SystemErr;
import uk.org.webcompere.systemstubs.stream.SystemOut;

@ExtendWith(SystemStubsExtension.class)
@ExtendWith(MuteForSuccessfulTests.class)
class ATest {
    
    @SystemStub
    private SystemOut systemOut = new SystemOut();
    
    @SystemStub
    private SystemErr systemErr = new SystemErr();

    @Test
    void passA() {
        System.out.println("passA out");
        System.err.println("passA err");
    }
   
    @Test
    void failA() {
        System.out.println("failA out");
        System.err.println("failA err");
        throw new RuntimeException();
    }
}   

package io.dockstore.client.cli;

import org.junit.jupiter.api.Test;
import org.junit.jupiter.api.Assertions;

class BTest extends ATest {
    
    @Test
    void passB() {
        System.out.println("passB out");
        System.err.println("passB err");
    }
    
    @Test
    void failB() {
        System.out.println("failB out");
        System.err.println("failB err");
        Assertions.fail();
    }
}   
```

**Review Instructions**
Find a failed CircleCI run that incorporates this change, and verify that the output is included, but only with the failed tests.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5242

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
