### PR TITLE
Handle StackOverflowError that Cromwell throws

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -713,7 +713,7 @@ public class WDLHandler implements LanguageHandlerInterface {
             tempMainDescriptor = createTempFile("main", DESCRIPTOR_SUFFIX);
             Files.asCharSink(tempMainDescriptor, StandardCharsets.UTF_8).write(primaryDescriptorContent);
             return Optional.of(wdlBridge.getInputFiles(tempMainDescriptor.getPath()));
-        } catch (SyntaxError | IOException e) {
+        } catch (StackOverflowError | SyntaxError | IOException e) { // StackOverflowError: https://github.com/dockstore/dockstore/issues/5496
             LOG.error("Error parsing WDL", e);
             return Optional.empty();
         } finally {

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
@@ -112,10 +112,8 @@ class WDLHandlerTest {
 
     @Test
     void testRecursiveImports() throws IOException {
-        final File recursiveWdl = new File(ResourceHelpers.resourceFilePath("recursive.wdl"));
-
         final WDLHandler wdlHandler = new WDLHandler();
-        String s = FileUtils.readFileToString(recursiveWdl, StandardCharsets.UTF_8);
+        String s = getFileContent("recursive.wdl");
         try {
             wdlHandler.checkForRecursiveHTTPImports(s, new HashSet<>());
             Assertions.fail("Should've detected recursive import");
@@ -258,6 +256,14 @@ class WDLHandlerTest {
         assertEquals(2, arrayInputWithTwoUrls.values().size(), "workflow.files array has 2 possible urls");
         final FileInputs fileInput = twoInputs.stream().filter(input -> input.type().equals("File")).findFirst().get();
         assertEquals(1, fileInput.values().size(), "workfile.file3 has one possible url");
+    }
+
+    @Test
+    void testFileInputsWithRecursiveImport() throws IOException {
+        final WDLHandler wdlHandler = new WDLHandler();
+        final String fileContent = getFileContent("recursive.wdl");
+        final Optional<Map<String, String>> fileInputs = wdlHandler.getFileInputs(fileContent, Set.of());
+        assertEquals(Optional.empty(), fileInputs, "Recursive import should not throw");
     }
 
     private String getFileContent(String path) throws IOException {


### PR DESCRIPTION
**Description**
Catches the StackOverflowError Cromwell throws for recursive imports.

I don't think we allow recursive WDL workflows to get into the DB anymore, see #5291, but there are existing ones, alas.

**Review Instructions**
Run the `/entries/updateOpenData` endpoint in staging. It should run to completion.

It will time out if running via Swagger; you'll need to verify it ran to completion by looking in the logs for this message:

```
Completed processing {} entries for open data
```

Where `{}` has been replaced by a number

**Issue**
#5496

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
