### PR TITLE
DOCK-2397: Redirect 500 error for invalid filters to a 400

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
@@ -53,7 +53,6 @@ import io.swagger.model.DescriptorType;
 import jakarta.ws.rs.client.Client;
 import java.util.List;
 import java.util.Optional;
-
 import org.apache.http.HttpStatus;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -204,7 +203,6 @@ class GitHubWorkflowIT extends BaseIT {
     void testGetPublishedWorkflowsWithInvalidSortCol() {
         final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
-        io.dockstore.openapi.client.ApiClient openAPIWebClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         final PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
 
         AppToolHelper.registerAppTool(webClient);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
@@ -199,7 +199,6 @@ class GitHubWorkflowIT extends BaseIT {
     /**
      * Tests that the correct error is given when provided an invalid value for sortCol when getting all published workflows
      *
-     * @throws ApiException exception used for errors coming back from the web service
      */
     @Test
     void testGetPublishedWorkflowsWithInvalidSortCol() {
@@ -219,10 +218,11 @@ class GitHubWorkflowIT extends BaseIT {
             workflowApi.allPublishedWorkflows(null, null, null, "invalid", null, false,
                     WorkflowSubClass.APPTOOL.getValue());
         } catch (ApiException e) {
-            assertTrue(e.getMessage().contains("Could not get published entries due to invalid arguments."));
+            assertTrue(e.getMessage().contains("Could not get published entries due to an invalid sortCol value. Error is "));
             assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode(), "There should be a 400 error");
         }
     }
+
     /**
      * Tests that the info for quay images included in CWL workflows are grabbed and that the trs endpoints convert this info correctly
      */

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
@@ -209,7 +209,7 @@ class GitHubWorkflowIT extends BaseIT {
 
         ApiException exception = assertThrows(ApiException.class, () -> workflowApi.allPublishedWorkflows(null, null, null, "invalid", null, false,
                     WorkflowSubClass.APPTOOL.getValue()));
-        assertTrue(exception.getMessage().contains("Could not process query due to the invalid sortCol value. Error is "));
+        assertTrue(exception.getMessage().contains("Could not process query due to the invalid sortCol value."));
         assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getCode(), "There should be a 400 error");
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
@@ -16,6 +16,7 @@
 
 package io.dockstore.client.cli;
 
+import static io.dockstore.webservice.jdbi.EntryDAO.INVALID_SORTCOL_MESSAGE;
 import static io.openapi.api.impl.ToolsApiServiceImpl.DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -215,7 +216,7 @@ class GitHubWorkflowIT extends BaseIT {
 
         ApiException exception = assertThrows(ApiException.class, () -> workflowApi.allPublishedWorkflows(null, null, null, "invalid", null, false,
                     WorkflowSubClass.APPTOOL.getValue()));
-        assertTrue(exception.getMessage().contains("Could not process query due to the invalid sortCol value."));
+        assertTrue(exception.getMessage().contains(INVALID_SORTCOL_MESSAGE));
         assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getCode(), "There should be a 400 error");
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
@@ -209,7 +209,7 @@ class GitHubWorkflowIT extends BaseIT {
 
         ApiException exception = assertThrows(ApiException.class, () -> workflowApi.allPublishedWorkflows(null, null, null, "invalid", null, false,
                     WorkflowSubClass.APPTOOL.getValue()));
-        assertTrue(exception.getMessage().contains("Could not get published entries due to an invalid sortCol value. Error is "));
+        assertTrue(exception.getMessage().contains("Could not process query due to the invalid sortCol value. Error is "));
         assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getCode(), "There should be a 400 error");
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
@@ -17,7 +17,13 @@
 package io.dockstore.client.cli;
 
 import static io.openapi.api.impl.ToolsApiServiceImpl.DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Lists;
 import io.dockstore.client.cli.BaseIT.TestStatus;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
@@ -17,12 +17,7 @@
 package io.dockstore.client.cli;
 
 import static io.openapi.api.impl.ToolsApiServiceImpl.DESCRIPTOR_FILE_SHA256_TYPE_FOR_TRS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.Lists;
 import io.dockstore.client.cli.BaseIT.TestStatus;
@@ -212,13 +207,10 @@ class GitHubWorkflowIT extends BaseIT {
         assertEquals(1, workflowApi.allPublishedWorkflows(null, null, null, null, null, false,
                 WorkflowSubClass.APPTOOL.getValue()).size(), "There should be 1 app tool published");
 
-        try {
-            workflowApi.allPublishedWorkflows(null, null, null, "invalid", null, false,
-                    WorkflowSubClass.APPTOOL.getValue());
-        } catch (ApiException e) {
-            assertTrue(e.getMessage().contains("Could not get published entries due to an invalid sortCol value. Error is "));
-            assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode(), "There should be a 400 error");
-        }
+        ApiException exception = assertThrows(ApiException.class, () -> workflowApi.allPublishedWorkflows(null, null, null, "invalid", null, false,
+                    WorkflowSubClass.APPTOOL.getValue()));
+        assertTrue(exception.getMessage().contains("Could not get published entries due to an invalid sortCol value. Error is "));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getCode(), "There should be a 400 error");
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -449,6 +449,24 @@ class SwaggerClientIT extends BaseIT {
         assertTrue(containers.isEmpty());
     }
 
+    /**
+     * Tests that the correct error is given when provided an invalid value for sortCol when getting all published tools
+     *
+     */
+    @Test
+    void testGetPublishedToolsWithInvalidSortCol() {
+        ApiClient client = getWebClient();
+        ContainersApi containersApi = new ContainersApi(client);
+        List<DockstoreTool> containers = containersApi.allPublishedContainers(null, null, "test6", null, null);
+        assertEquals(1, containers.size());
+        try {
+            containersApi.allPublishedContainers(null, null, "test6", "invalid", null);
+        } catch (ApiException e) {
+            assertTrue(e.getMessage().contains("Could not get published entries due to an invalid sortCol value. Error is "));
+            assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode(), "There should be a 400 error");
+        }
+    }
+
     @Test
     void testHidingTags() throws ApiException {
         ApiClient client = getAdminWebClient();

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -459,12 +459,9 @@ class SwaggerClientIT extends BaseIT {
         ContainersApi containersApi = new ContainersApi(client);
         List<DockstoreTool> containers = containersApi.allPublishedContainers(null, null, "test6", null, null);
         assertEquals(1, containers.size());
-        try {
-            containersApi.allPublishedContainers(null, null, "test6", "invalid", null);
-        } catch (ApiException e) {
-            assertTrue(e.getMessage().contains("Could not get published entries due to an invalid sortCol value. Error is "));
-            assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode(), "There should be a 400 error");
-        }
+        ApiException exception = assertThrows(ApiException.class, () -> containersApi.allPublishedContainers(null, null, "test6", "invalid", null));
+        assertTrue(exception.getMessage().contains("Could not get published entries due to an invalid sortCol value. Error is "));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getCode(), "There should be a 400 error");
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -460,7 +460,7 @@ class SwaggerClientIT extends BaseIT {
         List<DockstoreTool> containers = containersApi.allPublishedContainers(null, null, "test6", null, null);
         assertEquals(1, containers.size());
         ApiException exception = assertThrows(ApiException.class, () -> containersApi.allPublishedContainers(null, null, "test6", "invalid", null));
-        assertTrue(exception.getMessage().contains("Could not process query due to the invalid sortCol value. Error is "));
+        assertTrue(exception.getMessage().contains("Could not process query due to the invalid sortCol value."));
         assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getCode(), "There should be a 400 error");
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -460,7 +460,7 @@ class SwaggerClientIT extends BaseIT {
         List<DockstoreTool> containers = containersApi.allPublishedContainers(null, null, "test6", null, null);
         assertEquals(1, containers.size());
         ApiException exception = assertThrows(ApiException.class, () -> containersApi.allPublishedContainers(null, null, "test6", "invalid", null));
-        assertTrue(exception.getMessage().contains("Could not get published entries due to an invalid sortCol value. Error is "));
+        assertTrue(exception.getMessage().contains("Could not process query due to the invalid sortCol value. Error is "));
         assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getCode(), "There should be a 400 error");
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/SwaggerClientIT.java
@@ -18,6 +18,7 @@ package io.dockstore.client.cli;
 
 import static io.dockstore.common.DescriptorLanguage.CWL;
 import static io.dockstore.webservice.TokenResourceIT.GITHUB_ACCOUNT_USERNAME;
+import static io.dockstore.webservice.jdbi.EntryDAO.INVALID_SORTCOL_MESSAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -460,7 +461,7 @@ class SwaggerClientIT extends BaseIT {
         List<DockstoreTool> containers = containersApi.allPublishedContainers(null, null, "test6", null, null);
         assertEquals(1, containers.size());
         ApiException exception = assertThrows(ApiException.class, () -> containersApi.allPublishedContainers(null, null, "test6", "invalid", null));
-        assertTrue(exception.getMessage().contains("Could not process query due to the invalid sortCol value."));
+        assertTrue(exception.getMessage().contains(INVALID_SORTCOL_MESSAGE));
         assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getCode(), "There should be a 400 error");
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -410,8 +410,8 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
                         predicates.add(sortPath.isNotNull());
                     }
                 } catch (IllegalArgumentException e) {
-                    LOG.warn("Could not get published entries due to an invalid sortCol value. Error is ", e);
-                    throw new CustomWebApplicationException("Could not get published entries due to an invalid sortCol value. Error is "
+                    LOG.warn("Could not process query due to the invalid sortCol value. Error is ", e);
+                    throw new CustomWebApplicationException("Could not process query due to the invalid sortCol value. Error is "
                             + e.getMessage(), HttpStatus.SC_BAD_REQUEST);
                 }
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -45,6 +45,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+
+import jakarta.persistence.metamodel.Attribute;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.http.HttpStatus;
 import org.hibernate.Session;
@@ -403,7 +405,7 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
                 boolean hasSortCol = entry.getModel()
                         .getAttributes()
                         .stream()
-                        .map(attribute -> attribute.getName())
+                        .map(Attribute::getName)
                         .anyMatch(sortCol::equals);
 
                 if (!hasSortCol) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -71,6 +71,8 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
 
     private Class<T> typeOfT;
 
+    public static final String INVALID_SORTCOL_MESSAGE="Could not process query due to the invalid sortCol value.";
+
     EntryDAO(SessionFactory factory) {
         super(factory);
         /*
@@ -409,19 +411,18 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
                         .anyMatch(sortCol::equals);
 
                 if (!hasSortCol) {
-                    LOG.warn("Could not process query due to the invalid sortCol value.");
-                    throw new CustomWebApplicationException("Could not process query due to the invalid sortCol value.",
+                    LOG.error(INVALID_SORTCOL_MESSAGE);
+                    throw new CustomWebApplicationException(INVALID_SORTCOL_MESSAGE,
                             HttpStatus.SC_BAD_REQUEST);
 
                 } else {
                     Path<Object> sortPath = entry.get(sortCol);
                     if (!Strings.isNullOrEmpty(sortOrder) && "desc".equalsIgnoreCase(sortOrder)) {
                         query.orderBy(cb.desc(sortPath), cb.desc(entry.get("id")));
-                        predicates.add(sortPath.isNotNull());
                     } else {
                         query.orderBy(cb.asc(sortPath), cb.desc(entry.get("id")));
-                        predicates.add(sortPath.isNotNull());
                     }
+                    predicates.add(sortPath.isNotNull());
                 }
             }
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -400,7 +400,19 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
                     query.orderBy(cb.asc(cb.size(entry.<Collection>get("starredUsers"))), cb.desc(entry.get("id")));
                 }
             } else {
-                try {
+                boolean hasSortCol = entry.getModel()
+                        .getAttributes()
+                        .stream()
+                        .map(attribute -> attribute.getName())
+                        .anyMatch(sortCol::equals);
+
+                if (!hasSortCol) {
+                    LOG.warn("Could not process query due to the invalid sortCol value.");
+                    throw new CustomWebApplicationException("Could not process query due to the invalid sortCol value.",
+                            HttpStatus.SC_BAD_REQUEST);
+
+                }
+                else {
                     Path<Object> sortPath = entry.get(sortCol);
                     if (!Strings.isNullOrEmpty(sortOrder) && "desc".equalsIgnoreCase(sortOrder)) {
                         query.orderBy(cb.desc(sortPath), cb.desc(entry.get("id")));
@@ -409,10 +421,6 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
                         query.orderBy(cb.asc(sortPath), cb.desc(entry.get("id")));
                         predicates.add(sortPath.isNotNull());
                     }
-                } catch (IllegalArgumentException e) {
-                    LOG.warn("Could not process query due to the invalid sortCol value. Error is ", e);
-                    throw new CustomWebApplicationException("Could not process query due to the invalid sortCol value. Error is "
-                            + e.getMessage(), HttpStatus.SC_BAD_REQUEST);
                 }
             }
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -71,7 +71,7 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
 
     private Class<T> typeOfT;
 
-    public static final String INVALID_SORTCOL_MESSAGE="Could not process query due to the invalid sortCol value.";
+    public static final String INVALID_SORTCOL_MESSAGE = "Could not process query due to the invalid sortCol value.";
 
     EntryDAO(SessionFactory factory) {
         super(factory);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -411,8 +411,7 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
                     throw new CustomWebApplicationException("Could not process query due to the invalid sortCol value.",
                             HttpStatus.SC_BAD_REQUEST);
 
-                }
-                else {
+                } else {
                     Path<Object> sortPath = entry.get(sortCol);
                     if (!Strings.isNullOrEmpty(sortOrder) && "desc".equalsIgnoreCase(sortOrder)) {
                         query.orderBy(cb.desc(sortPath), cb.desc(entry.get("id")));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -410,7 +410,7 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
                         predicates.add(sortPath.isNotNull());
                     }
                 } catch (IllegalArgumentException e) {
-                    LOG.error("Could not get published entries due to an invalid sortCol value. Error is ", e);
+                    LOG.warn("Could not get published entries due to an invalid sortCol value. Error is ", e);
                     throw new CustomWebApplicationException("Could not get published entries due to an invalid sortCol value. Error is "
                             + e.getMessage(), HttpStatus.SC_BAD_REQUEST);
                 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -410,9 +410,9 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
                         predicates.add(sortPath.isNotNull());
                     }
                 } catch (IllegalArgumentException e) {
-                    LOG.error("Could not get published entries due to invalid arguments. Error is ", e);
-                    throw new CustomWebApplicationException("Could not get published entries due to invalid arguments. "
-                            + "Error is " + e.getMessage(), HttpStatus.SC_BAD_REQUEST);
+                    LOG.error("Could not get published entries due to an invalid sortCol value. Error is ", e);
+                    throw new CustomWebApplicationException("Could not get published entries due to an invalid sortCol value. Error is " +
+                            e.getMessage(), HttpStatus.SC_BAD_REQUEST);
                 }
             }
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -411,8 +411,8 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
                     }
                 } catch (IllegalArgumentException e) {
                     LOG.error("Could not get published entries due to an invalid sortCol value. Error is ", e);
-                    throw new CustomWebApplicationException("Could not get published entries due to an invalid sortCol value. Error is " +
-                            e.getMessage(), HttpStatus.SC_BAD_REQUEST);
+                    throw new CustomWebApplicationException("Could not get published entries due to an invalid sortCol value. Error is "
+                            + e.getMessage(), HttpStatus.SC_BAD_REQUEST);
                 }
             }
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -792,20 +792,13 @@ public class DockerRepoResource
         @ApiParam(value = "Sort column") @DefaultValue("stars") @QueryParam("sortCol") String sortCol,
         @ApiParam(value = "Sort order", allowableValues = "asc,desc") @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
         @Context HttpServletResponse response) {
-        try {
-            int maxLimit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);
-            List<Tool> tools = toolDAO.findAllPublished(offset, maxLimit, filter, sortCol, sortOrder);
-            filterContainersForHiddenTags(tools);
-            stripContent(tools);
-            response.addHeader("X-total-count", String.valueOf(toolDAO.countAllPublished(Optional.of(filter))));
-            response.addHeader("Access-Control-Expose-Headers", "X-total-count");
-            return tools;
-        } catch (IllegalArgumentException e) {
-            LOG.error("Could not get published tools due to invalid arguments. Error is " + e.getMessage(), e);
-            throw new CustomWebApplicationException("Could not get published tools due to invalid arguments. "
-                    + "Error is " + e.getMessage(), HttpStatus.SC_BAD_REQUEST);
-        }
-
+        int maxLimit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);
+        List<Tool> tools = toolDAO.findAllPublished(offset, maxLimit, filter, sortCol, sortOrder);
+        filterContainersForHiddenTags(tools);
+        stripContent(tools);
+        response.addHeader("X-total-count", String.valueOf(toolDAO.countAllPublished(Optional.of(filter))));
+        response.addHeader("Access-Control-Expose-Headers", "X-total-count");
+        return tools;
     }
 
     @GET

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -792,13 +792,20 @@ public class DockerRepoResource
         @ApiParam(value = "Sort column") @DefaultValue("stars") @QueryParam("sortCol") String sortCol,
         @ApiParam(value = "Sort order", allowableValues = "asc,desc") @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
         @Context HttpServletResponse response) {
-        int maxLimit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);
-        List<Tool> tools = toolDAO.findAllPublished(offset, maxLimit, filter, sortCol, sortOrder);
-        filterContainersForHiddenTags(tools);
-        stripContent(tools);
-        response.addHeader("X-total-count", String.valueOf(toolDAO.countAllPublished(Optional.of(filter))));
-        response.addHeader("Access-Control-Expose-Headers", "X-total-count");
-        return tools;
+        try {
+            int maxLimit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);
+            List<Tool> tools = toolDAO.findAllPublished(offset, maxLimit, filter, sortCol, sortOrder);
+            filterContainersForHiddenTags(tools);
+            stripContent(tools);
+            response.addHeader("X-total-count", String.valueOf(toolDAO.countAllPublished(Optional.of(filter))));
+            response.addHeader("Access-Control-Expose-Headers", "X-total-count");
+            return tools;
+        } catch (IllegalArgumentException e) {
+            LOG.error("Could not get published tools due to invalid arguments. Error is " + e.getMessage(), e);
+            throw new CustomWebApplicationException("Could not get published tools due to invalid arguments. "
+                    + "Error is " + e.getMessage(), HttpStatus.SC_BAD_REQUEST);
+        }
+
     }
 
     @GET

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -822,7 +822,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         } catch (IllegalArgumentException e) {
             LOG.error("Could not get published workflows due to invalid arguments. Error is " + e.getMessage(), e);
             throw new CustomWebApplicationException("Could not get published workflows due to invalid arguments. "
-                    + "Error is " + e.getMessage(), HttpStatus.SC_INTERNAL_SERVER_ERROR);
+                    + "Error is " + e.getMessage(), HttpStatus.SC_BAD_REQUEST);
         }
 
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -807,25 +807,17 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         @ApiParam(value = "Should only be used by Dockstore versions < 1.14.0. Indicates whether to get a service or workflow") @DefaultValue("false") @QueryParam("services") boolean services,
         @ApiParam(value = "Which workflow subclass to retrieve. If present takes precedence over services parameter") @QueryParam("subclass") WorkflowSubClass subclass,
         @Context HttpServletResponse response) {
-        try {
-            // delete the next line if GUI pagination is not working by 1.5.0 release
-            int maxLimit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);
-            final Class<Workflow> workflowClass = (Class<Workflow>) workflowSubClass(services, subclass);
-            List<Workflow> workflows = workflowDAO.findAllPublished(offset, maxLimit, filter, sortCol, sortOrder,
-                    workflowClass);
-            filterContainersForHiddenTags(workflows);
-            stripContent(workflows);
-            EntryDAO entryDAO = services ? serviceEntryDAO : bioWorkflowDAO;
-            response.addHeader("X-total-count", String.valueOf(entryDAO.countAllPublished(Optional.of(filter), workflowClass)));
-            response.addHeader("Access-Control-Expose-Headers", "X-total-count");
-            return workflows;
-        } catch (IllegalArgumentException e) {
-            LOG.error("Could not get published workflows due to invalid arguments. Error is " + e.getMessage(), e);
-            throw new CustomWebApplicationException("Could not get published workflows due to invalid arguments. "
-                    + "Error is " + e.getMessage(), HttpStatus.SC_BAD_REQUEST);
-        }
-
-
+        // delete the next line if GUI pagination is not working by 1.5.0 release
+        int maxLimit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);
+        final Class<Workflow> workflowClass = (Class<Workflow>) workflowSubClass(services, subclass);
+        List<Workflow> workflows = workflowDAO.findAllPublished(offset, maxLimit, filter, sortCol, sortOrder,
+                workflowClass);
+        filterContainersForHiddenTags(workflows);
+        stripContent(workflows);
+        EntryDAO entryDAO = services ? serviceEntryDAO : bioWorkflowDAO;
+        response.addHeader("X-total-count", String.valueOf(entryDAO.countAllPublished(Optional.of(filter), workflowClass)));
+        response.addHeader("Access-Control-Expose-Headers", "X-total-count");
+        return workflows;
     }
 
     @GET

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -807,7 +807,6 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         @ApiParam(value = "Should only be used by Dockstore versions < 1.14.0. Indicates whether to get a service or workflow") @DefaultValue("false") @QueryParam("services") boolean services,
         @ApiParam(value = "Which workflow subclass to retrieve. If present takes precedence over services parameter") @QueryParam("subclass") WorkflowSubClass subclass,
         @Context HttpServletResponse response) {
-        // delete the next line if GUI pagination is not working by 1.5.0 release
         int maxLimit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);
         final Class<Workflow> workflowClass = (Class<Workflow>) workflowSubClass(services, subclass);
         List<Workflow> workflows = workflowDAO.findAllPublished(offset, maxLimit, filter, sortCol, sortOrder,


### PR DESCRIPTION
**Description**
This PR redirects 500 errors that occur when providing invalid filters for the endpoints `/workflows/published` and `/containers/published`. 

**Review Instructions**
These curl commands should return a 400. 
`curl -X 'GET' "https://qa.dockstore.org/api/workflows/published?offset=42&limit=42&filter=string%20value&sortCol=string%20value&sortOrder=string%20value&services=True&subclass=BIOWORKFLOW" -H "accept: application/json"` 

`curl -X 'GET' "https://qa.dockstore.org/api/containers/published?offset=1&limit=42&filter=string%20value&sortCol=string%20value&sortOrder=string" -H "accept: application/json"`

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2397

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
