### PR TITLE
SEAB-5660: Remove getErrorMessage from CustomWebApplicationException

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/CustomWebApplicationException.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/CustomWebApplicationException.java
@@ -26,15 +26,8 @@ import org.apache.http.HttpStatus;
  */
 public class CustomWebApplicationException extends WebApplicationException {
 
-    public final String errorMessage;
-
     public CustomWebApplicationException(String message, int status) {
-        super(Response.status(status).entity(message).type(MediaType.TEXT_PLAIN).build());
-        this.errorMessage = message;
-    }
-
-    public String getErrorMessage() {
-        return errorMessage;
+        super(message, Response.status(status).entity(message).type(MediaType.TEXT_PLAIN).build());
     }
 
     public void rethrowIf5xx() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/WDLHandler.java
@@ -307,11 +307,8 @@ public class WDLHandler implements LanguageHandlerInterface {
                 String content = FileUtils.readFileToString(tempMainDescriptor, StandardCharsets.UTF_8);
                 try {
                     checkForRecursiveHTTPImports(content, new HashSet<>());
-                } catch (IOException e) {
+                } catch (IOException | CustomWebApplicationException e) {
                     validationMessageObject.put(primaryDescriptorFilePath, e.getMessage());
-                    return new VersionTypeValidation(false, validationMessageObject);
-                } catch (CustomWebApplicationException e) {
-                    validationMessageObject.put(primaryDescriptorFilePath, e.getErrorMessage());
                     return new VersionTypeValidation(false, validationMessageObject);
                 }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -451,7 +451,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
 
     private boolean isGitHubRateLimitError(Exception ex) {
         if (ex instanceof CustomWebApplicationException customWebAppEx) {
-            final String errorMessage = customWebAppEx.getErrorMessage();
+            final String errorMessage = customWebAppEx.getMessage();
             return errorMessage != null && errorMessage.startsWith(GitHubSourceCodeRepo.OUT_OF_GIT_HUB_RATE_LIMIT);
         }
         return false;
@@ -649,7 +649,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         if (ex instanceof ClassCastException) {
             return "Could not parse input.";
         }
-        String message = ex instanceof CustomWebApplicationException ? ((CustomWebApplicationException)ex).getErrorMessage() : ex.getMessage();
+        String message = ex.getMessage();
         if (ex instanceof DockstoreYamlHelper.DockstoreYamlException) {
             message = DockstoreYamlHelper.ERROR_READING_DOCKSTORE_YML + message;
         }

--- a/dockstore-webservice/src/test/java/core/WDLParseTest.java
+++ b/dockstore-webservice/src/test/java/core/WDLParseTest.java
@@ -375,7 +375,7 @@ class WDLParseTest {
         } catch (IOException e) {
             fail();
         } catch (CustomWebApplicationException e) {
-            assertTrue(StringUtils.contains(e.getErrorMessage(), ERROR_PARSING_WORKFLOW_YOU_MAY_HAVE_A_RECURSIVE_IMPORT));
+            assertTrue(StringUtils.contains(e.getMessage(), ERROR_PARSING_WORKFLOW_YOU_MAY_HAVE_A_RECURSIVE_IMPORT));
         }
         assertTrue(StringUtils.contains(versionTypeValidation.getMessage().get(recursiveWDL.getAbsolutePath()), ERROR_PARSING_WORKFLOW_YOU_MAY_HAVE_A_RECURSIVE_IMPORT));
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GitHubHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/GitHubHelperTest.java
@@ -22,7 +22,7 @@ class GitHubHelperTest {
             GitHubHelper.getGitHubAccessToken(CODE, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET);
             fail("No CustomWebApplicationException thrown");
         } catch (CustomWebApplicationException e) {
-            assertEquals("HTTP 400 Bad Request", e.getMessage());
+            assertEquals("Could not retrieve github.com token based on code", e.getMessage());
         }
     }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/StringInputValidationHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/StringInputValidationHelperTest.java
@@ -19,28 +19,28 @@ class StringInputValidationHelperTest {
             StringInputValidationHelper.checkEntryName(Tool.class, "!@#$/%^&*<foo><bar>");
             fail("Entry name with special characters that are not underscores and hyphens should fail validation.");
         } catch (CustomWebApplicationException ex) {
-            assertTrue(ex.getErrorMessage().contains("Invalid tool name"));
+            assertTrue(ex.getMessage().contains("Invalid tool name"));
         }
 
         try {
             StringInputValidationHelper.checkEntryName(AppTool.class, "foo bar");
             fail("Entry name with spaces should fail validation.");
         } catch (CustomWebApplicationException ex) {
-            assertTrue(ex.getErrorMessage().contains("Invalid tool name"));
+            assertTrue(ex.getMessage().contains("Invalid tool name"));
         }
 
         try {
             StringInputValidationHelper.checkEntryName(BioWorkflow.class, "-foo-");
             fail("Entry name with external hyphens should fail validation.");
         } catch (CustomWebApplicationException ex) {
-            assertTrue(ex.getErrorMessage().contains("Invalid workflow name"));
+            assertTrue(ex.getMessage().contains("Invalid workflow name"));
         }
 
         try {
             StringInputValidationHelper.checkEntryName(Service.class, "_foo_");
             fail("Entry name with external underscores should fail validation.");
         } catch (CustomWebApplicationException ex) {
-            assertTrue(ex.getErrorMessage().contains("Invalid service name"));
+            assertTrue(ex.getMessage().contains("Invalid service name"));
         }
 
         try {
@@ -49,7 +49,7 @@ class StringInputValidationHelperTest {
             StringInputValidationHelper.checkEntryName(BioWorkflow.class, longWorkflowName);
             fail("Entry name that exceeds " + ValidationConstants.ENTRY_NAME_LENGTH_MAX + " characters should fail validation.");
         } catch (CustomWebApplicationException ex) {
-            assertTrue(ex.getErrorMessage().contains("Invalid workflow name"));
+            assertTrue(ex.getMessage().contains("Invalid workflow name"));
         }
 
         try {

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
@@ -72,7 +72,7 @@ class ZenodoHelperTest {
             ZenodoHelper.createAliasUsingDoi(doi);
             fail("Was able to create an alias with an invalid prefix.");
         } catch (CustomWebApplicationException ex) {
-            assertTrue(ex.getErrorMessage().contains("Please create aliases without these prefixes"));
+            assertTrue(ex.getMessage().contains("Please create aliases without these prefixes"));
         }
     }
 
@@ -92,7 +92,7 @@ class ZenodoHelperTest {
             ZenodoHelper.setMetadataCreator(depositMetadata, bioWorkflow);
             fail("Should have failed");
         } catch (CustomWebApplicationException ex) {
-            assertEquals(ZenodoHelper.AT_LEAST_ONE_AUTHOR_IS_REQUIRED_TO_PUBLISH_TO_ZENODO, ex.getErrorMessage());
+            assertEquals(ZenodoHelper.AT_LEAST_ONE_AUTHOR_IS_REQUIRED_TO_PUBLISH_TO_ZENODO, ex.getMessage());
         }
     }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -294,7 +294,7 @@ class CWLHandlerTest {
             fail("Expected parsing error");
         } catch (CustomWebApplicationException e) {
             assertEquals(HttpStatus.SC_UNPROCESSABLE_ENTITY, e.getResponse().getStatus());
-            assertThat(e.getErrorMessage()).contains(CWLHandler.CWL_PARSE_ERROR);
+            assertThat(e.getMessage()).contains(CWLHandler.CWL_PARSE_ERROR);
 
         }
 
@@ -306,7 +306,7 @@ class CWLHandlerTest {
             fail("Expected cwlVersion error");
         } catch (CustomWebApplicationException e) {
             assertEquals(HttpStatus.SC_UNPROCESSABLE_ENTITY, e.getResponse().getStatus());
-            assertThat(e.getErrorMessage()).contains(CWLHandler.CWL_VERSION_ERROR);
+            assertThat(e.getMessage()).contains(CWLHandler.CWL_VERSION_ERROR);
         }
 
         // expect error based on an undefined cwlVersion
@@ -317,7 +317,7 @@ class CWLHandlerTest {
             fail("Expected undefined cwlVersion error");
         } catch (CustomWebApplicationException e) {
             assertEquals(HttpStatus.SC_UNPROCESSABLE_ENTITY, e.getResponse().getStatus());
-            assertThat(e.getErrorMessage()).contains(CWLHandler.CWL_NO_VERSION_ERROR);
+            assertThat(e.getMessage()).contains(CWLHandler.CWL_NO_VERSION_ERROR);
         }
 
         // expect error based on invalid JSON $import/$include
@@ -328,7 +328,7 @@ class CWLHandlerTest {
             fail("Expected parse error: value of workflow step run field should be a string, workflow, or tool");
         } catch (CustomWebApplicationException e) {
             assertEquals(HttpStatus.SC_UNPROCESSABLE_ENTITY, e.getResponse().getStatus());
-            assertThat(e.getErrorMessage()).contains(CWLHandler.CWL_PARSE_SECONDARY_ERROR);
+            assertThat(e.getMessage()).contains(CWLHandler.CWL_PARSE_SECONDARY_ERROR);
         }
     }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/WDLHandlerTest.java
@@ -118,7 +118,7 @@ class WDLHandlerTest {
             wdlHandler.checkForRecursiveHTTPImports(s, new HashSet<>());
             Assertions.fail("Should've detected recursive import");
         } catch (CustomWebApplicationException e) {
-            assertEquals(ERROR_PARSING_WORKFLOW_YOU_MAY_HAVE_A_RECURSIVE_IMPORT, e.getErrorMessage());
+            assertEquals(ERROR_PARSING_WORKFLOW_YOU_MAY_HAVE_A_RECURSIVE_IMPORT, e.getMessage());
         }
 
         final File notRecursiveWdl = new File(ResourceHelpers.resourceFilePath("valid_description_example.wdl"));
@@ -186,7 +186,7 @@ class WDLHandlerTest {
             Assertions.fail("Expected parsing error");
         } catch (CustomWebApplicationException e) {
             assertEquals(HttpStatus.SC_UNPROCESSABLE_ENTITY, e.getResponse().getStatus());
-            assertThat(e.getErrorMessage()).contains(WDLHandler.WDL_PARSE_ERROR);
+            assertThat(e.getMessage()).contains(WDLHandler.WDL_PARSE_ERROR);
         }
     }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/permissions/sam/SamPermissionsImplTest.java
@@ -570,7 +570,7 @@ class SamPermissionsImplTest {
                 janeDoeUserMock, workflowInstance, new Permission("johndoe@example.com", Role.WRITER));
             fail("Expected setPermission to throw exception");
         } catch (CustomWebApplicationException ex) {
-            assertTrue(ex.getMessage().contains(" 409 "));
+            assertTrue(ex.getMessage().startsWith("An unexpected error occurred. Please send a private message to"));
         }
     }
 
@@ -602,7 +602,7 @@ class SamPermissionsImplTest {
             samPermissionsImpl.getPermissionsForWorkflow(johnSmithUserMock, workflowInstance);
             fail("Non-owner shouldn't be able to get permissions");
         } catch (CustomWebApplicationException e) {
-            assertEquals("Forbidden", e.getErrorMessage());
+            assertEquals("Forbidden", e.getMessage());
         }
     }
 
@@ -624,13 +624,13 @@ class SamPermissionsImplTest {
             samPermissionsImpl.setPermission(noGoogleUser, workflowInstance, writerPermission);
             fail("Should not be able to set a permission without a Google token");
         } catch (CustomWebApplicationException e) {
-            assertEquals(SamPermissionsImpl.GOOGLE_ACCOUNT_MUST_BE_LINKED, e.getErrorMessage());
+            assertEquals(SamPermissionsImpl.GOOGLE_ACCOUNT_MUST_BE_LINKED, e.getMessage());
         }
         try {
             samPermissionsImpl.removePermission(noGoogleUser, workflowInstance, JOHN_SMITH_GMAIL_COM, Role.OWNER);
             fail("Should not be able to set a permission without a Google token");
         } catch (CustomWebApplicationException e) {
-            assertEquals(SamPermissionsImpl.GOOGLE_ACCOUNT_MUST_BE_LINKED, e.getErrorMessage());
+            assertEquals(SamPermissionsImpl.GOOGLE_ACCOUNT_MUST_BE_LINKED, e.getMessage());
         }
     }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/AliasableResourceInterfaceTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/AliasableResourceInterfaceTest.java
@@ -31,7 +31,7 @@ class AliasableResourceInterfaceTest {
                         user, true);
                 fail("An alias with an invalid prefix " + invalidPrefix + " was reported to be OK.");
             } catch (CustomWebApplicationException ex) {
-                assertTrue(ex.getErrorMessage().contains("Please create aliases without these prefixes"));
+                assertTrue(ex.getMessage().contains("Please create aliases without these prefixes"));
             }
         });
     }
@@ -67,7 +67,7 @@ class AliasableResourceInterfaceTest {
 
                 AliasableResourceInterface.checkAliases(Collections.singleton(zenodoDOI), user, true);
             } catch (CustomWebApplicationException ex) {
-                assertTrue(ex.getErrorMessage().contains("Please create aliases without this format"));
+                assertTrue(ex.getMessage().contains("Please create aliases without this format"));
             }
         });
     }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/UserResourceTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/UserResourceTest.java
@@ -20,7 +20,7 @@ class UserResourceTest {
                 UserResource.restrictUsername(username);
                 fail("Should not be able to create a username with a keyword.");
             } catch (CustomWebApplicationException ex) {
-                assertTrue(ex.errorMessage.contains("because it contains one or more of the following keywords:"));
+                assertTrue(ex.getMessage().contains("because it contains one or more of the following keywords:"));
             }
         }
     }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
@@ -29,7 +29,7 @@ class ToolsApiExtendedServiceImplTest {
             ToolsApiExtendedServiceImpl.checkSearchTermLimit(includeESQuery);
             fail("Should not pass search term length limit check");
         } catch (CustomWebApplicationException ex) {
-            assertTrue(ex.getErrorMessage().contains(searchRequestExceedsLimitMessage));
+            assertTrue(ex.getMessage().contains(searchRequestExceedsLimitMessage));
         }
 
         try {
@@ -40,7 +40,7 @@ class ToolsApiExtendedServiceImplTest {
             ToolsApiExtendedServiceImpl.checkSearchTermLimit(wildcardESQuery);
             fail("Should not pass search term length limit check");
         } catch (CustomWebApplicationException ex) {
-            assertTrue(ex.getErrorMessage().contains(searchRequestExceedsLimitMessage));
+            assertTrue(ex.getMessage().contains(searchRequestExceedsLimitMessage));
         }
 
         try {


### PR DESCRIPTION
**Description**
This PR fixes the 'lambda log "HTTP 400 Bad Request" message on failed publish' bug, as detailed in https://ucsc-cgl.atlassian.net/browse/SEAB-5660.

The bug happens because after a failed publish, the `LambdaEvent` message is set to the value returned by `CustomWebApplicationException.getMessage` here:
https://github.com/dockstore/dockstore/blob/10e130ee522ea1b3153b6706110c58d3166deaa8/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java#L586

Alas, `CustomWebApplicationException.getMessage` returns a generic HTTP error message (ex: "HTTP 400 Bad Request") synthesized from the status code in the `Response` which is passed to the superconstructor:
https://github.com/dockstore/dockstore/blob/10e130ee522ea1b3153b6706110c58d3166deaa8/dockstore-webservice/src/main/java/io/dockstore/webservice/CustomWebApplicationException.java#L32

Instead, at line 586, we should have called`getErrorMessage`, which would return the intended message, passed to the exception constructor here:
https://github.com/dockstore/dockstore/blob/10e130ee522ea1b3153b6706110c58d3166deaa8/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java#L1016

But then, I got to wondering... why the two different exception message methods, returning different messages?  I checked the blame, and apparently, `getErrorMessage` was added in https://github.com/dockstore/dockstore/pull/1853, but I couldn't find any explanation as to why.

Should `CustomWebApplicationException.getMessage` simply return the detailed message that we pass to its constructor?  My conclusion was 'yes', mostly because I couldn't think of any strong reason why not.

So, I deleted `CustomWebApplicationException.getErrorMessage`, made `getMessage` always return the detailed message, and adjusted some related code.

The Very Important Question: Are there ever situations where we'd _want_ to log the generic message, and does the detailed message ever contain sensitive information that we don't want to log or display?  Probably not, but please ponder/inspect...

**Review Instructions**
Register a workflow that has no valid branches via the `.dockstore.yml` path, with `publish: true`, and confirm that the lambda logs error message corresponding to the failed publish is "Repository does not meet requirements to publish.".

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5660

**Security**
See the Very Important Question above.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
