### PR TITLE
SEAB-5428: Change "ipynb" naming to "jupyter"

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
@@ -81,7 +81,7 @@ public enum DescriptorLanguage {
             return super.isRelevantFileType(type) || type == FileType.DOCKSTORE_SERVICE_OTHER;
         }
     },
-    IPYNB("ipynb", "Jupyter IPYNB notebook", FileType.DOCKSTORE_IPYNB, FileType.DOCKSTORE_NOTEBOOK_TEST_FILE, false, false, Set.of("ipynb"), false, false, Set.of(NOTEBOOK)) {
+    JUPYTER("jupyter", "Jupyter .ipynb notebook", FileType.DOCKSTORE_JUPYTER, FileType.DOCKSTORE_NOTEBOOK_TEST_FILE, false, false, Set.of("ipynb"), false, false, Set.of(NOTEBOOK)) {
         @Override
         public boolean isRelevantFileType(FileType type) {
             return super.isRelevantFileType(type) || type == FileType.DOCKSTORE_NOTEBOOK_REES || type == FileType.DOCKSTORE_NOTEBOOK_OTHER;
@@ -259,7 +259,7 @@ public enum DescriptorLanguage {
         DOCKSTORE_SERVICE_YML(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_SERVICE_TEST_JSON(FileTypeCategory.TEST_FILE), DOCKSTORE_SERVICE_OTHER(FileTypeCategory.OTHER),
         DOCKSTORE_GXFORMAT2(FileTypeCategory.GENERIC_DESCRIPTOR), GXFORMAT2_TEST_FILE(FileTypeCategory.TEST_FILE),
         DOCKSTORE_SWL(FileTypeCategory.GENERIC_DESCRIPTOR), SWL_TEST_JSON(FileTypeCategory.TEST_FILE),
-        DOCKSTORE_IPYNB(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_NOTEBOOK_REES(FileTypeCategory.CONFIGURATION_FILE), DOCKSTORE_NOTEBOOK_TEST_FILE(FileTypeCategory.TEST_FILE), DOCKSTORE_NOTEBOOK_OTHER(FileTypeCategory.OTHER);
+        DOCKSTORE_JUPYTER(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_NOTEBOOK_REES(FileTypeCategory.CONFIGURATION_FILE), DOCKSTORE_NOTEBOOK_TEST_FILE(FileTypeCategory.TEST_FILE), DOCKSTORE_NOTEBOOK_OTHER(FileTypeCategory.OTHER);
         // DOCKSTORE-2428 - demo how to add new workflow language
 
         private final FileTypeCategory category;

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlNotebook.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlNotebook.java
@@ -30,7 +30,7 @@ import javax.validation.constraints.NotNull;
 public class YamlNotebook implements Workflowish {
 
     private String name;
-    private String format = "ipynb";
+    private String format = "jupyter";
     private String language = "python";
     private String path;
     private Boolean publish;
@@ -50,16 +50,16 @@ public class YamlNotebook implements Workflowish {
     }
 
     /**
-     * Get the format (i.e. IPYNB) of the notebook file.
+     * Get the format (i.e. JUPYTER) of the notebook file.
      */
     @NotNull
-    @ValidDescriptorLanguage(entryType = EntryType.NOTEBOOK, message = "must be a supported notebook format (currently \"ipynb\")")
+    @ValidDescriptorLanguage(entryType = EntryType.NOTEBOOK, message = "must be a supported notebook format (currently \"jupyter\")")
     public String getFormat() {
         return format;
     }
 
     /**
-     * Set the format (i.e. IPYNB) of the notebook file.
+     * Set the format (i.e. JUPYTER) of the notebook file.
      */
     public void setFormat(String format) {
         this.format = format;

--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -134,7 +134,7 @@ class DockstoreYamlTest {
 
         final YamlNotebook notebook = notebooks.get(0);
         assertEquals("notebook0", notebook.getName());
-        assertEquals("Ipynb", notebook.getFormat());
+        assertEquals("Jupyter", notebook.getFormat());
         assertEquals("Python", notebook.getLanguage());
         assertEquals("/notebook0.ipynb", notebook.getPath());
         assertEquals(true, notebook.getPublish());
@@ -147,7 +147,7 @@ class DockstoreYamlTest {
 
         final YamlNotebook notebook1 = notebooks.get(1);
         assertEquals("notebook1", notebook1.getName());
-        assertEquals("ipynb", notebook1.getFormat());
+        assertEquals("jupyter", notebook1.getFormat());
         assertEquals("python", notebook1.getLanguage());
         assertEquals("/notebook1.ipynb", notebook1.getPath());
         assertEquals(null, notebook1.getPublish());

--- a/dockstore-common/src/test/resources/fixtures/dockstore12.yml
+++ b/dockstore-common/src/test/resources/fixtures/dockstore12.yml
@@ -72,7 +72,7 @@ service:
 
 notebooks:
   - name: notebook0
-    format: Ipynb
+    format: Jupyter
     language: Python
     path: /notebook0.ipynb
     publish: true

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -143,7 +143,7 @@ class NotebookIT extends BaseIT {
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
         ApiClient apiClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(apiClient);
-        workflowsApi.handleGitHubRelease("refs/tags/less-simple-v1", installationId, simpleRepo, BasicIT.USER_2_USERNAME);
+        workflowsApi.handleGitHubRelease("refs/tags/less-simple-v2", installationId, simpleRepo, BasicIT.USER_2_USERNAME);
         // Check only the values that should differ from testRegisterSimpleNotebook()
         String path = SourceControl.GITHUB + "/" + simpleRepo + "/simple";
         Workflow notebook = workflowsApi.getWorkflowByPath(path, WorkflowSubClass.NOTEBOOK, "versions");
@@ -200,7 +200,7 @@ class NotebookIT extends BaseIT {
         CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
         ApiClient openApiClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(openApiClient);
-        workflowsApi.handleGitHubRelease("refs/heads/less-simple", installationId, simpleRepo, BasicIT.USER_2_USERNAME);
+        workflowsApi.handleGitHubRelease("refs/tags/less-simple-v2", installationId, simpleRepo, BasicIT.USER_2_USERNAME);
         String path = "github.com/" + simpleRepo + "/simple";
         Long notebookID = workflowsApi.getWorkflowByPath(path, WorkflowSubClass.NOTEBOOK, "versions").getId();
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -127,7 +127,7 @@ class NotebookIT extends BaseIT {
         Workflow notebook = workflowsApi.getWorkflowByPath(path, WorkflowSubClass.NOTEBOOK, "versions");
         assertEquals(path, notebook.getFullWorkflowPath());
         assertTrue("notebook".equalsIgnoreCase(notebook.getType()));
-        assertEquals(Workflow.DescriptorTypeEnum.IPYNB, notebook.getDescriptorType());
+        assertEquals(Workflow.DescriptorTypeEnum.JUPYTER, notebook.getDescriptorType());
         assertEquals(Workflow.DescriptorTypeSubclassEnum.PYTHON, notebook.getDescriptorTypeSubclass());
         assertEquals(1, notebook.getWorkflowVersions().size());
         WorkflowVersion version = notebook.getWorkflowVersions().get(0);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/JupyterHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/JupyterHandler.java
@@ -46,8 +46,8 @@ import org.slf4j.LoggerFactory;
  * https://nbformat.readthedocs.io/en/latest/format_description.html
  * https://repo2docker.readthedocs.io/en/latest/specification.html
  */
-public class IpynbHandler implements LanguageHandlerInterface {
-    public static final Logger LOG = LoggerFactory.getLogger(IpynbHandler.class);
+public class JupyterHandler implements LanguageHandlerInterface {
+    public static final Logger LOG = LoggerFactory.getLogger(JupyterHandler.class);
 
     public static final Set<String> REES_FILES = Set.of("environment.yml", "Pipfile", "Pipfile.lock", "requirements.txt", "setup.py", "Project.toml", "REQUIRE", "install.R", "apt.txt", "DESCRIPTION", "postBuild", "start", "runtime.txt", "default.nix", "Dockerfile");
     public static final Set<String> REES_DIRS = Set.of("/", "/binder/", "/.binder/");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerFactory.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerFactory.java
@@ -63,8 +63,8 @@ public final class LanguageHandlerFactory {
             return new NextflowHandler();
         case SERVICE:
             return new LanguagePluginHandler(ServicePrototypePlugin.class);
-        case IPYNB:
-            return new IpynbHandler();
+        case JUPYTER:
+            return new JupyterHandler();
         default:
             // look through plugin list
             if (pluginMap.containsKey(type)) {
@@ -84,8 +84,8 @@ public final class LanguageHandlerFactory {
             return new NextflowHandler();
         case DOCKSTORE_SERVICE_YML:
             return new LanguagePluginHandler(ServicePrototypePlugin.class);
-        case DOCKSTORE_IPYNB:
-            return new IpynbHandler();
+        case DOCKSTORE_JUPYTER:
+            return new JupyterHandler();
         default:
             // look through plugin list
             if (fileTypeMap.containsKey(type)) {

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1049,7 +1049,7 @@ paths:
           - SWL
           - NFL
           - service
-          - ipynb
+          - jupyter
       - in: query
         name: namespace
         schema:
@@ -1704,7 +1704,7 @@ paths:
           - SWL
           - NFL
           - service
-          - ipynb
+          - jupyter
       responses:
         default:
           content:
@@ -1903,7 +1903,7 @@ paths:
             - GXFORMAT2_TEST_FILE
             - DOCKSTORE_SWL
             - SWL_TEST_JSON
-            - DOCKSTORE_IPYNB
+            - DOCKSTORE_JUPYTER
             - DOCKSTORE_NOTEBOOK_REES
             - DOCKSTORE_NOTEBOOK_TEST_FILE
             - DOCKSTORE_NOTEBOOK_OTHER
@@ -1986,7 +1986,7 @@ paths:
           - SWL
           - NFL
           - service
-          - ipynb
+          - jupyter
       responses:
         default:
           content:
@@ -2427,7 +2427,7 @@ paths:
                   - GXFORMAT2_TEST_FILE
                   - DOCKSTORE_SWL
                   - SWL_TEST_JSON
-                  - DOCKSTORE_IPYNB
+                  - DOCKSTORE_JUPYTER
                   - DOCKSTORE_NOTEBOOK_REES
                   - DOCKSTORE_NOTEBOOK_TEST_FILE
                   - DOCKSTORE_NOTEBOOK_OTHER
@@ -5894,7 +5894,7 @@ paths:
           - SWL
           - NFL
           - service
-          - ipynb
+          - jupyter
       - in: query
         name: namespace
         schema:
@@ -6588,7 +6588,7 @@ paths:
           - SWL
           - NFL
           - service
-          - ipynb
+          - jupyter
       responses:
         default:
           content:
@@ -6741,7 +6741,7 @@ paths:
           - SWL
           - NFL
           - service
-          - ipynb
+          - jupyter
       responses:
         default:
           content:
@@ -6777,7 +6777,7 @@ paths:
           - SWL
           - NFL
           - service
-          - ipynb
+          - jupyter
       responses:
         default:
           content:
@@ -7050,7 +7050,7 @@ paths:
           - SWL
           - NFL
           - service
-          - ipynb
+          - jupyter
       responses:
         default:
           content:
@@ -7476,7 +7476,7 @@ paths:
             - GXFORMAT2_TEST_FILE
             - DOCKSTORE_SWL
             - SWL_TEST_JSON
-            - DOCKSTORE_IPYNB
+            - DOCKSTORE_JUPYTER
             - DOCKSTORE_NOTEBOOK_REES
             - DOCKSTORE_NOTEBOOK_TEST_FILE
             - DOCKSTORE_NOTEBOOK_OTHER
@@ -8652,7 +8652,7 @@ components:
           - SWL
           - NFL
           - service
-          - ipynb
+          - jupyter
         version:
           type: string
     LanguageParsingRequest:
@@ -8673,7 +8673,7 @@ components:
           - SWL
           - NFL
           - service
-          - ipynb
+          - jupyter
         descriptorRelativePathInGit:
           type: string
           description: The relative path to the primary descriptor (relative to the
@@ -8980,7 +8980,7 @@ components:
           - SWL
           - NFL
           - service
-          - ipynb
+          - jupyter
         hasHTTPImports:
           type: boolean
         hasLocalImports:
@@ -9155,7 +9155,7 @@ components:
           - GXFORMAT2_TEST_FILE
           - DOCKSTORE_SWL
           - SWL_TEST_JSON
-          - DOCKSTORE_IPYNB
+          - DOCKSTORE_JUPYTER
           - DOCKSTORE_NOTEBOOK_REES
           - DOCKSTORE_NOTEBOOK_TEST_FILE
           - DOCKSTORE_NOTEBOOK_OTHER
@@ -9878,7 +9878,7 @@ components:
           - GXFORMAT2_TEST_FILE
           - DOCKSTORE_SWL
           - SWL_TEST_JSON
-          - DOCKSTORE_IPYNB
+          - DOCKSTORE_JUPYTER
           - DOCKSTORE_NOTEBOOK_REES
           - DOCKSTORE_NOTEBOOK_TEST_FILE
           - DOCKSTORE_NOTEBOOK_OTHER
@@ -10100,7 +10100,7 @@ components:
           - SWL
           - NFL
           - service
-          - ipynb
+          - jupyter
         descriptorTypeSubclass:
           type: string
           enum:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -1425,7 +1425,7 @@ paths:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
-        - "IPYNB"
+        - "JUPYTER"
       - name: "namespace"
         in: "query"
         description: "The Docker namespace (Tools only)"
@@ -2134,7 +2134,7 @@ paths:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
-        - "IPYNB"
+        - "JUPYTER"
       responses:
         200:
           description: "successful operation"
@@ -2326,7 +2326,7 @@ paths:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
-        - "IPYNB"
+        - "JUPYTER"
       responses:
         200:
           description: "successful operation"
@@ -5124,7 +5124,7 @@ paths:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
-        - "IPYNB"
+        - "JUPYTER"
       - name: "namespace"
         in: "query"
         description: "The Docker namespace (Tools only)"
@@ -5852,7 +5852,7 @@ paths:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
-        - "IPYNB"
+        - "JUPYTER"
       responses:
         200:
           description: "successful operation"
@@ -6017,7 +6017,7 @@ paths:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
-        - "IPYNB"
+        - "JUPYTER"
       responses:
         200:
           description: "successful operation"
@@ -6313,7 +6313,7 @@ paths:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
-        - "IPYNB"
+        - "JUPYTER"
       responses:
         200:
           description: "successful operation"
@@ -8061,7 +8061,7 @@ definitions:
         - "SWL"
         - "NEXTFLOW"
         - "SERVICE"
-        - "IPYNB"
+        - "JUPYTER"
       hasHTTPImports:
         type: "boolean"
       hasLocalImports:
@@ -8203,7 +8203,7 @@ definitions:
         - "GXFORMAT2_TEST_FILE"
         - "DOCKSTORE_SWL"
         - "SWL_TEST_JSON"
-        - "DOCKSTORE_IPYNB"
+        - "DOCKSTORE_JUPYTER"
         - "DOCKSTORE_NOTEBOOK_REES"
         - "DOCKSTORE_NOTEBOOK_TEST_FILE"
         - "DOCKSTORE_NOTEBOOK_OTHER"
@@ -8919,7 +8919,7 @@ definitions:
         - "GXFORMAT2_TEST_FILE"
         - "DOCKSTORE_SWL"
         - "SWL_TEST_JSON"
-        - "DOCKSTORE_IPYNB"
+        - "DOCKSTORE_JUPYTER"
         - "DOCKSTORE_NOTEBOOK_REES"
         - "DOCKSTORE_NOTEBOOK_TEST_FILE"
         - "DOCKSTORE_NOTEBOOK_OTHER"

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/JupyterHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/JupyterHandlerTest.java
@@ -51,11 +51,11 @@ import uk.org.webcompere.systemstubs.stream.SystemErr;
 import uk.org.webcompere.systemstubs.stream.SystemOut;
 
 /**
- * Tests public methods in IpynbHandler
+ * Tests public methods in JupyterHandler
  */
 @ExtendWith(SystemStubsExtension.class)
 @ExtendWith(MuteForSuccessfulTests.class)
-class IpynbHandlerTest {
+class JupyterHandlerTest {
 
     @SystemStub
     public final SystemOut systemOut = new SystemOut();
@@ -66,7 +66,7 @@ class IpynbHandlerTest {
     private static final String PATH = "/hello.ipynb";
     private static final String CONTENT = read("hello.ipynb");
 
-    private IpynbHandler handler;
+    private JupyterHandler handler;
     private Notebook notebook;
     private WorkflowVersion version;
   
@@ -95,8 +95,8 @@ class IpynbHandlerTest {
         return file;
     }
 
-    private SourceFile mockIpynb(String path, String content) {
-        return mockSourceFile(path, content, DescriptorLanguage.FileType.DOCKSTORE_IPYNB);
+    private SourceFile mockJupyter(String path, String content) {
+        return mockSourceFile(path, content, DescriptorLanguage.FileType.DOCKSTORE_JUPYTER);
     }
 
     private SourceCodeRepoInterface mockRepo(Set<String> paths) {
@@ -123,7 +123,7 @@ class IpynbHandlerTest {
 
     @BeforeEach
     void reset() {
-        handler = new IpynbHandler();
+        handler = new JupyterHandler();
         notebook = new Notebook();
         version = new WorkflowVersion();
     }
@@ -152,7 +152,7 @@ class IpynbHandlerTest {
 
     @Test
     void testParseWorkflowContentExtractVersion() {
-        SourceFile file = mockSourceFile(PATH, CONTENT, DescriptorLanguage.FileType.DOCKSTORE_IPYNB);
+        SourceFile file = mockSourceFile(PATH, CONTENT, DescriptorLanguage.FileType.DOCKSTORE_JUPYTER);
         handler.parseWorkflowContent(PATH, CONTENT, Set.of(file), version);
         assertEquals("4.0", file.getMetadata().getTypeVersion());
         assertEquals(List.of("4.0"), version.getVersionMetadata().getDescriptorTypeVersions());
@@ -186,43 +186,43 @@ class IpynbHandlerTest {
 
     @Test
     void testValidateWorkflowSet() {
-        notebook.setDescriptorType(DescriptorLanguage.IPYNB);
+        notebook.setDescriptorType(DescriptorLanguage.JUPYTER);
         notebook.setDescriptorTypeSubclass(DescriptorLanguageSubclass.PYTHON);
 
         // Well-formed.
-        SourceFile file = mockIpynb(PATH, CONTENT);
+        SourceFile file = mockJupyter(PATH, CONTENT);
         assertTrue(handler.validateWorkflowSet(Set.of(file), PATH, notebook).isValid());
 
         // Empty file.
-        file = mockIpynb(PATH, "");
+        file = mockJupyter(PATH, "");
         assertFalse(handler.validateWorkflowSet(Set.of(file), PATH, notebook).isValid());
 
         // Empty object.
-        file = mockIpynb(PATH, "{ }");
+        file = mockJupyter(PATH, "{ }");
         assertFalse(handler.validateWorkflowSet(Set.of(file), PATH, notebook).isValid());
 
         // Invalid JSON syntax.
-        file = mockIpynb(PATH, CONTENT.replaceFirst("\\{", "["));
+        file = mockJupyter(PATH, CONTENT.replaceFirst("\\{", "["));
         assertFalse(handler.validateWorkflowSet(Set.of(file), PATH, notebook).isValid());
 
         // Valid JSON but no "metadata" field.
-        file = mockIpynb(PATH, CONTENT.replaceFirst("\"metadata\"", "\"foo\""));
+        file = mockJupyter(PATH, CONTENT.replaceFirst("\"metadata\"", "\"foo\""));
         assertFalse(handler.validateWorkflowSet(Set.of(file), PATH, notebook).isValid());
 
         // Valid JSON but no "cells" field.
-        file = mockIpynb(PATH, CONTENT.replaceFirst("\"cells\"", "\"foo\""));
+        file = mockJupyter(PATH, CONTENT.replaceFirst("\"cells\"", "\"foo\""));
         assertFalse(handler.validateWorkflowSet(Set.of(file), PATH, notebook).isValid());
 
         // Valid JSON but no "nbformat" field.
-        file = mockIpynb(PATH, CONTENT.replaceFirst("\"nbformat\"", "\"foo\""));
+        file = mockJupyter(PATH, CONTENT.replaceFirst("\"nbformat\"", "\"foo\""));
         assertFalse(handler.validateWorkflowSet(Set.of(file), PATH, notebook).isValid());
 
         // Valid JSON but non-integer "nbformat" field.
-        file = mockIpynb(PATH, CONTENT.replaceFirst("4,", "\"foo\","));
+        file = mockJupyter(PATH, CONTENT.replaceFirst("4,", "\"foo\","));
         assertFalse(handler.validateWorkflowSet(Set.of(file), PATH, notebook).isValid());
 
         // Different programming language.
-        file = mockIpynb(PATH, CONTENT.replace("\"python\"", "\"julia\""));
+        file = mockJupyter(PATH, CONTENT.replace("\"python\"", "\"julia\""));
         assertFalse(handler.validateWorkflowSet(Set.of(file), PATH, notebook).isValid());
     }
 
@@ -233,6 +233,6 @@ class IpynbHandlerTest {
 
     @Test
     void testValidateTestParameterSet() {
-        handler.validateTestParameterSet(Set.of(mockIpynb(PATH, "")));
+        handler.validateTestParameterSet(Set.of(mockJupyter(PATH, "")));
     }
 }


### PR DESCRIPTION
**Description**
This PR replaces "ipynb" with "jupyter" in most of our notebooks-related naming scheme, the rationale being that most people will find "jupyter" more recognizable/understandable/natural.

**Review Instructions**
Confirm that the constants in `openapi.yaml` have changed from `ipynb` to `jupyter`.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5248

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
