### PR TITLE
DOCK-2004: Calculate Version validity later

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -716,6 +716,7 @@ public class WorkflowIT extends BaseIT {
         List<Validation> validations = workflowVersion.getValidations();
 
         assertEquals(1, validations.stream().filter(v -> !v.isValid() && v.getMessage() != null && v.getMessage().contains("not find main script")).count(), "should have a descriptive invalid validation");
+        assertFalse(workflowVersion.isValid());
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java
@@ -824,7 +824,7 @@ public abstract class SourceCodeRepoInterface {
      * @param version Version to check validation
      * @return True if valid workflow version, false otherwise
      */
-    private boolean isValidVersion(WorkflowVersion version) {
+    public boolean isValidVersion(WorkflowVersion version) {
         return version.getValidations().stream().filter(validation -> !Objects.equals(validation.getType(),
                 DescriptorLanguage.FileType.DOCKSTORE_YML)).allMatch(Validation::isValid);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -764,6 +764,9 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 setDockstoreYmlAuthorsForVersion(yamlAuthors, remoteWorkflowVersion);
             }
 
+            // Mark the version as valid/invalid.
+            remoteWorkflowVersion.setValid(gitHubSourceCodeRepo.isValidVersion(remoteWorkflowVersion));
+
             // So we have workflowversion which is the new version, we want to update the version and associated source files
             WorkflowVersion existingWorkflowVersion = workflowVersionDAO.getWorkflowVersionByWorkflowIdAndVersionName(workflow.getId(), remoteWorkflowVersion.getName());
             WorkflowVersion updatedWorkflowVersion;
@@ -811,9 +814,6 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             if (latestTagAsDefault && Version.ReferenceType.TAG.equals(updatedWorkflowVersion.getReferenceType()) && addedVersionIsNewer) {
                 workflow.setActualDefaultVersion(updatedWorkflowVersion);
             }
-
-            // Mark the version as valid/invalid.
-            updatedWorkflowVersion.setValid(gitHubSourceCodeRepo.isValidVersion(updatedWorkflowVersion));
 
             // Log that we've successfully added the version.
             LOG.info("Version " + remoteWorkflowVersion.getName() + " has been added to workflow " + workflow.getWorkflowPath() + ".");


### PR DESCRIPTION
**Description**
This PR partially fixes the problem that Nayeon found while verifying https://ucsc-cgl.atlassian.net/browse/DOCK-2004, wherein we changed the Nextflow language handler to fail gracefully when main script was named in the file, but could not be found.  Nayeon noticed that the resulting file validation showed up with the correct message and status, but the corresponding version was still marked as "valid" in the UI.  Good find!

The webservice marks a `Version` as "valid" iff all of the associated non-`.dockstore.yml` validations are true.  Previously, it performed this calculation here:
https://github.com/dockstore/dockstore/blob/2a4d4a00dd9051953ff9aaf0d296fed4f6fac324/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/SourceCodeRepoInterface.java#L817

This invocation occurred prior to some validations being added by the Nextflow language handler's `parseWorkflowContent`.  Thus, they weren't factored into the calculation.

This PR solves the problem by executing the same code later in the `.dockstore.yml` registration process.

Ideally, we would modify all registration paths similarly.  However, it's close to release time, and when inspecting the non-`.dockstore.yml` code paths, I felt like tweaking the other paths was much more risky, and difficult to tell if it would cause problems that might not be immediately apparent.  So, I left the existing invocation as is.  This means that the other registration paths will behave as before, and the webservice will perform a small but likely-negligible amount of extra work on each `.dockstore-yml`-based registration.

In summary, this PR fixes our preferred registration scheme, but the problem will remain for hosted workflows or entries registered with the old scheme, where such entries are of a type that invokes a language handler that adds "late" validations.  Is this an ok tradeoff, given the other considerations?  Please discuss.

**Review Instructions**
Repeat review instructions from https://github.com/dockstore/dockstore/pull/5294

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2004
https://github.com/dockstore/dockstore/issues/4599

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
