### PR TITLE
Add getPublishedContainer to OpenAPI

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -124,6 +124,7 @@ public class DockerRepoResource
     private static final Logger LOG = LoggerFactory.getLogger(DockerRepoResource.class);
     private static final String OPTIONAL_AUTH_MESSAGE = "Does not require authentication for published tools, authentication can be provided for restricted tools";
     public static final String UNABLE_TO_VERIFY_THAT_YOUR_TOOL_POINTS_AT_A_VALID_SOURCE_CONTROL_REPO = "unable to verify that your tool points at a valid source control repo";
+    private static final String GET_A_PUBLISHED_TOOL_DESC = "Get a published tool.";
 
     @Context
     private ResourceContext rc;
@@ -481,7 +482,8 @@ public class DockerRepoResource
     @Timed
     @UnitOfWork(readOnly = true)
     @Path("/published/{containerId}")
-    @ApiOperation(value = "Get a published tool.", notes = "NO authentication", response = Tool.class)
+    @Operation(operationId = "getPublishedContainer", description = GET_A_PUBLISHED_TOOL_DESC)
+    @ApiOperation(value = GET_A_PUBLISHED_TOOL_DESC, notes = "NO authentication", response = Tool.class)
     public Tool getPublishedContainer(@ApiParam(value = "Tool ID", required = true) @PathParam("containerId") Long containerId,
         @ApiParam(value = "Comma-delimited list of fields to include: validations") @QueryParam("include") String include) {
         Tool tool = toolDAO.findPublishedById(containerId);

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1420,6 +1420,30 @@ paths:
           description: default response
       tags:
       - containers
+  /containers/published/{containerId}:
+    get:
+      description: Get a published tool.
+      operationId: getPublishedContainer
+      parameters:
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - in: query
+        name: include
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockstoreTool'
+          description: default response
+      tags:
+      - containers
   /containers/registerManual:
     post:
       description: "Register a tool manually, along with tags."


### PR DESCRIPTION
**Description**
Discovered the endpoint isn't available to the UI in trying to address #5538 in the UI code.

**Review Instructions**
In the UI, `run npm prebuild`, and verify that the generated code contains a `getPublishedContainer` method.

**Issue**
#5538 

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
