### PR TITLE
swap readme precedence and add test

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -21,6 +21,7 @@ import io.dockstore.openapi.client.model.Collection;
 import io.dockstore.openapi.client.model.LambdaEvent;
 import io.dockstore.openapi.client.model.Organization;
 import io.dockstore.openapi.client.model.PublishRequest;
+import io.dockstore.openapi.client.model.SourceFile;
 import io.dockstore.openapi.client.model.Workflow;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
 import io.dockstore.openapi.client.model.WorkflowVersion;
@@ -185,5 +186,25 @@ class WebhookIT extends BaseIT {
 
         assertTrue(foobar.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.CUSTOM_README && v.getDescription().contains("an 'X' in it")));
         assertTrue(foobar2.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.CUSTOM_README && v.getDescription().contains("a '🙃' in it")));
+    }
+
+    @Test
+    void testReadMePathOverridesDescriptor() {
+        final ApiClient webClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowClient = new WorkflowsApi(webClient);
+
+        workflowClient.handleGitHubRelease("refs/tags/0.7", installationId, workflowDockstoreYmlRepo, BasicIT.USER_2_USERNAME);
+
+        Workflow foobar = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar", WorkflowSubClass.BIOWORKFLOW, "versions");
+        Workflow foobar2 = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar2", WorkflowSubClass.BIOWORKFLOW, "versions");
+
+
+        assertTrue(foobar.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.CUSTOM_README && v.getDescription().contains("an 'X' in it")));
+        assertTrue(foobar2.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.CUSTOM_README && v.getDescription().contains("a '🙃' in it")));
+        // check that the descriptors in question really did have potential descriptions
+        final List<SourceFile> foobarSourcefiles = workflowClient.getWorkflowVersionsSourcefiles(foobar.getId(), foobar.getWorkflowVersions().get(0).getId(), null);
+        final List<SourceFile> foobar2Sourcefiles = workflowClient.getWorkflowVersionsSourcefiles(foobar2.getId(), foobar2.getWorkflowVersions().get(0).getId(), null);
+        assertTrue(foobarSourcefiles.stream().anyMatch(s -> s.getContent().contains("This is a description")));
+        assertTrue(foobar2Sourcefiles.stream().anyMatch(s -> s.getContent().contains("This is a description")));
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -512,15 +512,15 @@ public abstract class SourceCodeRepoInterface {
             fileContent = first.get().getContent();
             LanguageHandlerInterface anInterface = LanguageHandlerFactory.getInterface(type);
             anInterface.parseWorkflowContent(filePath, fileContent, sourceFiles, version);
-            // Previously, version has no description
             boolean noDescription = (version.getDescription() == null || version.getDescription().isEmpty()) && version.getReference() != null;
-            // Previously, version has a README description
-            boolean oldReadMeDescription = (DescriptionSource.README == version.getDescriptionSource());
-            // Checking these conditions to prevent overwriting description from descriptor
-            if (noDescription || oldReadMeDescription) {
-                String readmeContent = getReadMeContent(repositoryId, version.getReference(), version.getReadMePath());
+            String readmeContent = getReadMeContent(repositoryId, version.getReference(), version.getReadMePath());
+            if (!Strings.isNullOrEmpty(version.getReadMePath())) {
+                // overwrite description from descriptor if there is a custom path specified in the .dockstore.yml
+                version.setDescriptionAndDescriptionSource(readmeContent, DescriptionSource.CUSTOM_README);
+            } else if (noDescription) {
+                // use the root README as a fallback if there is no other description
                 if (StringUtils.isNotBlank(readmeContent)) {
-                    version.setDescriptionAndDescriptionSource(readmeContent, Strings.isNullOrEmpty(version.getReadMePath()) ? DescriptionSource.README : DescriptionSource.CUSTOM_README);
+                    version.setDescriptionAndDescriptionSource(readmeContent, DescriptionSource.README);
                 }
             }
         }


### PR DESCRIPTION
**Description**
Swap order of precedence, order is now 

Order of precedence is: 
1) .dockstore.yml path
2) Description in descriptors
3) Regular readme


**Review Instructions**
Add workflows that use (n choose 2) out of a description in the (root readme, descriptor, or custom readme location). 
See that order of precedence is as above. 
.dockstore.yml looks like https://github.com/dockstore/dockstore/pull/5384#issue-1597683808

**Issue**
https://github.com/dockstore/dockstore/issues/5018

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
