### PR TITLE
Fix connection pool health check

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ConnectionPoolHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ConnectionPoolHealthCheck.java
@@ -19,11 +19,11 @@ public class ConnectionPoolHealthCheck extends HealthCheck  {
 
     @Override
     protected Result check() throws Exception {
-        final int size = (int)metricGauges.get("io.dropwizard.db.ManagedPooledDataSource.hibernate.size").getValue();
-        if (size == maxConnections) {
-            final int active = (int)metricGauges.get("io.dropwizard.db.ManagedPooledDataSource.hibernate.active").getValue();
+        final int activeConnections = (int)metricGauges.get("io.dropwizard.db.ManagedPooledDataSource.hibernate.active").getValue();
+        if (activeConnections == maxConnections) {
+            final int size = (int)metricGauges.get("io.dropwizard.db.ManagedPooledDataSource.hibernate.size").getValue();
             final int idle = (int)metricGauges.get("io.dropwizard.db.ManagedPooledDataSource.hibernate.idle").getValue();
-            LOG.info("size: {}, active: {}, idle: {}", size, active, idle);
+            LOG.info("size: {}, active: {}, idle: {}", size, activeConnections, idle);
             return Result.unhealthy("No database connections available");
         } else {
             return Result.healthy();


### PR DESCRIPTION
**Description**
Read more details about why this fix is needed [here](https://ucsc-cgl.atlassian.net/browse/SEAB-5674?focusedCommentId=45582). This PR fixes the connection pool health check so that it only counts the active connections.

**Review Instructions**
Need to wait for deploy to staging to review.

Spam a bunch of requests to staging to try to max out the connection pool (the max is 32 connections). This should cause the webservice container health check to fail and the container will be stopped and replaced (will result in a short down time in staging). Check the webservice logs for the webservice container that stopped and verify the the connection pool error has 0 idle connections.

**Issue**
[SEAB-5674](https://ucsc-cgl.atlassian.net/browse/SEAB-5674)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-5674]: https://ucsc-cgl.atlassian.net/browse/SEAB-5674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ