### PR TITLE
add create dates for join table entries via postgres

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -72,8 +72,11 @@ import io.swagger.client.model.Tag;
 import io.swagger.client.model.Tag.DoiStatusEnum;
 import io.swagger.client.model.Workflow;
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -1583,6 +1586,14 @@ class GeneralIT extends GeneralWorkflowBaseIT {
         // Add alias
         Entry entry = entryApi.addAliases(refresh.getId(), "foobar");
         assertTrue(entry.getAliases().containsKey("foobar"), "Should have alias foobar");
+
+        // check that dates are present
+        final Timestamp dbDate = testingPostgres.runSelectStatement("select dbcreatedate from entry_alias where id = " + entry.getId(), Timestamp.class);
+        assertNotNull(dbDate);
+        // check that date looks sane
+        final Calendar instance = GregorianCalendar.getInstance();
+        instance.set(2020, Calendar.MARCH, 13);
+        assertTrue(dbDate.after(instance.getTime()));
 
         // Get unpublished tool by alias as owner
         DockstoreTool aliasTool = containersApi.getToolByAlias("foobar");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Alias.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Alias.java
@@ -34,7 +34,7 @@ public class Alias implements Serializable {
     public String content = "";
 
     // database timestamps
-    @Column(updatable = false)
+    @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
     @CreationTimestamp
     private Timestamp dbCreateDate;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/OrcidPutCode.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/OrcidPutCode.java
@@ -16,7 +16,7 @@ public class OrcidPutCode implements Serializable {
     public String orcidPutCode;
 
     // database timestamps
-    @Column(updatable = false)
+    @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
     @CreationTimestamp
     private Timestamp dbCreateDate;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -325,7 +325,7 @@ public class SourceFile implements Comparable<SourceFile> {
         public String platformVersion = null;
 
         // database timestamps
-        @Column(updatable = false)
+        @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
         @CreationTimestamp
         private Timestamp dbCreateDate;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -611,7 +611,7 @@ public class User implements Principal, Comparable<User>, Serializable {
         @JsonIgnore
         public String onlineProfileId;
 
-        @Column(updatable = false)
+        @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
         @CreationTimestamp
         private Timestamp dbCreateDate;
         @Column()

--- a/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
@@ -384,4 +384,14 @@
     <changeSet author="svonworl" id="dropSubclassFromWorkflowVersion">
         <dropColumn columnName="subclass" tableName="workflowversion"/>
     </changeSet>
+    <changeSet author="dyuen (generated)" id="default_jointable_timestamps">
+        <addDefaultValue columnDataType="timestamp" columnName="dbcreatedate" defaultValueComputed="now()" tableName="collection_alias"/>
+        <addDefaultValue columnDataType="timestamp" columnName="dbcreatedate" defaultValueComputed="now()" tableName="entry_alias"/>
+        <addDefaultValue columnDataType="timestamp" columnName="dbcreatedate" defaultValueComputed="now()" tableName="organization_alias"/>
+        <addDefaultValue columnDataType="timestamp" columnName="dbcreatedate" defaultValueComputed="now()" tableName="workflowversion_alias"/>
+        <addDefaultValue columnDataType="timestamp" columnName="dbcreatedate" defaultValueComputed="now()" tableName="entry_orcidputcode"/>
+        <addDefaultValue columnDataType="timestamp" columnName="dbcreatedate" defaultValueComputed="now()" tableName="sourcefile_verified"/>
+        <addDefaultValue columnDataType="timestamp" columnName="dbcreatedate" defaultValueComputed="now()" tableName="user_profile"/>
+        <addDefaultValue columnDataType="timestamp" columnName="dbcreatedate" defaultValueComputed="now()" tableName="version_metadata_orcidputcode"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**Description**
Join table entries do not seem to trigger hibernate/JPA to properly fill in database timestamps. 
This allows the DB to step in

**Review Instructions**
These tables should have empty db create and update timestamps before this PR, should have create timestamps afterwards. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5301

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
