### PR TITLE
DOCK-2374: Switch to new codecov uploader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,10 @@ jobs:
           path: ~/junit
       - run:
           name: send coverage for unit tests
-          command: bash <(curl -s https://codecov.io/bash) -F unit-tests_and_non-confidential-tests || echo "Codecov did not collect coverage reports"
+          command: |
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            chmod +x codecov
+            ./codecov -F unit-tests_and_non-confidential-tests
       - run:
           name: run the non-confidential integration tests
           command: |
@@ -356,7 +359,10 @@ jobs:
             # The piping grep command is a temporary fix to this issue https://github.com/liquibase/liquibase/issues/2396
       - run:
           name: send coverage for non-confidential integration tests
-          command: bash <(curl -s https://codecov.io/bash) -F unit-tests_and_non-confidential-tests || echo "Codecov did not collect coverage reports"
+          command: |
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            chmod +x codecov
+            ./codecov -F unit-tests_and_non-confidential-tests
       - run:
           name: check that JPA classes are consistent with migrations
           command: |
@@ -585,7 +591,10 @@ commands:
           # The piping grep command is a temporary fix to this issue https://github.com/liquibase/liquibase/issues/2396
       - run:
           name: send coverage
-          command: bash <(curl -s https://codecov.io/bash) -F ${TESTING_PROFILE//-} || echo "Codecov did not collect coverage reports"
+          command: |
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            chmod +x codecov
+            ./codecov -F ${TESTING_PROFILE//-}
       - persist_coverage
 
   save_test_results:


### PR DESCRIPTION
**Description**
Switched to new Codecov Uploader from Bash Uploader since the latter will eventually be deprecated.

**Review Instructions**
Looking at the tests in CircleCI, the steps for "send coverage," "send coverage for unit tests," and "send coverage for non-confidential integration tests," should succeed and a result url should be available.

**Issue**
[DOCK-2374](https://ucsc-cgl.atlassian.net/browse/DOCK-2374)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ ] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
