### PR TITLE
Don't index private GitHub workflows

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
@@ -210,7 +210,7 @@ public abstract class GA4GHIT {
 
         // Check responses
         Response response = checkedResponse(baseURL
-            + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor/%2Fnested%2Ftest.cwl.json");
+            + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         String responseObject = response.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject);
@@ -219,7 +219,7 @@ public abstract class GA4GHIT {
             .get();
         assertEquals(HttpStatus.SC_NOT_FOUND, response2.getStatus());
         Response response3 = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor/%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor/%2Ftest.cwl.json");
         String responseObject3 = response3.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response3.getStatus());
         assertEquals("potato", responseObject3);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV1IT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV1IT.java
@@ -185,7 +185,7 @@ class GA4GHV1IT extends GA4GHIT {
 
         // Check responses
         Response response = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         ToolTestsV1 responseObject = response.readEntity(ToolTestsV1.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject.getTest());
@@ -193,7 +193,7 @@ class GA4GHV1IT extends GA4GHIT {
             .target(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Ftest.potato.json").request().get();
         assertEquals(HttpStatus.SC_NOT_FOUND, response2.getStatus());
         Response response3 = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
         ToolTestsV1 responseObject3 = response3.readEntity(ToolTestsV1.class);
         assertEquals(HttpStatus.SC_OK, response3.getStatus());
         assertEquals("potato", responseObject3.getTest());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2BetaIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2BetaIT.java
@@ -190,7 +190,7 @@ class GA4GHV2BetaIT extends GA4GHIT {
 
         // Check responses
         Response response = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         FileWrapper responseObject = response.readEntity(io.swagger.client.model.FileWrapper.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject.getContent());
@@ -198,7 +198,7 @@ class GA4GHV2BetaIT extends GA4GHIT {
             .target(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Ftest.potato.json").request().get();
         assertEquals(HttpStatus.SC_NOT_FOUND, response2.getStatus());
         Response response3 = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
         io.swagger.client.model.FileWrapper responseObject3 = response3.readEntity(io.swagger.client.model.FileWrapper.class);
         assertEquals(HttpStatus.SC_OK, response3.getStatus());
         assertEquals("potato", responseObject3.getContent());
@@ -278,12 +278,12 @@ class GA4GHV2BetaIT extends GA4GHIT {
 
         // Check responses
         Response response = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//nested/test.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//nested/test.cwl.json");
         String responseObject = response.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject);
         Response response2 = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//test.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//test.cwl.json");
         String responseObject2 = response2.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response2.getStatus());
         assertEquals("potato", responseObject2);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2CwltoolIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2CwltoolIT.java
@@ -103,7 +103,7 @@ class GA4GHV2CwltoolIT {
         CommonTestUtilities.setupTestWorkflow(SUPPORT);
         String command = "cwl-runner";
         String originalUrl =
-                baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/plain-CWL/descriptor//Dockstore.cwl";
+                baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/plain-CWL/descriptor//Dockstore.cwl";
         String descriptorPath = TestUtility.mimicNginxRewrite(originalUrl, basePath);
         String testParameterFilePath = ResourceHelpers.resourceFilePath("testWorkflow.json");
         ImmutablePair<String, String> stringStringImmutablePair = Utilities

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2FinalIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2FinalIT.java
@@ -224,7 +224,7 @@ class GA4GHV2FinalIT extends GA4GHIT {
 
         // Check responses
         Response response = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/CWL/descriptor/%2Fnested%2Ftest.cwl.json");
         FileWrapper responseObject = response.readEntity(FileWrapper.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject.getContent());
@@ -232,7 +232,7 @@ class GA4GHV2FinalIT extends GA4GHIT {
             .target(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/WDL/descriptor/%2Ftest.potato.json").request().get();
         assertEquals(HttpStatus.SC_NOT_FOUND, response2.getStatus());
         Response response3 = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/CWL/descriptor/%2Ftest.cwl.json");
         FileWrapper responseObject3 = response3.readEntity(FileWrapper.class);
         assertEquals(HttpStatus.SC_OK, response3.getStatus());
         assertEquals("potato", responseObject3.getContent());
@@ -312,12 +312,12 @@ class GA4GHV2FinalIT extends GA4GHIT {
 
         // Check responses
         Response response = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//nested/test.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//nested/test.cwl.json");
         String responseObject = response.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         assertEquals("nestedPotato", responseObject);
         Response response2 = checkedResponse(
-            baseURL + "tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//test.cwl.json");
+            baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/PLAIN_CWL/descriptor//test.cwl.json");
         String responseObject2 = response2.readEntity(String.class);
         assertEquals(HttpStatus.SC_OK, response2.getStatus());
         assertEquals("potato", responseObject2);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -55,6 +55,7 @@ class WebhookIT extends BaseIT {
     private final String taggedToolRepo = "dockstore-testing/tagged-apptool";
     private final String taggedToolRepoPath = "dockstore-testing/tagged-apptool/md5sum";
     private final String workflowDockstoreYmlRepo = "dockstore-testing/workflow-dockstore-yml";
+    private final String privateRepo = "dockstore-testing/secret-workflow";
 
     @BeforeEach
     public void cleanDB() {
@@ -221,4 +222,17 @@ class WebhookIT extends BaseIT {
         assertTrue(foobar.getWorkflowVersions().stream().allMatch(v -> "/README2.md".equals(v.getReadMePath()) && v.getDescription().contains("an 'X' in it")));
         assertTrue(foobar2.getWorkflowVersions().stream().allMatch(v -> "/docs/README.md".equals(v.getReadMePath()) && v.getDescription().contains("a '🙃' in it")));
     }
+
+    // TODO: Add private repo to dockstore-testing, then enable this test
+    //    @Test
+    //    void testPrivateRepos() {
+    //        final ApiClient webClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
+    //        WorkflowsApi workflowClient = new WorkflowsApi(webClient);
+    //        try {
+    //            workflowClient.handleGitHubRelease("refs/tags/1.0", installationId, privateRepo, BasicIT.USER_2_USERNAME);
+    //            fail("Should not be able to handle a private repo");
+    //        } catch (ApiException e) {
+    //            assertTrue(e.getMessage().contains(GitHubSourceCodeRepo.DO_NOT_PROCESS_PRIVATE_GITHUB_REPOS));
+    //        }
+    //    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -231,6 +231,20 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         }
     }
 
+    public void checkRepoNotPrivate(String repositoryId) {
+        GHRepository repository;
+        try {
+            repository = github.getRepository(repositoryId);
+        } catch (IOException e) {
+            final String msg = "Error determining if repo %s is private".formatted(repositoryId);
+            LOG.error(msg, e);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        }
+        if (repository.isPrivate()) {
+            throw new CustomWebApplicationException("Dockstore does not process private GitHub repositories", HttpStatus.SC_BAD_REQUEST);
+        }
+    }
+
     private String readFileFromRepo(String fileName, String reference, GHRepository repo) {
         GHRateLimit startRateLimit = null;
         try {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -125,6 +125,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
      * each section that starts with (?!.* is excluding a specific character
      */
     public static final Pattern GIT_BRANCH_TAG_PATTERN = Pattern.compile("^refs/(tags|heads)/((?!.*//)(?!.*\\^)(?!.*:)(?!.*\\\\)(?!.*@)(?!.*\\[)(?!.*\\?)(?!.*~)(?!.*\\.\\.)[\\p{Punct}\\p{L}\\d\\-_/]+)$");
+    public static final String DO_NOT_PROCESS_PRIVATE_GITHUB_REPOS = "Dockstore does not process private GitHub repositories";
     private static final Logger LOG = LoggerFactory.getLogger(GitHubSourceCodeRepo.class);
     private final GitHub github;
     private final String githubTokenUsername;
@@ -241,7 +242,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             throw new CustomWebApplicationException(msg, HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
         if (repository.isPrivate()) {
-            throw new CustomWebApplicationException("Dockstore does not process private GitHub repositories", HttpStatus.SC_BAD_REQUEST);
+            throw new CustomWebApplicationException(DO_NOT_PROCESS_PRIVATE_GITHUB_REPOS, HttpStatus.SC_BAD_REQUEST);
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -375,6 +375,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         PrintWriter messageWriter = new PrintWriter(stringWriter);
 
         try {
+            gitHubSourceCodeRepo.checkRepoNotPrivate(repository);
             SourceFile dockstoreYml = gitHubSourceCodeRepo.getDockstoreYml(repository, gitReference);
             // If this method doesn't throw an exception, it's a valid .dockstore.yml with at least one workflow or service.
             // It also converts a .dockstore.yml 1.1 file to a 1.2 object, if necessary.

--- a/dockstore-webservice/src/main/resources/migrations.test.testworkflow.xml
+++ b/dockstore-webservice/src/main/resources/migrations.test.testworkflow.xml
@@ -26,7 +26,7 @@
         </insert>
         <insert tableName="sourcefile">
             <column name="id" valueNumeric="33"/>
-            <column name="content" value="cwlVersion: v1.0&#10;class: CommandLineTool&#10;hints:&#10;  - class: DockerRequirement&#10;    dockerPull: java:7&#10;baseCommand: javac&#10;arguments:&#10;  - prefix: &quot;-d&quot;&#10;    valueFrom: $(runtime.outdir)&#10;inputs:&#10;  - id: src&#10;    type: File&#10;    inputBinding:&#10;      position: 1&#10;outputs:&#10;  - id: classfile&#10;    type: File&#10;    outputBinding:&#10;      glob: &quot;*.class&quot;&#10;"/>
+            <column name="content" value="cwlVersion: v1.0&#10;class: CommandLineTool&#10;hints:&#10;  - class: DockerRequirement&#10;    dockerPull: openjdk:17&#10;baseCommand: javac&#10;arguments:&#10;  - prefix: &quot;-d&quot;&#10;    valueFrom: $(runtime.outdir)&#10;inputs:&#10;  - id: src&#10;    type: File&#10;    inputBinding:&#10;      position: 1&#10;outputs:&#10;  - id: classfile&#10;    type: File&#10;    outputBinding:&#10;      glob: &quot;*.class&quot;&#10;"/>
             <column name="path" value="cwl/arguments.cwl"/>
             <column name="type" value="DOCKSTORE_CWL"/>
         </insert>
@@ -78,7 +78,7 @@
             <column name="defaultversion"/>
             <column name="description"/>
             <column name="email"/>
-            <column name="giturl" value="git@github.com:garyluu/testWorkflow.git"/>
+            <column name="giturl" value="git@github.com:dockstore-testing/testWorkflow.git"/>
             <column name="ispublished" valueBoolean="true"/>
             <column name="lastmodified"/>
             <column name="lastupdated" valueDate="2018-02-13 10:42:52.608"/>
@@ -86,7 +86,7 @@
             <column name="defaultworkflowpath" value="/Dockstore.cwl"/>
             <column name="descriptortype" value="cwl"/>
             <column name="mode" value="FULL"/>
-            <column name="organization" value="garyluu"/>
+            <column name="organization" value="dockstore-testing"/>
             <column name="repository" value="testWorkflow"/>
             <column name="sourcecontrol" value="github.com"/>
             <column name="workflowname"/>


### PR DESCRIPTION
**Description**
Made this a draft for now because there are no tests. They seem slightly tricky to implement with the GitHub app being involved, so I wanted to verify this approach before going down that road.

Please read detailed description [here](https://ucsc-cgl.atlassian.net/browse/SEAB-5038?focusedCommentId=45169).

**Review Instructions**
1. Create a private repo in GitHub
2. Enable the GitHub app for the repo/org in Dockstore
3. Commit and push a .dockstore.yml/workflow file to the private repo
4. Check that a corresponding workflow does not get created in Dockstore. There should also be a message in the GitHub App Logs in the UI, saying the private repos are not supported.

**Issue**
SEAB-5038

**Security**
@david4096 Please see SEAB-5038 ticket.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ ] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
