### PR TITLE
Return 415 if invalid JSON

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -93,6 +93,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
     public static final String INVALID_PLATFORM = "Invalid platform. Please select an individual platform.";
     public static final String TOOL_NOT_FOUND_ERROR = "Tool not found";
     public static final String VERSION_NOT_FOUND_ERROR = "Version not found";
+    public static final String SEARCH_QUERY_INVALID_JSON = "Search payload request is not valid JSON";
     private static final Logger LOG = LoggerFactory.getLogger(ToolsApiExtendedServiceImpl.class);
     private static final ToolsApiServiceImpl TOOLS_API_SERVICE_IMPL = new ToolsApiServiceImpl();
 
@@ -318,7 +319,12 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
      */
     protected static void checkSearchTermLimit(String query) {
         if (query != null) {
-            JSONObject json = new JSONObject(query);
+            JSONObject json;
+            try {
+                json = new JSONObject(query);
+            } catch (JSONException ex) {
+                throw new CustomWebApplicationException(SEARCH_QUERY_INVALID_JSON, HttpStatus.SC_BAD_REQUEST);
+            }
 
             try {
                 String include = json.getJSONObject("aggs").getJSONObject("autocomplete").getJSONObject("terms").getString("include");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -323,6 +323,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
             try {
                 json = new JSONObject(query);
             } catch (JSONException ex) {
+                LOG.error(SEARCH_QUERY_INVALID_JSON, ex);
                 throw new CustomWebApplicationException(SEARCH_QUERY_INVALID_JSON, HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE);
             }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -323,7 +323,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
             try {
                 json = new JSONObject(query);
             } catch (JSONException ex) {
-                throw new CustomWebApplicationException(SEARCH_QUERY_INVALID_JSON, HttpStatus.SC_BAD_REQUEST);
+                throw new CustomWebApplicationException(SEARCH_QUERY_INVALID_JSON, HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE);
             }
 
             try {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
@@ -94,6 +94,7 @@ public class ToolsExtendedApi {
 
     @POST
     @Path("/tools/entry/_search")
+    @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON})
     @ApiOperation(nickname = ToolsIndexSearch.OPERATION_ID, value = ToolsIndexSearch.SUMMARY, notes = ToolsIndexSearch.DESCRIPTION, response = String.class)
     @ApiResponses(value = {@ApiResponse(code = HttpStatus.SC_OK, message = ToolsIndexSearch.OK_RESPONSE, response = String.class)})

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -438,7 +438,7 @@ paths:
       operationId: toolsIndexSearch
       requestBody:
         content:
-          '*/*':
+          application/json:
             schema:
               type: string
       responses:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -523,6 +523,8 @@ paths:
       description: "This endpoint searches the indices for all published tools and\
         \ workflows. Used by utilities that expect to talk to an elastic search endpoint."
       operationId: "toolsIndexSearch"
+      consumes:
+      - "application/json"
       produces:
       - "application/json"
       parameters:

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
@@ -1,8 +1,5 @@
 package io.dockstore.webservice.resources.proposedGA4GH;
 
-import static io.dockstore.webservice.resources.proposedGA4GH.ToolsApiExtendedServiceImpl.SEARCH_QUERY_INVALID_JSON;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -12,7 +9,6 @@ import io.dockstore.webservice.CustomWebApplicationException;
 import io.dropwizard.testing.ResourceHelpers;
 import java.io.File;
 import java.io.IOException;
-import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 class ToolsApiExtendedServiceImplTest {
@@ -53,16 +49,5 @@ class ToolsApiExtendedServiceImplTest {
         } catch (CustomWebApplicationException ex) {
             fail("Queries that can't be parsed for an \"include\" key or wildcards should pass");
         }
-
-        // Test that queries with invalid JSON return a 400
-        CustomWebApplicationException exception = assertThrows(CustomWebApplicationException.class, () -> ToolsApiExtendedServiceImpl.checkSearchTermLimit("foobar"));
-        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponse().getStatus());
-        assertEquals(SEARCH_QUERY_INVALID_JSON, exception.getErrorMessage());
-        exception = assertThrows(CustomWebApplicationException.class, () -> ToolsApiExtendedServiceImpl.checkSearchTermLimit("{"));
-        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponse().getStatus());
-        assertEquals(SEARCH_QUERY_INVALID_JSON, exception.getErrorMessage());
-        exception = assertThrows(CustomWebApplicationException.class, () -> ToolsApiExtendedServiceImpl.checkSearchTermLimit("{\"aggs\":}"));
-        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponse().getStatus());
-        assertEquals(SEARCH_QUERY_INVALID_JSON, exception.getErrorMessage());
     }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
@@ -1,5 +1,8 @@
 package io.dockstore.webservice.resources.proposedGA4GH;
 
+import static io.dockstore.webservice.resources.proposedGA4GH.ToolsApiExtendedServiceImpl.SEARCH_QUERY_INVALID_JSON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -9,6 +12,7 @@ import io.dockstore.webservice.CustomWebApplicationException;
 import io.dropwizard.testing.ResourceHelpers;
 import java.io.File;
 import java.io.IOException;
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 class ToolsApiExtendedServiceImplTest {
@@ -49,5 +53,16 @@ class ToolsApiExtendedServiceImplTest {
         } catch (CustomWebApplicationException ex) {
             fail("Queries that can't be parsed for an \"include\" key or wildcards should pass");
         }
+
+        // Test that queries with invalid JSON return a 400
+        CustomWebApplicationException exception = assertThrows(CustomWebApplicationException.class, () -> ToolsApiExtendedServiceImpl.checkSearchTermLimit("foobar"));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponse().getStatus());
+        assertEquals(SEARCH_QUERY_INVALID_JSON, exception.getErrorMessage());
+        exception = assertThrows(CustomWebApplicationException.class, () -> ToolsApiExtendedServiceImpl.checkSearchTermLimit("{"));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponse().getStatus());
+        assertEquals(SEARCH_QUERY_INVALID_JSON, exception.getErrorMessage());
+        exception = assertThrows(CustomWebApplicationException.class, () -> ToolsApiExtendedServiceImpl.checkSearchTermLimit("{\"aggs\":}"));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, exception.getResponse().getStatus());
+        assertEquals(SEARCH_QUERY_INVALID_JSON, exception.getErrorMessage());
     }
 }


### PR DESCRIPTION
**Description**
This PR returns a 415 if the search query is invalid JSON.

**Review Instructions**
Need to wait for the 1.14.1 hotfix to be deployed to staging before reviewing.

In your terminal, execute search commands with invalid JSON like the following:
- `curl -X POST https://staging.dockstore.org/api/api/ga4gh/v2/extended/tools/entry/_search -H 'accept: application/json' -d "foo"`
- `curl -X POST https://staging.dockstore.org/api/api/ga4gh/v2/extended/tools/entry/_search -H 'accept: application/json' -d "{"`

The response should be a 415 stating that the query is invalid JSON.

Also navigate to the search page in staging and sanity check that search is still functioning as expected (click on a few facets, search something).

**Issue**
[SEAB-3840](https://ucsc-cgl.atlassian.net/browse/SEAB-3840)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-3840]: https://ucsc-cgl.atlassian.net/browse/SEAB-3840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ