### PR TITLE
Update zenodo client

### DIFF
--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-zenodo-client</artifactId>
-      <version>2.0.1</version>
+      <version>2.0.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-zenodo-client</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-zenodo-client</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.2</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-zenodo-client</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -36,6 +36,7 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.metamodel.Attribute;
 import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,8 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-
-import jakarta.persistence.metamodel.Attribute;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.http.HttpStatus;
 import org.hibernate.Session;

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
@@ -12,10 +12,24 @@ import io.dockstore.webservice.core.Author;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowVersion;
+import io.swagger.zenodo.client.ApiClient;
+import io.swagger.zenodo.client.api.PreviewApi;
 import io.swagger.zenodo.client.model.DepositMetadata;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class ZenodoHelperTest {
+
+    @Test
+    void testBasicFunctionality() {
+        ApiClient zenodoClient = new ApiClient();
+        String zenodoUrlApi = "https://sandbox.zenodo.org" + "/api";
+        zenodoClient.setBasePath(zenodoUrlApi);
+        PreviewApi previewApi = new PreviewApi(zenodoClient);
+        final Map map = (Map) previewApi.listLicenses();
+        // this is just a basic sanity check, the licenses api is one of the apis that does not require an access token, but it returns what looks like an elasticsearch object where the types don't match teh documentation
+        assertTrue(map.size() > 0);
+    }
 
     @Test
     void testcreateWorkflowTrsUrl() {

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
@@ -1,9 +1,6 @@
 package io.dockstore.webservice.helpers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import java.util.Map;
 
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
@@ -15,19 +12,24 @@ import io.dockstore.webservice.core.WorkflowVersion;
 import io.swagger.zenodo.client.ApiClient;
 import io.swagger.zenodo.client.api.PreviewApi;
 import io.swagger.zenodo.client.model.DepositMetadata;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class ZenodoHelperTest {
 
     @Test
     void testBasicFunctionality() {
         ApiClient zenodoClient = new ApiClient();
-        String zenodoUrlApi = "https://sandbox.zenodo.org" + "/api";
+        String zenodoUrlApi = "https://sandbox.zenodo.org/api";
         zenodoClient.setBasePath(zenodoUrlApi);
         PreviewApi previewApi = new PreviewApi(zenodoClient);
         final Map map = (Map) previewApi.listLicenses();
-        // this is just a basic sanity check, the licenses api is one of the apis that does not require an access token, but it returns what looks like an elasticsearch object where the types don't match teh documentation
+        // this is just a basic sanity check, the licenses api is one of the apis that does not require an access token, but it returns what
+        // looks like an elasticsearch object, this does not match the documentation. Ironically, we have this too for search. 
         assertTrue(map.size() > 0);
     }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
@@ -1,6 +1,9 @@
 package io.dockstore.webservice.helpers;
 
-import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
@@ -12,12 +15,8 @@ import io.dockstore.webservice.core.WorkflowVersion;
 import io.swagger.zenodo.client.ApiClient;
 import io.swagger.zenodo.client.api.PreviewApi;
 import io.swagger.zenodo.client.model.DepositMetadata;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class ZenodoHelperTest {
 


### PR DESCRIPTION
**Description**
Update zenodo client to jakarta and Java 17 like with the other libraries (see the various PRs associated with https://github.com/dockstore/dockstore/pull/5483 )
Add a test for some basic sanity, but since I changed the openapi.yaml as well in that other repo, we're kinda comparing apples and oranges 

**Review Instructions**
Unlike all the other libraries, this one didn't have to be updated to allow dockstore with dropwizard 4.0 to function. Thinking the tests for zenodo are particularly poor. QA doesn't seem hooked up, will update ticket with my findings when this is deployed to QA

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5513

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
