### PR TITLE
Remove some dependencies from the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM eclipse-temurin:17.0.3_7-jdk-focal
 
-# Wipe them out, all of them, to reduce CVEs
-RUN apt-get purge -y -- *python*  && apt-get -y autoremove
-
 # Update the APT cache
 # Prepare for Java download
 RUN apt-get update \
@@ -25,6 +22,20 @@ ARG galaxy_plugin_version=0.0.8
 RUN apt-get install -y wget
 RUN mkdir -p /root/.dockstore/language-plugins
 RUN wget -P /root/.dockstore/language-plugins https://artifacts.oicr.on.ca/artifactory/collab-release/com/github/galaxyproject/dockstore-galaxy-interface/dockstore-galaxy-interface/${galaxy_plugin_version}/dockstore-galaxy-interface-${galaxy_plugin_version}.jar
+
+# Wipe them out, all of them, to reduce CVEs
+RUN apt-get purge -y -- \
+    *python* \
+    wget \
+    *curl* \
+    bzip2 \
+    fonts-dejavu-core \
+    fontconfig* \
+    binutils* \
+    cpio \
+    *ssh* \
+    && \
+    apt-get -y autoremove
 
 # Install aide, file integrity verification
 RUN apt install cron aide aide-common -y --no-install-recommends && aideinit


### PR DESCRIPTION
**Description**

In an effort to reduce the dependencies in the Dockerfile this will remove some other unneeded packages. The underlying ticket is about resolving dependency issues that came up previously. Some of these have already been fixed by updates. This PR will address some existing lows by removing curl and binutils. https://quay.io/repository/dockstore/dockstore-webservice/manifest/sha256:9e37f93254ea254d68814057c87d5956d6ff76e2e04b4dc5d1ef67c0bb10756e?tab=vulnerabilities

Here is the total list of packages that are removed in this version, 59 in total via `apt list --installed`

```
 diff before after
8,10d7
< binutils-common/focal-updates,focal-security,now 2.34-6ubuntu1.6 amd64 [installed,automatic]
< binutils-x86-64-linux-gnu/focal-updates,focal-security,now 2.34-6ubuntu1.6 amd64 [installed,automatic]
< binutils/focal-updates,focal-security,now 2.34-6ubuntu1.6 amd64 [installed]
13d9
< bzip2/focal,now 1.0.8-2 amd64 [installed]
18d13
< curl/focal-updates,focal-security,now 7.68.0-1ubuntu2.18 amd64 [installed]
27,29d21
< fontconfig-config/focal,now 2.13.1-2ubuntu3 all [installed,automatic]
< fontconfig/focal,now 2.13.1-2ubuntu3 amd64 [installed]
< fonts-dejavu-core/focal,now 2.37-1 all [installed,automatic]
38d29
< libasn1-8-heimdal/focal-updates,focal-security,now 7.7.0+dfsg-1ubuntu1.4 amd64 [installed,automatic]
42d32
< libbinutils/focal-updates,focal-security,now 2.34-6ubuntu1.6 amd64 [installed,automatic]
44d33
< libbrotli1/focal-updates,focal-security,now 1.0.7-6ubuntu0.1 amd64 [installed,automatic]
52,54d40
< libctf-nobfd0/focal-updates,focal-security,now 2.34-6ubuntu1.6 amd64 [installed,automatic]
< libctf0/focal-updates,focal-security,now 2.34-6ubuntu1.6 amd64 [installed,automatic]
< libcurl4/focal-updates,focal-security,now 7.68.0-1ubuntu2.18 amd64 [installed,automatic]
57d42
< libexpat1/focal-updates,focal-security,now 2.2.9-1ubuntu0.6 amd64 [installed,automatic]
61,62d45
< libfontconfig1/focal,now 2.13.1-2ubuntu3 amd64 [installed,automatic]
< libfreetype6/focal-updates,focal-security,now 2.10.1-2ubuntu0.3 amd64 [installed,automatic]
68,72d50
< libgssapi-krb5-2/focal-updates,focal-security,now 1.17-6ubuntu4.3 amd64 [installed,automatic]
< libgssapi3-heimdal/focal-updates,focal-security,now 7.7.0+dfsg-1ubuntu1.4 amd64 [installed,automatic]
< libhcrypto4-heimdal/focal-updates,focal-security,now 7.7.0+dfsg-1ubuntu1.4 amd64 [installed,automatic]
< libheimbase1-heimdal/focal-updates,focal-security,now 7.7.0+dfsg-1ubuntu1.4 amd64 [installed,automatic]
< libheimntlm0-heimdal/focal-updates,focal-security,now 7.7.0+dfsg-1ubuntu1.4 amd64 [installed,automatic]
74d51
< libhx509-5-heimdal/focal-updates,focal-security,now 7.7.0+dfsg-1ubuntu1.4 amd64 [installed,automatic]
77,83d53
< libk5crypto3/focal-updates,focal-security,now 1.17-6ubuntu4.3 amd64 [installed,automatic]
< libkeyutils1/focal-updates,now 1.6-6ubuntu1.1 amd64 [installed,automatic]
< libkrb5-26-heimdal/focal-updates,focal-security,now 7.7.0+dfsg-1ubuntu1.4 amd64 [installed,automatic]
< libkrb5-3/focal-updates,focal-security,now 1.17-6ubuntu4.3 amd64 [installed,automatic]
< libkrb5support0/focal-updates,focal-security,now 1.17-6ubuntu4.3 amd64 [installed,automatic]
< libldap-2.4-2/focal-updates,focal-security,now 2.4.49+dfsg-2ubuntu1.9 amd64 [installed,automatic]
< libldap-common/focal-updates,focal-security,now 2.4.49+dfsg-2ubuntu1.9 all [installed,automatic]
92d61
< libnghttp2-14/focal-updates,focal-security,now 1.40.0-1ubuntu0.1 amd64 [installed,automatic]
100d68
< libpng16-16/focal,now 1.6.37-2 amd64 [installed,automatic]
102,104d69
< libpsl5/focal,now 0.21.0-1ubuntu1 amd64 [installed,automatic]
< libroken18-heimdal/focal-updates,focal-security,now 7.7.0+dfsg-1ubuntu1.4 amd64 [installed,automatic]
< librtmp1/focal,now 2.4+20151223.gitfa8646d.1-2build1 amd64 [installed,automatic]
113d77
< libsqlite3-0/focal-updates,focal-security,now 3.31.1-4ubuntu0.5 amd64 [installed,automatic]
115d78
< libssh-4/focal-updates,focal-security,now 0.9.3-2ubuntu2.3 amd64 [installed,automatic]
124d86
< libwind0-heimdal/focal-updates,focal-security,now 7.7.0+dfsg-1ubuntu1.4 amd64 [installed,automatic]
149d110
< wget/focal-updates,now 1.20.3-1ubuntu2 amd64 [installed]
```

**Review Instructions**

Verify the webservice can still start and run in the pared down container.

**Issue**

https://ucsc-cgl.atlassian.net/browse/SEAB-5629

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
