### PR TITLE
hack for galaxy version parsing for existing workflows

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/languages/GalaxyPluginIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/languages/GalaxyPluginIT.java
@@ -83,7 +83,7 @@ import uk.org.webcompere.systemstubs.stream.SystemOut;
 @Tag(WorkflowTest.NAME)
 class GalaxyPluginIT {
     public static final DropwizardTestSupport<DockstoreWebserviceConfiguration> SUPPORT;
-    public static final String GALAXY_PLUGIN_VERSION = "0.0.4";
+    public static final String GALAXY_PLUGIN_VERSION = "0.0.8";
     public static final String GALAXY_PLUGIN_FILENAME = "dockstore-galaxy-interface-" + GALAXY_PLUGIN_VERSION + ".jar";
     public static final String GALAXY_PLUGIN_LOCATION =
         "https://artifacts.oicr.on.ca/artifactory/collab-release/com/github/galaxyproject/dockstore-galaxy-interface/dockstore-galaxy-interface/"

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -608,7 +608,7 @@ public abstract class SourceCodeRepoInterface {
             DescriptorLanguage.FileType workflowDescriptorType = workflow.getTestParameterType();
 
             List<SourceFile> testParameterFiles = existingVersion.getSourceFiles().stream()
-                .filter((SourceFile u) -> u.getType() == workflowDescriptorType).collect(Collectors.toList());
+                .filter((SourceFile u) -> u.getType() == workflowDescriptorType).toList();
             testParameterFiles
                 .forEach(file -> this.readFile(repositoryId, existingVersion, sourceFileSet, workflowDescriptorType, file.getPath()));
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -34,6 +34,8 @@ import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.helpers.ElasticSearchHelper;
 import io.dockstore.webservice.helpers.StateManagerMode;
 import io.dropwizard.jackson.Jackson;
+import io.openapi.model.DescriptorType;
+import io.swagger.api.impl.ToolsImplCommon;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -513,7 +515,7 @@ public class ElasticListener implements StateListenerInterface {
             // Only set descriptor type versions if there's one descriptor type otherwise we can't tell which version belongs to which type without looking at the source files
             language = tool.getDescriptorType().get(0);
         } else if (entry instanceof BioWorkflow || entry instanceof AppTool) {
-            language = ((Workflow)entry).getDescriptorType().toString();
+            language = ToolsImplCommon.getDescriptorTypeFromDescriptorLanguage(((Workflow) entry).getDescriptorType()).map(DescriptorType::toString).orElse("unsupported language");
         } else {
             return List.of();
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -72,30 +72,29 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
             author.setEmail(workflowMetadata.getEmail());
             version.addAuthor(author);
         }
-        version.setDescriptorTypeVersionsFromSourceFiles(sourceFiles);
-        if (version.getVersionMetadata().getDescriptorTypeVersions().isEmpty()) {
-            // TODO: this can probably be removed after EntryResource.updateLanguageVersions is removed since this should only happen with previously imported data
-            // with old data, we need to re-parse original content since original parsing lacked file-level metadata
-            final Map<String, FileMetadata> stringFileMetadataMap = minimalLanguageInterface.indexWorkflowFiles(filepath, content, new FileReader() {
-                @Override
-                public String readFile(String path) {
-                    return sourceFiles.stream().filter(file -> file.getPath().equals(path)).findFirst().map(SourceFile::getContent).orElse(null);
-                }
 
-                @Override
-                public List<String> listFiles(String pathToDirectory) {
-                    return sourceFiles.stream().map(SourceFile::getPath).toList();
-                }
-            });
-            // save file versioning back to source files
-            sourceFiles.forEach(file -> {
-                final FileMetadata fileMetadata = stringFileMetadataMap.get(file.getPath());
-                if (fileMetadata != null) {
-                    file.getMetadata().setTypeVersion(fileMetadata.languageVersion());
-                }
-            });
-            version.setDescriptorTypeVersionsFromSourceFiles(sourceFiles);
-        }
+        // TODO: this can probably be removed after EntryResource.updateLanguageVersions is removed since this should only happen with previously imported data
+        // with old data, we need to re-parse original content since original parsing lacked file-level metadata
+        final Map<String, FileMetadata> stringFileMetadataMap = minimalLanguageInterface.indexWorkflowFiles(filepath, content, new FileReader() {
+            @Override
+            public String readFile(String path) {
+                return sourceFiles.stream().filter(file -> file.getPath().equals(path)).findFirst().map(SourceFile::getContent).orElse(null);
+            }
+
+            @Override
+            public List<String> listFiles(String pathToDirectory) {
+                return sourceFiles.stream().map(SourceFile::getPath).toList();
+            }
+        });
+        // save file versioning back to source files
+        sourceFiles.forEach(file -> {
+            final FileMetadata fileMetadata = stringFileMetadataMap.get(file.getPath());
+            if (fileMetadata != null) {
+                file.getMetadata().setTypeVersion(fileMetadata.languageVersion());
+            }
+        });
+        version.setDescriptorTypeVersionsFromSourceFiles(sourceFiles);
+
         version.setDescriptionAndDescriptionSource(workflowMetadata.getDescription(), DescriptionSource.DESCRIPTOR);
         // TODO: hook up validation object to version for parsing metadata
         return version;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguagePluginHandler.java
@@ -79,7 +79,7 @@ public class LanguagePluginHandler implements LanguageHandlerInterface {
             final Map<String, FileMetadata> stringFileMetadataMap = minimalLanguageInterface.indexWorkflowFiles(filepath, content, new FileReader() {
                 @Override
                 public String readFile(String path) {
-                    return sourceFiles.stream().filter(file -> file.getPath().equals(path)).findFirst().get().getContent();
+                    return sourceFiles.stream().filter(file -> file.getPath().equals(path)).findFirst().map(SourceFile::getContent).orElse(null);
                 }
 
                 @Override


### PR DESCRIPTION
**Description**
While reviewing https://github.com/dockstore/dockstore/issues/5270 noticed an issue with Galaxy workflows being missing from the descriptor language version facet. This hack allows for re-indexing of existing Galaxy workflows for version information 

**Review Instructions**
After initial run of `EntryResource.updateLanguageVersions` galaxy workflows should have language versions. 
If interested in SQL query to look at results (adds gxformat2 and gxformat1)
```
webservice_test=# select count(descriptortypeversions), descriptortypeversions from version_metadata group by descriptortypeversions order by count;
 count | descriptortypeversions 
-------+------------------------
     0 | 
     2 | v1.1    1.0
     2 | 1.0     v1.0
     2 | 1.0     draft-2
     2 | 4.0
     2 | v1.2    v1.0
     3 | gxformat2
     9 | 1.1
    10 | v1.2    v1.1
    13 | 1
    15 | development
    15 | v1.2    v1.1    v1.0
    28 | v1.2
    39 | v1.1    v1.0
   142 | draft-2 1.0
   152 | v1.1
   445 | 2
   705 | gxformat1
  2103 | v1.0
  8504 | draft-2
 35537 | 1.0
(21 rows)

```
New github app updates for Galaxy workflows should have them too

**Issue**
https://github.com/dockstore/dockstore/issues/5270

**Security**
None known

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
