### PR TITLE
SEAB-5613: added new lambdaEvents endpoint for admins

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
@@ -496,20 +496,20 @@ class SwaggerWebhookIT extends BaseIT {
             "Should not have a 0.2 version.");
 
         // Add version that doesn't exist
-        long failedCount = usersApi.getUserGitHubEvents("0", 10).stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count();
+        long failedCount = usersApi.getUserGitHubEvents(0, 10).stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count();
         try {
             client.handleGitHubRelease("refs/heads/idonotexist", installationId, workflowRepo, BasicIT.USER_2_USERNAME);
             fail("Should fail and not reach this point");
         } catch (io.dockstore.openapi.client.ApiException ex) {
-            assertEquals(failedCount + 1, usersApi.getUserGitHubEvents("0", 10).stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count(), "There should be one more unsuccessful event than before");
+            assertEquals(failedCount + 1, usersApi.getUserGitHubEvents(0, 10).stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count(), "There should be one more unsuccessful event than before");
         }
 
         // There should be 7 successful lambda events
-        List<io.dockstore.openapi.client.model.LambdaEvent> events = usersApi.getUserGitHubEvents("0", 10);
+        List<io.dockstore.openapi.client.model.LambdaEvent> events = usersApi.getUserGitHubEvents(0, 10);
         assertEquals(7, events.stream().filter(io.dockstore.openapi.client.model.LambdaEvent::isSuccess).count(), "There should be 7 successful events");
 
         // Test pagination for user github events
-        events = usersApi.getUserGitHubEvents("2", 2);
+        events = usersApi.getUserGitHubEvents(2, 2);
         assertEquals(2, events.size(), "There should be 2 events (id 8 and 9)");
         assertTrue(events.stream().anyMatch(lambdaEvent -> Objects.equals(8L, lambdaEvent.getId())), "Should have event with ID 8");
         assertTrue(events.stream().anyMatch(lambdaEvent -> Objects.equals(9L, lambdaEvent.getId())), "Should have event with ID 9");
@@ -1156,7 +1156,7 @@ class SwaggerWebhookIT extends BaseIT {
             workflowsApi.handleGitHubRelease("refs/heads/invalidWorkflowName", installationId, workflowRepo, BasicIT.USER_2_USERNAME);
         } catch (io.dockstore.openapi.client.ApiException ex) {
             assertEquals(LAMBDA_ERROR, ex.getCode(), "Should not be able to add a workflow with an invalid name");
-            List<io.dockstore.openapi.client.model.LambdaEvent> failEvents = usersApi.getUserGitHubEvents("0", 10);
+            List<io.dockstore.openapi.client.model.LambdaEvent> failEvents = usersApi.getUserGitHubEvents(0, 10);
             assertEquals(1, failEvents.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count(), "There should be 1 unsuccessful event");
             assertTrue(failEvents.get(0).getMessage().contains(ValidationConstants.ENTRY_NAME_REGEX_MESSAGE));
         }
@@ -1481,7 +1481,7 @@ class SwaggerWebhookIT extends BaseIT {
             workflowClient.handleGitHubRelease("refs/heads/sameWorkflowName-CWL", installationId, workflowDockstoreYmlRepo, BasicIT.USER_2_USERNAME);
             fail("should have thrown");
         } catch (io.dockstore.openapi.client.ApiException ex) {
-            List<io.dockstore.openapi.client.model.LambdaEvent> events = usersApi.getUserGitHubEvents("0", 10);
+            List<io.dockstore.openapi.client.model.LambdaEvent> events = usersApi.getUserGitHubEvents(0, 10);
             io.dockstore.openapi.client.model.LambdaEvent event = events.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).findFirst().get();
             String message = event.getMessage().toLowerCase();
             assertTrue(message.contains("descriptor language"));
@@ -1718,7 +1718,7 @@ class SwaggerWebhookIT extends BaseIT {
             fail("should have thrown");
         } catch (io.dockstore.openapi.client.ApiException ex) {
             // Confirm that the release failed and was logged correctly.
-            List<io.dockstore.openapi.client.model.LambdaEvent> events = usersApi.getUserGitHubEvents("0", 10);
+            List<io.dockstore.openapi.client.model.LambdaEvent> events = usersApi.getUserGitHubEvents(0, 10);
             assertEquals(1, events.size(), "There should be one event");
             assertEquals(0, events.stream().filter(io.dockstore.openapi.client.model.LambdaEvent::isSuccess).count(), "There should be no successful events");
             assertTrue(events.get(0).getMessage().contains(WDLHandler.ERROR_PARSING_WORKFLOW_YOU_MAY_HAVE_A_RECURSIVE_IMPORT), "Event message should indicate the problem");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -242,6 +242,7 @@ class WebhookIT extends BaseIT {
         System.out.println(lambdaEventsApi.getUserLambdaEvents(userid, "0", 100));
         List<LambdaEvent> lambdaEvents = lambdaEventsApi.getUserLambdaEvents(userid, "0", 100);
         assertEquals(1, lambdaEvents.size());
+        assertEquals("refs/tags/1.0", lambdaEvents.get(0).getReference());
     }
         
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -118,7 +118,7 @@ class WebhookIT extends BaseIT {
             workflowClient.handleGitHubRelease("refs/heads/sameWorkflowName-CWL", installationId, workflowDockstoreYmlRepo, BasicIT.USER_2_USERNAME);
             fail("should have thrown");
         } catch (ApiException ex) {
-            List<LambdaEvent> events = usersApi.getUserGitHubEvents("0", 10);
+            List<LambdaEvent> events = usersApi.getUserGitHubEvents(0, 10);
             LambdaEvent event = events.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).findFirst().get();
             String message = event.getMessage().toLowerCase();
             assertTrue(message.contains("descriptor language"));
@@ -239,7 +239,7 @@ class WebhookIT extends BaseIT {
         final ApiClient webClientAdminUser = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
         LambdaEventsApi lambdaEventsApi = new LambdaEventsApi(webClientAdminUser);
 
-        List<LambdaEvent> lambdaEvents = lambdaEventsApi.getUserLambdaEvents(userid, "0", 100);
+        List<LambdaEvent> lambdaEvents = lambdaEventsApi.getUserLambdaEvents(userid, 0, 100);
         assertEquals(1, lambdaEvents.size());
         assertEquals("refs/tags/1.0", lambdaEvents.get(0).getReference());
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -248,7 +248,7 @@ class WebhookIT extends BaseIT {
         try {
             lambdaEventsUser1Api.getUserLambdaEventsByOrganization(userid, "dockstore-testing", "0", 100);
             fail("Should have thrown");
-        } catch (io.dockstore.openapi.client.ApiException ex) {
+        } catch (ApiException ex) {
             assertEquals("Only an administrator or curator can use this endpoint.", ex.getMessage());
         }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -240,7 +240,7 @@ class WebhookIT extends BaseIT {
 
         System.out.println(lambdaEventsApi.getUserLambdaEventsByOrganization(userid, "dockstore-testing", "0", 100));
         List<LambdaEvent> lambdaEvents = lambdaEventsApi.getUserLambdaEventsByOrganization(userid, "dockstore-testing", "0", 100);
-        assertEquals( 1, lambdaEvents.size());
+        assertEquals(1, lambdaEvents.size());
 
         //verify nonadmins cannot use this endpoint
         final ApiClient user1Client = getOpenAPIWebClient(BasicIT.OTHER_USERNAME, testingPostgres);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -225,7 +225,6 @@ class WebhookIT extends BaseIT {
 
     @Test
     void testCheckingUserLambdaEventsAsAdmin() {
-        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
         final ApiClient userClient = getOpenAPIWebClient(BasicIT.USER_2_USERNAME, testingPostgres);
         WorkflowsApi userWorkflowsClient = new WorkflowsApi(userClient);
         UsersApi usersApi = new UsersApi(userClient);
@@ -238,19 +237,10 @@ class WebhookIT extends BaseIT {
         final ApiClient webClientAdminUser = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
         LambdaEventsApi lambdaEventsApi = new LambdaEventsApi(webClientAdminUser);
 
-        System.out.println(lambdaEventsApi.getUserLambdaEventsByOrganization(userid, "dockstore-testing", "0", 100));
-        List<LambdaEvent> lambdaEvents = lambdaEventsApi.getUserLambdaEventsByOrganization(userid, "dockstore-testing", "0", 100);
+        System.out.println(lambdaEventsApi.getUserLambdaEvents(userid, "0", 100));
+        List<LambdaEvent> lambdaEvents = lambdaEventsApi.getUserLambdaEvents(userid, "0", 100);
         assertEquals(1, lambdaEvents.size());
 
-        //verify nonadmins cannot use this endpoint
-        final ApiClient user1Client = getOpenAPIWebClient(BasicIT.OTHER_USERNAME, testingPostgres);
-        LambdaEventsApi lambdaEventsUser1Api = new LambdaEventsApi(user1Client);
-        try {
-            lambdaEventsUser1Api.getUserLambdaEventsByOrganization(userid, "dockstore-testing", "0", 100);
-            fail("Should have thrown");
-        } catch (ApiException ex) {
-            assertEquals("Only an administrator or curator can use this endpoint.", ex.getMessage());
-        }
 
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -239,7 +239,6 @@ class WebhookIT extends BaseIT {
         final ApiClient webClientAdminUser = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
         LambdaEventsApi lambdaEventsApi = new LambdaEventsApi(webClientAdminUser);
 
-        System.out.println(lambdaEventsApi.getUserLambdaEvents(userid, "0", 100));
         List<LambdaEvent> lambdaEvents = lambdaEventsApi.getUserLambdaEvents(userid, "0", 100);
         assertEquals(1, lambdaEvents.size());
         assertEquals("refs/tags/1.0", lambdaEvents.get(0).getReference());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -57,7 +57,7 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
         return list(query);
     }
 
-    public List<LambdaEvent> findByUser(User user, String offset, Integer limit) {
+    public List<LambdaEvent> findByUser(User user, Integer offset, Integer limit) {
         CriteriaBuilder cb = currentSession().getCriteriaBuilder();
         CriteriaQuery<LambdaEvent> query = criteriaQuery();
         Root<LambdaEvent> event = query.from(LambdaEvent.class);
@@ -69,7 +69,7 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
 
         query.select(event);
 
-        int primitiveOffset = Integer.parseInt(MoreObjects.firstNonNull(offset, "0"));
+        int primitiveOffset = (offset != null) ? offset : 0;
         TypedQuery<LambdaEvent> typedQuery = currentSession().createQuery(query).setFirstResult(primitiveOffset).setMaxResults(limit);
         return typedQuery.getResultList();
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -85,9 +85,8 @@ public class LambdaEventResource {
            @QueryParam("offset") @DefaultValue("0") Integer offset,
            @DefaultValue("1000") @QueryParam("limit") Integer limit) {
         final User user = userDAO.findById(userid);
-        final List<Token> githubTokens = tokenDAO.findGithubByUserId(userid);
-        if (githubTokens.isEmpty()) {
-            throw new CustomWebApplicationException("The user does not have GitHub connected to their account.", HttpStatus.SC_BAD_REQUEST);
+        if (user == null) {
+            throw new CustomWebApplicationException("User not found.", HttpStatus.SC_NOT_FOUND);
         }
         return lambdaEventDAO.findByUser(user, offset, limit);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -83,7 +83,7 @@ public class LambdaEventResource {
     public List<LambdaEvent> getUserLambdaEvents(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
            @PathParam("userid") long userid,
            @QueryParam("offset") @DefaultValue("0") String offset,
-           @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit) {
+           @DefaultValue("1000") @QueryParam("limit") Integer limit) {
         final User user = userDAO.findById(userid);
         final List<Token> githubTokens = tokenDAO.findGithubByUserId(userid);
         if (githubTokens.isEmpty()) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -78,11 +78,11 @@ public class LambdaEventResource {
     @UnitOfWork(readOnly = true)
     @RolesAllowed({ "admin", "curator"})
     @Path("/user/{userid}")
-    @Operation(operationId = "getUserLambdaEvents", description = "Get all of the Lambda Events for the given user and GitHub organization.",
+    @Operation(operationId = "getUserLambdaEvents", description = "Get all of the Lambda Events for the given user.",
             security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME))
-    public List<LambdaEvent> getUserLambdaEvents(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
+    public List<LambdaEvent> getUserLambdaEvents(@Parameter(hidden = true, name = "user")@Auth User authUser,
            @PathParam("userid") long userid,
-           @QueryParam("offset") @DefaultValue("0") String offset,
+           @QueryParam("offset") @DefaultValue("0") Integer offset,
            @DefaultValue("1000") @QueryParam("limit") Integer limit) {
         final User user = userDAO.findById(userid);
         final List<Token> githubTokens = tokenDAO.findGithubByUserId(userid);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -77,19 +77,19 @@ public class LambdaEventResource {
     @Timed
     @UnitOfWork(readOnly = true)
     @RolesAllowed({ "admin", "curator"})
-    @Path("/{userid}")
+    @Path("/user/{userid}")
     @Operation(operationId = "getUserLambdaEvents", description = "Get all of the Lambda Events for the given user and GitHub organization.",
             security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME))
     public List<LambdaEvent> getUserLambdaEvents(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
            @PathParam("userid") long userid,
            @QueryParam("offset") @DefaultValue("0") String offset,
            @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit) {
-        final User loggedInUser = userDAO.findById(authUser.getId());
+        final User user = userDAO.findById(userid);
         final List<Token> githubTokens = tokenDAO.findGithubByUserId(userid);
         if (githubTokens.isEmpty()) {
             throw new CustomWebApplicationException("The user does not have GitHub connected to their account.", HttpStatus.SC_BAD_REQUEST);
         }
-        return lambdaEventDAO.findByUser(loggedInUser, offset, limit);
+        return lambdaEventDAO.findByUser(user, offset, limit);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -75,29 +76,20 @@ public class LambdaEventResource {
     @GET
     @Timed
     @UnitOfWork(readOnly = true)
-    @Path("/{userid}/{organization}")
-    @Operation(operationId = "getUserLambdaEventsByOrganization", description = "Get all of the Lambda Events for the given user and GitHub organization.",
+    @RolesAllowed({ "admin", "curator"})
+    @Path("/{userid}")
+    @Operation(operationId = "getUserLambdaEvents", description = "Get all of the Lambda Events for the given user and GitHub organization.",
             security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME))
-    @ApiOperation(value = "See OpenApi for details")
-    public List<LambdaEvent> getUserLambdaEventsByOrganization(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
-           @ApiParam(value = "userid", required = true) @PathParam("userid") long userid,
-           @ApiParam(value = "organization", required = true) @PathParam("organization") String organization,
-           @ApiParam(value = PAGINATION_OFFSET_TEXT) @QueryParam("offset") @DefaultValue("0") String offset,
-           @ApiParam(value = PAGINATION_LIMIT_TEXT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit) {
+    public List<LambdaEvent> getUserLambdaEvents(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
+           @PathParam("userid") long userid,
+           @QueryParam("offset") @DefaultValue("0") String offset,
+           @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit) {
         final User loggedInUser = userDAO.findById(authUser.getId());
-        if (loggedInUser.getIsAdmin() || loggedInUser.isCurator()) {
-            final List<Token> githubTokens = tokenDAO.findGithubByUserId(userid);
-            if (githubTokens.isEmpty()) {
-                throw new CustomWebApplicationException("The user does not have GitHub connected to their account.", HttpStatus.SC_BAD_REQUEST);
-            }
-            final Token githubToken = githubTokens.get(0);
-            final Optional<List<String>> authorizedRepos = authorizedRepos(organization, githubToken);
-            return lambdaEventDAO.findByOrganization(organization, offset, limit, authorizedRepos);
-        } else {
-            String msg = "Only an administrator or curator can use this endpoint.";
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_UNAUTHORIZED);
+        final List<Token> githubTokens = tokenDAO.findGithubByUserId(userid);
+        if (githubTokens.isEmpty()) {
+            throw new CustomWebApplicationException("The user does not have GitHub connected to their account.", HttpStatus.SC_BAD_REQUEST);
         }
-
+        return lambdaEventDAO.findByUser(loggedInUser, offset, limit);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -83,7 +83,7 @@ public class LambdaEventResource {
     public List<LambdaEvent> getUserLambdaEvents(@Parameter(hidden = true, name = "user")@Auth User authUser,
            @PathParam("userid") long userid,
            @QueryParam("offset") @DefaultValue("0") Integer offset,
-           @DefaultValue("1000") @QueryParam("limit") Integer limit) {
+           @QueryParam("limit") @DefaultValue("1000") Integer limit) {
         final User user = userDAO.findById(userid);
         if (user == null) {
             throw new CustomWebApplicationException("User not found.", HttpStatus.SC_NOT_FOUND);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -76,7 +76,8 @@ public class LambdaEventResource {
     @Timed
     @UnitOfWork(readOnly = true)
     @Path("/{userid}/{organization}")
-    @Operation(operationId = "getUserLambdaEventsByOrganization", description = "Get all of the Lambda Events for the given user and GitHub organization.", security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME))
+    @Operation(operationId = "getUserLambdaEventsByOrganization", description = "Get all of the Lambda Events for the given user and GitHub organization.",
+            security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "See OpenApi for details")
     public List<LambdaEvent> getUserLambdaEventsByOrganization(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
            @ApiParam(value = "userid", required = true) @PathParam("userid") long userid,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -20,8 +20,6 @@ import static io.dockstore.webservice.Constants.USERNAME_CONTAINS_KEYWORD_PATTER
 import static io.dockstore.webservice.resources.ResourceConstants.APPEASE_SWAGGER_PATCH;
 import static io.dockstore.webservice.resources.ResourceConstants.JWT_SECURITY_DEFINITION_NAME;
 import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_LIMIT;
-import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_LIMIT_TEXT;
-import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_OFFSET_TEXT;
 
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.annotation.JsonView;
@@ -1192,8 +1190,8 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
             + "", description = "A list of GitHub Events for the logged in user", content = @Content(array = @ArraySchema(schema = @Schema(implementation = LambdaEvent.class))))
     @ApiOperation(value = "See OpenApi for details")
     public List<LambdaEvent> getUserGitHubEvents(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
-            @ApiParam(value = PAGINATION_OFFSET_TEXT) @QueryParam("offset") String offset,
-            @ApiParam(value = PAGINATION_LIMIT_TEXT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit) {
+            @QueryParam("offset") Integer offset,
+            @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit) {
         final User user = userDAO.findById(authUser.getId());
         checkNotNullUser(user);
         return lambdaEventDAO.findByUser(user, offset, limit);

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3378,16 +3378,17 @@ paths:
       summary: Get a list of test JSONs
       tags:
       - GA4GHV20
-  /lambdaEvents/{organization}:
+  /lambdaEvents/user/{userid}:
     get:
-      description: Get all of the Lambda Events for the given GitHub organization.
-      operationId: getLambdaEventsByOrganization
+      description: Get all of the Lambda Events for the given user and GitHub organization.
+      operationId: getUserLambdaEvents
       parameters:
       - in: path
-        name: organization
+        name: userid
         required: true
         schema:
-          type: string
+          type: integer
+          format: int64
       - in: query
         name: offset
         schema:
@@ -3412,17 +3413,16 @@ paths:
       - BEARER: []
       tags:
       - lambdaEvents
-  /lambdaEvents/{userid}:
+  /lambdaEvents/{organization}:
     get:
-      description: Get all of the Lambda Events for the given user and GitHub organization.
-      operationId: getUserLambdaEvents
+      description: Get all of the Lambda Events for the given GitHub organization.
+      operationId: getLambdaEventsByOrganization
       parameters:
       - in: path
-        name: userid
+        name: organization
         required: true
         schema:
-          type: integer
-          format: int64
+          type: string
       - in: query
         name: offset
         schema:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3388,6 +3388,46 @@ paths:
       - BEARER: []
       tags:
       - lambdaEvents
+  /lambdaEvents/{userid}/{organization}:
+    get:
+      description: Get all of the Lambda Events for the given user and GitHub organization.
+      operationId: getUserLambdaEventsByOrganization
+      parameters:
+      - in: path
+        name: userid
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - in: path
+        name: organization
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: offset
+        schema:
+          type: string
+          default: "0"
+      - in: query
+        name: limit
+        schema:
+          type: integer
+          format: int32
+          default: 100
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LambdaEvent'
+          description: default response
+      security:
+      - BEARER: []
+      tags:
+      - lambdaEvents
   /metadata/cli-info:
     get:
       description: Get Dockstore CLI information. NO authentication

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3380,7 +3380,7 @@ paths:
       - GA4GHV20
   /lambdaEvents/user/{userid}:
     get:
-      description: Get all of the Lambda Events for the given user and GitHub organization.
+      description: Get all of the Lambda Events for the given user.
       operationId: getUserLambdaEvents
       parameters:
       - in: path
@@ -3392,14 +3392,15 @@ paths:
       - in: query
         name: offset
         schema:
-          type: string
-          default: "0"
+          type: integer
+          format: int32
+          default: 0
       - in: query
         name: limit
         schema:
           type: integer
           format: int32
-          default: 100
+          default: 1000
       responses:
         default:
           content:
@@ -4955,7 +4956,8 @@ paths:
       - in: query
         name: offset
         schema:
-          type: string
+          type: integer
+          format: int32
       - in: query
         name: limit
         schema:


### PR DESCRIPTION
**Description**
This PR allows admins and curators to see a user's lambda events  through the backend for community lead purposes

**Review Instructions**
Try the new endpoint on qa with your admin account to see another user's github app logs.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5613

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
