### PR TITLE
SEAB-5281: Overhaul branch discovery during github app install

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
@@ -496,39 +496,39 @@ class SwaggerWebhookIT extends BaseIT {
             "Should not have a 0.2 version.");
 
         // Add version that doesn't exist
+        long failedCount = usersApi.getUserGitHubEvents("0", 10).stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count();
         try {
             client.handleGitHubRelease("refs/heads/idonotexist", installationId, workflowRepo, BasicIT.USER_2_USERNAME);
             fail("Should fail and not reach this point");
         } catch (io.dockstore.openapi.client.ApiException ex) {
-            List<io.dockstore.openapi.client.model.LambdaEvent> failureEvents = usersApi.getUserGitHubEvents("0", 10);
-            assertEquals(1, failureEvents.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count(), "There should be 1 unsuccessful event");
+            assertEquals(failedCount + 1, usersApi.getUserGitHubEvents("0", 10).stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count(), "There should be one more unsuccessful event than before");
         }
 
-        // There should be 5 successful lambda events
+        // There should be 7 successful lambda events
         List<io.dockstore.openapi.client.model.LambdaEvent> events = usersApi.getUserGitHubEvents("0", 10);
-        assertEquals(6, events.stream().filter(io.dockstore.openapi.client.model.LambdaEvent::isSuccess).count(), "There should be 5 successful events");
+        assertEquals(7, events.stream().filter(io.dockstore.openapi.client.model.LambdaEvent::isSuccess).count(), "There should be 7 successful events");
 
         // Test pagination for user github events
         events = usersApi.getUserGitHubEvents("2", 2);
-        assertEquals(2, events.size(), "There should be 2 events (id 3 and 4)");
-        assertTrue(events.stream().anyMatch(lambdaEvent -> Objects.equals(4L, lambdaEvent.getId())), "Should have event with ID 4");
-        assertTrue(events.stream().anyMatch(lambdaEvent -> Objects.equals(5L, lambdaEvent.getId())), "Should have event with ID 5");
+        assertEquals(2, events.size(), "There should be 2 events (id 8 and 9)");
+        assertTrue(events.stream().anyMatch(lambdaEvent -> Objects.equals(8L, lambdaEvent.getId())), "Should have event with ID 8");
+        assertTrue(events.stream().anyMatch(lambdaEvent -> Objects.equals(9L, lambdaEvent.getId())), "Should have event with ID 9");
 
         // Test the organization events endpoint
         List<io.dockstore.openapi.client.model.LambdaEvent> orgEvents = lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "0", 10);
-        assertEquals(7, orgEvents.size(), "There should be 7 events");
+        assertEquals(10, orgEvents.size(), "There should be 10 events");
 
         // Test pagination
         orgEvents = lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "2", 2);
-        assertEquals(2, orgEvents.size(), "There should be 2 events (id 3 and 4)");
-        assertTrue(orgEvents.stream().anyMatch(lambdaEvent -> Objects.equals(4L, lambdaEvent.getId())), "Should have event with ID 4");
-        assertTrue(orgEvents.stream().anyMatch(lambdaEvent -> Objects.equals(5L, lambdaEvent.getId())), "Should have event with ID 5");
+        assertEquals(2, orgEvents.size(), "There should be 2 events (id 8 and 9)");
+        assertTrue(orgEvents.stream().anyMatch(lambdaEvent -> Objects.equals(8L, lambdaEvent.getId())), "Should have event with ID 8");
+        assertTrue(orgEvents.stream().anyMatch(lambdaEvent -> Objects.equals(9L, lambdaEvent.getId())), "Should have event with ID 9");
 
         // Change organization to test filter
         testingPostgres.runUpdateStatement("UPDATE lambdaevent SET repository = 'workflow-dockstore-yml', organization = 'DockstoreTestUser3' WHERE id = '1'");
 
         orgEvents = lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "0", 10);
-        assertEquals(6, orgEvents.size(), "There should now be 6 events");
+        assertEquals(10, orgEvents.size(), "There should now be 10 events");
 
         try {
             lambdaEventsApi.getLambdaEventsByOrganization("IAmMadeUp", "0", 10);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1197,6 +1197,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         // For each push to a branch, add the branch name to the "end" of the linked set.
         // The code within can throw a checked IOException, so it's clumsy to combine with the previous stream expression.
         for (GHEventInfo push: pushes) {
+            // Get the ref of the pushed-to branch, typically a value like 'refs/heads/master'
             String ref = push.getPayload(GHEventPayload.Push.class).getRef();
             if (ref.startsWith(REFS_HEADS)) {
                 branches.add(ref.substring(REFS_HEADS.length()));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -361,9 +361,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @param username Username of GitHub user that triggered action
      * @param gitReference Git reference from GitHub (ex. refs/tags/1.0)
      * @param installationId GitHub App installation ID
+     * @param throwIfNotSuccessful throw if the release was not entirely successful
      * @return List of new and updated workflows
      */
-    protected void githubWebhookRelease(String repository, String username, String gitReference, long installationId) {
+    protected void githubWebhookRelease(String repository, String username, String gitReference, long installationId, boolean throwIfNotSuccessful) {
         // Grab Dockstore YML from GitHub
         GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createGitHubAppRepo(installationId);
         GHRateLimit startRateLimit = gitHubSourceCodeRepo.getGhRateLimitQuietly();
@@ -414,7 +415,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             gitHubSourceCodeRepo.reportOnGitHubRelease(startRateLimit, endRateLimit, repository, username, gitReference, isSuccessful);
         }
 
-        if (!isSuccessful) {
+        if (!isSuccessful && throwIfNotSuccessful) {
             throw new CustomWebApplicationException("At least one entry in .dockstore.yml could not be processed.", LAMBDA_FAILURE);
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -2067,7 +2067,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         if (LOG.isInfoEnabled()) {
             LOG.info(String.format("Branch/tag %s pushed to %s(%s)", Utilities.cleanForLogging(gitReference), Utilities.cleanForLogging(repository), Utilities.cleanForLogging(username)));
         }
-        githubWebhookRelease(repository, username, gitReference, Long.parseLong(installationId));
+        githubWebhookRelease(repository, username, gitReference, Long.parseLong(installationId), true);
     }
 
     @POST
@@ -2107,7 +2107,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                     LOG.info(String.format("Retrospectively processing branch/tag %s in %s(%s)", Utilities.cleanForLogging(gitReference), Utilities.cleanForLogging(repository),
                         Utilities.cleanForLogging(username)));
                 }
-                githubWebhookRelease(repository, username, gitReference, Long.parseLong(installationId));
+                githubWebhookRelease(repository, username, gitReference, Long.parseLong(installationId), false);
             }
         }
         return Response.status(HttpStatus.SC_OK).build();


### PR DESCRIPTION
**Description**
Recently, we changed the webservice so that when the lambda hits the endpoint that signals that our github app has been installed, we'd do a limited search of the repo(s) for branches that contained a `.dockstore.yml` and try to register them: https://github.com/dockstore/dockstore/pull/5335

When testing, we noticed that log entries were not appearing for some branches that should have been registered.  Further investigation showed that the webservice was missing branches that it should find, specifically those other than the default branch or a branch with one of the names ("main", "master", "develop") that we check.

The problem stems from the way we use the `queryCommits` kohsuke API call (and associate github endpoint).  We had coded the discovery code under the assumption that `queryCommits` finds all commits in the repo, across all branches, whereas the actual behavior is that is only finds commits on a single branch (if omitted, the default branch).  So, the code that depended on the "full repo commit search" didn't work.

I spent a while poring over the kohsuke and GitHub API docs, and there does not seem to be an efficient way to determine a list of recent commits, across all branches, that contain a path.

Given that this capability was at the core of the previous implementation, I came up with a different, if-vaguely-similar scheme, and rewrote the discovery code.

Basically, the new approach is to:
1.  retrieve a list of branches by inspecting the repo `/events` and `/refs` and sort so the most recently-pushed branches are first.
2.  move the default branch and the "likely" branches ("main", "master", "develop") to the front of the list, if they exist.
3.  inspect the first N branches in the list, and if they contain a commit that references `.dockstore.yml`, return their refs.

In summary, branches are checked in this order:
default -> ("main", "master", "develop" if they exist) -> recently-pushed -> anything else

This PR loosens the requirement that the commit referencing the `.dockstore.yml` must be on the head, and will thus discover a  branch that contains a `.dockstore.yml` but has additional intervening commits.  It is important to note that this scheme is approximate: a branch could contain a `.dockstore.yml`, but then a subsequent commit could delete it.  In this case, the ref would be returned, and the registration code would not be able to find the `.dockstore.yml` and fail, creating a failed entry in the logs.  We could check the tree to confirm the current existence of `.dockstore.yml`, but it would cost more API calls and/or more code (probably both).  It's a tradeoff, I can see arguments both ways.

Speaking of API calls, I added a request logging Interceptor to the okhttp client, and confirmed that for a given repo, to discover a maximum of N branches, where N is 5 (as currently), the webservice will issue a total of between 7 to 15 github requests (2-5 to create the list of branches, depending on the number of refs, and 1-2 per branch inspected).

It's not perfect, but it probably does a good-to-acceptable job on the vast majority of the real-world repos, and usually finds all the branches with `.dockstore.yml` in a repo with five branches or less.

This PR also changes the flow so that if the release on a branch is not successful (in a non-fatal fashion), an exception is no longer thrown, avoiding the short circuiting of the discovered-branch registration process.

**Review Instructions**
Create a repo with some branches that exercise the various criteria, install the github app on the repo, wait five minutes, and check to see if the logs and registered entries appear to be correct.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5281

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
