### PR TITLE
Set default descriptor type for tools

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiCRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiCRUDClientIT.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Lists;
 import io.dockstore.client.cli.BaseIT.TestStatus;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.Constants;
+import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.MuteForSuccessfulTests;
 import io.dockstore.common.Registry;
 import io.dockstore.common.Utilities;
@@ -211,6 +212,9 @@ class OpenApiCRUDClientIT extends BaseIT {
         HostedApi api = new HostedApi(webClient);
         DockstoreTool hostedTool = api
                 .createHostedTool(Registry.QUAY_IO.getDockerPath().toLowerCase(), "awesomeTool", null, "coolNamespace", null);
+        // Verify that a hosted tool with no versions has a default descriptor type
+        assertEquals(1, hostedTool.getDescriptorType().size());
+        assertEquals(DescriptorLanguage.CWL.toString(), hostedTool.getDescriptorType().get(0));
         // Should not be able to publish a hosted tool without valid versions
         ApiException exception = assertThrows(ApiException.class, () -> containersApi.publish(hostedTool.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true)));
         assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getCode());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiCRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiCRUDClientIT.java
@@ -20,6 +20,7 @@ import static io.openapi.api.impl.ToolClassesApiServiceImpl.COMMAND_LINE_TOOL;
 import static io.openapi.api.impl.ToolClassesApiServiceImpl.WORKFLOW;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Lists;
@@ -30,27 +31,29 @@ import io.dockstore.common.MuteForSuccessfulTests;
 import io.dockstore.common.Registry;
 import io.dockstore.common.Utilities;
 import io.dockstore.openapi.client.ApiClient;
+import io.dockstore.openapi.client.ApiException;
+import io.dockstore.openapi.client.api.ContainersApi;
 import io.dockstore.openapi.client.api.Ga4Ghv20Api;
+import io.dockstore.openapi.client.api.HostedApi;
 import io.dockstore.openapi.client.api.MetadataApi;
+import io.dockstore.openapi.client.model.DockstoreTool;
+import io.dockstore.openapi.client.model.PublishRequest;
 import io.dockstore.openapi.client.model.SourceControlBean;
+import io.dockstore.openapi.client.model.SourceFile;
 import io.dockstore.openapi.client.model.Tool;
 import io.dockstore.openapi.client.model.ToolClass;
 import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dropwizard.testing.DropwizardTestSupport;
 import io.dropwizard.testing.ResourceHelpers;
-import io.swagger.client.api.ContainersApi;
-import io.swagger.client.api.HostedApi;
-import io.swagger.client.model.DockstoreTool;
-import io.swagger.client.model.PublishRequest;
-import io.swagger.client.model.SourceFile;
-import io.swagger.model.DescriptorType;
+import io.openapi.model.DescriptorType;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.apache.commons.configuration2.INIConfiguration;
 import org.apache.commons.io.FileUtils;
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
@@ -123,21 +126,21 @@ class OpenApiCRUDClientIT extends BaseIT {
         File configFile = FileUtils.getFile("src", "test", "resources", "config");
         INIConfiguration parseConfig = Utilities.parseConfig(configFile.getAbsolutePath());
         webClient.setBasePath(parseConfig.getString(Constants.WEBSERVICE_BASE_PATH));
-        ContainersApi containersApi = new ContainersApi(getWebClient(ADMIN_USERNAME, testingPostgres));
+        ContainersApi containersApi = new ContainersApi(getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres));
 
         // cleanup to make math easier
         final List<DockstoreTool> dockstoreTools = containersApi.allPublishedContainers(0, 100, null, null, null);
         for (DockstoreTool tool : dockstoreTools) {
             // Publish tool
-            PublishRequest pub = CommonTestUtilities.createPublishRequest(false);
+            PublishRequest pub = CommonTestUtilities.createOpenAPIPublishRequest(false);
             containersApi.publish(tool.getId(), pub);
         }
 
         // create  a pile of workflows to test with
         for (int i = 0; i < 100; i++) {
-            HostedApi api = new HostedApi(getWebClient(ADMIN_USERNAME, testingPostgres));
+            HostedApi api = new HostedApi(getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres));
             DockstoreTool hostedTool = api
-                .createHostedTool("awesomeTool" + i, Registry.QUAY_IO.getDockerPath().toLowerCase(), DescriptorType.CWL.toString(), "coolNamespace", null);
+                .createHostedTool(Registry.QUAY_IO.getDockerPath().toLowerCase(), "awesomeTool" + i, DescriptorType.CWL.toString(), "coolNamespace", null);
             SourceFile descriptorFile = new SourceFile();
             descriptorFile
                 .setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("tar-param.cwl")), StandardCharsets.UTF_8));
@@ -149,7 +152,7 @@ class OpenApiCRUDClientIT extends BaseIT {
             dockerfile.setType(SourceFile.TypeEnum.DOCKERFILE);
             dockerfile.setPath("/Dockerfile");
             dockerfile.setAbsolutePath("/Dockerfile");
-            DockstoreTool dockstoreTool = api.editHostedTool(hostedTool.getId(), Lists.newArrayList(descriptorFile, dockerfile));
+            DockstoreTool dockstoreTool = api.editHostedTool(Lists.newArrayList(descriptorFile, dockerfile), hostedTool.getId());
             assertTrue(dockstoreTool.getLastModifiedDate() != null && dockstoreTool.getLastModified() != 0, "a tool lacks a date");
 
             SourceFile file2 = new SourceFile();
@@ -158,10 +161,10 @@ class OpenApiCRUDClientIT extends BaseIT {
             file2.setPath("/test.json");
             file2.setAbsolutePath("/test.json");
             // add one file and include the old one implicitly
-            api.editHostedTool(hostedTool.getId(), Lists.newArrayList(file2));
-            api.editHostedTool(hostedTool.getId(), Lists.newArrayList(descriptorFile, file2, dockerfile));
+            api.editHostedTool(Lists.newArrayList(file2), hostedTool.getId());
+            api.editHostedTool(Lists.newArrayList(descriptorFile, file2, dockerfile), hostedTool.getId());
             // Publish tool
-            PublishRequest pub = CommonTestUtilities.createPublishRequest(true);
+            PublishRequest pub = CommonTestUtilities.createOpenAPIPublishRequest(true);
             containersApi.publish(hostedTool.getId(), pub);
         }
 
@@ -199,5 +202,32 @@ class OpenApiCRUDClientIT extends BaseIT {
         // check on paging structure when mixing tools and workflows
         final List<Tool> mixedPage = ga4Ghv20Api.toolsGet(null, null, null, null, null, null, null, null, null, null, null, "3", 30);
         assertEquals(2, mixedPage.stream().map(Tool::getToolclass).distinct().count());
+    }
+
+    @Test
+    void testHostedToolPublishing() throws IOException {
+        ApiClient webClient = BaseIT.getOpenAPIWebClient(BaseIT.ADMIN_USERNAME, testingPostgres);
+        ContainersApi containersApi = new ContainersApi(getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres));
+        HostedApi api = new HostedApi(webClient);
+        DockstoreTool hostedTool = api
+                .createHostedTool(Registry.QUAY_IO.getDockerPath().toLowerCase(), "awesomeTool", null, "coolNamespace", null);
+        // Should not be able to publish a hosted tool without valid versions
+        ApiException exception = assertThrows(ApiException.class, () -> containersApi.publish(hostedTool.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true)));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getCode());
+
+        // Add a version to the hosted tool and publish
+        SourceFile descriptorFile = new SourceFile();
+        descriptorFile
+                .setContent(FileUtils.readFileToString(new File(ResourceHelpers.resourceFilePath("tar-param.cwl")), StandardCharsets.UTF_8));
+        descriptorFile.setType(SourceFile.TypeEnum.DOCKSTORE_CWL);
+        descriptorFile.setPath("/Dockstore.cwl");
+        descriptorFile.setAbsolutePath("/Dockstore.cwl");
+        SourceFile dockerfile = new SourceFile();
+        dockerfile.setContent("FROM ubuntu:latest");
+        dockerfile.setType(SourceFile.TypeEnum.DOCKERFILE);
+        dockerfile.setPath("/Dockerfile");
+        dockerfile.setAbsolutePath("/Dockerfile");
+        DockstoreTool dockstoreTool = api.editHostedTool(Lists.newArrayList(descriptorFile, dockerfile), hostedTool.getId());
+        containersApi.publish(dockstoreTool.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/DescriptorTypeConverter.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/DescriptorTypeConverter.java
@@ -1,36 +1,19 @@
 package io.dockstore.webservice.core;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Converter(autoApply = true)
-public class DescriptorTypeConverter implements AttributeConverter<List<String>, String> {
+public class DescriptorTypeConverter extends DelimitedValuesConverter {
     /**
-     * Checksums are stored in the database as a string with the format type:checksum and are comma separated.
+     * Descriptor types are stored in the database as a string and are comma separated.
      */
-    private static final Logger LOG = LoggerFactory.getLogger(DescriptorTypeConverter.class);
 
-    @Override
-    public String convertToDatabaseColumn(List<String> descriptorTypes) {
-        String dt = "";
-        if (descriptorTypes != null && !descriptorTypes.isEmpty()) {
-            dt = String.join(",", descriptorTypes);
-        }
-        return dt;
+    public DescriptorTypeConverter() {
+        super(",");
     }
 
     @Override
-    public List<String> convertToEntityAttribute(String descriptorTypes) {
-        List dt = new ArrayList();
-        if (StringUtils.isNotEmpty(descriptorTypes)) {
-            dt = Arrays.asList(descriptorTypes.split(","));
-        }
-        return dt;
+    public String getSubject(boolean isPlural) {
+        return "Descriptor type" + (isPlural ? "s" : "");
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -479,9 +479,15 @@ public class Tool extends Entry<Tool, Tag> {
     }
 
     public List<String> calculateDescriptorType() {
-        Set<DescriptorLanguage.FileType> set = this.getWorkflowVersions().stream().flatMap(tag -> tag.getSourceFiles().stream()).map(SourceFile::getType).collect(
-                Collectors.toSet());
-        return Arrays.stream(DescriptorLanguage.values()).filter(lang -> !(lang.toString().equals("cwl") || lang.toString().equals("wdl"))).filter(lang -> set.contains(lang.getFileType()))
-                .map(lang -> lang.toString()).distinct().collect(Collectors.toList());
+        Set<DescriptorLanguage.FileType> set = this.getWorkflowVersions().stream()
+                .flatMap(tag -> tag.getSourceFiles().stream())
+                .map(SourceFile::getType)
+                .collect(Collectors.toSet());
+        return Arrays.stream(DescriptorLanguage.values())
+                .filter(lang -> !(lang.toString().equals("cwl") || lang.toString().equals("wdl")))
+                .filter(lang -> set.contains(lang.getFileType()))
+                .map(lang -> lang.toString())
+                .distinct()
+                .collect(Collectors.toList());
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -495,14 +495,13 @@ public class Tool extends Entry<Tool, Tag> {
      * @return
      */
     public List<String> calculateDescriptorType() {
-        Set<DescriptorLanguage.FileType> set = this.getWorkflowVersions().stream()
+        Set<DescriptorLanguage.FileType> sourceFileTypes = this.getWorkflowVersions().stream()
                 .flatMap(tag -> tag.getSourceFiles().stream())
                 .map(SourceFile::getType)
                 .collect(Collectors.toSet());
         return Arrays.stream(DescriptorLanguage.values())
-                .filter(lang -> !(lang.toString().equals("cwl") || lang.toString().equals("wdl")))
-                .filter(lang -> set.contains(lang.getFileType()))
-                .map(lang -> lang.toString())
+                .filter(lang -> sourceFileTypes.contains(lang.getFileType()))
+                .map(DescriptorLanguage::toString)
                 .distinct()
                 .collect(Collectors.toList());
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Tool.java
@@ -28,7 +28,6 @@ import io.dockstore.common.ValidationConstants;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -110,6 +109,8 @@ public class Tool extends Entry<Tool, Tag> {
 
     static final String PUBLISHED_QUERY = " FROM Tool c WHERE c.isPublished = true ";
 
+    static final String DEFAULT_DESCRIPTOR_TYPE = DescriptorLanguage.CWL.toString();
+
     @Column(nullable = false, columnDefinition = "Text default 'AUTO_DETECT_QUAY_TAGS_AUTOMATED_BUILDS'")
     @Enumerated(EnumType.STRING)
     @ApiModelProperty(value = "This indicates what mode this is in which informs how we do things like refresh, dockstore specific", required = true, position = 13)
@@ -151,10 +152,10 @@ public class Tool extends Entry<Tool, Tag> {
             + "If tool was never built on quay.io, then last build will be null. N/A for hosted/manual path tools", position = 25, dataType = "long")
     private Date lastBuild;
 
-    @Column(nullable = false, columnDefinition = "varchar default ''")
+    @Column(nullable = false, columnDefinition = "varchar")
     @Convert(converter = DescriptorTypeConverter.class)
-    @ApiModelProperty(position = 28, accessMode = ApiModelProperty.AccessMode.READ_ONLY)
-    private List<String> descriptorType = new ArrayList<>();
+    @ApiModelProperty(position = 28, accessMode = ApiModelProperty.AccessMode.READ_ONLY, value = "The descriptor types for the tool, calculated from the tool's descriptor files. Defaults to CWL")
+    private List<String> descriptorType = List.of(DEFAULT_DESCRIPTOR_TYPE);
 
     @Column
     @Size(max = 256)
@@ -317,12 +318,23 @@ public class Tool extends Entry<Tool, Tag> {
         this.mode = mode;
     }
 
+    /**
+     * Gets the descriptor type list. Defaults to CWL if the list is empty.
+     * @return
+     */
     public List<String> getDescriptorType() {
+        if (this.descriptorType.isEmpty()) {
+            this.descriptorType = List.of(DEFAULT_DESCRIPTOR_TYPE);
+        }
         return this.descriptorType;
     }
 
+    /**
+     * Sets the descriptor type. Defaults to CWL if the descriptor type list is empty.
+     * @param descriptorType
+     */
     public void setDescriptorType(final List<String> descriptorType) {
-        this.descriptorType = descriptorType;
+        this.descriptorType = descriptorType.isEmpty() ? List.of(DEFAULT_DESCRIPTOR_TYPE) : descriptorType;
     }
 
     @JsonProperty("default_dockerfile_path")
@@ -478,6 +490,10 @@ public class Tool extends Entry<Tool, Tag> {
         getDefaultPaths().put(DescriptorLanguage.FileType.CWL_TEST_JSON, defaultTestCwlParameterFile);
     }
 
+    /**
+     * Calculates the descriptor types from the versions' source files.
+     * @return
+     */
     public List<String> calculateDescriptorType() {
         Set<DescriptorLanguage.FileType> set = this.getWorkflowVersions().stream()
                 .flatMap(tag -> tag.getSourceFiles().stream())

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -249,6 +249,8 @@ public abstract class AbstractImageRegistry {
                     .createSourceCodeRepo(tool.getGitUrl(), bitbucketToken == null ? null : bitbucketToken.getContent(),
                         gitlabToken == null ? null : gitlabToken.getContent(), githubToken);
                 updateTags(toolTags, tool, sourceCodeRepo, tagDAO, fileDAO, toolDAO, fileFormatDAO, eventDAO, user);
+                List<String> descriptorTypes = tool.calculateDescriptorType();
+                tool.setDescriptorType(descriptorTypes);
             } catch (Exception e) {
                 LOG.info(String.format("Refreshing %s error: %s", tool.getPath(), e));
                 exceptionMessages.add(String.format("Refreshing %s error: %s", tool.getPath(), e.getMessage()));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AbstractImageRegistry.java
@@ -249,8 +249,6 @@ public abstract class AbstractImageRegistry {
                     .createSourceCodeRepo(tool.getGitUrl(), bitbucketToken == null ? null : bitbucketToken.getContent(),
                         gitlabToken == null ? null : gitlabToken.getContent(), githubToken);
                 updateTags(toolTags, tool, sourceCodeRepo, tagDAO, fileDAO, toolDAO, fileFormatDAO, eventDAO, user);
-                List<String> descriptorTypes = tool.calculateDescriptorType();
-                tool.setDescriptorType(descriptorTypes);
             } catch (Exception e) {
                 LOG.info(String.format("Refreshing %s error: %s", tool.getPath(), e));
                 exceptionMessages.add(String.format("Refreshing %s error: %s", tool.getPath(), e.getMessage()));
@@ -344,8 +342,6 @@ public abstract class AbstractImageRegistry {
         updateTags(toolTags, tool, sourceCodeRepoInterface, tagDAO, fileDAO, toolDAO, fileFormatDAO, eventDAO, user);
         Tool updatedTool = newDBTools.get(0);
 
-        List<String> descriptorTypes = updatedTool.calculateDescriptorType();
-        updatedTool.setDescriptorType(descriptorTypes);
         logToolRefresh(dashboardPrefix, tool);
 
         String repositoryId = sourceCodeRepoInterface.getRepositoryId(updatedTool);
@@ -610,6 +606,8 @@ public abstract class AbstractImageRegistry {
             }
 
         }
+        List<String> descriptorTypes = tool.calculateDescriptorType();
+        tool.setDescriptorType(descriptorTypes);
         FileFormatHelper.updateFileFormats(tool, tool.getWorkflowVersions(), fileFormatDAO, true);
         // ensure updated tags are saved to the database, not sure why this is necessary. See GeneralIT#testImageIDUpdateDuringRefresh
         tool.getWorkflowVersions().forEach(tagDAO::create);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -724,16 +724,6 @@ public class DockerRepoResource
 
         final User foundUser = userDAO.findById(user.getId());
         if (request.getPublish()) {
-            boolean validTag = false;
-
-            Set<Tag> tags = tool.getWorkflowVersions();
-            for (Tag tag : tags) {
-                if (tag.isValid()) {
-                    validTag = true;
-                    break;
-                }
-            }
-
             if (tool.isPrivateAccess()) {
                 // Check that either tool maintainer email or author email is not null
                 List<String> authorEmails = tool.getAuthors().stream().map(Author::getEmail).filter(Objects::nonNull).toList();
@@ -744,7 +734,8 @@ public class DockerRepoResource
             }
 
             // Can publish a tool IF it has at least one valid tag (or is manual) and a git url
-            if (validTag && (!tool.getGitUrl().isEmpty()) || Objects.equals(tool.getMode(), ToolMode.HOSTED)) {
+            final boolean validTag = tool.getWorkflowVersions().stream().anyMatch(Version::isValid);
+            if (validTag && (!tool.getGitUrl().isEmpty() || Objects.equals(tool.getMode(), ToolMode.HOSTED))) {
                 tool.setIsPublished(true);
                 if (checker != null) {
                     if (!checker.getIsPublished()) {

--- a/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.14.0.xml
@@ -520,4 +520,10 @@
     <changeSet author="ktran (generated)" id="dropIsValidColumnForExecutionStatusMetric">
         <dropColumn columnName="isvalid" tableName="execution_status"/>
     </changeSet>
+    <changeSet author="ktran" id="setDefaultDescriptorTypeForToolsWithEmptyDescriptorType">
+        <sql dbms="postgresql">
+            UPDATE tool SET descriptortype='CWL' where descriptortype='';
+        </sql>
+        <dropDefaultValue columnDataType="varchar" columnName="descriptortype" tableName="tool"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -7421,6 +7421,8 @@ definitions:
       descriptorType:
         type: "array"
         position: 28
+        description: "The descriptor types for the tool, calculated from the tool's\
+          \ descriptor files. Defaults to CWL"
         readOnly: true
         items:
           type: "string"


### PR DESCRIPTION
**Description**
This PR sets a default descriptor type for tools. I chose `CWL` as the default descriptor type because workflows use CWL as the default as well, and we plan to eventually deprecate WDL tools.

The setting of a tool's descriptor type is slightly different from a workflows because it's calculated from the source files instead of being set explicitly. As a result, a tool can have no descriptor types if there are no source files. There are 644 tools with no descriptor types (DB value is `''`), 6 of which are published tools. All 6 tools are either auto Quay tools, or manual tools.


In theory, our code shouldn't allow publishing tools with no descriptor types because in order for a tool to be published, it needs to have valid versions, and our definition of valid is that the descriptor files are valid. If the descriptor files are present and valid, then we should've been able to calculate the descriptor types from them. I discovered two bugs where a user can publish a tool with no descriptor types:
- Bug 1: we didn't calculate the descriptor type using `calculateDescriptorType` in the `refreshToolsByOrganization` endpoint which is called when syncing fully automated Quay tools in the Register a Tool dialog (below). The tool can end up with valid versions after calling this endpoint, so the user can publish the tool, which has an empty descriptor type. This is a possible explanation for the published auto Quay tools with no empty descriptor types.
  - ![image](https://user-images.githubusercontent.com/25287123/236502427-ddab3089-85b8-49c0-b8d9-febc782585d4.png)
  - Note that we do call `calculateDescriptorType` when we refresh a single container, so if a user registered an automated Quay tool, the clicked refresh in the top right corner before publishing, then the tool would have the descriptor type calculated.
- Bug 2: Although none of the published empty descriptor tools are hosted tools, I noticed that you can publish a hosted tool with no versions and thus no descriptor types using the Swagger UI. The UI does block this though so a regular end user shouldn't be able to do this.

I couldn't find a bug for how the manual tools got published with empty descriptor types. When we first added the `descriptorType` column in this PR https://github.com/dockstore/dockstore/issues/3632, we ran a [migration](https://github.com/dockstore/dockstore/blob/0a146cf3ea7e316cee386c1ff4a52a0575d5b516/dockstore-webservice/src/main/resources/migrations.1.10.0.xml#L32-L48) that sets the descriptor type for existing tools.  My theory is that the tool was already published at this time, and the migration didn't add any descriptor type because the tools have no source files, so the column defaulted to `''`.

I added a migration that sets existing empty descriptor types to `CWL`.

By setting the default descriptor type to CWL, a published tool should never have an empty descriptor type again. On refresh, the tool's descriptor type will be calculated and set appropriately.

**Review Instructions**
On staging:
- SSM onto the deployer then ECS Exec into the jump server and execute this query in the database: `select count(*) from tool where descriptortype='';`. You should get `0`.
- Verify that you can't publish a hosted tool with no versions. Verify that a hosted tool with no version has the `CWL` descriptor type.
- Open the developer's tool in the browser, register an auto Quay tool in the Register a Tool dialog, check the console for the response of the `"/{userId}/containers/{organization}/refresh"` call and verify that the tool has a descriptor type that's correct for your tool.

**Issue**
[SEAB-5006](https://ucsc-cgl.atlassian.net/browse/SEAB-5006)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-5006]: https://ucsc-cgl.atlassian.net/browse/SEAB-5006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ