### PR TITLE
DOCK-2391: return 415 for google token endpoint

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -437,6 +437,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
         try {
             element = gson.fromJson(satellizerJson, JsonElement.class);
         } catch (JsonSyntaxException ex) {
+            LOG.warn("Invalid JSON provided");
             throw new CustomWebApplicationException(INVALID_JSON, HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE);
         }
         JsonObject satellizerObject = element.getAsJsonObject();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -437,7 +437,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
         try {
             element = gson.fromJson(satellizerJson, JsonElement.class);
         } catch (JsonSyntaxException ex) {
-            LOG.warn("Invalid JSON provided");
+            LOG.warn(INVALID_JSON);
             throw new CustomWebApplicationException(INVALID_JSON, HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE);
         }
         JsonObject satellizerObject = element.getAsJsonObject();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -37,6 +37,7 @@ import com.google.common.io.BaseEncoding;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 import io.dockstore.common.HttpStatusMessageConstants;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
@@ -83,6 +84,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -131,6 +133,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     private static final Logger LOG = LoggerFactory.getLogger(TokenResource.class);
     private static final String TOKEN_NOT_FOUND_DESCRIPTION = "Token not found";
     private static final String USER_NOT_FOUND_MESSAGE = "User not found";
+    public static final String INVALID_JSON = "Invalid JSON provided";
 
     private final TokenDAO tokenDAO;
     private final UserDAO userDAO;
@@ -417,6 +420,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
     @Timed
     @UnitOfWork
     @Path("/google")
+    @Consumes(MediaType.APPLICATION_JSON)
     @JsonView(TokenViews.Auth.class)
     @Operation(operationId = "addGoogleToken", description = "Allow satellizer to post a new Google token to Dockstore.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully posted a new Google token to Dockstore", content = @Content(schema = @Schema(implementation = Token.class)))
@@ -429,7 +433,12 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME)}, notes = "A post method is required by satellizer to send the Google token", response = Token.class)
     public Token addGoogleToken(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth Optional<User> authUser, @ApiParam("code") String satellizerJson) {
         Gson gson = new Gson();
-        JsonElement element = gson.fromJson(satellizerJson, JsonElement.class);
+        JsonElement element;
+        try {
+            element = gson.fromJson(satellizerJson, JsonElement.class);
+        } catch (JsonSyntaxException ex) {
+            throw new CustomWebApplicationException(INVALID_JSON, HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE);
+        }
         JsonObject satellizerObject = element.getAsJsonObject();
         final String code = getCodeFromSatellizerObject(satellizerObject);
         final String redirectUri = getRedirectURIFromSatellizerObject(satellizerObject);

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -866,7 +866,7 @@ paths:
       operationId: addGoogleToken
       requestBody:
         content:
-          '*/*':
+          application/json:
             schema:
               type: string
       responses:

--- a/dockstore-webservice/src/main/resources/swagger.yaml
+++ b/dockstore-webservice/src/main/resources/swagger.yaml
@@ -1370,6 +1370,8 @@ paths:
       summary: "Allow satellizer to post a new Google token to Dockstore."
       description: "A post method is required by satellizer to send the Google token"
       operationId: "addGoogleToken"
+      consumes:
+      - "application/json"
       produces:
       - "application/json"
       parameters:


### PR DESCRIPTION
**Description**
This PR returns a 415 error when an invalid json is provided for `/auth/tokens/google`.

**Review Instructions**
After the 1.14.1 hotfix is deployed to staging, execute curl commands with invalid JSON

```
curl -X 'POST' \
  'http://staging.dockstore.org/api/auth/tokens/google' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <redacted>' \
  -d '"string"'
```

```
curl -X 'POST' \
  'http://staging.dockstore.org/api/auth/tokens/google' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <redacted>' \
  -d '"{"'
```

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2391

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
