### PR TITLE
Add OpenAPI Auth annotation

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/UserResourceDockerRegistriesIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/UserResourceDockerRegistriesIT.java
@@ -52,7 +52,7 @@ class UserResourceDockerRegistriesIT extends BaseIT {
         ApiClient client = getOpenAPIWebClient(USER_1_USERNAME, testingPostgres);
         UsersApi usersApi = new UsersApi(client);
         List<String> actualNamespaces = usersApi.getDockerRegistriesOrganization("quay.io");
-        List<String> expectedNamespaces = Arrays.asList("dockstore", "dockstoretestuser");
+        List<String> expectedNamespaces = Arrays.asList("dockstoretestuser");
         assertEquals(expectedNamespaces, actualNamespaces, "Should have the expected namespaces");
         try {
             usersApi.getDockerRegistriesOrganization("fakeDockerRegistry");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
@@ -276,7 +276,7 @@ public class ToolsExtendedApi {
         @ApiResponse(code = HttpStatus.SC_OK, message = AggregatedMetricsGet.OK_RESPONSE, response = Map.class),
         @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = AggregatedMetricsGet.NOT_FOUND_RESPONSE, response = Error.class),
         @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = AggregatedMetricsGet.UNAUTHORIZED_RESPONSE, response = Error.class)})
-    @Operation(operationId = "aggregatedMetricsGet", summary = AggregatedMetricsGet.SUMMARY, description = AggregatedMetricsGet.DESCRIPTION)
+    @Operation(operationId = "aggregatedMetricsGet", summary = AggregatedMetricsGet.SUMMARY, description = AggregatedMetricsGet.DESCRIPTION, security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME))
     public Map<Partner, Metrics> aggregatedMetricsGet(@ApiParam(hidden = true) @Parameter(hidden = true) @Auth Optional<User> user,
         @ApiParam(value = AggregatedMetricsGet.ID_DESCRIPTION, required = true) @Parameter(description = AggregatedMetricsGet.ID_DESCRIPTION,
                 in = ParameterIn.PATH) @PathParam("id") String id,

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -569,6 +569,8 @@ paths:
                 additionalProperties:
                   $ref: '#/components/schemas/Metrics'
           description: default response
+      security:
+      - BEARER: []
       summary: Get aggregated execution metrics for a tool from all platforms
       tags:
       - extendedGA4GH


### PR DESCRIPTION
**Description**
Add the auth annotation for OpenAPI for the aggregatedMetricsGet.

**Review Instructions**
Go to https://qa.dockstore.org/api/static/swagger-ui/index.html#/extendedGA4GH/aggregatedMetricsGet, and make sure the padlock is there. BUT, also make sure you're not seeing #5621, where the padlock is incorrectly appearing for all endpoints.

**Issue**
#5464

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
