### PR TITLE
Fix failing metrics test from 1.14 merge

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -492,22 +492,6 @@ public abstract class Version<T extends Version> implements Comparable<T> {
         this.authors.add(author);
     }
 
-    /**
-     * Sets the versions authors using authors from the descriptor.
-     * @param newAuthors
-     */
-    @JsonIgnore
-    public void setAuthorsFromDescriptor(Set<Author> newAuthors) {
-        // If it's a .dockstore.yml workflow, clear authors because it may be from the .dockstore.yml
-        if (this.parent instanceof Workflow workflow && workflow.getMode() == WorkflowMode.DOCKSTORE_YML) {
-            this.getOrcidAuthors().clear();
-            this.setAuthors(newAuthors);
-        } else {
-            // Don't need to worry about existing authors if it's not a .dockstore.yml because the authors are always from the descriptor
-            this.authors.addAll(newAuthors);
-        }
-    }
-
     public void setAuthors(final Set<Author> authors) {
         this.authors.clear();
         if (authors != null) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/Metrics.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/Metrics.java
@@ -162,6 +162,7 @@ public class Metrics {
         return additionalAggregatedMetrics;
     }
 
+    @JsonProperty
     public void setAdditionalAggregatedMetrics(Map<String, Object> additionalAggregatedMetrics) {
         this.additionalAggregatedMetrics = additionalAggregatedMetrics;
     }


### PR DESCRIPTION
**Description**
This PR fixes the [failing test](https://app.circleci.com/pipelines/github/dockstore/dockstore/9912/workflows/6645ef57-f01a-4d65-8b0e-36d3dbd95081/jobs/33629/tests#failed-test-0) from merging the 1.14 tag into the develop branch.

Summary of issue:
- The `additionalAggregatedMetrics` field is only meant to be deserialized because the field is transient and not stored in the DB so the value is always null when using the GET endpoint to get aggregated metrics. The deserialization allows users to submit additional aggregated metrics not defined by our schema which is then stored as a JSON string in S3.
- For some reason, the existing jackson annotations don't deserialize the `additionalAggregatedMetrics` field for the `Metrics` object, causing the test failure.
  - The test submits an additional aggregated metric using the `additionalAggregatedMetrics` field and confirms that the file content in S3 contains the metric. Since deserialization of the field didn't work, `null` was the value for `additionalAggregatedMetrics` in S3, so when the test tried to retrieve the additional metric, it ran into a NPE.

Adding `@JsonProperty` to the setter fixed the problem.

Misc change:
- I saw that there was an unused function that I added in an authors PR I did a while back, so I removed it

**Review Instructions**
Builds should pass in the develop branch

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
