### PR TITLE
Only apply CORS headers to TRS endpoints

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV1IT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV1IT.java
@@ -241,8 +241,8 @@ class GA4GHV1IT extends GA4GHIT {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add("Origin", origin);
         Response response = client.target(nginxRewrittenPath).request().headers(headers).get();
-        assertEquals(response.getHeaders().getFirst("Access-Control-Allow-Credentials"), "true");
-        assertEquals(response.getHeaders().getFirst("Access-Control-Allow-Origin"), origin);
+        assertEquals("true", response.getHeaders().getFirst("Access-Control-Allow-Credentials"));
+        assertEquals(origin, response.getHeaders().getFirst("Access-Control-Allow-Origin"));
     }
 
     @Override

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV1IT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV1IT.java
@@ -241,8 +241,8 @@ class GA4GHV1IT extends GA4GHIT {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add("Origin", origin);
         Response response = client.target(nginxRewrittenPath).request().headers(headers).get();
-        assertTrue(response.getHeaders().getFirst("Access-Control-Allow-Credentials").equals("true"));
-        assertTrue(response.getHeaders().getFirst("Access-Control-Allow-Origin").equals(origin));
+        assertEquals(response.getHeaders().getFirst("Access-Control-Allow-Credentials"), "true");
+        assertEquals(response.getHeaders().getFirst("Access-Control-Allow-Origin"), origin);
     }
 
     @Override

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV1IT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV1IT.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.TestUtility;
 import io.swagger.client.model.MetadataV1;
 import io.swagger.client.model.ToolClass;
 import io.swagger.client.model.ToolDockerfile;
@@ -31,6 +32,8 @@ import io.swagger.client.model.ToolV1;
 import io.swagger.client.model.ToolVersionV1;
 import io.swagger.model.ToolDescriptor;
 import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.apache.http.HttpStatus;
@@ -225,6 +228,21 @@ class GA4GHV1IT extends GA4GHIT {
         // note: v1 really does expect only one item
         ToolDockerfile responseObject = response.readEntity(ToolDockerfile.class);
         assertTrue(!responseObject.getDockerfile().isEmpty() && !responseObject.getUrl().isEmpty());
+    }
+
+    /*
+    Checks the GA4GHv1 endpoints to make sure the CORS header is present
+     */
+
+    @Test
+    void testV1CorsHeader() {
+        final String origin = "http://mysite.org";
+        String nginxRewrittenPath = TestUtility.mimicNginxRewrite(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/dockerfile", basePath);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Origin", origin);
+        Response response = client.target(nginxRewrittenPath).request().headers(headers).get();
+        assertTrue(response.getHeaders().getFirst("Access-Control-Allow-Credentials").equals("true"));
+        assertTrue(response.getHeaders().getFirst("Access-Control-Allow-Origin").equals(origin));
     }
 
     @Override

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2BetaIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2BetaIT.java
@@ -18,6 +18,7 @@ package io.dockstore.client.cli;
 import static io.dockstore.common.FixtureUtility.fixture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -33,6 +34,7 @@ import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
@@ -181,6 +183,23 @@ class GA4GHV2BetaIT extends GA4GHIT {
         Response response = client.target(nginxRewrittenPath).request().headers(headers).get();
         assertEquals("true", response.getHeaders().getFirst("Access-Control-Allow-Credentials"));
         assertEquals(origin, response.getHeaders().getFirst("Access-Control-Allow-Origin"));
+    }
+
+    /*
+    Checks to make sure the CORS header is not applied to the extended endpoints
+     */
+
+    @Test
+    void testV2BetaExtendedNoCorsHeader() {
+        final String origin = "http://mysite.org";
+        final List<String> paths = Arrays.asList("extended/organizations", "extended/tools/index");
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Origin", origin);
+        paths.stream().forEach(path -> {
+            Response response = client.target(baseURL + path).request().headers(headers).get();
+            assertFalse(response.getHeaders().containsKey("Access-Control-Allow-Credentials"));
+            assertFalse(response.getHeaders().containsKey("Access-Control-Allow-Origin"));
+        });
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2BetaIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2BetaIT.java
@@ -179,8 +179,8 @@ class GA4GHV2BetaIT extends GA4GHIT {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add("Origin", origin);
         Response response = client.target(nginxRewrittenPath).request().headers(headers).get();
-        assertEquals(response.getHeaders().getFirst("Access-Control-Allow-Credentials"), "true");
-        assertEquals(response.getHeaders().getFirst("Access-Control-Allow-Origin"), origin);
+        assertEquals("true", response.getHeaders().getFirst("Access-Control-Allow-Credentials"));
+        assertEquals(origin, response.getHeaders().getFirst("Access-Control-Allow-Origin"));
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2BetaIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2BetaIT.java
@@ -179,8 +179,8 @@ class GA4GHV2BetaIT extends GA4GHIT {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add("Origin", origin);
         Response response = client.target(nginxRewrittenPath).request().headers(headers).get();
-        assertTrue(response.getHeaders().getFirst("Access-Control-Allow-Credentials").equals("true"));
-        assertTrue(response.getHeaders().getFirst("Access-Control-Allow-Origin").equals(origin));
+        assertEquals(response.getHeaders().getFirst("Access-Control-Allow-Credentials"), "true");
+        assertEquals(response.getHeaders().getFirst("Access-Control-Allow-Origin"), origin);
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2BetaIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2BetaIT.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.TestUtility;
 import io.swagger.client.model.FileWrapper;
 import io.swagger.client.model.Metadata;
 import io.swagger.client.model.Tool;
@@ -29,6 +30,8 @@ import io.swagger.client.model.ToolClass;
 import io.swagger.client.model.ToolFile;
 import io.swagger.client.model.ToolVersion;
 import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.apache.http.HttpStatus;
@@ -165,6 +168,19 @@ class GA4GHV2BetaIT extends GA4GHIT {
         FileWrapper responseObject = response.readEntity(FileWrapper.class);
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertDescriptor(SUPPORT.getObjectMapper().writeValueAsString(responseObject));
+    }
+    /*
+    Checks the GA4GHv2 beta endpoints to make sure the CORS header is present
+     */
+    @Test
+    void testV2BetaCorsHeader() {
+        final String origin = "http://mysite.org";
+        String nginxRewrittenPath = TestUtility.mimicNginxRewrite(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/CWL/descriptor/%2Fnested%2Ftest.cwl.json", basePath);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Origin", origin);
+        Response response = client.target(nginxRewrittenPath).request().headers(headers).get();
+        assertTrue(response.getHeaders().getFirst("Access-Control-Allow-Credentials").equals("true"));
+        assertTrue(response.getHeaders().getFirst("Access-Control-Allow-Origin").equals(origin));
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2FinalIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2FinalIT.java
@@ -292,8 +292,8 @@ class GA4GHV2FinalIT extends GA4GHIT {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add("Origin", origin);
         Response response = client.target(nginxRewrittenPath).request().headers(headers).get();
-        assertTrue(response.getHeaders().getFirst("Access-Control-Allow-Credentials").equals("true"));
-        assertTrue(response.getHeaders().getFirst("Access-Control-Allow-Origin").equals(origin));
+        assertEquals(response.getHeaders().getFirst("Access-Control-Allow-Credentials"), "true");
+        assertEquals(response.getHeaders().getFirst("Access-Control-Allow-Origin"), origin);
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2FinalIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2FinalIT.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.TestUtility;
 import io.dockstore.openapi.client.model.FileWrapper;
 import io.dockstore.openapi.client.model.TRSService;
 import io.dockstore.openapi.client.model.Tool;
@@ -31,6 +32,7 @@ import io.dockstore.openapi.client.model.ToolFile;
 import io.dockstore.openapi.client.model.ToolVersion;
 import io.openapi.model.Service;
 import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
@@ -278,6 +280,20 @@ class GA4GHV2FinalIT extends GA4GHIT {
         FileWrapper responseObject = response.readEntity(FileWrapper.class);
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertDescriptor(SUPPORT.getObjectMapper().writeValueAsString(responseObject));
+    }
+
+    /*
+    Checks the GA4GHv2 final endpoints to make sure the CORS header is present
+     */
+    @Test
+    void testV2FinalCorsHeader() {
+        final String origin = "http://mysite.org";
+        String nginxRewrittenPath = TestUtility.mimicNginxRewrite(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/dockerfile", basePath);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Origin", origin);
+        Response response = client.target(nginxRewrittenPath).request().headers(headers).get();
+        assertTrue(response.getHeaders().getFirst("Access-Control-Allow-Credentials").equals("true"));
+        assertTrue(response.getHeaders().getFirst("Access-Control-Allow-Origin").equals(origin));
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2FinalIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2FinalIT.java
@@ -292,8 +292,8 @@ class GA4GHV2FinalIT extends GA4GHIT {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add("Origin", origin);
         Response response = client.target(nginxRewrittenPath).request().headers(headers).get();
-        assertEquals(response.getHeaders().getFirst("Access-Control-Allow-Credentials"), "true");
-        assertEquals(response.getHeaders().getFirst("Access-Control-Allow-Origin"), origin);
+        assertEquals("true", response.getHeaders().getFirst("Access-Control-Allow-Credentials"));
+        assertEquals(origin, response.getHeaders().getFirst("Access-Control-Allow-Origin"));
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiIT.java
@@ -18,7 +18,8 @@ package io.dockstore.client.cli;
 
 import static io.dockstore.common.CommonTestUtilities.PUBLIC_CONFIG_PATH;
 import static io.dockstore.common.CommonTestUtilities.WAIT_TIME;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import io.dockstore.client.cli.BaseIT.TestStatus;
 import io.dockstore.common.CommonTestUtilities;
@@ -58,7 +59,7 @@ import uk.org.webcompere.systemstubs.stream.SystemOut;
 class OpenApiIT {
 
     public static final DropwizardTestSupport<DockstoreWebserviceConfiguration> SUPPORT = new DropwizardTestSupport<>(
-        DockstoreWebserviceApplication.class, CommonTestUtilities.PUBLIC_CONFIG_PATH);
+            DockstoreWebserviceApplication.class, CommonTestUtilities.PUBLIC_CONFIG_PATH);
     protected static jakarta.ws.rs.client.Client client;
 
     @SystemStub
@@ -84,7 +85,7 @@ class OpenApiIT {
     @Disabled("no longer generated in 1.15 with transition to jakarta")
     void testSwagger20() {
         Response response = client.target(baseURL + "swagger.json").request().get();
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertEquals(response.getStatus(), HttpStatus.SC_OK);
         // To prevent connection leak?
         response.readEntity(String.class);
     }
@@ -101,15 +102,15 @@ class OpenApiIT {
         headers.add("Origin", origin);
         paths.stream().forEach(path -> {
             Response response = client.target(baseURL + path).request().headers(headers).get();
-            assertThat(response.getHeaders().containsKey("Access-Control-Allow-Credentials")).isFalse();
-            assertThat(response.getHeaders().containsKey("Access-Control-Allow-Origin")).isFalse();
+            assertFalse(response.getHeaders().containsKey("Access-Control-Allow-Credentials"));
+            assertFalse(response.getHeaders().containsKey("Access-Control-Allow-Origin"));
         });
     }
 
     @Test
     void testOpenApi30() {
         Response response = client.target(baseURL + "openapi.yaml").request().get();
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertEquals(response.getStatus(), HttpStatus.SC_OK);
         // To prevent connection leak?
         response.readEntity(String.class);
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiIT.java
@@ -28,7 +28,11 @@ import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.testing.DropwizardTestSupport;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.http.HttpStatus;
 import org.glassfish.jersey.client.ClientProperties;
 import org.junit.jupiter.api.AfterAll;
@@ -83,6 +87,23 @@ class OpenApiIT {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         // To prevent connection leak?
         response.readEntity(String.class);
+    }
+
+    /*
+    Tests to make sure CORS headers are NOT present on a non-GA4GH endpoint
+     */
+
+    @Test
+    void testDockstoreNoCors() {
+        final String origin = "http://mysite.org";
+        final List<String> paths = Arrays.asList("api/categories", "openapi.yaml");
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Origin", origin);
+        paths.stream().forEach(path -> {
+            Response response = client.target(baseURL + path).request().headers(headers).get();
+            assertThat(response.getHeaders().containsKey("Access-Control-Allow-Credentials")).isFalse();
+            assertThat(response.getHeaders().containsKey("Access-Control-Allow-Origin")).isFalse();
+        });
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiIT.java
@@ -85,7 +85,7 @@ class OpenApiIT {
     @Disabled("no longer generated in 1.15 with transition to jakarta")
     void testSwagger20() {
         Response response = client.target(baseURL + "swagger.json").request().get();
-        assertEquals(response.getStatus(), HttpStatus.SC_OK);
+        assertEquals(HttpStatus.SC_OK, response.getStatus());
         // To prevent connection leak?
         response.readEntity(String.class);
     }
@@ -110,7 +110,7 @@ class OpenApiIT {
     @Test
     void testOpenApi30() {
         Response response = client.target(baseURL + "openapi.yaml").request().get();
-        assertEquals(response.getStatus(), HttpStatus.SC_OK);
+        assertEquals(HttpStatus.SC_OK, response.getStatus());
         // To prevent connection leak?
         response.readEntity(String.class);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -470,12 +470,13 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         // optional CORS support
         // Enable CORS headers
         // final FilterRegistration.Dynamic cors = environment.servlets().addFilter("CORS", CrossOriginFilter.class);
+        final String methods = "GET,HEAD,POST,DELETE,PUT,OPTIONS,PATCH";
         CORS_ENDPOINTS.stream().forEach(urlContext -> {
             FilterHolder filterHolder = environment.getApplicationContext().addFilter(CrossOriginFilter.class, urlContext, EnumSet.of(REQUEST));
 
-            filterHolder.setInitParameter(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "GET,HEAD,POST,DELETE,PUT,OPTIONS,PATCH");
+            filterHolder.setInitParameter(ACCESS_CONTROL_ALLOW_METHODS_HEADER, methods);
             filterHolder.setInitParameter(ALLOWED_ORIGINS_PARAM, "*");
-            filterHolder.setInitParameter(ALLOWED_METHODS_PARAM, "GET,POST,DELETE,PUT,OPTIONS,PATCH");
+            filterHolder.setInitParameter(ALLOWED_METHODS_PARAM, methods);
             filterHolder.setInitParameter(ALLOWED_HEADERS_PARAM,
                     "Accept-Encoding,Authorization,X-Requested-With,Content-Type,Accept,Origin,Access-Control-Request-Headers,cache-control");
         });

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -191,7 +191,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
     public static final String GA4GH_API_PATH_V2_BETA = "/api/ga4gh/v2";
     public static final String GA4GH_API_PATH_V2_FINAL = "/ga4gh/trs/v2";
     public static final String GA4GH_API_PATH_V1 = "/api/ga4gh/v1";
-    public static final List<String> CORS_ENDPOINTS = Arrays.asList(
+    private static final List<String> CORS_ENDPOINTS = Arrays.asList(
             GA4GH_API_PATH_V2_BETA + "/*",
             GA4GH_API_PATH_V2_FINAL + "/*",
             GA4GH_API_PATH_V1 + "/*");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -192,7 +192,9 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
     public static final String GA4GH_API_PATH_V2_FINAL = "/ga4gh/trs/v2";
     public static final String GA4GH_API_PATH_V1 = "/api/ga4gh/v1";
     private static final List<String> CORS_ENDPOINTS = Arrays.asList(
-            GA4GH_API_PATH_V2_BETA + "/*",
+            GA4GH_API_PATH_V2_BETA + "/metadata/*",
+            GA4GH_API_PATH_V2_BETA + "/tools/*",
+            GA4GH_API_PATH_V2_BETA + "/toolClasses/*",
             GA4GH_API_PATH_V2_FINAL + "/*",
             GA4GH_API_PATH_V1 + "/*");
     public static final String DOCKSTORE_WEB_CACHE = "/tmp/dockstore-web-cache";

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -473,7 +473,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         CORS_ENDPOINTS.stream().forEach(urlContext -> {
             FilterHolder filterHolder = environment.getApplicationContext().addFilter(CrossOriginFilter.class, urlContext, EnumSet.of(REQUEST));
 
-            filterHolder.setInitParameter(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "GET,POST,DELETE,PUT,OPTIONS,PATCH");
+            filterHolder.setInitParameter(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "GET,HEAD,POST,DELETE,PUT,OPTIONS,PATCH");
             filterHolder.setInitParameter(ALLOWED_ORIGINS_PARAM, "*");
             filterHolder.setInitParameter(ALLOWED_METHODS_PARAM, "GET,POST,DELETE,PUT,OPTIONS,PATCH");
             filterHolder.setInitParameter(ALLOWED_HEADERS_PARAM,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -161,6 +161,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -190,6 +191,10 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
     public static final String GA4GH_API_PATH_V2_BETA = "/api/ga4gh/v2";
     public static final String GA4GH_API_PATH_V2_FINAL = "/ga4gh/trs/v2";
     public static final String GA4GH_API_PATH_V1 = "/api/ga4gh/v1";
+    public static final List<String> CORS_ENDPOINTS = Arrays.asList(
+            GA4GH_API_PATH_V2_BETA + "/*",
+            GA4GH_API_PATH_V2_FINAL + "/*",
+            GA4GH_API_PATH_V1 + "/*");
     public static final String DOCKSTORE_WEB_CACHE = "/tmp/dockstore-web-cache";
     public static final String DOCKSTORE_WEB_CACHE_MISS_LOG_FILE = "/tmp/dockstore-web-cache.misses.log";
     public static final File CACHE_MISS_LOG_FILE = new File(DOCKSTORE_WEB_CACHE_MISS_LOG_FILE);
@@ -463,13 +468,16 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         // optional CORS support
         // Enable CORS headers
         // final FilterRegistration.Dynamic cors = environment.servlets().addFilter("CORS", CrossOriginFilter.class);
-        final FilterHolder filterHolder = environment.getApplicationContext().addFilter(CrossOriginFilter.class, "/*", EnumSet.of(REQUEST));
+        CORS_ENDPOINTS.stream().forEach(urlContext -> {
+            FilterHolder filterHolder = environment.getApplicationContext().addFilter(CrossOriginFilter.class, urlContext, EnumSet.of(REQUEST));
 
-        filterHolder.setInitParameter(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "GET,POST,DELETE,PUT,OPTIONS,PATCH");
-        filterHolder.setInitParameter(ALLOWED_ORIGINS_PARAM, "*");
-        filterHolder.setInitParameter(ALLOWED_METHODS_PARAM, "GET,POST,DELETE,PUT,OPTIONS,PATCH");
-        filterHolder.setInitParameter(ALLOWED_HEADERS_PARAM,
-                "Authorization, X-Auth-Username, X-Auth-Password, X-Requested-With,Content-Type,Accept,Origin,Access-Control-Request-Headers,cache-control");
+            filterHolder.setInitParameter(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "GET,POST,DELETE,PUT,OPTIONS,PATCH");
+            filterHolder.setInitParameter(ALLOWED_ORIGINS_PARAM, "*");
+            filterHolder.setInitParameter(ALLOWED_METHODS_PARAM, "GET,POST,DELETE,PUT,OPTIONS,PATCH");
+            filterHolder.setInitParameter(ALLOWED_HEADERS_PARAM,
+                    "Authorization, X-Auth-Username, X-Auth-Password, X-Requested-With,Content-Type,Accept,Origin,Access-Control-Request-Headers,cache-control");
+        });
+
 
         // Initialize GitHub App Installation Access Token cache
         CacheConfigManager.initCache(configuration.getGitHubAppId(), configuration.getGitHubAppPrivateKeyFile());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -475,7 +475,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             filterHolder.setInitParameter(ALLOWED_ORIGINS_PARAM, "*");
             filterHolder.setInitParameter(ALLOWED_METHODS_PARAM, "GET,POST,DELETE,PUT,OPTIONS,PATCH");
             filterHolder.setInitParameter(ALLOWED_HEADERS_PARAM,
-                    "Authorization, X-Auth-Username, X-Auth-Password, X-Requested-With,Content-Type,Accept,Origin,Access-Control-Request-Headers,cache-control");
+                    "Accept-Encoding,Authorization,X-Requested-With,Content-Type,Accept,Origin,Access-Control-Request-Headers,cache-control");
         });
 
 


### PR DESCRIPTION
**Description**

Following on previous discussions, this PR modifies the headers returned by the webservice to selectively apply CORS headers for TRS endpoints only. This should allow current launch-with features to continue to work as expected while protecting usage of internal Dockstore API endpoints from other web applications.

**Review Instructions**

Verify that the CORS headers are applied as expected. Replace localhost with QA if reviewing in QA. Can also be checked from a browser

```
# each of these should return
# access-control-allow-origin: https://text.com
# access-control-allow-credentials: true
curl -I -H 'Origin: https://text.com' localhost:8080/api/ga4gh/v1/metadata | grep access-control
curl -I -H 'Origin: https://text.com' localhost:8080/api/ga4gh/v2/metadata  | grep access-control
curl -I -H 'Origin: https://text.com' localhost:8080/api/ga4gh/trs/v2/service-info | grep access-control
# any other API path should not have the header applied
# grep should show nothing
curl -I -H 'Origin: https://text.com' localhost:8080/api/organizations | grep access-control
```

**Issue**

https://ucsc-cgl.atlassian.net/browse/SEAB-5518

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [n/a] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
