### PR TITLE
SEAB-5116: Miscellaneous notebook tweaks

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -133,7 +133,7 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
     // this one is annoying since the codegen doesn't seem to pick up @JsonValue in the DescriptorLanguage enum
     @Column(nullable = false)
     @Convert(converter = DescriptorLanguageConverter.class)
-    @ApiModelProperty(value = "This is a descriptor type for the workflow, by default either SMK, CWL, WDL, NFL, or gxformat2 (Defaults to CWL).", required = true, position = 18, allowableValues = "SMK, CWL, WDL, NFL, gxformat2, service, ipynb")
+    @ApiModelProperty(value = "This is a descriptor type for the workflow, by default either SMK, CWL, WDL, NFL, or gxformat2 (Defaults to CWL).", required = true, position = 18, allowableValues = "SMK, CWL, WDL, NFL, gxformat2, service, jupyter")
     private DescriptorLanguage descriptorType;
 
     // TODO: Change this to LAZY, this is the source of all our problems

--- a/dockstore-webservice/src/main/java/io/swagger/model/ToolDescriptor.java
+++ b/dockstore-webservice/src/main/java/io/swagger/model/ToolDescriptor.java
@@ -17,7 +17,6 @@ package io.swagger.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dockstore.common.DescriptorLanguage;
-import io.openapi.model.DescriptorType;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.Objects;

--- a/dockstore-webservice/src/main/java/io/swagger/model/ToolDescriptor.java
+++ b/dockstore-webservice/src/main/java/io/swagger/model/ToolDescriptor.java
@@ -17,6 +17,7 @@ package io.swagger.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dockstore.common.DescriptorLanguage;
+import io.openapi.model.DescriptorType;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.Objects;

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -9720,12 +9720,13 @@ components:
         type:
           type: string
           enum:
-          - SMK
           - CWL
           - WDL
           - NFL
+          - GALAXY
+          - SMK
           - SERVICE
-          - GXFORMAT2
+          - JUPYTER
         url:
           type: string
       required:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -9720,13 +9720,12 @@ components:
         type:
           type: string
           enum:
+          - SMK
           - CWL
           - WDL
           - NFL
-          - GALAXY
-          - SMK
           - SERVICE
-          - JUPYTER
+          - GXFORMAT2
         url:
           type: string
       required:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -8778,12 +8778,13 @@ definitions:
       type:
         type: "string"
         enum:
-        - "SMK"
         - "CWL"
         - "WDL"
         - "NFL"
+        - "GALAXY"
+        - "SMK"
         - "SERVICE"
-        - "GXFORMAT2"
+        - "JUPYTER"
       url:
         type: "string"
         example: "https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/ea2a5db69bd20a42976838790bc29294df3af02b/delly_docker/Delly.cwl"

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -8778,12 +8778,13 @@ definitions:
       type:
         type: "string"
         enum:
-        - "SMK"
         - "CWL"
         - "WDL"
         - "NFL"
+        - "GALAXY"
+        - "SMK"
         - "SERVICE"
-        - "GXFORMAT2"
+        - "JUPYTER"
       url:
         type: "string"
         example: "https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/ea2a5db69bd20a42976838790bc29294df3af02b/delly_docker/Delly.cwl"
@@ -9526,7 +9527,7 @@ definitions:
         - "NFL"
         - "gxformat2"
         - "service"
-        - "ipynb"
+        - "jupyter"
       workflow_path:
         type: "string"
         position: 19

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -8778,13 +8778,12 @@ definitions:
       type:
         type: "string"
         enum:
+        - "SMK"
         - "CWL"
         - "WDL"
         - "NFL"
-        - "GALAXY"
-        - "SMK"
         - "SERVICE"
-        - "JUPYTER"
+        - "GXFORMAT2"
       url:
         type: "string"
         example: "https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/ea2a5db69bd20a42976838790bc29294df3af02b/delly_docker/Delly.cwl"


### PR DESCRIPTION
**Description**
In support of https://ucsc-cgl.atlassian.net/browse/SEAB-5116, this PR makes a couple of small notebook-related changes to the webservice:

1. Corrects a value (ipynb -> jupyter) of the workflow descriptor type.
2. Changes the `ToolDescriptor` class so it imports the TRS openapi `DescriptorType` (rather than defaulting to the version corresponding to the TRS swagger), which causes the new type enum "jupyter" value to be included in the generated webservice openapi and swagger schemas.

This PR changes the "galaxy" type enum value that appears in the corresponding webservice schema files, because it differs between the TRS openapi and swagger files used to build.  Will that break anything?  My initial conclusion is "probably not", but please scrutinize.

**Review Instructions**
Confirm that the "jupyter" value now appears in the `ToolDescriptor` type enum in `openapi.yaml`.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5116

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
