### PR TITLE
SEAB-5205: Additional ES-related notebook test

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SearchResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SearchResourceIT.java
@@ -143,12 +143,12 @@ class SearchResourceIT extends BaseIT {
         String s = extendedGa4GhApi.toolsIndexSearch(exampleESQuery);
         assertTrue(s.contains("\"type\":\"Notebook\""));
         assertTrue(s.contains("\"repository\":\"simple-notebook\""));
-        assertTrue(s.contains("\"descriptorType\":\"ipynb\""));
+        assertTrue(s.contains("\"descriptorType\":\"jupyter\""));
         assertTrue(s.contains("\"descriptorTypeSubclass\":\"Python\""));
 
         // confirm the presence of the notebook source file
-        String newQuery = StringUtils.replace(exampleESQuery, "*.sourceFiles", "");
-        String t = extendedGa4GhApi.toolsIndexSearch(newQuery);
+        String fileQuery = StringUtils.replace(exampleESQuery, "*.sourceFiles", "");
+        String t = extendedGa4GhApi.toolsIndexSearch(fileQuery);
         assertTrue(t.contains("/notebook.ipynb"));
     }
 


### PR DESCRIPTION
**Description**
This PR adds an integration test that confirms that notebooks are indexed by and retrievable from ElasticSearch after they are registered and published.  We deferred the implementation of this test until the notebooks registration mechanism was completed.

**Review Instructions**
Confirm that the new test is running and passes.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5205

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
