### PR TITLE
use same regex for webhook delete as for create events

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1,6 +1,7 @@
 
 package io.dockstore.webservice;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -120,6 +121,23 @@ class WebhookIT extends BaseIT {
             assertTrue(message.contains("workflow"));
             assertTrue(message.contains("version"));
         }
+    }
+
+    @Test
+    void testWackyBranchCreationAndDeletion() {
+        final ApiClient webClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowClient = new WorkflowsApi(webClient);
+
+        // needs to be a branch to match branch deletion below
+        workflowClient.handleGitHubRelease("refs/heads/孤独のグルメ", installationId, workflowDockstoreYmlRepo, BasicIT.USER_2_USERNAME);
+
+        Workflow foobar = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar", WorkflowSubClass.BIOWORKFLOW, "versions");
+        assertEquals(1, foobar.getWorkflowVersions().size());
+
+        workflowClient.handleGitHubBranchDeletion(workflowDockstoreYmlRepo, BasicIT.USER_2_USERNAME, "refs/heads/孤独のグルメ", installationId);
+
+        foobar = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar", WorkflowSubClass.BIOWORKFLOW, "versions");
+        assertEquals(0, foobar.getWorkflowVersions().size());
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHelper.java
@@ -1,8 +1,9 @@
 package io.dockstore.webservice.helpers;
 
+import static io.dockstore.webservice.helpers.GitHubSourceCodeRepo.GIT_BRANCH_TAG_PATTERN;
+
 import java.util.Optional;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,9 +25,8 @@ public final class GitHelper {
      * @return Optional Git reference name
      */
     public static Optional<String> parseGitHubReference(String gitReference) {
-        // Match the github reference (ex. refs/heads/feature/foobar or refs/tags/1.0)
-        Pattern pattern = Pattern.compile("^refs/(tags|heads)/([a-zA-Z0-9]++([./_-]?[a-zA-Z0-9]+)*)$");
-        Matcher matcher = pattern.matcher(gitReference);
+        // Match the GitHub reference (ex. refs/heads/feature/foobar or refs/tags/1.0)
+        Matcher matcher = GIT_BRANCH_TAG_PATTERN.matcher(gitReference);
 
         if (!matcher.find()) {
             return Optional.empty();


### PR DESCRIPTION
**Description**
Allow branch deletion events to use the same regex as release events. 

**Review Instructions**
Should be able to follow testing example in the ticket. Basically create a weird branch and then delete it. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5256

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
