### PR TITLE
Remove unused getSpecificUser endpoint

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -243,22 +243,6 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @GET
     @Timed
     @UnitOfWork(readOnly = true)
-    @Path("/{userId}")
-    @Operation(operationId = "getSpecificUser", description = "Get user by id.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
-    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A user with the specified userId", content = @Content(schema = @Schema(implementation = User.class)))
-    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
-    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = USER_NOT_FOUND_DESCRIPTION)
-    @ApiOperation(nickname = "getSpecificUser", value = "Get user by id.", authorizations = { @Authorization(value = JWT_SECURITY_DEFINITION_NAME) }, response = User.class)
-    public User getUser(@ApiParam(hidden = true) @Parameter(hidden = true) @Auth User authUser, @ApiParam("User to return") @PathParam("userId") long userId) {
-        checkUserId(authUser, userId);
-        User user = userDAO.findById(userId);
-        checkNotNullUser(user);
-        return user;
-    }
-
-    @GET
-    @Timed
-    @UnitOfWork(readOnly = true)
     @Path("/user")
     @Operation(operationId = "getUser", description = "Get the logged-in user.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "The logged-in user", content = @Content(schema = @Schema(implementation = User.class)))

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -5469,32 +5469,6 @@ paths:
       - BEARER: []
       tags:
       - users
-  /users/{userId}:
-    get:
-      description: Get user by id.
-      operationId: getSpecificUser
-      parameters:
-      - in: path
-        name: userId
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-          description: A user with the specified userId
-        "403":
-          description: Forbidden
-        "404":
-          description: User not found
-      security:
-      - BEARER: []
-      tags:
-      - users
   /users/{userId}/appTools:
     get:
       description: List all appTools owned by the authenticated user.


### PR DESCRIPTION
**Description**
Removes the unused `getSpecficUser` endpoint.

Background and reasoning discussed in this [JIRA comment](https://ucsc-cgl.atlassian.net/browse/SEAB-5635?focusedCommentId=45516).

**Review Instructions**
This [endpoint](https://qa.dockstore.org/api/static/swagger-ui/index.html#/users/getSpecificUser) should no longer be present.

**Issue**
SEAB-5635

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
