### PR TITLE
Feature/apptool count fix

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
@@ -40,6 +40,7 @@ import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.core.SourceFile;
 import io.dockstore.webservice.helpers.AppToolHelper;
 import io.dockstore.webservice.jdbi.FileDAO;
+import io.dropwizard.client.JerseyClientBuilder;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.api.UsersApi;
@@ -51,6 +52,7 @@ import io.swagger.client.model.WorkflowVersion;
 import io.swagger.model.DescriptorType;
 import java.util.List;
 import java.util.Optional;
+import javax.ws.rs.client.Client;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
@@ -184,6 +186,10 @@ class GitHubWorkflowIT extends BaseIT {
         workflowApi.publish(appTool.getId(), publishRequest);
         assertEquals(1, workflowApi.allPublishedWorkflows(null, null, null, null, null, false,
             WorkflowSubClass.APPTOOL.getValue()).size(), "There should be 1 app tool published");
+        // there should be one app tool account to header count too
+        Client jerseyClient = new JerseyClientBuilder(SUPPORT.getEnvironment()).build("test client");
+        CommonTestUtilities.testXTotalCount(jerseyClient, String.format("http://localhost:%d/workflows/published?subclass=APPTOOL", SUPPORT.getLocalPort()), 1);
+
         assertEquals(publishedWorkflowsCount, workflowApi.allPublishedWorkflows(null, null, null, null, null, false,
             WorkflowSubClass.BIOWORKFLOW.getValue()).size(), "Published workflow count should be unchanged");
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -16,6 +16,8 @@
 
 package io.dockstore.common;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
@@ -48,14 +50,19 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.ws.rs.client.Client;
 import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
 import org.apache.commons.configuration2.INIConfiguration;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.Executor;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.http.HttpStatus;
 import org.assertj.core.util.Files;
+import org.glassfish.jersey.client.ClientProperties;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
@@ -615,6 +622,14 @@ public final class CommonTestUtilities {
             }
         }
         return Optional.empty();
+    }
+
+    public static void testXTotalCount(Client jerseyClient, String path, int expectedValue) {
+        Response response = jerseyClient.target(path).request().property(ClientProperties.READ_TIMEOUT, 0).get();
+        assertEquals(HttpStatus.SC_OK, response.getStatus());
+        MultivaluedMap<String, Object> headers = response.getHeaders();
+        Object xTotalCount = headers.getFirst("X-total-count");
+        assertEquals(String.valueOf(expectedValue), xTotalCount);
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ServiceIT.java
@@ -55,10 +55,7 @@ import io.swagger.client.model.Tool;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.client.Client;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
-import org.glassfish.jersey.client.ClientProperties;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
@@ -158,8 +155,8 @@ class ServiceIT extends BaseIT {
         assertTrue(workflows.size() >= 2 && workflows.stream()
             .noneMatch(workflow -> workflow.getDescriptorType().getValue().equalsIgnoreCase(DescriptorLanguage.SERVICE.toString())));
         Client jerseyClient = new JerseyClientBuilder(SUPPORT.getEnvironment()).build("test client");
-        testXTotalCount(jerseyClient, String.format("http://localhost:%d/workflows/published", SUPPORT.getLocalPort()));
-        testXTotalCount(jerseyClient, String.format("http://localhost:%d/workflows/published?services=true", SUPPORT.getLocalPort()));
+        CommonTestUtilities.testXTotalCount(jerseyClient, String.format("http://localhost:%d/workflows/published", SUPPORT.getLocalPort()), 2);
+        CommonTestUtilities.testXTotalCount(jerseyClient, String.format("http://localhost:%d/workflows/published?services=true", SUPPORT.getLocalPort()), 2);
         assertTrue(services.size() >= 1 && services.stream()
             .allMatch(workflow -> workflow.getDescriptorType().getValue().equalsIgnoreCase(DescriptorLanguage.SERVICE.toString())));
 
@@ -171,20 +168,6 @@ class ServiceIT extends BaseIT {
         final io.swagger.client.model.Workflow workflow = client.getWorkflow(invoke.getServiceID(), "");
         assertFalse(workflow.getStarredUsers().isEmpty());
         assertTrue(workflow.getLabels().stream().anyMatch(label -> "batman".equals(label.getValue())));
-    }
-
-    /**
-     * Test X-total-count.  It so happens there's two services and two bioworkflows
-     *
-     * @param jerseyClient Jersey Client to test endpoint
-     * @param path         Path of endpoint
-     */
-    private void testXTotalCount(Client jerseyClient, String path) {
-        Response response = jerseyClient.target(path).request().property(ClientProperties.READ_TIMEOUT, 0).get();
-        assertEquals(HttpStatus.SC_OK, response.getStatus());
-        MultivaluedMap<String, Object> headers = response.getHeaders();
-        Object xTotalCount = headers.getFirst("X-total-count");
-        assertEquals("2", xTotalCount);
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -290,12 +290,17 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
     }
 
     public long countAllPublished(Optional<String> filter) {
+        return countAllPublished(filter, null);
+    }
+
+
+    public long countAllPublished(Optional<String> filter, Class<T> classType) {
         if (filter.isEmpty()) {
             return countAllPublished();
         }
         CriteriaBuilder cb = currentSession().getCriteriaBuilder();
         CriteriaQuery<Long> query = cb.createQuery(Long.class);
-        Root<T> entry = query.from(typeOfT);
+        Root<T> entry = query.from(classType != null ? classType : typeOfT);
         processQuery(filter.get(), "", "", cb, query, entry);
         query.select(cb.count(entry));
         return currentSession().createQuery(query).getSingleResult();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -808,12 +808,13 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         @Context HttpServletResponse response) {
         // delete the next line if GUI pagination is not working by 1.5.0 release
         int maxLimit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);
+        final Class<Workflow> workflowClass = (Class<Workflow>) workflowSubClass(services, subclass);
         List<Workflow> workflows = workflowDAO.findAllPublished(offset, maxLimit, filter, sortCol, sortOrder,
-            (Class<Workflow>) workflowSubClass(services, subclass));
+            workflowClass);
         filterContainersForHiddenTags(workflows);
         stripContent(workflows);
         EntryDAO entryDAO = services ? serviceEntryDAO : bioWorkflowDAO;
-        response.addHeader("X-total-count", String.valueOf(entryDAO.countAllPublished(Optional.of(filter))));
+        response.addHeader("X-total-count", String.valueOf(entryDAO.countAllPublished(Optional.of(filter), workflowClass)));
         response.addHeader("Access-Control-Expose-Headers", "X-total-count");
         return workflows;
     }

--- a/dockstore-webservice/src/main/resources/import.sql
+++ b/dockstore-webservice/src/main/resources/import.sql
@@ -31,7 +31,7 @@ CREATE UNIQUE INDEX case_insensitive_notebook_workflowname on notebook using btr
 CREATE UNIQUE INDEX partial_workflow_name ON workflow USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
 CREATE UNIQUE INDEX partial_workflow_name_masterlist ON fullworkflowpath USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
 -- see https://github.com/dockstore/dockstore/issues/5287, the id may need to be incremented depending on how often people stumble into this
-CREATE UNIQUE INDEX case_insensitive_workflow_workflowname on workflow using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null and id > 18876;
+CREATE UNIQUE INDEX case_insensitive_workflow_workflowname on workflow using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null and id > 21207;
 CREATE UNIQUE INDEX partial_tool_name ON tool USING btree (registry, namespace, name) WHERE toolname IS NULL;
 CREATE UNIQUE INDEX partial_apptool_name ON apptool USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;
 CREATE UNIQUE INDEX partial_notebook_name ON notebook USING btree (sourcecontrol, organization, repository) WHERE workflowname IS NULL;

--- a/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
@@ -291,7 +291,7 @@
             CREATE UNIQUE INDEX case_insensitive_apptool_toolname on apptool using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null;
             CREATE UNIQUE INDEX case_insensitive_notebook_workflowname on notebook using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null;
             -- see https://github.com/dockstore/dockstore/issues/5287, the id may need to be incremented depending on how often people stumble into this
-            CREATE UNIQUE INDEX case_insensitive_workflow_workflowname on workflow using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null and id > 18876;
+            CREATE UNIQUE INDEX case_insensitive_workflow_workflowname on workflow using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null and id > 21207;
         </sql>
     </changeSet>
     <changeSet author="dyuen (generated)" id="per_version_readme_path">


### PR DESCRIPTION
**Description**
The total count for apptools was bugged, using the total count for all entries instead. 
Also had to update the constraint from https://github.com/dockstore/dockstore/issues/5287 , looks like more people accidentally created workflows with different casing

**Review Instructions**
The total count for https://dockstore.org/apptools (or whatever environment) should make sense (i.e. on the order of 110 entries rather than 3000+ entries)

**Issue**
https://github.com/dockstore/dockstore/issues/5436

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
