### PR TITLE
Tweak API message for hosted entries

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -92,6 +92,7 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
         implements AuthenticatedResourceInterface, EntryVersionHelper {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractHostedEntryResource.class);
+    private static final String UPDATED_SOURCEFILES = "Set of updated source files, add files by adding new files with unknown paths, delete files by including them with null content";
     private final FileDAO fileDAO;
     private final UserDAO userDAO;
     private final PermissionsInterface permissionsInterface;
@@ -189,8 +190,8 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
     @Consumes(MediaType.APPLICATION_JSON)
     public T editHosted(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth User user,
         @ApiParam(value = "Entry to modify.", required = true) @Parameter(description = "Entry to modify", name = "entryId", in = ParameterIn.PATH) @PathParam("entryId") Long entryId,
-        @ApiParam(value = "Set of updated sourcefiles, add files by adding new files with unknown paths, delete files by including them with emptied content", required = true)
-        @Parameter(description = "Set of updated sourcefiles, add files by adding new files with unknown paths, delete files by including them with emptied content", name = "sourceFiles", required = true) Set<SourceFile> sourceFiles) {
+        @ApiParam(value = UPDATED_SOURCEFILES, required = true)
+        @Parameter(description = UPDATED_SOURCEFILES, name = "sourceFiles", required = true) Set<SourceFile> sourceFiles) {
         T entry = getEntryDAO().findById(entryId);
         checkNotNullEntry(entry);
         checkCanWrite(user, entry);

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1217,8 +1217,8 @@ paths:
               items:
                 $ref: '#/components/schemas/SourceFile'
               uniqueItems: true
-        description: "Set of updated sourcefiles, add files by adding new files with\
-          \ unknown paths, delete files by including them with emptied content"
+        description: "Set of updated source files, add files by adding new files with\
+          \ unknown paths, delete files by including them with null content"
         required: true
       responses:
         default:
@@ -6129,8 +6129,8 @@ paths:
               items:
                 $ref: '#/components/schemas/SourceFile'
               uniqueItems: true
-        description: "Set of updated sourcefiles, add files by adding new files with\
-          \ unknown paths, delete files by including them with emptied content"
+        description: "Set of updated source files, add files by adding new files with\
+          \ unknown paths, delete files by including them with null content"
         required: true
       responses:
         default:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -1597,8 +1597,8 @@ paths:
         format: "int64"
       - in: "body"
         name: "body"
-        description: "Set of updated sourcefiles, add files by adding new files with\
-          \ unknown paths, delete files by including them with emptied content"
+        description: "Set of updated source files, add files by adding new files with\
+          \ unknown paths, delete files by including them with null content"
         required: true
         schema:
           type: "array"
@@ -5383,8 +5383,8 @@ paths:
         format: "int64"
       - in: "body"
         name: "body"
-        description: "Set of updated sourcefiles, add files by adding new files with\
-          \ unknown paths, delete files by including them with emptied content"
+        description: "Set of updated source files, add files by adding new files with\
+          \ unknown paths, delete files by including them with null content"
         required: true
         schema:
           type: "array"


### PR DESCRIPTION
**Description**
Tweak OpenAPI message for updating a hosted entry.

To delete a file, its content needs to be set to null, not an empty string.

**Review Instructions**
Go to https://staging.dockstore.org/api/static/swagger-ui/index.html#/hosted/editHostedTool, and verify the description says `...null content` instead of `...emptied content`.

**Issue**
#5489

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
