### PR TITLE
Don't return VersionMetadata.description in JSON response

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
@@ -15,6 +15,7 @@
  */
 package io.dockstore.webservice.core;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.CollectionTable;
@@ -74,6 +75,7 @@ public class VersionMetadata {
     @Enumerated(EnumType.STRING)
     protected Version.DOIStatus doiStatus;
 
+    @JsonIgnore
     @Column(columnDefinition = "TEXT")
     @ApiModelProperty(value = "This is a human-readable description of this container and what it is trying to accomplish, required GA4GH")
     @Schema(description = "This is a human-readable description of this container and what it is trying to accomplish, required GA4GH")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -442,7 +442,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         array = @ArraySchema(schema = @Schema(implementation = WorkflowVersion.class))))
     @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad Request")
     public Set<WorkflowVersion> getWorkflowVersions(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth User user,
-        @ApiParam(value = "workflowID", required = true) @Parameter(name = "workflowId", description = "id of the worflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId) {
+        @ApiParam(value = "workflowID", required = true) @Parameter(name = "workflowId", description = "id of the workflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId) {
         Workflow workflow = workflowDAO.findById(workflowId);
         checkNotNullEntry(workflow);
         checkCanExamine(user, workflow);

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -7469,7 +7469,7 @@ paths:
       description: Return first 200 versions in an entry
       operationId: getWorkflowVersions
       parameters:
-      - description: id of the worflow
+      - description: id of the workflow
         in: path
         name: workflowId
         required: true
@@ -10576,10 +10576,6 @@ components:
     VersionMetadata:
       type: object
       properties:
-        description:
-          type: string
-          description: "This is a human-readable description of this container and\
-            \ what it is trying to accomplish, required GA4GH"
         descriptorTypeVersions:
           type: array
           items:


### PR DESCRIPTION
**Description**
It's already a property of Version; don't duplicate.

**Review Instructions**
* Follow instructions steps to reproduce in #5587, using qa instead of staging; the second curl command should not return a description.
* It would be good to do a sanity check in the UI to verify that nothing is broken by this change; view both public and unpublished workflows and tools in the UI.

**Issue**
#5587

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
