### PR TITLE
Enable non-curator to update org

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -369,6 +369,7 @@ public class OrganizationIT extends BaseIT {
         newOrganization = organizationsApiUser2.getOrganizationById(organization.getId());
         String link = "http://www.anothersite.com";
         newOrganization.setLink(link);
+        newOrganization.setUsers(null); // It's null when the UI fetches the org. A little unclear why it's not already null in this test. See https://github.com/dockstore/dockstore/issues/5559
         organization = organizationsApiUser2.updateOrganization(newOrganization, organization.getId());
 
         // There should be two MODIFY_ORG events

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
@@ -582,11 +582,11 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
             throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
         }
 
-        Organization oldOrganization = organizationDAO.findById(id);
+        final Organization oldOrganization = organizationDAO.findById(id);
 
         // Ensure that the user is an admin or maintainer of the organization
         if (!user.isCurator() && !user.getIsAdmin()) {
-            boolean isUserAdminOrMaintainer = isUserAdminOrMaintainer(organization, user.getId());
+            final boolean isUserAdminOrMaintainer = isUserAdminOrMaintainer(oldOrganization, user.getId());
             if (!isUserAdminOrMaintainer) {
                 String msg = "You do not have permissions to update the organization.";
                 LOG.info(msg);


### PR DESCRIPTION
**Description**
Enables a non-curator to update an org.

**Review Instructions**
1. Be an admin of an org
2. Don't be a Dockstore curator or admin
3. Navigate to the org
4. Click Edit to edit the org, make some change(s) in the dialog, click `Update Organization`
5. It should work and not give you an error.

**Issue**
#5559

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
