### PR TITLE
make migration survive next change

### DIFF
--- a/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
@@ -293,6 +293,7 @@
             CREATE UNIQUE INDEX case_insensitive_apptool_toolname on apptool using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null;
             CREATE UNIQUE INDEX case_insensitive_notebook_workflowname on notebook using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null;
             -- see https://github.com/dockstore/dockstore/issues/5287, the id may need to be incremented depending on how often people stumble into this
+            -- remember to add new valid checksum values above when changing this limit to avoid a migration failure
             CREATE UNIQUE INDEX case_insensitive_workflow_workflowname on workflow using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null and id > 21207;
         </sql>
     </changeSet>

--- a/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
@@ -286,6 +286,8 @@
         </sql>
     </changeSet>
     <changeSet id="tighten constraint for names" author="dyuen">
+        <validCheckSum>8:c3f62dac8fdb39029443416261f10a9b</validCheckSum>
+        <validCheckSum>8:dc78648569654a8993edb1619c02cb78</validCheckSum>
         <sql dbms="postgresql">
             CREATE UNIQUE INDEX case_insensitive_toolname on tool using btree (registry, namespace, name, lower(toolname)) where toolname is not null;
             CREATE UNIQUE INDEX case_insensitive_apptool_toolname on apptool using btree (sourcecontrol, organization, repository, lower(workflowname)) where workflowname is not null;


### PR DESCRIPTION
**Description**
There's a tricky little wrinkle to changing existing migrations even with the migration awaiting final deployment on develop..
Whereas a prod DB has no migrations and thus changing the constraint id is fine (or should be fine when doing the actual prod deploy), the staging/qa DB already has migrations applied and thus we need to either avoid changing the changeset or avoiding a validation event. 

Avoiding the changeset is impossible since we do get the occasional new workflow with a bad conflicting name, so allowing through checksums from old migrations as we change the limit seems like a compromise. 
https://www.liquibase.com/blog/what-affects-changeset-checksums

**Review Instructions**
Redeploy of qa nightly (on weekdays) should work

**Issue**
Follow-up on https://github.com/dockstore/dockstore/pull/5439

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
