### PR TITLE
SEAB-5437: added notebook to getUserEntries endpoint

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntrySearchType.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntrySearchType.java
@@ -21,5 +21,6 @@ public enum EntrySearchType {
      */
     TOOLS,
     WORKFLOWS,
-    SERVICES
+    SERVICES,
+    NOTEBOOKS
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -820,6 +820,9 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
         if (type == null || type == EntrySearchType.SERVICES) {
             entriesLite.addAll(serviceDAO.findEntryVersions(userId));
         }
+        if (type == null || type == EntrySearchType.NOTEBOOKS) {
+            entriesLite.addAll(notebookDAO.findEntryVersions(userId));
+        }
 
         //cleanup fields for UI: filter(if applicable), sort, and limit by count(if applicable)
         List<EntryUpdateTime> filteredEntries = entriesLite

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -5370,6 +5370,7 @@ paths:
           - TOOLS
           - WORKFLOWS
           - SERVICES
+          - NOTEBOOKS
       responses:
         "200":
           content:


### PR DESCRIPTION
**Description**
This PR adds `NOTEBOOKS` to `EntrySearchType` such that it can be included in the `getUserEntries` endpoint.

**Review Instructions**
Review that notebooks are correctly added to the endpoint.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5437

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
