### PR TITLE
Feature/public orcid api fallback

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/Hoverfly.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/Hoverfly.java
@@ -176,7 +176,11 @@ public final class Hoverfly {
                     .get("/v3.0/0000-0000-0000-0000").anyBody().willReturn(notFound())
                     .get("/v3.0/1111-1111-1111-1111").anyBody().willReturn(notFound())
                     .get("/v3.0/0000-1234-5678-0000").anyBody().willReturn(notFound()),
-
+            service("https://pub.orcid.org")
+                    // Since it's repetitive to mock all the responses needed to create an OrcidAuthor for these IDs, simulate that the ORCID IDs don't exist.
+                    .get("/v3.0/0000-0000-0000-0000").anyBody().willReturn(notFound())
+                    .get("/v3.0/1111-1111-1111-1111").anyBody().willReturn(notFound())
+                    .get("/v3.0/0000-1234-5678-0000").anyBody().willReturn(notFound()),
             service("https://sandbox.orcid.org")
                     .post("/oauth/token").anyBody().willReturn(success(GSON.toJson(getFakeTokenResponse("")), MediaType.APPLICATION_JSON))
     );

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ORCIDHelperFallbackTest.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ORCIDHelperFallbackTest.java
@@ -1,0 +1,47 @@
+package io.dockstore.webservice;
+
+import static io.dockstore.common.Hoverfly.ORCID_USER_3;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.NonConfidentialTest;
+import io.dockstore.webservice.core.OrcidAuthorInformation;
+import io.dockstore.webservice.helpers.ORCIDHelper;
+import io.dropwizard.testing.DropwizardTestSupport;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This tests using the public ORCID api when the members API is unavailable.
+ */
+@Tag(NonConfidentialTest.NAME)
+class ORCIDHelperFallbackTest {
+
+    public static final DropwizardTestSupport<DockstoreWebserviceConfiguration> SUPPORT = new DropwizardTestSupport<>(
+        DockstoreWebserviceApplication.class, CommonTestUtilities.PUBLIC_CONFIG_PATH);
+
+    @BeforeAll
+    public static void dumpDBAndCreateSchema() throws Exception {
+        CommonTestUtilities.dropAndRecreateNoTestData(SUPPORT, CommonTestUtilities.PUBLIC_CONFIG_PATH);
+        SUPPORT.before();
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        SUPPORT.after();
+    }
+
+    @Test
+    void testOrcidAuthorNoCreds() {
+        Optional<OrcidAuthorInformation> orcidAuthorInformation = ORCIDHelper.getOrcidAuthorInformation(ORCID_USER_3, null);
+        assertTrue(orcidAuthorInformation.isPresent(), "Should be able to get Orcid Author information");
+        assertNotNull(orcidAuthorInformation.get().getOrcid());
+        assertNotNull(orcidAuthorInformation.get().getName());
+        assertNotNull(orcidAuthorInformation.get().getAffiliation());
+        assertNotNull(orcidAuthorInformation.get().getRole());
+    }
+}

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -173,23 +173,6 @@ class WebhookIT extends BaseIT {
     }
 
     @Test
-    void testAuthorsWithReadMe() {
-        final ApiClient webClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
-        WorkflowsApi workflowClient = new WorkflowsApi(webClient);
-
-        workflowClient.handleGitHubRelease("refs/heads/master", installationId, workflowDockstoreYmlRepo, BasicIT.USER_2_USERNAME);
-
-        Workflow foobar = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar", WorkflowSubClass.BIOWORKFLOW, "versions");
-        Workflow foobar2 = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar2", WorkflowSubClass.BIOWORKFLOW, "versions");
-
-
-        assertTrue(foobar.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.README && v.getDescription().contains("A repo that includes .dockstore.yml"
-            + "\n")));
-        assertTrue(foobar2.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.README && v.getDescription().contains("A repo that includes .dockstore.yml"
-            + "\n")));
-    }
-
-    @Test
     void testAlternateReadMeLocation() {
         final ApiClient webClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowClient = new WorkflowsApi(webClient);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -173,6 +173,23 @@ class WebhookIT extends BaseIT {
     }
 
     @Test
+    void testAuthorsWithReadMe() {
+        final ApiClient webClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowClient = new WorkflowsApi(webClient);
+
+        workflowClient.handleGitHubRelease("refs/heads/master", installationId, workflowDockstoreYmlRepo, BasicIT.USER_2_USERNAME);
+
+        Workflow foobar = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar", WorkflowSubClass.BIOWORKFLOW, "versions");
+        Workflow foobar2 = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar2", WorkflowSubClass.BIOWORKFLOW, "versions");
+
+
+        assertTrue(foobar.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.README && v.getDescription().contains("A repo that includes .dockstore.yml"
+            + "\n")));
+        assertTrue(foobar2.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.README && v.getDescription().contains("A repo that includes .dockstore.yml"
+            + "\n")));
+    }
+
+    @Test
     void testAlternateReadMeLocation() {
         final ApiClient webClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowClient = new WorkflowsApi(webClient);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
 import java.util.Collection;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -70,6 +71,8 @@ public final class ORCIDHelper {
     private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
 
     private static String baseApiUrl; // baseApiUrl should result in something like "https://api.sandbox.orcid.org/v3.0/" or "https://api.orcid.org/v3.0/"
+    private static String basePublicUrl; // basePublicUrl should result in something like "https://pub.sandbox.orcid.org/v3.0/" or "https://pub.orcid.org/v3.0/"
+
     private static String baseUrl; // baseUrl should be something like "https://sandbox.orcid.org/" or "https://orcid.org/"
     private static String orcidClientId;
     private static String orcidClientSecret;
@@ -85,6 +88,7 @@ public final class ORCIDHelper {
             baseUrl = orcidAuthUrl.getProtocol() + "://" + orcidAuthUrl.getHost() + "/";
             // baseApiUrl should result in something like "https://api.sandbox.orcid.org/v3.0/" or "https://api.orcid.org/v3.0/"
             baseApiUrl = orcidAuthUrl.getProtocol() + "://api." + orcidAuthUrl.getHost() + "/v3.0/";
+            basePublicUrl = orcidAuthUrl.getProtocol() + "://pub." + orcidAuthUrl.getHost() + "/v3.0/";
         } catch (MalformedURLException e) {
             LOG.error("The ORCID Auth URL in the dropwizard configuration file is malformed.", e);
             throw new CustomWebApplicationException("The ORCID Auth URL in the dropwizard configuration file is malformed.", HttpStatus.SC_INTERNAL_SERVER_ERROR);
@@ -100,7 +104,7 @@ public final class ORCIDHelper {
 
     /**
      * Get a read-public access token for reading public information.
-     * https://info.orcid.org/documentation/api-tutorials/api-tutorial-read-data-on-a-record/#Get_an_access_token
+     * <a href="https://info.orcid.org/documentation/api-tutorials/api-tutorial-read-data-on-a-record/#Get_an_access_token">...</a>
      * @return An access token
      */
     public static Optional<String> getOrcidAccessToken() {
@@ -375,8 +379,17 @@ public final class ORCIDHelper {
         HttpRequest request = HttpRequest.newBuilder().uri(new URI(baseApiUrl + id))
                 .header(HttpHeaders.CONTENT_TYPE, ORCID_XML_CONTENT_TYPE)
                 .header(HttpHeaders.AUTHORIZATION, JWT_SECURITY_DEFINITION_NAME + " " + token).GET().build();
-        return HttpClient.newBuilder().proxy(ProxySelector.getDefault()).build().send(request,
-                HttpResponse.BodyHandlers.ofString());
+        final HttpResponse<String> memberAPIResponse = HttpClient.newBuilder().proxy(ProxySelector.getDefault()).build().send(request,
+            BodyHandlers.ofString());
+        if (memberAPIResponse.statusCode() == HttpStatus.SC_OK) {
+            return memberAPIResponse;
+        }
+        // a failure above interpreted by https://groups.google.com/g/orcid-api-users/c/0gXLWIxi9GU seems to indicate
+        // rather than giving up, we can try the public API without a token which is sufficient for this request
+        request = HttpRequest.newBuilder().uri(new URI(basePublicUrl + id))
+            .header(HttpHeaders.CONTENT_TYPE, ORCID_XML_CONTENT_TYPE)
+            .GET().build();
+        return HttpClient.newBuilder().proxy(ProxySelector.getDefault()).build().send(request, BodyHandlers.ofString());
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
@@ -88,7 +88,8 @@ public final class ORCIDHelper {
             baseUrl = orcidAuthUrl.getProtocol() + "://" + orcidAuthUrl.getHost() + "/";
             // baseApiUrl should result in something like "https://api.sandbox.orcid.org/v3.0/" or "https://api.orcid.org/v3.0/"
             baseApiUrl = orcidAuthUrl.getProtocol() + "://api." + orcidAuthUrl.getHost() + "/v3.0/";
-            basePublicUrl = orcidAuthUrl.getProtocol() + "://pub." + orcidAuthUrl.getHost() + "/v3.0/";
+            // if hitting the public API, no point in using the sandbox public API
+            basePublicUrl = orcidAuthUrl.getProtocol() + "://pub." + orcidAuthUrl.getHost().replaceFirst("^sandbox.", "") + "/v3.0/";
         } catch (MalformedURLException e) {
             LOG.error("The ORCID Auth URL in the dropwizard configuration file is malformed.", e);
             throw new CustomWebApplicationException("The ORCID Auth URL in the dropwizard configuration file is malformed.", HttpStatus.SC_INTERNAL_SERVER_ERROR);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
@@ -71,7 +71,7 @@ public final class ORCIDHelper {
     private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
 
     private static String baseApiUrl; // baseApiUrl should result in something like "https://api.sandbox.orcid.org/v3.0/" or "https://api.orcid.org/v3.0/"
-    private static String basePublicUrl; // basePublicUrl should result in something like "https://pub.sandbox.orcid.org/v3.0/" or "https://pub.orcid.org/v3.0/"
+    private static String basePublicUrl; // basePublicUrl should result in something like "https://pub.orcid.org/v3.0/"
 
     private static String baseUrl; // baseUrl should be something like "https://sandbox.orcid.org/" or "https://orcid.org/"
     private static String orcidClientId;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ORCIDHelper.java
@@ -220,7 +220,7 @@ public final class ORCIDHelper {
     }
 
     /**
-     * This updates an existing ORCID work
+     * This updates an existing ORCID work.
      * @return
      */
     public static HttpResponse<String> putWorkString(String id, String workString, String token, String putCode)
@@ -232,7 +232,7 @@ public final class ORCIDHelper {
 
 
     /**
-     * Get the ORCID put code from the response
+     * Get the ORCID put code from the response.
      *
      * @param httpResponse
      * @return


### PR DESCRIPTION
**Description**
Looks like qa/staging only has a client id/secret id that can use public API access, prod has a client id/secret id that can use member API access. The failure is that the endpoint in question is available in both APIs but we only request via the member one. There does not seem to be an obvious way of telling what kind of credentials are actually being provided.

This specific call (orcid authors) can be used via the public API if the member api is not available.  Unsure if there is an advantage to using the member api when the public api is sufficient (may be more performant, less likely to be rate-limited?) so using the public API as a fallback ttps://groups.google.com/g/orcid-api-users/c/0gXLWIxi9GU

**Review Instructions**
See if orcid author information is retrieved on qa and staging as this fix is deployed to those environments. 
https://qa.dockstore.org/workflows/github.com/aofarrel/myco/myco_cleaned is a good example if it is present

**Issue**
https://github.com/dockstore/dockstore/issues/5441
https://ucsc-cgl.atlassian.net/browse/SEAB-4985

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
