### PR TITLE
Add description endpoint for version description

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGitHubWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGitHubWorkflowIT.java
@@ -237,6 +237,8 @@ class BitBucketGitHubWorkflowIT extends BaseIT {
     void testManualRegisterThenPublish() throws ApiException {
         final ApiClient webClient = getWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowApi = new WorkflowsApi(webClient);
+        final io.dockstore.openapi.client.api.WorkflowsApi openApiWorkflowsApi =
+            new io.dockstore.openapi.client.api.WorkflowsApi(getOpenAPIWebClient(USER_2_USERNAME, testingPostgres));
 
         // Make publish request (true)
         final PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
@@ -265,7 +267,7 @@ class BitBucketGitHubWorkflowIT extends BaseIT {
         final String tagName = "1.0.0";
 
         Optional<WorkflowVersion> testWDL = refreshedWorkflow.getWorkflowVersions().stream().filter(workflowVersion -> workflowVersion.getName().equals(tagName)).findFirst();
-        assertTrue(testWDL.get().getDescription().contains("test repo for CWL and WDL workflows"),
+        assertTrue(openApiWorkflowsApi.getWorkflowVersionDescription(refreshedWorkflow.getId(), testWDL.get().getId()).contains("test repo for CWL and WDL workflows"),
             "A workflow version with a descriptor that does not have a description should fall back to README");
 
         // Intentionally mess up description to test if refresh fixes it
@@ -275,7 +277,7 @@ class BitBucketGitHubWorkflowIT extends BaseIT {
         workflowApi.publish(githubWorkflow.getId(), publishRequest);
 
         testWDL = refreshedWorkflow.getWorkflowVersions().stream().filter(workflowVersion -> workflowVersion.getName().equals(tagName)).findFirst();
-        assertTrue(testWDL.get().getDescription().contains("test repo for CWL and WDL workflows"), "A workflow version that had a README description should get updated");
+        assertTrue(openApiWorkflowsApi.getWorkflowVersionDescription(refreshedWorkflow.getId(), testWDL.get().getId()).contains("test repo for CWL and WDL workflows"), "A workflow version that had a README description should get updated");
 
         // Assert some things
         assertEquals(1, workflowApi.allPublishedWorkflows(null, null, null, null, null, false, null).size(),

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
@@ -504,13 +504,16 @@ class GitHubWorkflowIT extends BaseIT {
     void cwlVersion11() {
         final ApiClient userApiClient = getWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi userWorkflowsApi = new WorkflowsApi(userApiClient);
+        final io.dockstore.openapi.client.api.WorkflowsApi openApiWorkflowsApi =
+            new io.dockstore.openapi.client.api.WorkflowsApi(
+                getOpenAPIWebClient(USER_2_USERNAME, testingPostgres));
         userWorkflowsApi.manualRegister("github", "dockstore-testing/Workflows-For-CI", "/cwl/v1.1/metadata.cwl", "metadata", "cwl",
             "/cwl/v1.1/cat-job.json");
         final Workflow workflowByPathGithub = userWorkflowsApi
             .getWorkflowByPath("github.com/dockstore-testing/Workflows-For-CI/metadata", BIOWORKFLOW, null);
         final Workflow workflow = userWorkflowsApi.refresh(workflowByPathGithub.getId(), true);
         workflow.getWorkflowVersions().forEach(workflowVersion -> {
-            assertEquals("Print the contents of a file to stdout using 'cat' running in a docker container.", workflowVersion.getDescription());
+            assertEquals("Print the contents of a file to stdout using 'cat' running in a docker container.", openApiWorkflowsApi.getWorkflowVersionDescription(workflow.getId(), workflowVersion.getId()));
             assertEquals(1, workflowVersion.getAuthors().size());
             assertEquals("Peter Amstutz", workflowVersion.getAuthors().get(0).getName());
             assertEquals("peter.amstutz@curoverse.com", workflowVersion.getAuthors().get(0).getEmail());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
@@ -474,13 +474,11 @@ class SwaggerWebhookIT extends BaseIT {
         Optional<io.dockstore.openapi.client.model.WorkflowVersion> masterVersion = workflow.getWorkflowVersions().stream().filter((io.dockstore.openapi.client.model.WorkflowVersion version) -> Objects.equals(version.getName(), "master")).findFirst();
         assertEquals("Test User", masterVersion.get().getAuthor(), "Should have author set");
         assertEquals("test@dockstore.org", masterVersion.get().getEmail(), "Should have email set");
-        assertEquals("This is a description", masterVersion.get().getDescription(), "Should have email set");
 
         masterVersion = workflow2.getWorkflowVersions().stream().filter((io.dockstore.openapi.client.model.WorkflowVersion version) -> Objects.equals(version.getName(), "master")).findFirst();
         assertEquals("Test User", masterVersion.get().getAuthor(), "Should have author set");
         assertTrue(masterVersion.get().isValid(), "Should be valid");
         assertEquals("test@dockstore.org", masterVersion.get().getEmail(), "Should have email set");
-        assertEquals("This is a description", masterVersion.get().getDescription(), "Should have email set");
 
         boolean hasLegacyVersion = workflow.getWorkflowVersions().stream().anyMatch(
                 io.dockstore.openapi.client.model.WorkflowVersion::isLegacyVersion);
@@ -1643,7 +1641,6 @@ class SwaggerWebhookIT extends BaseIT {
         assertTrue(defaultVersion.isPresent());
         assertEquals("Test User", defaultVersion.get().getAuthor(), "Version should have author set");
         assertEquals("test@dockstore.org", defaultVersion.get().getEmail(), "Version should have email set");
-        assertEquals("This is a description", defaultVersion.get().getDescription(), "Version should have email set");
 
         // Check that the workflow metadata is the same as the default version's metadata
         checkWorkflowMetadataWithDefaultVersionMetadata(workflow, defaultVersion.get());
@@ -1696,7 +1693,6 @@ class SwaggerWebhookIT extends BaseIT {
         assertEquals(1, defaultVersion.getAuthors().size());
         assertEquals(defaultVersion.getAuthors().size(), workflow.getAuthors().size());
         assertEquals(defaultVersion.getAuthors().get(0), workflow.getAuthors().get(0), "Workflow author should equal default version author");
-        assertEquals(defaultVersion.getDescription(), workflow.getDescription(), "Workflow description should equal default version description");
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -155,8 +155,8 @@ class WebhookIT extends BaseIT {
         Workflow foobar2 = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar2", WorkflowSubClass.BIOWORKFLOW, "versions");
 
 
-        assertTrue(foobar.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.DESCRIPTOR && v.getDescription().contains("This is a description")));
-        assertTrue(foobar2.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.DESCRIPTOR && v.getDescription().contains("This is a description")));
+        assertTrue(foobar.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.DESCRIPTOR && workflowClient.getWorkflowVersionDescription(foobar.getId(), v.getId()).contains("This is a description")));
+        assertTrue(foobar2.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.DESCRIPTOR && workflowClient.getWorkflowVersionDescription(foobar2.getId(), v.getId()).contains("This is a description")));
     }
 
     @Test
@@ -170,9 +170,9 @@ class WebhookIT extends BaseIT {
         Workflow foobar2 = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar2", WorkflowSubClass.BIOWORKFLOW, "versions");
 
 
-        assertTrue(foobar.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.README && v.getDescription().contains("A repo that includes .dockstore.yml"
+        assertTrue(foobar.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.README && workflowClient.getWorkflowVersionDescription(foobar.getId(), v.getId()).contains("A repo that includes .dockstore.yml"
             + "\n")));
-        assertTrue(foobar2.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.README && v.getDescription().contains("A repo that includes .dockstore.yml"
+        assertTrue(foobar2.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.README && workflowClient.getWorkflowVersionDescription(foobar2.getId(), v.getId()).contains("A repo that includes .dockstore.yml"
             + "\n")));
     }
 
@@ -187,8 +187,8 @@ class WebhookIT extends BaseIT {
         Workflow foobar2 = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar2", WorkflowSubClass.BIOWORKFLOW, "versions");
 
 
-        assertTrue(foobar.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.CUSTOM_README && v.getDescription().contains("an 'X' in it")));
-        assertTrue(foobar2.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.CUSTOM_README && v.getDescription().contains("a '🙃' in it")));
+        assertTrue(foobar.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.CUSTOM_README && workflowClient.getWorkflowVersionDescription(foobar.getId(), v.getId()).contains("an 'X' in it")));
+        assertTrue(foobar2.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.CUSTOM_README && workflowClient.getWorkflowVersionDescription(foobar2.getId(), v.getId()).contains("a '🙃' in it")));
     }
 
     @Test
@@ -201,8 +201,8 @@ class WebhookIT extends BaseIT {
         Workflow foobar = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar", WorkflowSubClass.BIOWORKFLOW, "versions");
         Workflow foobar2 = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar2", WorkflowSubClass.BIOWORKFLOW, "versions");
 
-        assertTrue(foobar.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.CUSTOM_README && v.getDescription().contains("an 'X' in it")));
-        assertTrue(foobar2.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.CUSTOM_README && v.getDescription().contains("a '🙃' in it")));
+        assertTrue(foobar.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.CUSTOM_README && workflowClient.getWorkflowVersionDescription(foobar.getId(), v.getId()).contains("an 'X' in it")));
+        assertTrue(foobar2.getWorkflowVersions().stream().allMatch(v -> v.getDescriptionSource() == DescriptionSourceEnum.CUSTOM_README && workflowClient.getWorkflowVersionDescription(foobar2.getId(), v.getId()).contains("a '🙃' in it")));
         // check that the descriptors in question really did have potential descriptions
         final List<SourceFile> foobarSourcefiles = workflowClient.getWorkflowVersionsSourcefiles(foobar.getId(), foobar.getWorkflowVersions().get(0).getId(), null);
         final List<SourceFile> foobar2Sourcefiles = workflowClient.getWorkflowVersionsSourcefiles(foobar2.getId(), foobar2.getWorkflowVersions().get(0).getId(), null);
@@ -212,17 +212,17 @@ class WebhookIT extends BaseIT {
         // Change the README path and description in the DB to dummy values
         testingPostgres.runUpdateStatement("update workflowversion set readmepath = null");
         testingPostgres.runUpdateStatement("update version_metadata set description = null");
-        foobar = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar", WorkflowSubClass.BIOWORKFLOW, "versions");
-        foobar2 = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar2", WorkflowSubClass.BIOWORKFLOW, "versions");
-        assertTrue(foobar.getWorkflowVersions().stream().allMatch(v -> v.getReadMePath() == null && v.getDescription() == null));
-        assertTrue(foobar2.getWorkflowVersions().stream().allMatch(v -> v.getReadMePath() == null && v.getDescription() == null));
+        final Workflow foobarA = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar", WorkflowSubClass.BIOWORKFLOW, "versions");
+        final Workflow foobar2A = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar2", WorkflowSubClass.BIOWORKFLOW, "versions");
+        assertTrue(foobarA.getWorkflowVersions().stream().allMatch(v -> v.getReadMePath() == null && workflowClient.getWorkflowVersionDescription(foobarA.getId(), v.getId()) == null));
+        assertTrue(foobar2A.getWorkflowVersions().stream().allMatch(v -> v.getReadMePath() == null && workflowClient.getWorkflowVersionDescription(foobar2A.getId(), v.getId()) == null));
 
         // The GitHub release should update the readmepath and description to the correct values
         workflowClient.handleGitHubRelease("refs/tags/0.7", installationId, workflowDockstoreYmlRepo, BasicIT.USER_2_USERNAME);
-        foobar = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar", WorkflowSubClass.BIOWORKFLOW, "versions");
-        foobar2 = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar2", WorkflowSubClass.BIOWORKFLOW, "versions");
-        assertTrue(foobar.getWorkflowVersions().stream().allMatch(v -> "/README2.md".equals(v.getReadMePath()) && v.getDescription().contains("an 'X' in it")));
-        assertTrue(foobar2.getWorkflowVersions().stream().allMatch(v -> "/docs/README.md".equals(v.getReadMePath()) && v.getDescription().contains("a '🙃' in it")));
+        final Workflow foobarB = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar", WorkflowSubClass.BIOWORKFLOW, "versions");
+        final Workflow foobar2B = workflowClient.getWorkflowByPath("github.com/" + workflowDockstoreYmlRepo + "/foobar2", WorkflowSubClass.BIOWORKFLOW, "versions");
+        assertTrue(foobarB.getWorkflowVersions().stream().allMatch(v -> "/README2.md".equals(v.getReadMePath()) && workflowClient.getWorkflowVersionDescription(foobarB.getId(), v.getId()).contains("an 'X' in it")));
+        assertTrue(foobar2B.getWorkflowVersions().stream().allMatch(v -> "/docs/README.md".equals(v.getReadMePath()) && workflowClient.getWorkflowVersionDescription(foobar2B.getId(), v.getId()).contains("a '🙃' in it")));
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -455,6 +455,7 @@ public abstract class Version<T extends Version> implements Comparable<T> {
         }
     }
 
+    @JsonIgnore
     @ApiModelProperty(position = 22)
     public String getDescription() {
         return this.getVersionMetadata().description;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
@@ -15,6 +15,7 @@
  */
 package io.dockstore.webservice.core;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.CollectionTable;
@@ -74,6 +75,7 @@ public class VersionMetadata {
     @Enumerated(EnumType.STRING)
     protected Version.DOIStatus doiStatus;
 
+    @JsonIgnore
     @Column(columnDefinition = "TEXT")
     @ApiModelProperty(value = "This is a human-readable description of this container and what it is trying to accomplish, required GA4GH")
     @Schema(description = "This is a human-readable description of this container and what it is trying to accomplish, required GA4GH")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoTagResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoTagResource.java
@@ -322,7 +322,7 @@ public class DockerRepoTagResource implements AuthenticatedResourceInterface, En
         if (!tool.getIsPublished()) {
             checkCanExamine(user.orElse(null), tool);
         }
-        final Version version = versionDAO.findVersionInEntry(containerId, tagId);
+        final Version<Tag> version = tagDAO.findVersionInEntry(containerId, tagId);
         if (version == null) {
             throw new CustomWebApplicationException("Tag " + tagId + " does not exist for container " + containerId, HttpStatus.SC_NOT_FOUND);
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -475,7 +475,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @UnitOfWork(readOnly = true)
     @Operation(operationId = "getWorkflowVersionDescription", description = "Retrieve a workflow version's description", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Retrieve a workflow version's description", content = @Content(
-        mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = String.class)))
+        mediaType = MediaType.TEXT_PLAIN, schema = @Schema(implementation = String.class)))
     @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad Request")
     public String getWorkflowVersionDescription(@Parameter(hidden = true, name = "user") @Auth User user,
         @Parameter(name = "workflowId", description = "id of the workflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -477,10 +477,10 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Retrieve a workflow version's description", content = @Content(
         mediaType = MediaType.TEXT_PLAIN, schema = @Schema(implementation = String.class)))
     @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad Request")
-    public String getWorkflowVersionDescription(@Parameter(hidden = true, name = "user") @Auth User user,
+    public String getWorkflowVersionDescription(@Parameter(hidden = true, name = "user") @Auth Optional<User> user,
         @Parameter(name = "workflowId", description = "id of the workflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
         @Parameter(name = "workflowVersionId", description = "id of the workflow version", required = true, in = ParameterIn.PATH) @PathParam("workflowVersionId") Long workflowVersionId) {
-        final WorkflowVersion workflowVersion = getWorkflowVersion(user, workflowId, workflowVersionId);
+        final WorkflowVersion workflowVersion = getWorkflowVersion(user.orElse(null), workflowId, workflowVersionId);
         return workflowVersion.getDescription();
     }
 
@@ -1565,7 +1565,9 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     private WorkflowVersion getWorkflowVersion(final User user, final Long workflowId,  final Long workflowVersionId) {
         Workflow workflow = workflowDAO.findById(workflowId);
         checkNotNullEntry(workflow);
-        checkCanExamine(user, workflow);
+        if (!workflow.getIsPublished()) {
+            checkCanExamine(user, workflow);
+        }
 
         WorkflowVersion workflowVersion = this.workflowVersionDAO.findById(workflowVersionId);
         if (workflowVersion == null) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -463,16 +463,25 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         @Parameter(name = "workflowId", description = "id of the workflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
         @Parameter(name = "workflowVersionId", description = "id of the workflow version", required = true, in = ParameterIn.PATH) @PathParam("workflowVersionId") Long workflowVersionId,
         @Parameter(name = "include", description = VERSION_INCLUDE_MESSAGE, in = ParameterIn.QUERY) @QueryParam("include") String include) {
-        Workflow workflow = workflowDAO.findById(workflowId);
-        checkNotNullEntry(workflow);
-        checkCanExamine(user, workflow);
-
-        WorkflowVersion workflowVersion = this.workflowVersionDAO.findById(workflowVersionId);
-        if (workflowVersion == null) {
-            throw new CustomWebApplicationException("Version " + workflowVersionId + " does not exist for this workflow", HttpStatus.SC_NOT_FOUND);
-        }
+        WorkflowVersion workflowVersion =
+            getWorkflowVersion(user, workflowId, workflowVersionId);
         initializeAdditionalFields(include, workflowVersion);
         return workflowVersion;
+    }
+
+    @GET
+    @Path("/{workflowId}/workflowVersions/{workflowVersionId}/description")
+    @Produces(MediaType.TEXT_PLAIN)
+    @UnitOfWork(readOnly = true)
+    @Operation(operationId = "getWorkflowVersionDescription", description = "Retrieve a workflow version's description", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Retrieve a workflow version's description", content = @Content(
+        mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = String.class)))
+    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad Request")
+    public String getWorkflowVersionDescription(@Parameter(hidden = true, name = "user") @Auth User user,
+        @Parameter(name = "workflowId", description = "id of the workflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
+        @Parameter(name = "workflowVersionId", description = "id of the workflow version", required = true, in = ParameterIn.PATH) @PathParam("workflowVersionId") Long workflowVersionId) {
+        final WorkflowVersion workflowVersion = getWorkflowVersion(user, workflowId, workflowVersionId);
+        return workflowVersion.getDescription();
     }
 
     @PUT
@@ -1552,6 +1561,19 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
         return workflowVersion;
     }
+
+    private WorkflowVersion getWorkflowVersion(final User user, final Long workflowId,  final Long workflowVersionId) {
+        Workflow workflow = workflowDAO.findById(workflowId);
+        checkNotNullEntry(workflow);
+        checkCanExamine(user, workflow);
+
+        WorkflowVersion workflowVersion = this.workflowVersionDAO.findById(workflowVersionId);
+        if (workflowVersion == null) {
+            throw new CustomWebApplicationException("Version " + workflowVersionId + " does not exist for this workflow", HttpStatus.SC_NOT_FOUND);
+        }
+        return workflowVersion;
+    }
+
 
     /**
      * This method will find the main descriptor file based on the workflow version passed in the parameter

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -7597,6 +7597,38 @@ paths:
       - BEARER: []
       tags:
       - workflows
+  /workflows/{workflowId}/workflowVersions/{workflowVersionId}/description:
+    get:
+      description: Retrieve a workflow version's description
+      operationId: getWorkflowVersionDescription
+      parameters:
+      - description: id of the workflow
+        in: path
+        name: workflowId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - description: id of the workflow version
+        in: path
+        name: workflowVersionId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Retrieve a workflow version's description
+        "400":
+          description: Bad Request
+      security:
+      - BEARER: []
+      tags:
+      - workflows
   /workflows/{workflowId}/workflowVersions/{workflowVersionId}/orcidAuthors:
     get:
       description: Retrieve ORCID author information for a workflow version
@@ -9745,8 +9777,6 @@ components:
         dbUpdateDate:
           type: integer
           format: int64
-        description:
-          type: string
         descriptionSource:
           type: string
           enum:
@@ -10504,8 +10534,6 @@ components:
         dbUpdateDate:
           type: integer
           format: int64
-        description:
-          type: string
         descriptionSource:
           type: string
           enum:
@@ -10613,10 +10641,6 @@ components:
     VersionMetadata:
       type: object
       properties:
-        description:
-          type: string
-          description: "This is a human-readable description of this container and\
-            \ what it is trying to accomplish, required GA4GH"
         descriptorTypeVersions:
           type: array
           items:
@@ -10894,8 +10918,6 @@ components:
         dbUpdateDate:
           type: integer
           format: int64
-        description:
-          type: string
         descriptionSource:
           type: string
           enum:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -7619,7 +7619,7 @@ paths:
       responses:
         "200":
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
           description: Retrieve a workflow version's description

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1991,6 +1991,36 @@ paths:
       - BEARER: []
       tags:
       - containertags
+  /containers/{containerId}/tags/{tagId}/description:
+    get:
+      description: Retrieve a tag's description
+      operationId: getTagDescription
+      parameters:
+      - description: Container to retrieve the version from
+        in: path
+        name: containerId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - description: Tag to retrieve the description from
+        in: path
+        name: tagId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        default:
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: default response
+      security:
+      - BEARER: []
+      tags:
+      - containertags
   /containers/{containerId}/tags/{tagId}/sourcefiles:
     get:
       description: Retrieve sourcefiles for a container's version


### PR DESCRIPTION
**Description**
Removes `description` from the `WorkflowVersion` response, both as a top level property and from VersionMetadata. Folding #5588 into this, which just removed the duplication of the description in the response. One irksome thing is that the property will continue to exist in Swagger, but its value will be null. I also had to update some Swagger tests to use OpenAPI to fetch the description.

Adds new `description` endpoints off containers and workflows paths.

For the workflow mentioned in the issue, fetching the versions in staging without this change returns a ~16MB response.

Removing the duplicated descriptions brings down the response to ~285K -- the savings is 40K readme file size x 200, doubled by duplication.

The CLI does not access the workflow version description, so no change is required there, and this should not break older clients.

The UI does display the description, so I've updated the UI in dockstore/dockstore-ui2#1812 to make the extra call to fetch the description for the current version.

This doesn't really fix the bug as written up; we're still fetching 200 versions. But we're reducing the response size by a factor of 50.

**Review Instructions**
1. Verify the description property is not present in the proprietary API
2. Verify both the public and my workflow/tool pages correctly display the version's description.


**Issue**
SEAB-4592

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
