### PR TITLE
Hardcode region for ToolTester S3Client to us-east-1

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
@@ -210,7 +210,7 @@ public abstract class GA4GHIT {
 
         // Check responses
         Response response = checkedResponse(baseURL
-            + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor/%2Fnested%2Ftest.cwl.json");
+            + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         String responseObject = response.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject);
@@ -219,7 +219,7 @@ public abstract class GA4GHIT {
             .get();
         assertEquals(HttpStatus.SC_NOT_FOUND, response2.getStatus());
         Response response3 = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor/%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor/%2Ftest.cwl.json");
         String responseObject3 = response3.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response3.getStatus());
         assertEquals("potato", responseObject3);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV1IT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV1IT.java
@@ -185,7 +185,7 @@ class GA4GHV1IT extends GA4GHIT {
 
         // Check responses
         Response response = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         ToolTestsV1 responseObject = response.readEntity(ToolTestsV1.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject.getTest());
@@ -193,7 +193,7 @@ class GA4GHV1IT extends GA4GHIT {
             .target(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Ftest.potato.json").request().get();
         assertEquals(HttpStatus.SC_NOT_FOUND, response2.getStatus());
         Response response3 = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
         ToolTestsV1 responseObject3 = response3.readEntity(ToolTestsV1.class);
         assertEquals(HttpStatus.SC_OK, response3.getStatus());
         assertEquals("potato", responseObject3.getTest());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2BetaIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2BetaIT.java
@@ -190,7 +190,7 @@ class GA4GHV2BetaIT extends GA4GHIT {
 
         // Check responses
         Response response = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         FileWrapper responseObject = response.readEntity(io.swagger.client.model.FileWrapper.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject.getContent());
@@ -198,7 +198,7 @@ class GA4GHV2BetaIT extends GA4GHIT {
             .target(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Ftest.potato.json").request().get();
         assertEquals(HttpStatus.SC_NOT_FOUND, response2.getStatus());
         Response response3 = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
         io.swagger.client.model.FileWrapper responseObject3 = response3.readEntity(io.swagger.client.model.FileWrapper.class);
         assertEquals(HttpStatus.SC_OK, response3.getStatus());
         assertEquals("potato", responseObject3.getContent());
@@ -278,12 +278,12 @@ class GA4GHV2BetaIT extends GA4GHIT {
 
         // Check responses
         Response response = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//nested/test.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//nested/test.cwl.json");
         String responseObject = response.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject);
         Response response2 = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//test.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//test.cwl.json");
         String responseObject2 = response2.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response2.getStatus());
         assertEquals("potato", responseObject2);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2CwltoolIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2CwltoolIT.java
@@ -103,7 +103,7 @@ class GA4GHV2CwltoolIT {
         CommonTestUtilities.setupTestWorkflow(SUPPORT);
         String command = "cwl-runner";
         String originalUrl =
-                baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/plain-CWL/descriptor//Dockstore.cwl";
+                baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/plain-CWL/descriptor//Dockstore.cwl";
         String descriptorPath = TestUtility.mimicNginxRewrite(originalUrl, basePath);
         String testParameterFilePath = ResourceHelpers.resourceFilePath("testWorkflow.json");
         ImmutablePair<String, String> stringStringImmutablePair = Utilities

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2FinalIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2FinalIT.java
@@ -224,7 +224,7 @@ class GA4GHV2FinalIT extends GA4GHIT {
 
         // Check responses
         Response response = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         FileWrapper responseObject = response.readEntity(FileWrapper.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject.getContent());
@@ -232,7 +232,7 @@ class GA4GHV2FinalIT extends GA4GHIT {
             .target(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Ftest.potato.json").request().get();
         assertEquals(HttpStatus.SC_NOT_FOUND, response2.getStatus());
         Response response3 = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
         FileWrapper responseObject3 = response3.readEntity(FileWrapper.class);
         assertEquals(HttpStatus.SC_OK, response3.getStatus());
         assertEquals("potato", responseObject3.getContent());
@@ -312,12 +312,12 @@ class GA4GHV2FinalIT extends GA4GHIT {
 
         // Check responses
         Response response = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//nested/test.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//nested/test.cwl.json");
         String responseObject = response.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject);
         Response response2 = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//test.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//test.cwl.json");
         String responseObject2 = response2.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response2.getStatus());
         assertEquals("potato", responseObject2);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/tooltester/ToolTesterS3Client.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/tooltester/ToolTesterS3Client.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
@@ -42,12 +43,14 @@ import software.amazon.awssdk.services.s3.model.S3Object;
  * @since 24/04/19
  */
 public class ToolTesterS3Client {
+    private static final Region TOOLTESTER_BUCKET_REGION = Region.US_EAST_1;
     private final S3Client s3;
     private final String bucketName;
 
     public ToolTesterS3Client(String bucketName) {
         this.bucketName = bucketName;
-        this.s3 = S3ClientHelper.createS3Client();
+        // Purposely hardcoding the region because the ToolTester bucket is always in us-east-1
+        this.s3 = S3ClientHelper.createS3Client(TOOLTESTER_BUCKET_REGION);
     }
 
     public ToolTesterS3Client(String bucketName, S3Client s3Client) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/S3ClientHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/S3ClientHelper.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
@@ -52,10 +53,21 @@ public final class S3ClientHelper {
      * Creates an S3Client. Purposely not specifying a region because the <a href="https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/awscore/client/builder/AwsClientBuilder.html#region(software.amazon.awssdk.regions.Region)">docs</a>
      * say that it will identify according to the listed logic. Since we deploy with Fargate, the AWS_REGION environment variable will automatically be set
      * and the SDK will grab the region from that.
+     * This assumes that the bucket being accessed was created in the same region as the region that webservice is running in.
      * @return
      */
     public static S3Client createS3Client() {
         return initS3ClientBuilder().build();
+    }
+
+    /**
+     * Creates an S3Client with a specific region specified.
+     * Should only use this if the bucket being accessed was created in a different region from the region that the webservice is running in.
+     * @param region
+     * @return
+     */
+    public static S3Client createS3Client(Region region) {
+        return initS3ClientBuilder().region(region).build();
     }
 
     /**

--- a/dockstore-webservice/src/main/resources/migrations.test.testworkflow.xml
+++ b/dockstore-webservice/src/main/resources/migrations.test.testworkflow.xml
@@ -26,7 +26,7 @@
         </insert>
         <insert tableName="sourcefile">
             <column name="id" valueNumeric="33"/>
-            <column name="content" value="cwlVersion: v1.0&#10;class: CommandLineTool&#10;hints:&#10;  - class: DockerRequirement&#10;    dockerPull: java:7&#10;baseCommand: javac&#10;arguments:&#10;  - prefix: &quot;-d&quot;&#10;    valueFrom: $(runtime.outdir)&#10;inputs:&#10;  - id: src&#10;    type: File&#10;    inputBinding:&#10;      position: 1&#10;outputs:&#10;  - id: classfile&#10;    type: File&#10;    outputBinding:&#10;      glob: &quot;*.class&quot;&#10;"/>
+            <column name="content" value="cwlVersion: v1.0&#10;class: CommandLineTool&#10;hints:&#10;  - class: DockerRequirement&#10;    dockerPull: openjdk:17&#10;baseCommand: javac&#10;arguments:&#10;  - prefix: &quot;-d&quot;&#10;    valueFrom: $(runtime.outdir)&#10;inputs:&#10;  - id: src&#10;    type: File&#10;    inputBinding:&#10;      position: 1&#10;outputs:&#10;  - id: classfile&#10;    type: File&#10;    outputBinding:&#10;      glob: &quot;*.class&quot;&#10;"/>
             <column name="path" value="cwl/arguments.cwl"/>
             <column name="type" value="DOCKSTORE_CWL"/>
         </insert>
@@ -78,7 +78,7 @@
             <column name="defaultversion"/>
             <column name="description"/>
             <column name="email"/>
-            <column name="giturl" value="git@github.com:garyluu/testWorkflow.git"/>
+            <column name="giturl" value="git@github.com:dockstore-testing/testWorkflow.git"/>
             <column name="ispublished" valueBoolean="true"/>
             <column name="lastmodified"/>
             <column name="lastupdated" valueDate="2018-02-13 10:42:52.608"/>
@@ -86,7 +86,7 @@
             <column name="defaultworkflowpath" value="/Dockstore.cwl"/>
             <column name="descriptortype" value="cwl"/>
             <column name="mode" value="FULL"/>
-            <column name="organization" value="garyluu"/>
+            <column name="organization" value="dockstore-testing"/>
             <column name="repository" value="testWorkflow"/>
             <column name="sourcecontrol" value="github.com"/>
             <column name="workflowname"/>


### PR DESCRIPTION
**Description**
This PR hard codes the region of the S3Client used for the ToolTester bucket to us-east-1 because that bucket is always in us-east-1. Read this [comment](https://ucsc-cgl.atlassian.net/browse/DOCK-1859?focusedCommentId=45160) for more info about the error. TLDR: the tooltester bucket is always in us-east-1, but the S3Client created uses the region that the webservice container is running in. For staging, it's us-west-2, and the mismatch in regions between the bucket and S3Client causes an error when retrieving the ToolTester logs.

**Review Instructions**
Follow instructions in https://github.com/dockstore/dockstore/pull/5431

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-1859
#4359 

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
