### PR TITLE
test out potentially temporary fix for es indexing issue

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
@@ -106,7 +106,7 @@ import uk.org.webcompere.systemstubs.stream.SystemOut;
 @Tag(LocalStackTest.NAME)
 class ExtendedMetricsTRSOpenApiIT extends BaseIT {
 
-    private static final String DOCKSTORE_WORKFLOW_CNV_REPO = "DockstoreTestUser2/dockstore_workflow_cnv";
+    public static final String DOCKSTORE_WORKFLOW_CNV_REPO = "DockstoreTestUser2/dockstore_workflow_cnv";
     private static final String DOCKSTORE_WORKFLOW_CNV_PATH = SourceControl.GITHUB + "/" + DOCKSTORE_WORKFLOW_CNV_REPO;
     private static final Gson GSON = new Gson();
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
@@ -109,6 +109,8 @@ class ExtendedTRSApiIT extends BaseIT {
         workflowCount += testingPostgres.runSelectStatement("select count(*) from tool where checkerid = " + checkerWorkflow.getId(), long.class);
         assertEquals(2, workflowCount);
 
+        checkerWorkflow = workflowsApi.getWorkflow(checkerWorkflow.getId(), "");
+        assertEquals(2, checkerWorkflow.getParentEntries().size());
 
         ExtendedGa4GhApi api = new ExtendedGa4GhApi(webClient);
         // test json results

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSIT.java
@@ -1,0 +1,114 @@
+/*
+ *    Copyright 2018 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.dockstore.client.cli;
+
+import static io.dockstore.client.cli.ExtendedMetricsTRSOpenApiIT.DOCKSTORE_WORKFLOW_CNV_REPO;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.dockstore.client.cli.BaseIT.TestStatus;
+import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.ConfidentialTest;
+import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.common.MuteForSuccessfulTests;
+import io.dockstore.common.Registry;
+import io.dockstore.common.SourceControl;
+import io.dockstore.openapi.client.ApiClient;
+import io.dockstore.openapi.client.api.ContainersApi;
+import io.dockstore.openapi.client.api.ExtendedGa4GhApi;
+import io.dockstore.openapi.client.api.WorkflowsApi;
+import io.dockstore.openapi.client.model.DockstoreTool;
+import io.dockstore.openapi.client.model.Workflow;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.stream.SystemErr;
+import uk.org.webcompere.systemstubs.stream.SystemOut;
+
+/**
+ * Extra confidential integration tests, focuses on proposed GA4GH extensions
+ * {@link BaseIT}
+ *
+ */
+@ExtendWith(SystemStubsExtension.class)
+@ExtendWith(MuteForSuccessfulTests.class)
+@ExtendWith(TestStatus.class)
+@Tag(ConfidentialTest.NAME)
+class ExtendedTRSIT extends BaseIT {
+
+    @SystemStub
+    public final SystemOut systemOut = new SystemOut();
+    @SystemStub
+    public final SystemErr systemErr = new SystemErr();
+
+    @BeforeEach
+    @Override
+    public void resetDBBetweenTests() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
+    }
+
+    @Test
+    void testSimpleIndex() {
+        final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        final WorkflowsApi workflowsApi = new WorkflowsApi(webClient);
+        final ContainersApi containersApi = new ContainersApi(webClient);
+
+        Workflow workflow = workflowsApi.manualRegister(SourceControl.GITHUB.name(), DOCKSTORE_WORKFLOW_CNV_REPO, "/workflow/cnv.cwl", "my-workflow", "cwl",
+            "/test.json");
+        workflow = workflowsApi.refresh1(workflow.getId(), false);
+        workflowsApi.publish1(workflow.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
+
+        Workflow checkerWorkflow = workflowsApi.manualRegister(SourceControl.GITHUB.name(), "DockstoreTestUser2/hello-dockstore-workflow", "/Dockstore.cwl", "cwlworkflow",
+            DescriptorLanguage.CWL.getShortName(), "");
+        checkerWorkflow = workflowsApi.refresh1(checkerWorkflow.getId(), true);
+        workflowsApi.publish1(checkerWorkflow.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
+
+        // Manually register a tool
+        DockstoreTool newTool = new DockstoreTool();
+        newTool.setMode(DockstoreTool.ModeEnum.MANUAL_IMAGE_PATH);
+        newTool.setName("my-md5sum");
+        newTool.setGitUrl("git@github.com:DockstoreTestUser2/md5sum-checker.git");
+        newTool.setDefaultDockerfilePath("/md5sum/Dockerfile");
+        newTool.setDefaultCwlPath("/md5sum/md5sum-tool.cwl");
+        newTool.setRegistryString(Registry.QUAY_IO.getDockerPath());
+        newTool.setNamespace("dockstoretestuser2");
+        newTool.setToolname("altname");
+        newTool.setPrivateAccess(false);
+        newTool.setDefaultCWLTestParameterFile("/testcwl.json");
+        DockstoreTool githubTool = containersApi.registerManual(newTool);
+
+        // Refresh the workflow
+        DockstoreTool refresh = containersApi.refresh(githubTool.getId());
+        containersApi.publish(refresh.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
+
+        // add a checker workflow to two workflows
+        testingPostgres.runUpdateStatement("update workflow set checkerid = '" + checkerWorkflow.getId() + "' where id = '" + workflow.getId() + "'");
+        testingPostgres.runUpdateStatement("update tool set checkerid = '" + checkerWorkflow.getId() + "' where id = '" + refresh.getId() + "'");
+        long workflowCount = testingPostgres.runSelectStatement("select count(*) from workflow where checkerid = " + checkerWorkflow.getId(), long.class);
+        workflowCount += testingPostgres.runSelectStatement("select count(*) from tool where checkerid = " + checkerWorkflow.getId(), long.class);
+        assertEquals(2, workflowCount);
+
+
+        ExtendedGa4GhApi api = new ExtendedGa4GhApi(webClient);
+        final Integer integer = api.updateTheWorkflowsAndToolsIndices();
+        assertTrue(integer > 0);
+    }
+
+}

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SearchResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SearchResourceIT.java
@@ -16,7 +16,6 @@
 package io.dockstore.webservice;
 
 import static io.dockstore.common.CommonTestUtilities.restartElasticsearch;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -26,15 +25,15 @@ import io.dockstore.client.cli.BaseIT.TestStatus;
 import io.dockstore.client.cli.WorkflowIT;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.MuteForSuccessfulTests;
+import io.dockstore.openapi.client.ApiClient;
+import io.dockstore.openapi.client.ApiException;
+import io.dockstore.openapi.client.api.EntriesApi;
+import io.dockstore.openapi.client.api.ExtendedGa4GhApi;
+import io.dockstore.openapi.client.api.MetadataApi;
+import io.dockstore.openapi.client.api.WorkflowsApi;
+import io.dockstore.openapi.client.model.Workflow;
+import io.dockstore.openapi.client.model.WorkflowSubClass;
 import io.dockstore.webservice.helpers.AppToolHelper;
-import io.swagger.client.ApiClient;
-import io.swagger.client.ApiException;
-import io.swagger.client.ApiResponse;
-import io.swagger.client.api.EntriesApi;
-import io.swagger.client.api.ExtendedGa4GhApi;
-import io.swagger.client.api.MetadataApi;
-import io.swagger.client.api.WorkflowsApi;
-import io.swagger.client.model.Workflow;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -83,7 +82,7 @@ class SearchResourceIT extends BaseIT {
                 if (counter > 5) {
                     fail(s + " does not have the correct amount of hits");
                 } else {
-                    long sleepTime = 1000 * counter;
+                    long sleepTime = 1000L * counter;
                     Thread.sleep(sleepTime);
                     waitForIndexRefresh(hit, extendedGa4GhApi, counter + 1, esQuery);
                 }
@@ -93,30 +92,28 @@ class SearchResourceIT extends BaseIT {
         }
     }
 
-    private void waitForIndexRefresh(int hit, ExtendedGa4GhApi extendedGa4GhApi, int counter) {
-        waitForIndexRefresh(hit, extendedGa4GhApi, counter, exampleESQuery);
+    private void waitForIndexRefresh(int hit, ExtendedGa4GhApi extendedGa4GhApi) {
+        waitForIndexRefresh(hit, extendedGa4GhApi, 0, exampleESQuery);
     }
 
     @Test
     void testSearchOperations() throws ApiException {
-        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         ExtendedGa4GhApi extendedGa4GhApi = new ExtendedGa4GhApi(webClient);
         EntriesApi entriesApi = new EntriesApi(webClient);
         // update the search index
-        ApiResponse<Void> voidApiResponse = extendedGa4GhApi.toolsIndexGetWithHttpInfo();
-        int statusCode = voidApiResponse.getStatusCode();
-        assertEquals(200, statusCode);
-        waitForIndexRefresh(0, extendedGa4GhApi, 0);
+        extendedGa4GhApi.updateTheWorkflowsAndToolsIndices();
+        waitForIndexRefresh(0, extendedGa4GhApi);
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
         workflowApi.manualRegister("github", "DockstoreTestUser2/dockstore_workflow_cnv", "/workflow/cnv.cwl", "", "cwl", "/test.json");
         final Workflow workflowByPathGithub = workflowApi
-            .getWorkflowByPath(WorkflowIT.DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, BIOWORKFLOW, null);
+            .getWorkflowByPath(WorkflowIT.DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, WorkflowSubClass.BIOWORKFLOW, null);
         // do targeted refresh, should promote workflow to fully-fleshed out workflow
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
-        entriesApi.addAliases(workflow.getId(), "potatoAlias");
-        workflowApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(false));
-        workflowApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
-        waitForIndexRefresh(1, extendedGa4GhApi,  0);
+        final Workflow workflow = workflowApi.refresh1(workflowByPathGithub.getId(), false);
+        entriesApi.addAliases1(workflow.getId(), "potatoAlias");
+        workflowApi.publish1(workflow.getId(), CommonTestUtilities.createOpenAPIPublishRequest(false));
+        workflowApi.publish1(workflow.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
+        waitForIndexRefresh(1, extendedGa4GhApi);
         // after publication index should include workflow
         String s = extendedGa4GhApi.toolsIndexSearch(exampleESQuery);
         assertTrue(s.contains("\"aliases\":{\"potatoAlias\":{}}"), s + " should've contained potatoAlias");
@@ -129,11 +126,11 @@ class SearchResourceIT extends BaseIT {
     }
 
     @Test
-    void testNotebook() throws ApiException {
+    void testNotebook() {
         // register a simple published notebook
-        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
-        workflowApi.handleGitHubRelease("dockstore-testing/simple-notebook", USER_2_USERNAME, "refs/tags/simple-published-v1", AppToolHelper.INSTALLATION_ID);
+        workflowApi.handleGitHubRelease("refs/tags/simple-published-v1", AppToolHelper.INSTALLATION_ID, "dockstore-testing/simple-notebook", USER_2_USERNAME);
 
         // wait until the notebook is indexed
         ExtendedGa4GhApi extendedGa4GhApi = new ExtendedGa4GhApi(webClient);
@@ -158,7 +155,7 @@ class SearchResourceIT extends BaseIT {
      */
     @Test
     void testElasticSearchHealthCheck() {
-        final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
+        final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         ExtendedGa4GhApi extendedGa4GhApi = new ExtendedGa4GhApi(webClient);
         MetadataApi metadataApi = new MetadataApi(webClient);
 
@@ -170,8 +167,8 @@ class SearchResourceIT extends BaseIT {
         }
 
         // Update the search index
-        extendedGa4GhApi.toolsIndexGet();
-        waitForIndexRefresh(0, extendedGa4GhApi,  0);
+        extendedGa4GhApi.updateTheWorkflowsAndToolsIndices();
+        waitForIndexRefresh(0, extendedGa4GhApi);
         try {
             metadataApi.checkElasticSearch();
             fail("Should fail even with index because there's no hits");
@@ -183,13 +180,13 @@ class SearchResourceIT extends BaseIT {
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
         workflowApi.manualRegister("github", "DockstoreTestUser2/dockstore_workflow_cnv", "/workflow/cnv.cwl", "", "cwl", "/test.json");
         final Workflow workflowByPathGithub = workflowApi
-            .getWorkflowByPath(WorkflowIT.DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, BIOWORKFLOW, null);
+            .getWorkflowByPath(WorkflowIT.DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, WorkflowSubClass.BIOWORKFLOW, null);
         // do targeted refresh, should promote workflow to fully-fleshed out workflow
-        final Workflow workflow = workflowApi.refresh(workflowByPathGithub.getId(), false);
+        final Workflow workflow = workflowApi.refresh1(workflowByPathGithub.getId(), false);
 
-        workflowApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
+        workflowApi.publish1(workflow.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
 
-        waitForIndexRefresh(1, extendedGa4GhApi,  0);
+        waitForIndexRefresh(1, extendedGa4GhApi);
 
         // Should not fail since a workflow exists in index
         try {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/AppTool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/AppTool.java
@@ -55,12 +55,17 @@ public class AppTool extends Workflow {
     }
 
     @Override
-    public Set<Entry> getParentEntry() {
+    public Entry getParentEntry() {
         return null;
     }
 
     @Override
-    public void setParentEntry(Set<Entry> parentEntry) {
+    public Set<Entry> getParentEntries() {
+        return Set.of();
+    }
+
+    @Override
+    public void setParentEntry(Entry parentEntry) {
         if (parentEntry == null) {
             return;
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/AppTool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/AppTool.java
@@ -22,6 +22,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
+import java.util.Set;
 
 @ApiModel(value = "AppTool", description = "This describes one app tool in dockstore as a special degenerate case of a workflow", parent = Workflow.class)
 @Entity
@@ -54,12 +55,12 @@ public class AppTool extends Workflow {
     }
 
     @Override
-    public Entry getParentEntry() {
+    public Set<Entry> getParentEntry() {
         return null;
     }
 
     @Override
-    public void setParentEntry(Entry parentEntry) {
+    public void setParentEntry(Set<Entry> parentEntry) {
         if (parentEntry == null) {
             return;
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/AppTool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/AppTool.java
@@ -22,7 +22,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
-import java.util.HashSet;
 import java.util.Set;
 
 @ApiModel(value = "AppTool", description = "This describes one app tool in dockstore as a special degenerate case of a workflow", parent = Workflow.class)
@@ -57,7 +56,7 @@ public class AppTool extends Workflow {
 
     @Override
     public Set<Entry> getParentEntry() {
-        return new HashSet<>();
+        return null;
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/AppTool.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/AppTool.java
@@ -22,6 +22,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
+import java.util.HashSet;
 import java.util.Set;
 
 @ApiModel(value = "AppTool", description = "This describes one app tool in dockstore as a special degenerate case of a workflow", parent = Workflow.class)
@@ -56,7 +57,7 @@ public class AppTool extends Workflow {
 
     @Override
     public Set<Entry> getParentEntry() {
-        return null;
+        return new HashSet<>();
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
@@ -72,7 +72,7 @@ public class BioWorkflow extends Workflow {
 
     @Override
     public Entry getParentEntry() {
-        if (parentEntries != null) {
+        if (parentEntries != null && !parentEntries.isEmpty()) {
             return parentEntries.iterator().next();
         }
         return null;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
@@ -27,6 +27,7 @@ import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -54,7 +55,7 @@ public class BioWorkflow extends Workflow {
     @OneToMany(mappedBy = "checkerWorkflow", targetEntity = Entry.class, fetch = FetchType.EAGER)
     @JsonIgnore
     @ApiModelProperty(value = "The parent ID of a checker workflow. Null if not a checker workflow. Required for checker workflows.", position = 22)
-    private Set<Entry> parentEntry;
+    private Set<Entry> parentEntries;
 
     @Column(columnDefinition = "boolean default false")
     private boolean isChecker = false;
@@ -70,13 +71,24 @@ public class BioWorkflow extends Workflow {
     }
 
     @Override
-    public Set<Entry> getParentEntry() {
-        return parentEntry;
+    public Entry getParentEntry() {
+        if (parentEntries != null) {
+            return parentEntries.iterator().next();
+        }
+        return null;
     }
 
     @Override
-    public void setParentEntry(Set<Entry> parentEntry) {
-        this.parentEntry = parentEntry;
+    public Set<Entry> getParentEntries() {
+        return parentEntries;
+    }
+
+    @Override
+    public void setParentEntry(Entry parentEntry) {
+        if (parentEntries == null) {
+            parentEntries = new HashSet<>();
+        }
+        this.parentEntries.add(parentEntry);
     }
 
     @Override
@@ -91,9 +103,9 @@ public class BioWorkflow extends Workflow {
 
     @JsonProperty("parent_id")
     public Long getParentId() {
-        if (parentEntry != null && !parentEntry.isEmpty()) {
+        if (parentEntries != null && !parentEntries.isEmpty()) {
             // TODO this is weird, but to not break backwards compatibility for now ...
-            return parentEntry.iterator().next().getId();
+            return parentEntries.iterator().next().getId();
         } else {
             return null;
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
@@ -91,8 +91,8 @@ public class BioWorkflow extends Workflow {
 
     @JsonProperty("parent_id")
     public Long getParentId() {
-        if (parentEntry != null && parentEntry.size() > 0) {
-            // TODO this is weird, but ...
+        if (parentEntry != null && !parentEntry.isEmpty()) {
+            // TODO this is weird, but to not break backwards compatibility for now ...
             return parentEntry.iterator().next().getId();
         } else {
             return null;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/BioWorkflow.java
@@ -25,8 +25,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.Set;
 
 /**
  * These represent actual workflows in terms of CWL, WDL, and other bioinformatics workflows
@@ -50,10 +51,10 @@ import jakarta.persistence.Table;
 @SuppressWarnings("checkstyle:magicnumber")
 public class BioWorkflow extends Workflow {
 
-    @OneToOne(mappedBy = "checkerWorkflow", targetEntity = Entry.class, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "checkerWorkflow", targetEntity = Entry.class, fetch = FetchType.EAGER)
     @JsonIgnore
     @ApiModelProperty(value = "The parent ID of a checker workflow. Null if not a checker workflow. Required for checker workflows.", position = 22)
-    private Entry parentEntry;
+    private Set<Entry> parentEntry;
 
     @Column(columnDefinition = "boolean default false")
     private boolean isChecker = false;
@@ -69,12 +70,12 @@ public class BioWorkflow extends Workflow {
     }
 
     @Override
-    public Entry getParentEntry() {
+    public Set<Entry> getParentEntry() {
         return parentEntry;
     }
 
     @Override
-    public void setParentEntry(Entry parentEntry) {
+    public void setParentEntry(Set<Entry> parentEntry) {
         this.parentEntry = parentEntry;
     }
 
@@ -90,8 +91,9 @@ public class BioWorkflow extends Workflow {
 
     @JsonProperty("parent_id")
     public Long getParentId() {
-        if (parentEntry != null) {
-            return parentEntry.getId();
+        if (parentEntry != null && parentEntry.size() > 0) {
+            // TODO this is weird, but ...
+            return parentEntry.iterator().next().getId();
         } else {
             return null;
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -43,13 +43,13 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.MapKeyEnumerated;
 import jakarta.persistence.NamedNativeQueries;
 import jakarta.persistence.NamedNativeQuery;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Transient;
 import jakarta.persistence.UniqueConstraint;
@@ -196,7 +196,7 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
 
     @JsonIgnore
     @JoinColumn(name = "checkerid", unique = true)
-    @OneToOne(targetEntity = BioWorkflow.class, fetch = FetchType.EAGER)
+    @ManyToOne(targetEntity = BioWorkflow.class, fetch = FetchType.LAZY)
     @ApiModelProperty(value = "The id of the associated checker workflow")
     private BioWorkflow checkerWorkflow;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
@@ -43,8 +43,13 @@ import java.util.Set;
 public class Notebook extends Workflow {
 
     @Override
-    public Set<Entry> getParentEntry() {
+    public Entry getParentEntry() {
         return null;
+    }
+
+    @Override
+    public Set<Entry> getParentEntries() {
+        return Set.of();
     }
 
     @Override
@@ -58,7 +63,7 @@ public class Notebook extends Workflow {
     }
 
     @Override
-    public void setParentEntry(Set<Entry> parentEntry) {
+    public void setParentEntry(Entry parentEntry) {
         throw new UnsupportedOperationException("cannot add a checker workflow to a Notebook");
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
@@ -21,6 +21,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
+import java.util.Set;
 
 @ApiModel(value = "Notebook", description = "This describes one notebook in the dockstore as a special degenerate case of a workflow", parent = Workflow.class)
 @Entity
@@ -42,7 +43,7 @@ import jakarta.persistence.Table;
 public class Notebook extends Workflow {
 
     @Override
-    public Entry getParentEntry() {
+    public Set<Entry> getParentEntry() {
         return null;
     }
 
@@ -57,7 +58,7 @@ public class Notebook extends Workflow {
     }
 
     @Override
-    public void setParentEntry(Entry parentEntry) {
+    public void setParentEntry(Set<Entry> parentEntry) {
         throw new UnsupportedOperationException("cannot add a checker workflow to a Notebook");
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
@@ -21,7 +21,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
-import java.util.HashSet;
 import java.util.Set;
 
 @ApiModel(value = "Notebook", description = "This describes one notebook in the dockstore as a special degenerate case of a workflow", parent = Workflow.class)
@@ -45,7 +44,7 @@ public class Notebook extends Workflow {
 
     @Override
     public Set<Entry> getParentEntry() {
-        return new HashSet<>();
+        return null;
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
@@ -21,6 +21,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
+import java.util.HashSet;
 import java.util.Set;
 
 @ApiModel(value = "Notebook", description = "This describes one notebook in the dockstore as a special degenerate case of a workflow", parent = Workflow.class)
@@ -44,7 +45,7 @@ public class Notebook extends Workflow {
 
     @Override
     public Set<Entry> getParentEntry() {
-        return null;
+        return new HashSet<>();
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Service.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Service.java
@@ -41,8 +41,13 @@ public class Service extends Workflow {
     }
 
     @Override
-    public Set<Entry> getParentEntry() {
+    public Entry getParentEntry() {
         return null;
+    }
+
+    @Override
+    public Set<Entry> getParentEntries() {
+        return Set.of();
     }
 
     @Override
@@ -56,7 +61,7 @@ public class Service extends Workflow {
     }
 
     @Override
-    public void setParentEntry(Set<Entry> parentEntry) {
+    public void setParentEntry(Entry parentEntry) {
         throw new UnsupportedOperationException("cannot add a checker workflow to a Service");
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Service.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Service.java
@@ -21,6 +21,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
+import java.util.Set;
 
 @ApiModel(value = "Service", description = "This describes one service in the dockstore as a special degenerate case of a workflow", parent = Workflow.class)
 @Entity
@@ -40,7 +41,7 @@ public class Service extends Workflow {
     }
 
     @Override
-    public Entry getParentEntry() {
+    public Set<Entry> getParentEntry() {
         return null;
     }
 
@@ -55,7 +56,7 @@ public class Service extends Workflow {
     }
 
     @Override
-    public void setParentEntry(Entry parentEntry) {
+    public void setParentEntry(Set<Entry> parentEntry) {
         throw new UnsupportedOperationException("cannot add a checker workflow to a Service");
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Service.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Service.java
@@ -21,6 +21,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
+import java.util.HashSet;
 import java.util.Set;
 
 @ApiModel(value = "Service", description = "This describes one service in the dockstore as a special degenerate case of a workflow", parent = Workflow.class)
@@ -42,7 +43,7 @@ public class Service extends Workflow {
 
     @Override
     public Set<Entry> getParentEntry() {
-        return null;
+        return new HashSet<>();
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Service.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Service.java
@@ -21,7 +21,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
-import java.util.HashSet;
 import java.util.Set;
 
 @ApiModel(value = "Service", description = "This describes one service in the dockstore as a special degenerate case of a workflow", parent = Workflow.class)
@@ -43,7 +42,7 @@ public class Service extends Workflow {
 
     @Override
     public Set<Entry> getParentEntry() {
-        return new HashSet<>();
+        return null;
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -180,9 +180,11 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
         return this.getWorkflowPath();
     }
 
-    public abstract Set<Entry> getParentEntry();
+    public abstract Entry getParentEntry();
 
-    public abstract void setParentEntry(Set<Entry> parentEntry);
+    public abstract Set<Entry> getParentEntries();
+
+    public abstract void setParentEntry(Entry parentEntry);
 
     /**
      * Copies some of the attributes of the source workflow to the target workflow

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -182,6 +182,7 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
 
     public abstract Entry getParentEntry();
 
+    @JsonProperty
     public abstract Set<Entry> getParentEntries();
 
     public abstract void setParentEntry(Entry parentEntry);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Workflow.java
@@ -180,9 +180,9 @@ public abstract class Workflow extends Entry<Workflow, WorkflowVersion> {
         return this.getWorkflowPath();
     }
 
-    public abstract Entry getParentEntry();
+    public abstract Set<Entry> getParentEntry();
 
-    public abstract void setParentEntry(Entry parentEntry);
+    public abstract void setParentEntry(Set<Entry> parentEntry);
 
     /**
      * Copies some of the attributes of the source workflow to the target workflow

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
@@ -110,13 +110,13 @@ public class ToolsExtendedApi {
     @Path("/tools/index")
     @UnitOfWork
     @RolesAllowed({"curator", "admin"})
-    @Produces({MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN})
     @ApiOperation(value = ToolsIndexGet.SUMMARY, notes = ToolsIndexGet.DESCRIPTION, authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME)}, response = Integer.class)
     @ApiResponses(value = {@ApiResponse(code = HttpStatus.SC_OK, message = ToolsIndexGet.OK_RESPONSE)})
     @Operation(operationId = ToolsIndexGet.SUMMARY, summary = ToolsIndexGet.SUMMARY, description = ToolsIndexGet.DESCRIPTION, security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME), responses = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = HttpStatus.SC_OK
-            + "", description = ToolsIndexGet.OK_RESPONSE, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Integer.class)))
+            + "", description = ToolsIndexGet.OK_RESPONSE, content = { @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Integer.class)), @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(implementation = Integer.class))})
     })
     public Response toolsIndexGet(@ApiParam(hidden = true) @Parameter(hidden = true) @Auth User user, @Context SecurityContext securityContext)
         throws NotFoundException {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
@@ -110,13 +110,13 @@ public class ToolsExtendedApi {
     @Path("/tools/index")
     @UnitOfWork
     @RolesAllowed({"curator", "admin"})
-    @Produces({MediaType.TEXT_PLAIN})
+    @Produces({MediaType.APPLICATION_JSON})
     @ApiOperation(value = ToolsIndexGet.SUMMARY, notes = ToolsIndexGet.DESCRIPTION, authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME)}, response = Integer.class)
     @ApiResponses(value = {@ApiResponse(code = HttpStatus.SC_OK, message = ToolsIndexGet.OK_RESPONSE)})
     @Operation(operationId = ToolsIndexGet.SUMMARY, summary = ToolsIndexGet.SUMMARY, description = ToolsIndexGet.DESCRIPTION, security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME), responses = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = HttpStatus.SC_OK
-            + "", description = ToolsIndexGet.OK_RESPONSE, content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(implementation = Integer.class)))
+            + "", description = ToolsIndexGet.OK_RESPONSE, content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Integer.class)))
     })
     public Response toolsIndexGet(@ApiParam(hidden = true) @Parameter(hidden = true) @Auth User user, @Context SecurityContext securityContext)
         throws NotFoundException {

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -460,7 +460,7 @@ paths:
       responses:
         "200":
           content:
-            text/plain:
+            application/json:
               schema:
                 type: integer
                 format: int32
@@ -10706,7 +10706,10 @@ components:
             $ref: '#/components/schemas/FileFormat'
           uniqueItems: true
         parentEntry:
-          $ref: '#/components/schemas/Entry'
+          type: array
+          items:
+            $ref: '#/components/schemas/Entry'
+          uniqueItems: true
         path:
           type: string
         repository:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -10709,11 +10709,13 @@ components:
           items:
             $ref: '#/components/schemas/FileFormat'
           uniqueItems: true
-        parentEntry:
+        parentEntries:
           type: array
           items:
             $ref: '#/components/schemas/Entry'
           uniqueItems: true
+        parentEntry:
+          $ref: '#/components/schemas/Entry'
         path:
           type: string
         repository:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -464,6 +464,10 @@ paths:
               schema:
                 type: integer
                 format: int32
+            text/plain:
+              schema:
+                type: integer
+                format: int32
           description: Workflows and tools indices populated with entries.
       security:
       - BEARER: []


### PR DESCRIPTION
**Description**
qa was displaying an inability to completely index, investigating found three issues
* hibernate was dying on a eagerly fetched relationship, seems to be a known issue ( https://stackoverflow.com/questions/74782228/org-hibernate-assertionfailure-force-initializing-collection-loading  https://discourse.hibernate.org/t/force-initializing-collection-loading/7172  https://stackoverflow.com/questions/76295691/modelmapper-error-org-hibernate-assertionfailure-force-initializing-collection )
* changing it to lazy as a workaround revealed another issue, presumably a breaking change with hibernate 6 (although seems like an improvement), although we never think of a checker workflow as N:1, it actually is and somehow one got into the DB, so changing from 1:1 to N:1 (not sure if makes sense that a workflow can test multiple workflows, but maybe) 
* client generated library seems to throw an error when requesting text/plain (when adding a new test), ended up adding a backwards compatible workaround with multiple response types

**Review Instructions**
Should be able to run a full elasticsearch index API call on qa.
Checker workflow facets should still looks the same (i.e. hoping that the search results just rely on the checker id/ischecker boolean and not an embedded checker workflow)

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5571

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
