### PR TITLE
Feature/5397/s3gs

### DIFF
--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/LambdaUrlCheckerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/LambdaUrlCheckerTest.java
@@ -17,6 +17,7 @@
 package io.dockstore.webservice.helpers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.dockstore.common.MuteForSuccessfulTests;
 import io.dockstore.webservice.helpers.CheckUrlInterface.UrlStatus;
@@ -29,24 +30,46 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 @ExtendWith(MuteForSuccessfulTests.class)
 class LambdaUrlCheckerTest {
 
+    private static final LambdaUrlChecker LAMBDA_URL_CHECKER = new LambdaUrlChecker("https://this.url.is.unused.in.these.tests");
+
     /**
      * Tests the LambdaUrlChecker for cases where it does not actually invoke the lambda, due to
      * validation it performs before invoking said lambda.
      */
     @Test
     void testCheckUrls() {
-        final LambdaUrlChecker lambdaUrlChecker =
-            new LambdaUrlChecker("https://this.url.is.unused.in.these.tests");
 
         // Lambda not invoked because there are no values
-        assertEquals(UrlStatus.ALL_OPEN, lambdaUrlChecker.checkUrls(Set.of()),
+        assertEquals(UrlStatus.ALL_OPEN, LAMBDA_URL_CHECKER.checkUrls(Set.of()),
             "No urls should return all open");
 
         // Lambda not invoked because the value is not a Java URL (no protocol)
-        assertEquals(UrlStatus.NOT_ALL_OPEN, lambdaUrlChecker.checkUrls(Set.of("localfile.cram")), "A local file is a malformed url");
+        assertEquals(UrlStatus.NOT_ALL_OPEN, LAMBDA_URL_CHECKER.checkUrls(Set.of("localfile.cram")), "A local file is a malformed url");
 
         // Lambda is not invoked because s3 is not a protocol that Java recognizes out of the box
-        assertEquals(UrlStatus.NOT_ALL_OPEN, lambdaUrlChecker.checkUrls(Set.of("s3://human-pangenomics/working/HPRC_PLUS/HG005/raw_data/Illumina/child/5A1-24481579/5A1_S5_L001_R1_001.fastq.gz")),
+        assertEquals(UrlStatus.NOT_ALL_OPEN, LAMBDA_URL_CHECKER.checkUrls(Set.of("s3://human-pangenomics/working/HPRC_PLUS/HG005/raw_data/Illumina/child/5A1-24481579/5A1_S5_L001_R1_001.fastq.gz")),
             "s3 protocol not recognized by Java");
+    }
+
+    @Test
+    void testConvertToUrl() {
+        final String s3Uri = LAMBDA_URL_CHECKER.convertGsOrS3Uri(
+                "s3://human-pangenomics/working/HPRC_PLUS/HG002/assemblies/year1_f1_assembly_v2_genbank/HG002.maternal.f1_assembly_v2_genbank.fa.gz");
+        assertEquals("https://human-pangenomics.s3.amazonaws.com/working/HPRC_PLUS/HG002/assemblies/year1_f1_assembly_v2_genbank/HG002.maternal.f1_assembly_v2_genbank.fa.gz", s3Uri);
+
+        final String gsUri = LAMBDA_URL_CHECKER.convertGsOrS3Uri("gs://gcs-public-data--genomics/cannabis/README.txt");
+        assertEquals("https://storage.googleapis.com/gcs-public-data--genomics/cannabis/README.txt", gsUri);
+
+        final String dockstoreUrl = "https://dockstore.org";
+        final String alreadyAnHttpsUrl = LAMBDA_URL_CHECKER.convertGsOrS3Uri(dockstoreUrl);
+        assertEquals(dockstoreUrl, alreadyAnHttpsUrl);
+
+        // Edge cases
+        assertNull(LAMBDA_URL_CHECKER.convertGsOrS3Uri(null));
+        assertEquals("", LAMBDA_URL_CHECKER.convertGsOrS3Uri(""));
+        final String invalidS3Protocol = "s3:///whatever";
+        assertEquals(invalidS3Protocol, LAMBDA_URL_CHECKER.convertGsOrS3Uri(invalidS3Protocol));
+        final String invalidGsProtocol = "gs:///whatever";
+        assertEquals(invalidGsProtocol, LAMBDA_URL_CHECKER.convertGsOrS3Uri(invalidGsProtocol));
     }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/LambdaUrlCheckerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/LambdaUrlCheckerTest.java
@@ -45,10 +45,6 @@ class LambdaUrlCheckerTest {
 
         // Lambda not invoked because the value is not a Java URL (no protocol)
         assertEquals(UrlStatus.NOT_ALL_OPEN, LAMBDA_URL_CHECKER.checkUrls(Set.of("localfile.cram")), "A local file is a malformed url");
-
-        // Lambda is not invoked because s3 is not a protocol that Java recognizes out of the box
-        assertEquals(UrlStatus.NOT_ALL_OPEN, LAMBDA_URL_CHECKER.checkUrls(Set.of("s3://human-pangenomics/working/HPRC_PLUS/HG005/raw_data/Illumina/child/5A1-24481579/5A1_S5_L001_R1_001.fastq.gz")),
-            "s3 protocol not recognized by Java");
     }
 
     @Test


### PR DESCRIPTION
**Description**
Converts s3 and gs URIs to https urls before sending them off to the lambda for verification.

For Azure, I could not find Azure URIs with a custom protocol, just https ones, so those should just work already (we have some. In theory.

**Review Instructions**
After one time OpenData endpoint has been executed, Human Pangenome workflow versions such as this [one](https://qa.dockstore.org/workflows/github.com/human-pangenomics/hpp_production_workflows/Quast:master?tab=info) should be flagged as open data (they have test parameter files referencing a public s3 bucket).

**Issue**
#5397 
DOCK-2337

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
