### PR TITLE
Remove trailing slash from the lambda url

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/LambdaUrlChecker.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/LambdaUrlChecker.java
@@ -42,7 +42,13 @@ public final class LambdaUrlChecker implements CheckUrlInterface {
     private String checkUrlLambdaUrl;
 
     public LambdaUrlChecker(String checkUrlLambdaUrl) {
-        this.checkUrlLambdaUrl = checkUrlLambdaUrl;
+        // Hackish, remove trailing slash if present. Ideally, the configured url would just not have the trailing slash to begin with,
+        // but see discussion linked from SEAB-5416 -- it's hard to reset in production without downtime.
+        this.checkUrlLambdaUrl = checkUrlLambdaUrl.replaceAll("/$", "");
+    }
+
+    String getCheckUrlLambdaUrl() {
+        return checkUrlLambdaUrl;
     }
 
     private Optional<Boolean> checkUrl(String url) {

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/LambdaUrlCheckerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/LambdaUrlCheckerTest.java
@@ -68,4 +68,11 @@ class LambdaUrlCheckerTest {
         final String invalidGsProtocol = "gs:///whatever";
         assertEquals(invalidGsProtocol, LAMBDA_URL_CHECKER.convertGsOrS3Uri(invalidGsProtocol));
     }
+
+    @Test
+    void testStripTrailingSlash() {
+        final String url = "https://dockstore.org";
+        assertEquals(url, new LambdaUrlChecker(url + "/").getCheckUrlLambdaUrl());
+        assertEquals(url, new LambdaUrlChecker(url).getCheckUrlLambdaUrl());
+    }
 }


### PR DESCRIPTION
**Description**
Removes the trailing slash, if any, from the checkLambdaUrl. As currently configured in its deploy, the API Gateway/lambda invocation will fail if the url has a trailing slash.

The first better fix would be to not have the trailing slash in the web.yml file in the first place, but due to Cloud Formation stack dependencies, this is unfortunately easily not doable without some downtime in prod.

The second better fix would be to configure API Gateway to work with both the trailing slash and without, but that requires more API Gateway knowledge than I currently have, and doesn't seem worth the effort.

The CheckUrl API Gateway is not exposed to the public, and this fix does not prevent either of above two fixes later, if we desire. So I'm going with this slightly hackish approach.

**Review Instructions**
Verify that the checkUrl lambda has been invoked by navigating to the checkUrl lambda in AWS Console, click Monitor. You should see invocations, and if you click View CloudWatch Logs, the log group should exist and should have entries.

**Issue**
SEAB-5416

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
