### PR TITLE
Test 1.13 CLI with 1.14 webservice

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,7 +493,7 @@ commands:
           name: install pip
           command: |
             sudo apt update
-            sudo apt install python3-distutils python3-dev python3-pip libxml2-dev libxslt-dev
+            sudo apt install python3-distutils python3-dev python3-pip
             # For debug purposes, a python3 version was installed in the image, pip is untagged
             python3 --version
             pip3 --version

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -82,7 +82,7 @@ import org.slf4j.LoggerFactory;
 public final class CommonTestUtilities {
 
     private static final Logger LOG = LoggerFactory.getLogger(CommonTestUtilities.class);
-    public static final String OLD_DOCKSTORE_VERSION = "1.12.0";
+    public static final String OLD_DOCKSTORE_VERSION = "1.13.0";
     public static final List<String> COMMON_MIGRATIONS = List.of("1.3.0.generated", "1.3.1.consistency", "1.4.0", "1.5.0", "1.6.0", "1.7.0",
             "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0", "1.14.0");
     // Travis is slow, need to wait up to 1 min for webservice to return

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -11,7 +11,7 @@ if [ "${TESTING_PROFILE}" = "unit-tests" ] || [ "${TESTING_PROFILE}" == "automat
 fi
 
 if [ "${TESTING_PROFILE}" = "regression-integration-tests" ]; then
-    pip3 install -r dockstore-webservice/src/main/resources/requirements/1.13.0/requirements3.txt
+    pip3 install -r dockstore-webservice/src/main/resources/requirements/1.14.0/requirements3.txt
 elif [ "${TESTING_PROFILE}" == "language-parsing-tests" ]; then
     pip3 install -r dockstore-webservice/src/main/resources/requirements/1.14.0/requirements3.txt
 else

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -11,7 +11,7 @@ if [ "${TESTING_PROFILE}" = "unit-tests" ] || [ "${TESTING_PROFILE}" == "automat
 fi
 
 if [ "${TESTING_PROFILE}" = "regression-integration-tests" ]; then
-    pip3 install -r dockstore-webservice/src/main/resources/requirements/1.14.0/requirements3.txt
+    pip3 install -r dockstore-webservice/src/main/resources/requirements/1.13.0/requirements3.txt
 elif [ "${TESTING_PROFILE}" == "language-parsing-tests" ]; then
     pip3 install -r dockstore-webservice/src/main/resources/requirements/1.14.0/requirements3.txt
 else

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -11,9 +11,9 @@ if [ "${TESTING_PROFILE}" = "unit-tests" ] || [ "${TESTING_PROFILE}" == "automat
 fi
 
 if [ "${TESTING_PROFILE}" = "regression-integration-tests" ]; then
-    pip3 install -r dockstore-webservice/src/main/resources/requirements/1.10.0/requirements3.txt
-elif [ "${TESTING_PROFILE}" == "language-parsing-tests" ]; then
     pip3 install -r dockstore-webservice/src/main/resources/requirements/1.13.0/requirements3.txt
+elif [ "${TESTING_PROFILE}" == "language-parsing-tests" ]; then
+    pip3 install -r dockstore-webservice/src/main/resources/requirements/1.14.0/requirements3.txt
 else
-    pip3 install --user -r dockstore-webservice/src/main/resources/requirements/1.13.0/requirements3.txt
+    pip3 install --user -r dockstore-webservice/src/main/resources/requirements/1.14.0/requirements3.txt
 fi


### PR DESCRIPTION
**Description**
This PR bumps the `OLD_DOCKSTORE_VERSION` to 1.13.0 in order to test the 1.13 CLI with the 1.14 webservice. The branch name starts with `release` to trigger the regression tests and [they all passed](https://app.circleci.com/pipelines/github/dockstore/dockstore/9885/workflows/5f508f9a-9ba0-444e-87d7-1f44c56fa101/jobs/33411).

The ticket description also mentioned to check that [cwltool still works with the new version of the TRS API](https://github.com/dockstore/dockstore/pull/5246#pullrequestreview-1190938842) since the parameter order changed in Java. Confirmed that this is covered by the regression tests: https://github.com/dockstore/dockstore/blob/631094574f361e3dd75b17e6abf9f04ae8d17ef6/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2CwltoolIT.java#L95
- I also ran cwltool with this [example](https://github.com/common-workflow-language/cwltool#use-with-ga4gh-tool-registry-api) except I substituted the first argument with the TRS URL from staging and it was successful. The command was: 
  ```
  cwltool https://staging.dockstore.org/api/api/ga4gh/v2/tools/quay.io%2Fcollaboratory%2Fdockstore-tool-bamstats/versions/latest/plain-CWL/descriptor/Dockstore.cwl test.json
  ```

**Review Instructions**
The regression-integration-tests job on CircleCI for the [release branch](https://app.circleci.com/pipelines/github/dockstore/dockstore?branch=release%2F1.14) should pass.

**Issue**
[SEAB-5039](https://ucsc-cgl.atlassian.net/browse/SEAB-5039)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-5039]: https://ucsc-cgl.atlassian.net/browse/SEAB-5039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ