### PR TITLE
Add cost metric

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 363 third-party dependencies.
+Lists of 364 third-party dependencies.
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-slf4j (com.typesafe.akka:akka-slf4j_2.13:2.5.32 - https://akka.io/)
@@ -251,6 +251,7 @@ Lists of 363 third-party dependencies.
      (Apache License, Version 2.0) Joda-Time (joda-time:joda-time:2.12.5 - https://www.joda.org/joda-time/)
      (Public Domain) JSON in Java (org.json:json:20230227 - https://github.com/douglascrockford/JSON-java)
      (Revised BSD License) JSONLD Java :: Core (com.github.jsonld-java:jsonld-java:0.8.3 - http://github.com/jsonld-java/jsonld-java/jsonld-java/)
+     (Apache License, Version 2.0) JSR 354 (Money and Currency API) (javax.money:money-api:1.1 - https://javamoney.github.io/)
      (MIT License) JUL to SLF4J bridge (org.slf4j:jul-to-slf4j:2.0.7 - http://www.slf4j.org)
      (Eclipse Public License v2.0) JUnit Jupiter (Aggregator) (org.junit.jupiter:junit-jupiter:5.9.2 - https://junit.org/junit5/)
      (Eclipse Public License v2.0) JUnit Jupiter API (org.junit.jupiter:junit-jupiter-api:5.9.2 - https://junit.org/junit5/)

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 
-Lists of 364 third-party dependencies.
+Lists of 366 third-party dependencies.
      (Apache License, Version 2.0) akka-actor (com.typesafe.akka:akka-actor_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-protobuf (com.typesafe.akka:akka-protobuf_2.13:2.5.32 - https://akka.io/)
      (Apache License, Version 2.0) akka-slf4j (com.typesafe.akka:akka-slf4j_2.13:2.5.32 - https://akka.io/)
@@ -213,6 +213,7 @@ Lists of 364 third-party dependencies.
      (The Apache Software License, Version 2.0) java-diff-utils (io.github.java-diff-utils:java-diff-utils:4.12 - https://github.com/java-diff-utils/java-diff-utils/java-diff-utils)
      (CDDL/GPLv2+CE) JavaBeans Activation Framework (com.sun.activation:javax.activation:1.2.0 - http://java.net/all/javax.activation/)
      (Apache License 2.0) (LGPL 2.1) (MPL 1.1) Javassist (org.javassist:javassist:3.29.2-GA - http://www.javassist.org/)
+     (CDDL + GPLv2 with classpath exception) javax.annotation API (javax.annotation:javax.annotation-api:1.3.2 - http://jcp.org/en/jsr/detail?id=250)
      (Eclipse Distribution License - v 1.0) JAXB Core (org.glassfish.jaxb:jaxb-core:3.0.2 - https://eclipse-ee4j.github.io/jaxb-ri/)
      (Eclipse Distribution License - v 1.0) JAXB Runtime (org.glassfish.jaxb:jaxb-runtime:3.0.2 - https://eclipse-ee4j.github.io/jaxb-ri/)
      (Apache License, version 2.0) JBoss Logging 3 (org.jboss.logging:jboss-logging:3.4.3.Final - http://www.jboss.org)
@@ -290,6 +291,7 @@ Lists of 364 third-party dependencies.
      (Eclipse Distribution License - v 1.0) MIME streaming extension (org.jvnet.mimepull:mimepull:1.9.15 - https://github.com/eclipse-ee4j/metro-mimepull)
      (The MIT License) mockito-core (org.mockito:mockito-core:3.12.4 - https://github.com/mockito/mockito)
      (The MIT License) mockito-inline (org.mockito:mockito-inline:3.12.4 - https://github.com/mockito/mockito)
+     (Apache 2 License) Moneta Core (org.javamoney.moneta:moneta-core:1.4.2 - http://javamoney.org)
      (MIT license) mouse (org.typelevel:mouse_2.13:1.0.10 - https://typelevel.org/mouse)
      (Apache License, Version 2.0) Netty Reactive Streams HTTP support (com.typesafe.netty:netty-reactive-streams-http:2.0.5 - https://github.com/playframework/netty-reactive-streams/netty-reactive-streams-http)
      (Apache License, Version 2.0) Netty Reactive Streams Implementation (com.typesafe.netty:netty-reactive-streams:2.0.5 - https://github.com/playframework/netty-reactive-streams/netty-reactive-streams)

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -82,6 +82,7 @@ POM as their parent.
         <docker-client.version>3.3.0</docker-client.version>
         <system-stubs.version>2.0.1</system-stubs.version>
         <jjwt.suite.version>0.11.5</jjwt.suite.version>
+        <moneta.version>0.11.5</moneta.version>
 
         <skipTests>false</skipTests>
         <skipITs>true</skipITs>
@@ -732,7 +733,14 @@ POM as their parent.
             <dependency>
                 <groupId>org.javamoney</groupId>
                 <artifactId>moneta</artifactId>
-                <version>1.1</version>
+                <version>${moneta.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.javamoney.moneta</groupId>
+                <artifactId>moneta-core</artifactId>
+                <version>${moneta.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.money</groupId>

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -729,6 +729,17 @@ POM as their parent.
                 <version>1.3.2</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.javamoney</groupId>
+                <artifactId>moneta</artifactId>
+                <version>1.1</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.money</groupId>
+                <artifactId>money-api</artifactId>
+                <version>1.1</version>
+            </dependency>
+
             <!-- mocking dependencies -->
             <dependency>
                 <groupId>org.powermock</groupId>

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -82,7 +82,7 @@ POM as their parent.
         <docker-client.version>3.3.0</docker-client.version>
         <system-stubs.version>2.0.1</system-stubs.version>
         <jjwt.suite.version>0.11.5</jjwt.suite.version>
-        <moneta.version>0.11.5</moneta.version>
+        <moneta.version>1.4.2</moneta.version>
 
         <skipTests>false</skipTests>
         <skipITs>true</skipITs>

--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -130,6 +130,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.javamoney.moneta</groupId>
+      <artifactId>moneta-core</artifactId>
+      <version>1.4.2</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.money</groupId>
       <artifactId>money-api</artifactId>
       <version>1.1</version>

--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -130,6 +130,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>javax.money</groupId>
+      <artifactId>money-api</artifactId>
+      <version>1.1</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.broadinstitute</groupId>
       <artifactId>wdl-draft3_2.13</artifactId>
       <version>84</version>

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -120,6 +120,10 @@
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.money</groupId>
+            <artifactId>money-api</artifactId>
+        </dependency>
 
 
         <!-- broad - cromwell stuff -->

--- a/dockstore-common/pom.xml
+++ b/dockstore-common/pom.xml
@@ -121,6 +121,10 @@
             <artifactId>commons-beanutils</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.javamoney.moneta</groupId>
+            <artifactId>moneta-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.money</groupId>
             <artifactId>money-api</artifactId>
         </dependency>
@@ -411,6 +415,7 @@
 
                             <usedDependencies>
                                 <usedDependency>jakarta.annotation:jakarta.annotation-api</usedDependency>
+                                <usedDependency>org.javamoney.moneta:moneta-core</usedDependency>
                             </usedDependencies>
                         </configuration>
                     </execution>

--- a/dockstore-common/src/main/java/io/dockstore/common/metrics/FormatCheckHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/metrics/FormatCheckHelper.java
@@ -17,6 +17,8 @@
 
 package io.dockstore.common.metrics;
 
+import static javax.money.Monetary.isCurrencyAvailable;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
@@ -58,5 +60,13 @@ public final class FormatCheckHelper {
             LOG.warn("Execution date {} is not in ISO 8601 date format and could not be parsed to a Date", executionDate, e);
             return Optional.empty();
         }
+    }
+
+    /**
+     * Check that the Currency Code is valid by using the Java Money library.
+     * @param currencyCode Currency code to check
+     */
+    public static boolean isValidCurrencyCode(String currencyCode) {
+        return isCurrencyAvailable(currencyCode);
     }
 }

--- a/dockstore-common/src/test/java/io/dockstore/common/metrics/FormatCheckHelperTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/metrics/FormatCheckHelperTest.java
@@ -41,4 +41,11 @@ class FormatCheckHelperTest {
         assertTrue(FormatCheckHelper.checkExecutionDateISO8601Format("2023-03-31T15:06:49Z").isPresent());
         assertFalse(FormatCheckHelper.checkExecutionDateISO8601Format("2023-03-31T15:06:49").isPresent(), "Should fail because it's not in UTC");
     }
+
+    @Test
+    void testIsValidCurrencyCode() {
+        assertTrue(FormatCheckHelper.isValidCurrencyCode("USD"));
+        assertTrue(FormatCheckHelper.isValidCurrencyCode("CAD"));
+        assertFalse(FormatCheckHelper.isValidCurrencyCode("ABC"));
+    }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
@@ -62,6 +62,7 @@ import io.dockstore.openapi.client.api.ContainersApi;
 import io.dockstore.openapi.client.api.ExtendedGa4GhApi;
 import io.dockstore.openapi.client.api.UsersApi;
 import io.dockstore.openapi.client.api.WorkflowsApi;
+import io.dockstore.openapi.client.model.Cost;
 import io.dockstore.openapi.client.model.CpuMetric;
 import io.dockstore.openapi.client.model.ExecutionStatusMetric;
 import io.dockstore.openapi.client.model.ExecutionTimeMetric;
@@ -678,7 +679,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
             execution.setExecutionTime("PT5M");
             execution.setCpuRequirements(2);
             execution.setMemoryRequirementsGB(2.0);
-            execution.setCostUSD(9.99);
+            execution.setCost(new Cost().value(9.99));
             execution.setRegion("us-central1");
             Map<String, Object> additionalProperties = Map.of("schema.org:totalTime", "PT5M");
             execution.setAdditionalProperties(additionalProperties);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
@@ -678,6 +678,8 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
             execution.setExecutionTime("PT5M");
             execution.setCpuRequirements(2);
             execution.setMemoryRequirementsGB(2.0);
+            execution.setCostUSD(9.99);
+            execution.setRegion("us-central1");
             Map<String, Object> additionalProperties = Map.of("schema.org:totalTime", "PT5M");
             execution.setAdditionalProperties(additionalProperties);
             executions.add(execution);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
@@ -208,9 +208,13 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         verifyRunExecutionMetricsDataContent(metricsData, runExecutions);
 
         // Send validation metrics data to S3 for the same workflow version, but different platform
-        List<io.dockstore.openapi.client.model.ValidationExecution> validationExecutions = List.of(new io.dockstore.openapi.client.model.ValidationExecution().isValid(true).validatorTool(
-                ValidationExecution.ValidatorToolEnum.MINIWDL).validatorToolVersion("v1.9.1").dateExecuted(
-                Instant.now().toString())); // This workflow version successfully validated with miniwdl
+        // This workflow version successfully validated with miniwdl
+        ValidationExecution validationExecution = new ValidationExecution();
+        validationExecution.setIsValid(true);
+        validationExecution.setValidatorTool(ValidationExecution.ValidatorToolEnum.MINIWDL);
+        validationExecution.setValidatorToolVersion("v1.9.1");
+        validationExecution.setDateExecuted(Instant.now().toString());
+        List<io.dockstore.openapi.client.model.ValidationExecution> validationExecutions = List.of(validationExecution);
         extendedGa4GhApi.executionMetricsPost(new ExecutionsRequestBody().validationExecutions(validationExecutions), platform2, workflowId, workflowVersionId, description);
         metricsDataList = verifyMetricsDataList(workflowId, workflowVersionId, 2);
         metricsData = verifyMetricsDataInfo(metricsDataList, workflowId, workflowVersionId, platform2, String.format(workflowExpectedS3KeyPrefixFormat, platform2));
@@ -291,6 +295,13 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         assertEquals(HttpStatus.SC_UNPROCESSABLE_ENTITY, exception.getCode(), "Should not be able to submit metrics if ExecutionStatus is missing");
         assertTrue(exception.getMessage().contains("executionStatus") && exception.getMessage().contains("is missing"), "Should not be able to submit metrics if ExecutionStatus is missing");
 
+        // Test that the response body must contain dateExecuted for RunExecution
+        List<RunExecution> runExecutionsWithMissingDate = createRunExecutions(1);
+        runExecutionsWithMissingDate.forEach(execution -> execution.setDateExecuted(null));
+        exception = assertThrows(ApiException.class, () -> extendedGa4GhApi.executionMetricsPost(new ExecutionsRequestBody().runExecutions(runExecutionsWithMissingDate), platform, id, versionId, description));
+        assertEquals(HttpStatus.SC_UNPROCESSABLE_ENTITY, exception.getCode(), "Should not be able to submit metrics if dateExecuted is missing");
+        assertTrue(exception.getMessage().contains("dateExecuted") && exception.getMessage().contains("is missing"), "Should not be able to submit metrics if dateExecuted is missing");
+
         // Test that malformed ExecutionTimes for RunExecution throw an exception
         List<RunExecution> malformedExecutionTimes = List.of(
                 new RunExecution().executionStatus(RunExecution.ExecutionStatusEnum.SUCCESSFUL).executionTime("1 second"),
@@ -309,8 +320,11 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         assertTrue(exception.getMessage().contains("isValid") && exception.getMessage().contains("validatorTool") && exception.getMessage().contains("is missing"), "Should not be able to submit metrics if required fields for ValidationExecution are missing");
 
         // Test that malformed dateExecuteds for ValidationExecution throw an exception
-        List<ValidationExecution> malformedDateExecuteds = List.of(new ValidationExecution().dateExecuted("March 23, 2023").isValid(true).validatorTool(
-                ValidationExecution.ValidatorToolEnum.MINIWDL));
+        ValidationExecution validationExecution = new ValidationExecution();
+        validationExecution.setIsValid(true);
+        validationExecution.setValidatorTool(ValidationExecution.ValidatorToolEnum.MINIWDL);
+        validationExecution.setDateExecuted("March 23, 2023");
+        List<ValidationExecution> malformedDateExecuteds = List.of(validationExecution);
         exception = assertThrows(ApiException.class, () -> extendedGa4GhApi.executionMetricsPost(new ExecutionsRequestBody().validationExecutions(malformedDateExecuteds), platform, id, versionId, description));
         assertEquals(HttpStatus.SC_UNPROCESSABLE_ENTITY, exception.getCode(), "Should not be able to submit metrics if dateExecuted is malformed");
         assertTrue(exception.getMessage().contains(EXECUTION_DATE_FORMAT_ERROR));
@@ -676,6 +690,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
             // A successful execution that ran for 5 minutes, requires 2 CPUs and 2 GBs of memory
             RunExecution execution = new RunExecution();
             execution.setExecutionStatus(RunExecution.ExecutionStatusEnum.SUCCESSFUL);
+            execution.setDateExecuted(Instant.now().toString());
             execution.setExecutionTime("PT5M");
             execution.setCpuRequirements(2);
             execution.setMemoryRequirementsGB(2.0);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/metrics/MetricsIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/metrics/MetricsIT.java
@@ -33,6 +33,7 @@ import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowVersion;
+import io.dockstore.webservice.core.metrics.CostStatisticMetric;
 import io.dockstore.webservice.core.metrics.CpuStatisticMetric;
 import io.dockstore.webservice.core.metrics.ExecutionStatusCountMetric;
 import io.dockstore.webservice.core.metrics.ExecutionTimeStatisticMetric;
@@ -184,6 +185,10 @@ class MetricsIT extends BaseIT {
         // The minimum CPU used was 1GB, the maximum was 4GB, and the average was 2G. 10 data points were used to calculate the average
         MemoryStatisticMetric memoryStatisticMetric = new MemoryStatisticMetric(1.0, 4.0, 2.5, 10);
         metrics.setMemory(memoryStatisticMetric);
+
+        // Add aggregated information about the cost of the workflow run
+        CostStatisticMetric costStatisticMetric = new CostStatisticMetric(1.00, 4.00, 2.50, 10);
+        metrics.setCost(costStatisticMetric);
 
         // Add aggregated information about validation
         // Add a successful miniwdl validation

--- a/dockstore-integration-testing/src/test/resources/prototype-metrics-request-body.json
+++ b/dockstore-integration-testing/src/test/resources/prototype-metrics-request-body.json
@@ -2,6 +2,7 @@
   "runExecutions": [
     {
       "executionStatus": "SUCCESSFUL",
+      "dateExecuted": "2023-03-31T15:06:49.888745366Z",
       "totalTime": "PT5m",
       "additionalProperties": {
         "@context": {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -68,6 +68,7 @@ import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.VersionMetadata;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowVersion;
+import io.dockstore.webservice.core.metrics.CostStatisticMetric;
 import io.dockstore.webservice.core.metrics.CountMetric;
 import io.dockstore.webservice.core.metrics.CpuStatisticMetric;
 import io.dockstore.webservice.core.metrics.ExecutionStatusCountMetric;
@@ -231,7 +232,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             Tag.class, Label.class, SourceFile.class, Workflow.class, CollectionOrganization.class, WorkflowVersion.class, FileFormat.class,
             Organization.class, Notification.class, OrganizationUser.class, Event.class, Collection.class, Validation.class, BioWorkflow.class, Service.class, VersionMetadata.class, Image.class, Checksum.class, LambdaEvent.class,
             ParsedInformation.class, EntryVersion.class, DeletedUsername.class, CloudInstance.class, Author.class, OrcidAuthor.class,
-            AppTool.class, Category.class, FullWorkflowPath.class, Notebook.class, SourceFileMetadata.class, Metrics.class, CpuStatisticMetric.class, MemoryStatisticMetric.class, ExecutionTimeStatisticMetric.class,
+            AppTool.class, Category.class, FullWorkflowPath.class, Notebook.class, SourceFileMetadata.class, Metrics.class, CpuStatisticMetric.class, MemoryStatisticMetric.class, ExecutionTimeStatisticMetric.class, CostStatisticMetric.class,
             CountMetric.class, ExecutionStatusCountMetric.class, ValidationStatusCountMetric.class, ValidatorInfo.class, ValidatorVersionInfo.class) {
         @Override
         public DataSourceFactory getDataSourceFactory(DockstoreWebserviceConfiguration configuration) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/Cost.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/Cost.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.dockstore.webservice.core.metrics;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "Cost", description = "Cost represents a monetary amount in USD")
+public class Cost {
+    private static final String DEFAULT_CURRENCY = "USD";
+
+    // We may eventually want to allow different currencies to be submitted
+    @Schema(description = "The currency of the cost value", defaultValue = DEFAULT_CURRENCY)
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private String currency = DEFAULT_CURRENCY;
+
+    @Schema(description = "The numerical value of the cost", example = "5.99")
+    private Double value;
+
+    @JsonCreator
+    public Cost(@JsonProperty("value") Double value) {
+        this.value = value;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+
+    public Double getValue() {
+        return value;
+    }
+
+    public void setValue(Double value) {
+        this.value = value;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/CostStatisticMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/CostStatisticMetric.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.dockstore.webservice.core.metrics;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "cost_metric")
+@Schema(name = "CostMetric", description = "This describes aggregated cost metrics for workflow executions in USD.")
+public class CostStatisticMetric extends StatisticMetric {
+    public static final String UNIT = "USD";
+
+    public CostStatisticMetric() {
+    }
+
+    @JsonCreator
+    public CostStatisticMetric(
+            @JsonProperty("minimum") Double minimum,
+            @JsonProperty("maximum") Double maximum,
+            @JsonProperty("average") Double average,
+            @JsonProperty("numberOfDataPointsForAverage") int numberOfDataPointsForAverage) {
+        super(minimum, maximum, average, numberOfDataPointsForAverage, UNIT);
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/CostStatisticMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/CostStatisticMetric.java
@@ -34,9 +34,9 @@ public class CostStatisticMetric extends StatisticMetric {
 
     @JsonCreator
     public CostStatisticMetric(
-            @JsonProperty("minimum") Double minimum,
-            @JsonProperty("maximum") Double maximum,
-            @JsonProperty("average") Double average,
+            @JsonProperty("minimum") double minimum,
+            @JsonProperty("maximum") double maximum,
+            @JsonProperty("average") double average,
             @JsonProperty("numberOfDataPointsForAverage") int numberOfDataPointsForAverage) {
         super(minimum, maximum, average, numberOfDataPointsForAverage, UNIT);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/CostStatisticMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/CostStatisticMetric.java
@@ -40,4 +40,10 @@ public class CostStatisticMetric extends StatisticMetric {
             @JsonProperty("numberOfDataPointsForAverage") int numberOfDataPointsForAverage) {
         super(minimum, maximum, average, numberOfDataPointsForAverage, UNIT);
     }
+
+    @Override
+    @Schema(description = "The unit of the data points", defaultValue = UNIT) // Override schema to provide a default value
+    public String getUnit() {
+        return super.getUnit();
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/CpuStatisticMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/CpuStatisticMetric.java
@@ -30,7 +30,7 @@ public class CpuStatisticMetric extends StatisticMetric {
     public CpuStatisticMetric() {
     }
 
-    public CpuStatisticMetric(Double minimum, Double maximum, Double average, int numberOfDataPointsForAverage) {
+    public CpuStatisticMetric(double minimum, double maximum, double average, int numberOfDataPointsForAverage) {
         super(minimum, maximum, average, numberOfDataPointsForAverage);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/Execution.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/Execution.java
@@ -18,7 +18,9 @@
 package io.dockstore.webservice.core.metrics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dockstore.webservice.core.metrics.constraints.ISO8601ExecutionDate;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 
 /**
@@ -29,6 +31,12 @@ public abstract class Execution {
 
     protected Execution() {
     }
+
+    @NotNull
+    @ISO8601ExecutionDate
+    @JsonProperty(required = true)
+    @Schema(description = "The date and time that the execution occurred in ISO 8601 UTC date format", requiredMode = Schema.RequiredMode.REQUIRED, example = "2023-03-31T15:06:49.888745366Z")
+    private String dateExecuted;
 
     @JsonProperty
     @Schema(description = "Additional properties that aren't defined. Provide a context, like one from schema.org, if you want to use a specific vocabulary",
@@ -41,6 +49,14 @@ public abstract class Execution {
             }
             """)
     private Map<String, Object> additionalProperties;
+
+    public String getDateExecuted() {
+        return dateExecuted;
+    }
+
+    public void setDateExecuted(String dateExecuted) {
+        this.dateExecuted = dateExecuted;
+    }
 
     public Map<String, Object> getAdditionalProperties() {
         return additionalProperties;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/ExecutionTimeStatisticMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/ExecutionTimeStatisticMetric.java
@@ -39,9 +39,9 @@ public class ExecutionTimeStatisticMetric extends StatisticMetric {
 
     @JsonCreator
     public ExecutionTimeStatisticMetric(
-            @JsonProperty("minimum") Double minimum,
-            @JsonProperty("maximum") Double maximum,
-            @JsonProperty("average") Double average,
+            @JsonProperty("minimum") double minimum,
+            @JsonProperty("maximum") double maximum,
+            @JsonProperty("average") double average,
             @JsonProperty("numberOfDataPointsForAverage") int numberOfDataPointsForAverage) {
         super(minimum, maximum, average, numberOfDataPointsForAverage, UNIT);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/ExecutionTimeStatisticMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/ExecutionTimeStatisticMetric.java
@@ -45,4 +45,10 @@ public class ExecutionTimeStatisticMetric extends StatisticMetric {
             @JsonProperty("numberOfDataPointsForAverage") int numberOfDataPointsForAverage) {
         super(minimum, maximum, average, numberOfDataPointsForAverage, UNIT);
     }
+
+    @Override
+    @Schema(description = "The unit of the data points", defaultValue = UNIT) // Override schema to provide a default value
+    public String getUnit() {
+        return super.getUnit();
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/MemoryStatisticMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/MemoryStatisticMetric.java
@@ -42,4 +42,10 @@ public class MemoryStatisticMetric extends StatisticMetric {
             @JsonProperty("numberOfDataPointsForAverage") int numberOfDataPointsForAverage) {
         super(minimum, maximum, average, numberOfDataPointsForAverage, UNIT);
     }
+
+    @Override
+    @Schema(description = "The unit of the data points", defaultValue = UNIT) // Override schema to provide a default value
+    public String getUnit() {
+        return super.getUnit();
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/MemoryStatisticMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/MemoryStatisticMetric.java
@@ -36,9 +36,9 @@ public class MemoryStatisticMetric extends StatisticMetric {
 
     @JsonCreator
     public MemoryStatisticMetric(
-            @JsonProperty("minimum") Double minimum,
-            @JsonProperty("maximum") Double maximum,
-            @JsonProperty("average") Double average,
+            @JsonProperty("minimum") double minimum,
+            @JsonProperty("maximum") double maximum,
+            @JsonProperty("average") double average,
             @JsonProperty("numberOfDataPointsForAverage") int numberOfDataPointsForAverage) {
         super(minimum, maximum, average, numberOfDataPointsForAverage, UNIT);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/Metrics.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/Metrics.java
@@ -80,6 +80,13 @@ public class Metrics {
 
     @Valid
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "cost", referencedColumnName = "id")
+    @ApiModelProperty(value = "Aggregated cost metrics in USD")
+    @Schema(description = "Aggregated cost metrics in USD")
+    private CostStatisticMetric cost;
+
+    @Valid
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "validationstatus", referencedColumnName = "id")
     @ApiModelProperty(value = "Aggregated validation status metrics")
     @Schema(description = "Aggregated validation status metrics")
@@ -147,6 +154,14 @@ public class Metrics {
 
     public void setCpu(CpuStatisticMetric cpu) {
         this.cpu = cpu;
+    }
+
+    public CostStatisticMetric getCost() {
+        return cost;
+    }
+
+    public void setCost(CostStatisticMetric cost) {
+        this.cost = cost;
     }
 
     public ValidationStatusCountMetric getValidationStatus() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/RunExecution.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/RunExecution.java
@@ -50,6 +50,18 @@ public class RunExecution extends Execution {
     @Schema(description = "Number of CPUs required for the execution", example = "2")
     private Integer cpuRequirements;
 
+    @JsonProperty
+    @Schema(description = "The cost of the execution in USD", example = "5.99")
+    private Double costUSD;
+
+    /**
+     * Recording the region because cloud services may cost different amounts in different regions.
+     * For now, the region is only recorded and is not used when aggregating the cost metric.
+     */
+    @JsonProperty
+    @Schema(description = "The region the workflow was executed in", example = "us-central1")
+    private String region;
+
     public RunExecution() {
     }
 
@@ -87,5 +99,21 @@ public class RunExecution extends Execution {
 
     public void setCpuRequirements(Integer cpuRequirements) {
         this.cpuRequirements = cpuRequirements;
+    }
+
+    public Double getCostUSD() {
+        return costUSD;
+    }
+
+    public void setCostUSD(Double costUSD) {
+        this.costUSD = costUSD;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/RunExecution.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/RunExecution.java
@@ -51,8 +51,8 @@ public class RunExecution extends Execution {
     private Integer cpuRequirements;
 
     @JsonProperty
-    @Schema(description = "The cost of the execution in USD", example = "5.99")
-    private Double costUSD;
+    @Schema(description = "The cost of the execution in USD")
+    private Cost cost;
 
     /**
      * Recording the region because cloud services may cost different amounts in different regions.
@@ -101,12 +101,12 @@ public class RunExecution extends Execution {
         this.cpuRequirements = cpuRequirements;
     }
 
-    public Double getCostUSD() {
-        return costUSD;
+    public Cost getCost() {
+        return cost;
     }
 
-    public void setCostUSD(Double costUSD) {
-        this.costUSD = costUSD;
+    public void setCost(Cost cost) {
+        this.cost = cost;
     }
 
     public String getRegion() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/StatisticMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/StatisticMetric.java
@@ -50,25 +50,25 @@ public abstract class StatisticMetric {
     @NotNull
     @ApiModelProperty(value = "The minimum value from the data points", required = true)
     @Schema(description = "The minimum value from the data points", requiredMode = RequiredMode.REQUIRED)
-    private Double minimum;
+    private double minimum;
 
     @Column(nullable = false)
     @NotNull
     @ApiModelProperty(value = "The maximum value from the data points", required = true)
     @Schema(description = "The maximum value from the data points", requiredMode = RequiredMode.REQUIRED)
-    private Double maximum;
+    private double maximum;
 
     @Column(nullable = false)
     @NotNull
     @ApiModelProperty(value = "The average value from the data points", required = true)
     @Schema(description = "The average value from the data points", requiredMode = RequiredMode.REQUIRED)
-    private Double average;
+    private double average;
 
     @Column(nullable = false)
     @NotNull
     @ApiModelProperty(value = "The number of data points used to calculate the average", required = true)
     @Schema(description = "The number of data points used to calculate the average", requiredMode = RequiredMode.REQUIRED)
-    private Integer numberOfDataPointsForAverage;
+    private int numberOfDataPointsForAverage;
 
     @Column
     @ApiModelProperty(value = "The unit of the data points")
@@ -90,11 +90,11 @@ public abstract class StatisticMetric {
     protected StatisticMetric() {
     }
 
-    protected StatisticMetric(Double minimum, Double maximum, Double average, Integer numberOfDataPointsForAverage) {
+    protected StatisticMetric(double minimum, double maximum, double average, int numberOfDataPointsForAverage) {
         this(minimum, maximum, average, numberOfDataPointsForAverage, null);
     }
 
-    protected StatisticMetric(Double minimum, Double maximum, Double average, Integer numberOfDataPointsForAverage, String unit) {
+    protected StatisticMetric(double minimum, double maximum, double average, int numberOfDataPointsForAverage, String unit) {
         this.minimum = minimum;
         this.maximum = maximum;
         this.average = average;
@@ -110,27 +110,27 @@ public abstract class StatisticMetric {
         this.id = id;
     }
 
-    public Double getMinimum() {
+    public double getMinimum() {
         return minimum;
     }
 
-    public void setMinimum(Double minimum) {
+    public void setMinimum(double minimum) {
         this.minimum = minimum;
     }
 
-    public Double getMaximum() {
+    public double getMaximum() {
         return maximum;
     }
 
-    public void setMaximum(Double maximum) {
+    public void setMaximum(double maximum) {
         this.maximum = maximum;
     }
 
-    public Double getAverage() {
+    public double getAverage() {
         return average;
     }
 
-    public void setAverage(Double average) {
+    public void setAverage(double average) {
         this.average = average;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/ValidationExecution.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/ValidationExecution.java
@@ -18,7 +18,6 @@
 package io.dockstore.webservice.core.metrics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.dockstore.webservice.core.metrics.constraints.ISO8601ExecutionDate;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotNull;
@@ -46,12 +45,6 @@ public class ValidationExecution extends Execution {
 
     @Schema(description = "The error message for a failed validation by the validator tool")
     private String errorMessage;
-
-    @NotNull
-    @ISO8601ExecutionDate
-    @JsonProperty(required = true)
-    @Schema(description = "The date and time that the validator tool was executed in ISO 8601 UTC date format", requiredMode = RequiredMode.REQUIRED, example = "2023-03-31T15:06:49.888745366Z")
-    private String dateExecuted;
 
     public ValidationExecution() {
     }
@@ -91,14 +84,6 @@ public class ValidationExecution extends Execution {
 
     public void setErrorMessage(String errorMessage) {
         this.errorMessage = errorMessage;
-    }
-
-    public String getDateExecuted() {
-        return dateExecuted;
-    }
-
-    public void setDateExecuted(String dateExecuted) {
-        this.dateExecuted = dateExecuted;
     }
 
     /**

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -84,4 +84,30 @@
         </sql>
         <dropColumn columnName="accepted" tableName="organization_user"/>
     </changeSet>
+    <changeSet author="ktran (generated)" id="addCostMetric">
+        <createTable tableName="cost_metric">
+            <column name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="cost_metric_pkey"/>
+            </column>
+            <column name="average" type="FLOAT8">
+                <constraints nullable="false"/>
+            </column>
+            <column name="dbcreatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="dbupdatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="maximum" type="FLOAT8">
+                <constraints nullable="false"/>
+            </column>
+            <column name="minimum" type="FLOAT8">
+                <constraints nullable="false"/>
+            </column>
+            <column name="numberofdatapointsforaverage" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="unit" type="VARCHAR(255)"/>
+        </createTable>
+        <addColumn tableName="metrics">
+            <column name="cost" type="int8"/>
+        </addColumn>
+        <addForeignKeyConstraint baseColumnNames="cost" baseTableName="metrics" constraintName="fk_cost_metrics" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="cost_metric"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -8086,6 +8086,20 @@ components:
           type: string
         zenodoScope:
           type: string
+    Cost:
+      type: object
+      description: Cost represents a monetary amount in USD
+      properties:
+        currency:
+          type: string
+          default: USD
+          description: The currency of the cost value
+          readOnly: true
+        value:
+          type: number
+          format: double
+          description: The numerical value of the cost
+          example: 5.99
     CostMetric:
       type: object
       description: This describes aggregated cost metrics for workflow executions
@@ -8114,6 +8128,7 @@ components:
           description: The number of data points used to calculate the average
         unit:
           type: string
+          default: USD
           description: The unit of the data points
           readOnly: true
       required:
@@ -8817,6 +8832,7 @@ components:
           description: The number of data points used to calculate the average
         unit:
           type: string
+          default: s
           description: The unit of the data points
           readOnly: true
       required:
@@ -9154,6 +9170,7 @@ components:
           description: The number of data points used to calculate the average
         unit:
           type: string
+          default: GB
           description: The unit of the data points
           readOnly: true
       required:
@@ -9466,11 +9483,8 @@ components:
       - $ref: '#/components/schemas/Execution'
       - type: object
         properties:
-          costUSD:
-            type: number
-            format: double
-            description: The cost of the execution in USD
-            example: 5.99
+          cost:
+            $ref: '#/components/schemas/Cost'
           cpuRequirements:
             type: integer
             format: int32

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -8802,6 +8802,13 @@ components:
             '@context':
               schema: https://schema.org
             schema:actionStatus: CompletedActionStatus
+        dateExecuted:
+          type: string
+          description: The date and time that the execution occurred in ISO 8601 UTC
+            date format
+          example: 2023-03-31T15:06:49.888745366Z
+      required:
+      - dateExecuted
     ExecutionStatusMetric:
       type: object
       description: Aggregated metrics about workflow execution statuses
@@ -9543,6 +9550,7 @@ components:
             example: us-central1
       description: Metrics of a workflow execution on a platform
       required:
+      - dateExecuted
       - executionStatus
     Service:
       type: object
@@ -10383,11 +10391,6 @@ components:
       - $ref: '#/components/schemas/Execution'
       - type: object
         properties:
-          dateExecuted:
-            type: string
-            description: The date and time that the validator tool was executed in
-              ISO 8601 UTC date format
-            example: 2023-03-31T15:06:49.888745366Z
           errorMessage:
             type: string
             description: The error message for a failed validation by the validator

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -8112,6 +8112,41 @@ components:
           type: string
         zenodoScope:
           type: string
+    CostMetric:
+      type: object
+      description: This describes aggregated cost metrics for workflow executions
+        in USD.
+      properties:
+        average:
+          type: number
+          format: double
+          description: The average value from the data points
+        id:
+          type: integer
+          format: int64
+          description: Implementation specific ID for statistical metrics in this
+            webservice
+        maximum:
+          type: number
+          format: double
+          description: The maximum value from the data points
+        minimum:
+          type: number
+          format: double
+          description: The minimum value from the data points
+        numberOfDataPointsForAverage:
+          type: integer
+          format: int32
+          description: The number of data points used to calculate the average
+        unit:
+          type: string
+          description: The unit of the data points
+          readOnly: true
+      required:
+      - average
+      - maximum
+      - minimum
+      - numberOfDataPointsForAverage
     CpuMetric:
       type: object
       description: This describes aggregated CPU metrics for workflow executions.
@@ -9158,6 +9193,8 @@ components:
             type: object
             description: Additional aggregated metrics
           description: Additional aggregated metrics
+        cost:
+          $ref: '#/components/schemas/CostMetric'
         cpu:
           $ref: '#/components/schemas/CpuMetric'
         executionStatusCount:
@@ -9451,6 +9488,11 @@ components:
       - $ref: '#/components/schemas/Execution'
       - type: object
         properties:
+          costUSD:
+            type: number
+            format: double
+            description: The cost of the execution in USD
+            example: 5.99
           cpuRequirements:
             type: integer
             format: int32
@@ -9473,6 +9515,10 @@ components:
             format: double
             description: Memory requirements for the execution in GB
             example: 2
+          region:
+            type: string
+            description: The region the workflow was executed in
+            example: us-central1
       description: Metrics of a workflow execution on a platform
       required:
       - executionStatus

--- a/keysmap.list
+++ b/keysmap.list
@@ -29,8 +29,8 @@ org.kohsuke:github-api:pom:1.123                                    = badSig
 com.spotify:docker-client:pom:8.16.0                                = badSig
 org.eclipse.jetty.toolchain:jetty-servlet-api:pom:4.0.6                              = badSig
 org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:pom:5.0.2     = badSig
-org.javamoney:moneta:pom:1.1                                        = badSig
-org.javamoney:moneta:jar:1.1                                        = badSig
+org.javamoney:moneta:pom:1.4.2                                      = badSig
+org.javamoney.moneta:moneta-core:pom:1.4.2                          = badSig
 javax.money:money-api:pom:1.1                                       = badSig
 
 * 									                                = noSig

--- a/keysmap.list
+++ b/keysmap.list
@@ -29,7 +29,9 @@ org.kohsuke:github-api:pom:1.123                                    = badSig
 com.spotify:docker-client:pom:8.16.0                                = badSig
 org.eclipse.jetty.toolchain:jetty-servlet-api:pom:4.0.6                              = badSig
 org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:pom:5.0.2     = badSig
-
+org.javamoney:moneta:pom:1.1                                        = badSig
+org.javamoney:moneta:jar:1.1                                        = badSig
+javax.money:money-api:pom:1.1                                       = badSig
 
 * 									                                = noSig
 *									                                = any


### PR DESCRIPTION
**Description**
This PR adds a cost metric. It also adds a region field to `RunExecution` because the cost may vary depending on the region the cloud service is in. This region field is only recorded and is not aggregated for now.

Companion PRs:
- https://github.com/dockstore/dockstore-support/pull/471
- https://github.com/dockstore/dockstore-ui2/pull/1805

**Review Instructions**
See instructions in https://github.com/dockstore/dockstore-support/pull/471

**Issue**
[SEAB-5625](https://ucsc-cgl.atlassian.net/browse/SEAB-5625)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-5625]: https://ucsc-cgl.atlassian.net/browse/SEAB-5625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ