### PR TITLE
Open Data Check for Hosted Workflows

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 377 third-party dependencies.
+Lists of 376 third-party dependencies.
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-slf4j (com.typesafe.akka:akka-slf4j_2.13:2.5.32 - https://akka.io/)
@@ -264,7 +264,6 @@ Lists of 377 third-party dependencies.
      (Public Domain) JSON in Java (org.json:json:20220924 - https://github.com/douglascrockford/JSON-java)
      (Revised BSD License) JSONLD Java :: Core (com.github.jsonld-java:jsonld-java:0.8.3 - http://github.com/jsonld-java/jsonld-java/jsonld-java/)
      (MIT License) JUL to SLF4J bridge (org.slf4j:jul-to-slf4j:1.7.36 - http://www.slf4j.org)
-     (Eclipse Public License 1.0) JUnit (junit:junit:4.13.2 - http://junit.org)
      (Eclipse Public License v2.0) JUnit Jupiter (Aggregator) (org.junit.jupiter:junit-jupiter:5.9.2 - https://junit.org/junit5/)
      (Eclipse Public License v2.0) JUnit Jupiter API (org.junit.jupiter:junit-jupiter-api:5.9.2 - https://junit.org/junit5/)
      (Eclipse Public License v2.0) JUnit Jupiter Engine (org.junit.jupiter:junit-jupiter-engine:5.9.2 - https://junit.org/junit5/)

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckUrlHelperFullIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckUrlHelperFullIT.java
@@ -101,12 +101,9 @@ public class CheckUrlHelperFullIT {
         final ApiClient
             webClient = CommonTestUtilities.getOpenAPIWebClient(true, BasicIT.USER_2_USERNAME, testingPostgres);
         final HostedApi hostedApi = new HostedApi(webClient);
-        final io.dockstore.openapi.client.api.WorkflowsApi
-            workflowsApi = new io.dockstore.openapi.client.api.WorkflowsApi(webClient);
-        final io.dockstore.openapi.client.model.Workflow hostedWorkflow =
-            CommonTestUtilities.createHostedWorkflowWithVersion(hostedApi);
-        final io.dockstore.openapi.client.model.WorkflowVersion
-            workflowVersion = workflowsApi.getWorkflowVersions(hostedWorkflow.getId()).get(0);
+        final WorkflowsApi workflowsApi = new WorkflowsApi(webClient);
+        final Workflow hostedWorkflow = CommonTestUtilities.createHostedWorkflowWithVersion(hostedApi);
+        final WorkflowVersion workflowVersion = workflowsApi.getWorkflowVersions(hostedWorkflow.getId()).get(0);
         assertTrue(workflowVersion.getVersionMetadata().isPublicAccessibleTestParameterFile(), "Should be public because the descriptor has no parameters at all");
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckUrlHelperFullIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckUrlHelperFullIT.java
@@ -82,7 +82,8 @@ public class CheckUrlHelperFullIT {
         client.handleGitHubRelease(gitReference, installationId, workflowRepo, dockstoreTestUser2);
 
         WorkflowVersion workflowVersion = getWorkflowVersion(client);
-        assertFalse(workflowVersion.getVersionMetadata().isPublicAccessibleTestParameterFile(), "Should be set to true since there's no inaccessible URL in the JSON");
+        final String noFilesInJsonForInputParameters = "Should be set to false since the workflow has a file input parameter, and the JSON has no files";
+        assertFalse(workflowVersion.getVersionMetadata().isPublicAccessibleTestParameterFile(), noFilesInJsonForInputParameters);
 
         testingPostgres.runUpdateStatement("update version_metadata set publicaccessibletestparameterfile = null");
         workflowVersion = getWorkflowVersion(client);
@@ -91,7 +92,7 @@ public class CheckUrlHelperFullIT {
         // Test updating existing version
         client.handleGitHubRelease(gitReference, installationId, workflowRepo, dockstoreTestUser2);
         workflowVersion = getWorkflowVersion(client);
-        assertFalse(workflowVersion.getVersionMetadata().isPublicAccessibleTestParameterFile(), "Should be set to false since the workflow has a file input parameter, and the JSON has no files");
+        assertFalse(workflowVersion.getVersionMetadata().isPublicAccessibleTestParameterFile(), noFilesInJsonForInputParameters);
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckUrlHelperFullIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckUrlHelperFullIT.java
@@ -20,8 +20,10 @@ import static io.dockstore.client.cli.BaseIT.getOpenAPIWebClient;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.dockstore.client.cli.BaseIT.TestStatus;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
+import io.dockstore.common.MuteForSuccessfulTests;
 import io.dockstore.common.TestingPostgres;
 import io.dockstore.openapi.client.ApiClient;
 import io.dockstore.openapi.client.api.HostedApi;
@@ -42,6 +44,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag(ConfidentialTest.NAME)
 @ExtendWith(DropwizardExtensionsSupport.class)
+@ExtendWith(MuteForSuccessfulTests.class)
+@ExtendWith(TestStatus.class)
 public class CheckUrlHelperFullIT {
 
     public static String fakeCheckUrlLambdaBaseURL = "http://fakecheckurllambdabaseurl:3000";

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
@@ -16,10 +16,10 @@
 
 package io.dockstore.client.cli;
 
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ClientRegressionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ClientRegressionIT.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
@@ -62,7 +61,7 @@ import uk.org.webcompere.systemstubs.stream.SystemOut;
 @Tag(RegressionTest.NAME)
 class ClientRegressionIT extends BaseIT {
     @TempDir
-    public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+    public static File temporaryFolder;
     private static File dockstore;
     private static File testJson;
 
@@ -77,11 +76,11 @@ class ClientRegressionIT extends BaseIT {
     public static void getOldDockstoreClient() throws IOException {
         TestUtility.createFakeDockstoreConfigFile();
         URL url = new URL("https://github.com/dockstore/dockstore-cli/releases/download/" + OLD_DOCKSTORE_VERSION + "/dockstore");
-        dockstore = temporaryFolder.newFile("dockstore");
+        dockstore = new File(temporaryFolder, "dockstore");
         FileUtils.copyURLToFile(url, dockstore);
         assertTrue(dockstore.setExecutable(true));
         url = new URL("https://raw.githubusercontent.com/DockstoreTestUser/dockstore_parameter_test/master/test.cwl.json");
-        testJson = temporaryFolder.newFile("test.cwl.json");
+        testJson = new File(temporaryFolder, "test.cwl.json");
         FileUtils.copyURLToFile(url, testJson);
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSSwaggerIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSSwaggerIT.java
@@ -16,7 +16,7 @@
 
 package io.dockstore.client.cli;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.dockstore.client.cli.BaseIT.TestStatus;
 import io.dockstore.common.CommonTestUtilities;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralRegressionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralRegressionIT.java
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.rules.TemporaryFolder;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 import uk.org.webcompere.systemstubs.stream.SystemErr;
@@ -64,7 +63,7 @@ import uk.org.webcompere.systemstubs.stream.SystemOut;
 @Tag(RegressionTest.NAME)
 class GeneralRegressionIT extends BaseIT {
     @TempDir
-    public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+    public static File temporaryFolder;
     static URL url;
     static File dockstore;
     private static final String DOCKERHUB_TOOL_PATH = "registry.hub.docker.com/testPath/testUpdatePath/test5";
@@ -78,7 +77,7 @@ class GeneralRegressionIT extends BaseIT {
     public static void getOldDockstoreClient() throws IOException {
         TestUtility.createFakeDockstoreConfigFile();
         url = new URL("https://github.com/dockstore/dockstore-cli/releases/download/" + OLD_DOCKSTORE_VERSION + "/dockstore");
-        dockstore = temporaryFolder.newFile("dockstore");
+        dockstore = new File(temporaryFolder, "dockstore");
         FileUtils.copyURLToFile(url, dockstore);
         Assertions.assertTrue(dockstore.setExecutable(true));
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowBaseIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowBaseIT.java
@@ -1,9 +1,9 @@
 package io.dockstore.client.cli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.swagger.client.api.ContainersApi;
 import io.swagger.client.model.DockstoreTool;
@@ -20,10 +20,10 @@ class GeneralWorkflowBaseIT extends BaseIT {
      * @param tags
      */
     protected static void verifyChecksumsAreSaved(List<Tag> tags) {
-        assertTrue("The list of tags should not be empty", tags.size() > 0);
+        assertTrue(tags.size() > 0, "The list of tags should not be empty");
         for (Tag tag : tags) {
             List<Image> images = tag.getImages();
-            assertTrue("Tag should have an image", images.size() > 0);
+            assertTrue(images.size() > 0, "Tag should have an image");
             String hashType = tag.getImages().get(0).getChecksums().get(0).getType();
             String checksum = tag.getImages().get(0).getChecksums().get(0).getChecksum();
             assertNotNull(hashType);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowRegressionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowRegressionIT.java
@@ -47,7 +47,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.rules.TemporaryFolder;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 import uk.org.webcompere.systemstubs.stream.SystemErr;
@@ -71,7 +70,7 @@ class GeneralWorkflowRegressionIT extends BaseIT {
     public static final String KNOWN_BREAKAGE_MOVING_TO_1_9_0 = "Known breakage moving to 1.9.0";
 
     @TempDir
-    public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+    public static File temporaryFolder;
     static URL url;
     static File dockstore;
     private static File md5sumJson;
@@ -84,14 +83,14 @@ class GeneralWorkflowRegressionIT extends BaseIT {
     public static void getOldDockstoreClient() throws IOException {
         TestUtility.createFakeDockstoreConfigFile();
         url = new URL("https://github.com/dockstore/dockstore-cli/releases/download/" + OLD_DOCKSTORE_VERSION + "/dockstore");
-        dockstore = temporaryFolder.newFile("dockstore");
+        dockstore = new File(temporaryFolder, "dockstore");
         FileUtils.copyURLToFile(url, dockstore);
         assertTrue(dockstore.setExecutable(true));
         url = new URL("https://raw.githubusercontent.com/DockstoreTestUser2/md5sum-checker/1.6.0/checker-input-cwl.json");
-        md5sumJson = temporaryFolder.newFile("md5sum-wrapper-tool.json");
+        md5sumJson = new File(temporaryFolder, "md5sum-wrapper-tool.json");
         FileUtils.copyURLToFile(url, md5sumJson);
         url = new URL("https://raw.githubusercontent.com/DockstoreTestUser2/md5sum-checker/1.6.0/md5sum.input");
-        File md5sumInput = temporaryFolder.newFile("md5sum.input");
+        File md5sumInput = new File(temporaryFolder, "md5sum.input");
         FileUtils.copyURLToFile(url, md5sumInput);
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/HostedWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/HostedWorkflowIT.java
@@ -16,11 +16,9 @@
 
 package io.dockstore.client.cli;
 
-import static io.dockstore.common.DescriptorLanguage.CWL;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.google.common.collect.Lists;
 import io.dockstore.client.cli.BaseIT.TestStatus;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
@@ -34,7 +32,6 @@ import io.dockstore.openapi.client.api.HostedApi;
 import io.dockstore.openapi.client.api.WorkflowsApi;
 import io.dockstore.openapi.client.model.DockstoreTool;
 import io.dockstore.openapi.client.model.Entry;
-import io.dockstore.openapi.client.model.SourceFile;
 import io.dockstore.openapi.client.model.Workflow;
 import io.dockstore.openapi.client.model.WorkflowVersion;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
@@ -88,15 +85,7 @@ class HostedWorkflowIT extends BaseIT {
         final WorkflowsApi workflowsApi = new WorkflowsApi(getOpenAPIWebClient(USER_2_USERNAME, testingPostgres));
 
         // Test same for hosted workflows
-        Workflow hostedWorkflow = hostedApi.createHostedWorkflow(null, "awesomeTool", CWL.getShortName(), null, null);
-        SourceFile file = new SourceFile();
-        file.setContent("cwlVersion: v1.0\n" + "class: Workflow");
-        file.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
-        file.setPath("/Dockstore.cwl");
-        file.setAbsolutePath("/Dockstore.cwl");
-        hostedWorkflow = hostedApi.editHostedWorkflow(Lists.newArrayList(file), hostedWorkflow.getId());
-        file.setContent("cwlVersion: v1.1\n" + "class: Workflow");
-        hostedWorkflow = hostedApi.editHostedWorkflow(Lists.newArrayList(file), hostedWorkflow.getId());
+        Workflow hostedWorkflow = CommonTestUtilities.createHostedWorkflowWithVersion(hostedApi);
         WorkflowVersion hostedVersion = workflowsApi.getWorkflowVersions(hostedWorkflow.getId()).get(0);
 
         // delete default version via DB

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/LimitedCRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/LimitedCRUDClientIT.java
@@ -18,10 +18,10 @@ package io.dockstore.client.cli;
 
 import static io.dockstore.common.DescriptorLanguage.CWL;
 import static io.dockstore.common.DescriptorLanguage.WDL;
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.Lists;
 import io.dockstore.client.cli.BaseIT.TestStatus;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MetadataIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/MetadataIT.java
@@ -1,6 +1,7 @@
 package io.dockstore.client.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.dockstore.client.cli.BaseIT.TestStatus;
 import io.dockstore.common.MuteForSuccessfulTests;
@@ -13,7 +14,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
@@ -78,7 +78,7 @@ class MetadataIT extends BaseIT {
         String endpoint = "/metadata/runner_dependencies";
         List<Pair> queryParams = this.queryParams();
         queryParams.addAll(apiClient.parameterToPairs("", "client_version", "1.2"));
-        ApiException exception = Assert.assertThrows(ApiException.class, () -> this.get_request(endpoint, queryParams));
+        ApiException exception = assertThrows(ApiException.class, () -> this.get_request(endpoint, queryParams));
         assertEquals(HttpStatus.BAD_REQUEST_400, exception.getCode());
         assertEquals("Invalid value for client version: `1.2`. Value must be like `1.13.0`)", exception.getResponseBody());
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -16,6 +16,7 @@
 
 package io.dockstore.common;
 
+import static io.dockstore.common.DescriptorLanguage.CWL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.dockerjava.api.DockerClient;
@@ -25,9 +26,13 @@ import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
 import com.github.dockerjava.transport.DockerHttpClient;
+import com.google.common.collect.Lists;
 import com.google.common.hash.Hashing;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import io.dockstore.openapi.client.api.HostedApi;
+import io.dockstore.openapi.client.model.SourceFile;
+import io.dockstore.openapi.client.model.Workflow;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.core.Token;
@@ -630,6 +635,19 @@ public final class CommonTestUtilities {
         MultivaluedMap<String, Object> headers = response.getHeaders();
         Object xTotalCount = headers.getFirst("X-total-count");
         assertEquals(String.valueOf(expectedValue), xTotalCount);
+    }
+
+    public static Workflow createHostedWorkflowWithVersion(final HostedApi hostedApi) {
+        Workflow hostedWorkflow = hostedApi.createHostedWorkflow(null, "awesomeTool", CWL.getShortName(), null, null);
+        SourceFile file = new SourceFile();
+        file.setContent("cwlVersion: v1.0\n" + "class: Workflow");
+        file.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
+        file.setPath("/Dockstore.cwl");
+        file.setAbsolutePath("/Dockstore.cwl");
+        hostedWorkflow = hostedApi.editHostedWorkflow(Lists.newArrayList(file), hostedWorkflow.getId());
+        file.setContent("cwlVersion: v1.1\n" + "class: Workflow");
+        hostedWorkflow = hostedApi.editHostedWorkflow(Lists.newArrayList(file), hostedWorkflow.getId());
+        return hostedWorkflow;
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -18,6 +18,8 @@ package io.dockstore.common;
 
 import static io.dockstore.common.DescriptorLanguage.CWL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Container;
@@ -71,7 +73,6 @@ import org.glassfish.jersey.client.ClientProperties;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -360,7 +361,7 @@ public final class CommonTestUtilities {
         try {
             application.run("db", "migrate", configPath, "--include", String.join(",", migrations));
         } catch (Exception e) {
-            Assert.fail("database migration failed");
+            fail("database migration failed");
         }
     }
 
@@ -368,7 +369,7 @@ public final class CommonTestUtilities {
         try {
             application.run("db", "drop-all", "--confirm-delete-everything", configPath);
         } catch (Exception e) {
-            Assert.fail("database drop-all failed");
+            fail("database drop-all failed");
         }
     }
 
@@ -533,9 +534,9 @@ public final class CommonTestUtilities {
     }
 
     public static void checkToolList(String log) {
-        Assert.assertTrue(log.contains("NAME"));
-        Assert.assertTrue(log.contains("DESCRIPTION"));
-        Assert.assertTrue(log.toLowerCase().contains("git repo"));
+        assertTrue(log.contains("NAME"));
+        assertTrue(log.contains("DESCRIPTION"));
+        assertTrue(log.toLowerCase().contains("git repo"));
     }
 
     public static void restartElasticsearch() throws IOException {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/TestUtility.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/TestUtility.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import org.apache.commons.io.FileUtils;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,8 +32,6 @@ import org.slf4j.LoggerFactory;
 public final class TestUtility {
 
     private static final Logger LOG = LoggerFactory.getLogger(TestUtility.class);
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
 
     private TestUtility() {
         // utility class

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/MetadataResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/MetadataResourceIT.java
@@ -17,6 +17,7 @@
 package io.dockstore.webservice;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -29,7 +30,6 @@ import io.dockstore.openapi.client.model.HealthCheckResult;
 import io.dropwizard.testing.DropwizardTestSupport;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -94,7 +94,7 @@ class MetadataResourceIT extends BaseIT {
             fail("Hibernate and connection pool health checks should not fail");
         }
 
-        Assert.assertThrows(ApiException.class, () -> metadataApi.checkHealth(List.of("foobar")));
+        assertThrows(ApiException.class, () -> metadataApi.checkHealth(List.of("foobar")));
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
@@ -24,11 +24,11 @@ import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
 import static io.openapi.api.impl.ToolClassesApiServiceImpl.COMMAND_LINE_TOOL;
 import static io.openapi.api.impl.ToolClassesApiServiceImpl.NOTEBOOK;
 import static io.openapi.api.impl.ToolClassesApiServiceImpl.WORKFLOW;
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -701,6 +701,10 @@
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -638,6 +638,10 @@
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -425,8 +425,8 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         environment.jersey().register(new UserResourceDockerRegistries(getHibernate().getSessionFactory()));
         final MetadataResource metadataResource = new MetadataResource(getHibernate().getSessionFactory(), configuration);
         environment.jersey().register(metadataResource);
-        environment.jersey().register(new HostedToolResource(getHibernate().getSessionFactory(), authorizer, configuration.getLimitConfig()));
-        environment.jersey().register(new HostedWorkflowResource(getHibernate().getSessionFactory(), authorizer, configuration.getLimitConfig()));
+        environment.jersey().register(new HostedToolResource(getHibernate().getSessionFactory(), authorizer, configuration));
+        environment.jersey().register(new HostedWorkflowResource(getHibernate().getSessionFactory(), authorizer, configuration));
         environment.jersey().register(new OrganizationResource(getHibernate().getSessionFactory()));
         environment.jersey().register(new LambdaEventResource(getHibernate().getSessionFactory()));
         environment.jersey().register(new NotificationResource(getHibernate().getSessionFactory()));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedToolResource.java
@@ -82,7 +82,7 @@ public class HostedToolResource extends AbstractHostedEntryResource<Tool, Tag, T
     private final TagDAO tagDAO;
     private final SessionFactory sessionFactory;
 
-    public HostedToolResource(SessionFactory sessionFactory, PermissionsInterface permissionsInterface, DockstoreWebserviceConfiguration.LimitConfig limitConfig) {
+    public HostedToolResource(SessionFactory sessionFactory, PermissionsInterface permissionsInterface, DockstoreWebserviceConfiguration limitConfig) {
         super(sessionFactory, permissionsInterface, limitConfig);
         this.tagDAO = new TagDAO(sessionFactory);
         this.toolDAO = new ToolDAO(sessionFactory);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/HostedWorkflowResource.java
@@ -90,8 +90,8 @@ public class HostedWorkflowResource extends AbstractHostedEntryResource<Workflow
     private final PermissionsInterface permissionsInterface;
     private final SessionFactory sessionFactory;
 
-    public HostedWorkflowResource(SessionFactory sessionFactory, PermissionsInterface permissionsInterface, DockstoreWebserviceConfiguration.LimitConfig limitConfig) {
-        super(sessionFactory, permissionsInterface, limitConfig);
+    public HostedWorkflowResource(SessionFactory sessionFactory, PermissionsInterface permissionsInterface, DockstoreWebserviceConfiguration config) {
+        super(sessionFactory, permissionsInterface, config);
         this.workflowVersionDAO = new WorkflowVersionDAO(sessionFactory);
         this.workflowDAO = new WorkflowDAO(sessionFactory);
         this.permissionsInterface = permissionsInterface;


### PR DESCRIPTION
**Description**
When a hosted workflow version is updated, checks if the version is open data. We were previously only checking for open data on source control updates, which is why hosted workflows were being missed.

In writing a test for it, we discovered that CheckUrlHelperFullIT, where I added the new test, was not being run at all on CircleCI. It turned out to be because the test had not been migrated from JUnit 4 to JUnit 5. I moved it to use JUnit 5 annotations, as well as using `DropWizardExtension` to replace the deprecated `DropwizardAppRule`. Also switched it to use OpenAPI instead of Swagger.

Completely removed JUnit 4 from the classpath, making the necessary migrations, so JUnit 4 doesn't accidentally creep back in.

**Review Instructions**
Verify that open data calculation is working correctly for hosted workflows. These two that David had created in discovering the bug are useful starting points. Note that unless the Open Data harvesting endpoint has been implemented and executed (SEAB-5364), you'll need to save new version to see if it's working correctly.

* https://qa.dockstore.org/workflows/dockstore.org/david4096/cwltest:8?tab=info
* https://qa.dockstore.org/workflows/dockstore.org/david4096/testwdl:3?tab=info

**Issue**
#5339 
https://ucsc-cgl.atlassian.net/browse/DOCK-2315

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
