### PR TITLE
DOCK-2383: changed User auth to optional

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -1542,7 +1542,6 @@ class GeneralIT extends GeneralWorkflowBaseIT {
      */
     @Test
     void testCheckUser() {
-        // Authorized user should pass
         ApiClient client = getWebClient(USER_2_USERNAME, testingPostgres);
         UsersApi userApi = new UsersApi(client);
         boolean userOneExists = userApi.checkUserExists("DockstoreTestUser2");
@@ -1552,7 +1551,7 @@ class GeneralIT extends GeneralWorkflowBaseIT {
         boolean fakeUserExists = userApi.checkUserExists("NotARealUser");
         assertFalse(fakeUserExists);
 
-        // Unauthorized user should fail
+        // Unauthorized user should still be able to check
         ApiClient unauthClient = CommonTestUtilities.getWebClient(false, "", testingPostgres);
         UsersApi unauthUserApi = new UsersApi(unauthClient);
         boolean failed = false;
@@ -1561,7 +1560,7 @@ class GeneralIT extends GeneralWorkflowBaseIT {
         } catch (ApiException ex) {
             failed = true;
         }
-        assertTrue(failed, "Should throw an exception when not authorized.");
+        assertFalse(failed, "Should not throw an exception when unauthorized.");
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -470,7 +470,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = HttpStatusMessageConstants.BAD_REQUEST)
     @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
     @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
-    public boolean checkUserExists(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,
+    public boolean checkUserExists(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth Optional<User> user,
                                    @ApiParam("User name to check") @PathParam("username") @NotBlank String username) {
         @SuppressWarnings("deprecation")
         User foundUser = userDAO.findByUsername(username);


### PR DESCRIPTION
**Description**
This PR changes the User authentication in the `users/checkUser` endpoint to `Optional`.

Before fix:
![Screenshot from 2023-05-10 13-34-46](https://github.com/dockstore/dockstore/assets/61166764/f4319d64-cabb-4d1c-acf5-d7d000354874)

After fix:
![Screenshot from 2023-05-10 13-45-43](https://github.com/dockstore/dockstore/assets/61166764/87484864-d9fa-4be8-88cc-0410529b34d7)


**Review Instructions**
Log out and go to https://qa.dockstore.org/users/hyunnaye and confirm that the credentials error is not shown.

**Issue**
https://github.com/dockstore/dockstore/issues/5480

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
