### PR TITLE
cwlavro update

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 364 third-party dependencies.
+Lists of 363 third-party dependencies.
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-slf4j (com.typesafe.akka:akka-slf4j_2.13:2.5.32 - https://akka.io/)
@@ -14,7 +14,7 @@ Lists of 364 third-party dependencies.
      (Apache License, Version 2.0) Apache Commons Codec (commons-codec:commons-codec:1.15 - https://commons.apache.org/proper/commons-codec/)
      (Apache License, Version 2.0) Apache Commons Collections (commons-collections:commons-collections:3.2.2 - http://commons.apache.org/collections/)
      (Apache License, Version 2.0) Apache Commons Compress (org.apache.commons:commons-compress:1.21 - https://commons.apache.org/proper/commons-compress/)
-     (Apache License, Version 2.0) (The Apache Software License, Version 2.0) Apache Commons Configuration (org.apache.commons:commons-configuration2:2.8.0 - https://commons.apache.org/proper/commons-configuration/)
+     (Apache License, Version 2.0) Apache Commons Configuration (org.apache.commons:commons-configuration2:2.8.0 - https://commons.apache.org/proper/commons-configuration/)
      (Apache License, Version 2.0) Apache Commons Exec (org.apache.commons:commons-exec:1.3 - http://commons.apache.org/proper/commons-exec/)
      (Apache License, Version 2.0) Apache Commons IO (commons-io:commons-io:2.11.0 - https://commons.apache.org/proper/commons-io/)
      (Apache License, Version 2.0) Apache Commons Lang (org.apache.commons:commons-lang3:3.12.0 - https://commons.apache.org/proper/commons-lang/)
@@ -92,7 +92,6 @@ Lists of 364 third-party dependencies.
      (Apache License, Version 2.0) ClassMate (com.fasterxml:classmate:1.5.1 - https://github.com/FasterXML/java-classmate)
      (The Apache License, Version 2.0) com.helger:profiler (com.helger:profiler:1.1.1 - https://github.com/phax/profiler)
      (The Apache Software License, Version 2.0) Commons Digester (commons-digester:commons-digester:2.1 - http://commons.apache.org/digester/)
-     (The Apache Software License, Version 2.0) Commons Lang (commons-lang:commons-lang:2.6 - http://commons.apache.org/lang/)
      (BSD-3-Clause) commons-compiler (org.codehaus.janino:commons-compiler:3.1.6 - http://janino-compiler.github.io/commons-compiler/)
      (Apache License 2.0) compiler (com.github.spullara.mustache.java:compiler:0.9.10 - http://github.com/spullara/mustache.java)
      (Apache-2.0) config (com.typesafe:config:1.4.1 - https://github.com/lightbend/config)
@@ -109,8 +108,8 @@ Lists of 364 third-party dependencies.
      (Cromwell License https://github.com/broadinstitute/cromwell/blob/develop/LICENSE.txt) cromwell-wdl-transforms-new-base (org.broadinstitute:cromwell-wdl-transforms-new-base_2.13:84 - no url defined)
      (Cromwell License https://github.com/broadinstitute/cromwell/blob/develop/LICENSE.txt) cromwell-wdl-transforms-shared (org.broadinstitute:cromwell-wdl-transforms-shared_2.13:84 - no url defined)
      (Cromwell License https://github.com/broadinstitute/cromwell/blob/develop/LICENSE.txt) cromwell-wom (org.broadinstitute:cromwell-wom_2.13:84 - no url defined)
-     (Apache License, Version 2.0) cwlavro-generated (io.cwl:cwlavro-generated:2.0.4.7 - no url defined)
-     (Apache License, Version 2.0) cwlavro-tools (io.cwl:cwlavro-tools:2.0.4.7 - no url defined)
+     (Apache License, Version 2.0) cwlavro-generated (io.cwl:cwlavro-generated:2.0.4.8 - no url defined)
+     (Apache License, Version 2.0) cwlavro-tools (io.cwl:cwlavro-tools:2.0.4.8 - no url defined)
      (The Apache Software License, Version 2.0) docker-java-api (com.github.docker-java:docker-java-api:3.3.0 - https://github.com/docker-java/docker-java)
      (The Apache Software License, Version 2.0) docker-java-core (com.github.docker-java:docker-java-core:3.3.0 - https://github.com/docker-java/docker-java)
      (The Apache Software License, Version 2.0) docker-java-transport (com.github.docker-java:docker-java-transport:3.3.0 - https://github.com/docker-java/docker-java)

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -65,7 +65,7 @@ POM as their parent.
         <powermock.version>2.0.9</powermock.version>
         <postgresql.version>42.4.3</postgresql.version>
         <mockito.version>3.12.4</mockito.version>
-        <cwlavro.version>2.0.4.7</cwlavro.version>
+        <cwlavro.version>2.0.4.8</cwlavro.version>
         <okhttp.version>4.10.0</okhttp.version>
         <slf4j.version>2.0.7</slf4j.version>
         <httpcomponents.version>4.5.14</httpcomponents.version>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -544,7 +544,7 @@
     <dependency>
       <groupId>io.cwl</groupId>
       <artifactId>cwlavro-tools</artifactId>
-      <version>2.0.4.7</version>
+      <version>2.0.4.8</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -560,7 +560,7 @@
     <dependency>
       <groupId>io.cwl</groupId>
       <artifactId>cwlavro-generated</artifactId>
-      <version>2.0.4.7</version>
+      <version>2.0.4.8</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -36,6 +36,7 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.metamodel.Attribute;
 import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,8 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-
-import jakarta.persistence.metamodel.Attribute;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.http.HttpStatus;
 import org.hibernate.Session;


### PR DESCRIPTION
**Description**
Gets us close to turning on transitive dependency ban to enforce old dependencies even from transitive dependencies. 
The last dependency is just the swagger-core 1.6.8 dependency
i.e. once we turn off swagger 2.0 and fully transition to openapi 3.0, we may be able to turn on the check assuming no other transitives are brought in

**Review Instructions**
n/a should build and function as before, just with a more consistent classpath

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
