### PR TITLE
null check and add test for cwl location

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckUrlIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckUrlIT.java
@@ -73,6 +73,10 @@ class CheckUrlIT {
         }
         """;
 
+    private static final String TEST_JSON_WITH_FOOBAR = """
+        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="Layer_1" x="0" y="0" enable-background="new 0 0 575.7 458.6" version="1.1" viewBox="0 0 575.7 458.6" xml:space="preserve"><polygon fill="#7785AB" points="256.5 338.4 129.6 301.3 129.6 176.6 256.5 139.8"/><polygon fill="#7785AB" points="433.6 288.6 265.4 338.4 265.4 139.8 433.6 189.2"/><path fill="#FFF" d="M227.5,278.2c0,13.3-11.5,21.7-24.5,19c-11.9-2.4-20.8-13.5-20.8-24.8c0-11.4,9-20.1,20.9-19.5 C216.1,253.5,227.5,264.9,227.5,278.2z"/><path fill="#FFF" d="M198.6,191.4c0,9-7.1,17-15.4,17.9c-7.8,0.8-13.7-5-13.7-13.1c0-8.1,6-15.9,13.8-17.6 C191.6,176.7,198.7,182.4,198.6,191.4z"/><path fill="#FFF" d="M156,256.1c0,5.6-3.8,9.7-8.3,9.1c-4.3-0.5-7.7-5.1-7.7-10.3c0-5.2,3.4-9.3,7.7-9.2 C152.2,245.9,156,250.5,156,256.1z"/><polygon fill="none" stroke="#FFF" stroke-miterlimit="10" stroke-width="5.604" points="183.4 195.3 208.7 279.4 147.5 256.2"/><line x1="302.9" x2="302.9" y1="176.6" y2="297.1" fill="none" stroke="#FFF" stroke-linecap="round" stroke-miterlimit="10" stroke-width="4.452" opacity=".43"/><line x1="328.9" x2="328.9" y1="181.8" y2="291.8" fill="none" stroke="#FFF" stroke-linecap="round" stroke-miterlimit="10" stroke-width="4.452" opacity=".43"/><line x1="350.8" x2="350.8" y1="186.2" y2="287.5" fill="none" stroke="#FFF" stroke-linecap="round" stroke-miterlimit="10" stroke-width="4.452" opacity=".43"/><line x1="369.5" x2="369.5" y1="190.3" y2="284" fill="none" stroke="#FFF" stroke-linecap="round" stroke-miterlimit="10" stroke-width="4.452" opacity=".43"/><line x1="385.6" x2="385.6" y1="193.6" y2="280.8" fill="none" stroke="#FFF" stroke-linecap="round" stroke-miterlimit="10" stroke-width="4.452" opacity=".43"/><line x1="399.6" x2="399.6" y1="196.5" y2="278.1" fill="none" stroke="#FFF" stroke-linecap="round" stroke-miterlimit="10" stroke-width="4.452" opacity=".43"/><line x1="411.9" x2="411.9" y1="199.1" y2="275.7" fill="none" stroke="#FFF" stroke-linecap="round" stroke-miterlimit="10" stroke-width="4.452" opacity=".43"/><line x1="422.7" x2="422.7" y1="201.3" y2="273.6" fill="none" stroke="#FFF" stroke-linecap="round" stroke-miterlimit="10" stroke-width="4.452" opacity=".43"/><polygon fill="#7785AB" points="303.6 166.4 265.4 157.2 265.4 133.5 303.6 145.4"/><polygon fill="#7785AB" points="433.6 198.7 422 196 422 181.9 433.6 185.6"/><polygon fill="#7785AB" points="256.5 156 233.6 161.6 233.6 140.4 256.5 133.3"/><polygon fill="#7785AB" points="139.8 184.9 129.6 187.4 129.6 172.2 139.8 169"/><polygon fill="#7785AB" points="256.4 344.5 231.9 336.9 231.9 315 256.4 320.9"/><polygon fill="#7785AB" points="139.2 308.3 129.6 305.3 129.6 290.4 139.2 292.7"/><polygon fill="#7785AB" points="303.7 332.4 265.5 344.4 265.5 321.5 303.7 312.1"/><polygon fill="#7785AB" points="433.5 292 422 295.6 422 283.9 433.5 281"/><path fill="#7785AB" d="M182.7,162c0,2.5-1.9,5.1-4.2,5.7c-2.3,0.6-4.1-0.9-4.1-3.3s1.8-5,4.1-5.7C180.8,158,182.7,159.5,182.7,162z"/><path fill="#7785AB" d="M182.7,316.5c0,2.5-1.9,4-4.2,3.3c-2.3-0.7-4.1-3.2-4.1-5.7c0-2.4,1.8-3.9,4.1-3.3 C180.8,311.4,182.7,313.9,182.7,316.5z"/></svg>
+        """;
+
     private static final String CWL_WITH_FILE_INPUT = """
         cwlVersion: v1.0
         class: Workflow
@@ -194,6 +198,19 @@ class CheckUrlIT {
     }
 
     @Test
+    void checkUrlsFromFoobar() {
+        WorkflowVersion workflowVersion = setupWorkflowVersion(
+            WDL_WITH_FILES_INPUT, FileType.DOCKSTORE_WDL,
+            TEST_JSON_WITH_FOOBAR,
+            FileType.WDL_TEST_JSON);
+        assertNull(workflowVersion.getVersionMetadata().getPublicAccessibleTestParameterFile(), "Double-check that it's not originally true/false");
+        AbstractWorkflowResource.publicAccessibleUrls(workflowVersion, createCheckUrlInterface(OPEN_URLS),
+            DescriptorLanguage.WDL);
+        // just don't die
+        assertFalse(workflowVersion.getVersionMetadata().getPublicAccessibleTestParameterFile());
+    }
+
+    @Test
     void checkUrlsFromLambdaTerriblyWrong() {
         WorkflowVersion workflowVersion = setupWorkflowVersion(WDL_WITH_FILES_INPUT,
             FileType.DOCKSTORE_WDL, WDL_TEST_JSON,
@@ -261,6 +278,18 @@ class CheckUrlIT {
             DescriptorLanguage.CWL);
         // allow location as a synonym for PATH
         assertTrue(workflowVersion.getVersionMetadata().getPublicAccessibleTestParameterFile());
+    }
+
+    @Test
+    void checkCwlDescriptorWithFoobar() {
+        final WorkflowVersion workflowVersion =
+            setupWorkflowVersion(CWL_WITH_FILE_INPUT, FileType.DOCKSTORE_CWL, TEST_JSON_WITH_FOOBAR,
+                FileType.CWL_TEST_JSON);
+        assertNull(workflowVersion.getVersionMetadata().getPublicAccessibleTestParameterFile(), "Double-check that it's not originally true/false");
+        AbstractWorkflowResource.publicAccessibleUrls(workflowVersion, createCheckUrlInterface(UrlStatus.ALL_OPEN),
+            DescriptorLanguage.CWL);
+        // just don't die
+        assertFalse(workflowVersion.getVersionMetadata().getPublicAccessibleTestParameterFile());
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/CWLTestParameterFileHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/CWLTestParameterFileHelper.java
@@ -96,13 +96,8 @@ public class CWLTestParameterFileHelper {
     }
 
     private List<String> getPaths(JSONObject fileJsonObject) {
-        if (fileJsonObject.has(PATH) || fileJsonObject.has(LOCATION)) {
-            final String path;
-            if (fileJsonObject.has(PATH)) {
-                path = fileJsonObject.getString(PATH);
-            } else {
-                path = fileJsonObject.getString(LOCATION);
-            }
+        String path = fileJsonObject.optString(PATH, fileJsonObject.optString(LOCATION, null));
+        if (path != null) {
             final List<String> secondaryFiles = getSecondaryFiles(fileJsonObject);
             return Stream.concat(Stream.of(path), secondaryFiles.stream()).toList();
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/CWLTestParameterFileHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/CWLTestParameterFileHelper.java
@@ -70,6 +70,7 @@ import org.json.JSONObject;
 public class CWLTestParameterFileHelper {
 
     private static final String PATH = "path";
+    private static final String LOCATION = "location";
     private static final String CLASS = "class";
     private static final String FILE = "File";
     private static final String SECONDARY_FILES = "secondaryFiles";
@@ -95,9 +96,17 @@ public class CWLTestParameterFileHelper {
     }
 
     private List<String> getPaths(JSONObject fileJsonObject) {
-        final String path = fileJsonObject.getString(PATH);
-        final List<String> secondaryFiles = getSecondaryFiles(fileJsonObject);
-        return Stream.concat(Stream.of(path), secondaryFiles.stream()).toList();
+        if (fileJsonObject.has(PATH) || fileJsonObject.has(LOCATION)) {
+            final String path;
+            if (fileJsonObject.has(PATH)) {
+                path = fileJsonObject.getString(PATH);
+            } else {
+                path = fileJsonObject.getString(LOCATION);
+            }
+            final List<String> secondaryFiles = getSecondaryFiles(fileJsonObject);
+            return Stream.concat(Stream.of(path), secondaryFiles.stream()).toList();
+        }
+        return List.of();
     }
 
     private List<String> getSecondaryFiles(JSONObject jsonObject) {


### PR DESCRIPTION
**Description**
Issue was that a "location" rather than a "path" was killing the open data check in a way that killed the whole thing. 
Added a null check and allowed location as a synonym for path. 

See use of location in https://doc.arvados.org/rnaseq-cwl-training/03-running/index.html 
https://www.commonwl.org/v1.0/CommandLineTool.html#File


**Review Instructions**
Try a json parameter file with a location instead of a file path. 
Try random garbage in a test parameter file and ensure it doesn't crash

**Issue**
https://github.com/dockstore/dockstore/issues/5457

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
