### PR TITLE
SEAB-5438: Support old notebooks

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -176,7 +176,7 @@ class NotebookIT extends BaseIT {
     void testRegisterOldNotebook() {
         ApiClient apiClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(apiClient);
-        workflowsApi.handleGitHubRelease("refs/heads/old", installationId, simpleRepo, BasicIT.USER_2_USERNAME);
+        workflowsApi.handleGitHubRelease("refs/tags/old-v1", installationId, simpleRepo, BasicIT.USER_2_USERNAME);
         // Check a few fields to make sure we registered successfully
         String path = simpleRepoPath + "/old";
         Workflow notebook = workflowsApi.getWorkflowByPath(path, WorkflowSubClass.NOTEBOOK, "versions");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/JupyterHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/JupyterHandler.java
@@ -53,6 +53,7 @@ public class JupyterHandler implements LanguageHandlerInterface {
     public static final Set<String> REES_DIRS = Set.of("/", "/binder/", "/.binder/");
 
     private static final String PYTHON = "python";
+    private static final int FOUR = 4;
 
     @Override
     public Version parseWorkflowContent(String filePath, String content, Set<SourceFile> sourceFiles, Version version) {
@@ -94,8 +95,8 @@ public class JupyterHandler implements LanguageHandlerInterface {
         // According to this link, older notebook environments had "no UI to support multiple worksheets":
         // https://github.com/ipython/ipython/wiki/IPEP-17%3a-Notebook-Format-4
         // So, if the major version < 4 and a list of worksheets exists, return the cells from the first one:
-        if (notebook.getFormatMajor() != null && notebook.getFormatMajor() < 4 &&
-            notebook.getWorksheets() != null && notebook.getWorksheets().size() > 0) {
+        if (notebook.getFormatMajor() != null && notebook.getFormatMajor() < FOUR
+            && notebook.getWorksheets() != null && notebook.getWorksheets().size() > 0) {
             return notebook.getWorksheets().get(0).getCells();
         }
         return notebook.getCells();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/JupyterHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/JupyterHandler.java
@@ -89,12 +89,13 @@ public class JupyterHandler implements LanguageHandlerInterface {
     }
 
     private List<Nbformat.Cell> findCells(Nbformat notebook) {
-        // Notebooks with major version 4 have a root level "cells" property.
-        // Older notebooks have a root level "worksheets" property, consisting of a list of worksheets, each of which contains a "cells" field.
+        // Notebooks with major version 4 have a root-level "cells" property.
+        // Older notebooks have a root-level "worksheets" property, consisting of a list of worksheets, each of which contains a "cells" field.
         // According to this link, older notebook environments had "no UI to support multiple worksheets":
         // https://github.com/ipython/ipython/wiki/IPEP-17%3a-Notebook-Format-4
-        // So, if a list of worksheets exists, return the cells from the first one:
-        if (notebook.getWorksheets() != null && notebook.getWorksheets().size() > 0) {
+        // So, if the major version < 4 and a list of worksheets exists, return the cells from the first one:
+        if (notebook.getFormatMajor() != null && notebook.getFormatMajor() < 4 &&
+            notebook.getWorksheets() != null && notebook.getWorksheets().size() > 0) {
             return notebook.getWorksheets().get(0).getCells();
         }
         return notebook.getCells();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/JupyterHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/JupyterHandler.java
@@ -88,7 +88,7 @@ public class JupyterHandler implements LanguageHandlerInterface {
         return notebook;
     }
 
-    private List<Cell> findCells(Nbformat notebook) {
+    private List<Nbformat.Cell> findCells(Nbformat notebook) {
         // Notebooks with major version 4 have a root level "cells" property.
         // Older notebooks have a root level "worksheets" property, consisting of a list of worksheets, each of which contains a "cells" field.
         // According to this link, older notebook environments had "no UI to support multiple worksheets":
@@ -274,7 +274,7 @@ public class JupyterHandler implements LanguageHandlerInterface {
             return cells;
         }
 
-        public List<Cell> getWorksheets() {
+        public List<Worksheet> getWorksheets() {
             return worksheets;
         }
 
@@ -335,8 +335,13 @@ public class JupyterHandler implements LanguageHandlerInterface {
         }
 
         public static class Worksheet {
+
             @SerializedName("cells")
             private List<Cell> cells;
+
+            public List<Cell> getCells() {
+                return cells;
+            }
         }
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/JupyterHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/JupyterHandler.java
@@ -79,13 +79,25 @@ public class JupyterHandler implements LanguageHandlerInterface {
         if (notebook.getMetadata() == null) {
             throw new JsonParseException("Notebook is missing the 'metadata' field");
         }
-        if (notebook.getCells() == null) {
+        if (findCells(notebook) == null) {
             throw new JsonParseException("Notebook is missing the 'cells' field");
         }
         if (notebook.getFormatMajor() == null || notebook.getFormatMinor() == null) {
             throw new JsonParseException("Notebook format fields are missing or malformed");
         }
         return notebook;
+    }
+
+    private List<Cell> findCells(Nbformat notebook) {
+        // Notebooks with major version 4 have a root level "cells" property.
+        // Older notebooks have a root level "worksheets" property, consisting of a list of worksheets, each of which contains a "cells" field.
+        // According to this link, older notebook environments had "no UI to support multiple worksheets":
+        // https://github.com/ipython/ipython/wiki/IPEP-17%3a-Notebook-Format-4
+        // So, if a list of worksheets exists, return the cells from the first one:
+        if (notebook.getWorksheets() != null && notebook.getWorksheets().size() > 0) {
+            return notebook.getWorksheets().get(0).getCells();
+        }
+        return notebook.getCells();
     }
 
     private void processAuthors(Nbformat notebook, Version version) {
@@ -243,6 +255,9 @@ public class JupyterHandler implements LanguageHandlerInterface {
         @SerializedName("cells")
         private List<Cell> cells;
 
+        @SerializedName("worksheets")
+        private List<Worksheet> worksheets;
+
         public Integer getFormatMajor() {
             return formatMajor;
         }
@@ -251,12 +266,16 @@ public class JupyterHandler implements LanguageHandlerInterface {
             return formatMinor;
         }
 
+        public Metadata getMetadata() {
+            return metadata;
+        }
+
         public List<Cell> getCells() {
             return cells;
         }
 
-        public Metadata getMetadata() {
-            return metadata;
+        public List<Cell> getWorksheets() {
+            return worksheets;
         }
 
         public static class Metadata {
@@ -313,6 +332,11 @@ public class JupyterHandler implements LanguageHandlerInterface {
         }
 
         public static class Cell {
+        }
+
+        public static class Worksheet {
+            @SerializedName("cells")
+            private List<Cell> cells;
         }
     }
 }


### PR DESCRIPTION
**Description**
This PR changes the webservice to allow older notebooks (with major format < 4) to be registered.

The primary modification is that, for older notebooks, the notebook processing code looks for the notebook cells in the first worksheet of `worksheets` field.  The `worksheets` field existed in previous versions of the format and was jettisoned for a root-level `cells` field during the format 3->4 transition:
https://github.com/ipython/ipython/wiki/IPEP-17%3a-Notebook-Format-4

**Review Instructions**
Register a Jupyter notebook with major format < 4 and confirm that you were successful.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5438

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
