### PR TITLE
DOCK-2412: Reenable migration caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,8 +574,7 @@ commands:
       - run:
           name: run integration test
           command: |  # Runs normally if it is not being run in parallel
-            # Caching migrations is causing PR to fail, see https://github.com/dockstore/dockstore/issues/5548
-            # export DOCKSTORE_CACHE_MIGRATIONS=true
+            export DOCKSTORE_CACHE_MIGRATIONS=true
             if [ $CIRCLE_NODE_TOTAL != 1 ] 
             then
               ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate -P$TESTING_PROFILE,coverage -ntp \

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
@@ -103,7 +103,7 @@ class ExtendedTRSApiIT extends BaseIT {
         containersApi.publish(refresh.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
 
         // Try to set a single checker workflow to two entries
-        // For now, this subtest is disabled.  It will probably be
+        // TODO: For now, this subtest is disabled.  It will probably be
         // reenabled in some form as part of https://ucsc-cgl.atlassian.net/browse/SEAB-5848
         /*
         testingPostgres.runUpdateStatement("update workflow set checkerid = '" + checkerWorkflow.getId() + "' where id = '" + workflow.getId() + "'");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
@@ -19,7 +19,6 @@ package io.dockstore.client.cli;
 import static io.dockstore.client.cli.ExtendedMetricsTRSOpenApiIT.DOCKSTORE_WORKFLOW_CNV_REPO;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import io.dockstore.client.cli.BaseIT.TestStatus;
 import io.dockstore.common.CommonTestUtilities;
@@ -104,6 +103,9 @@ class ExtendedTRSApiIT extends BaseIT {
         containersApi.publish(refresh.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
 
         // Try to set a single checker workflow to two entries
+        // For now, this subtest is disabled.  It will probably be
+        // reenabled in some form as part of https://ucsc-cgl.atlassian.net/browse/SEAB-5848
+        /*
         testingPostgres.runUpdateStatement("update workflow set checkerid = '" + checkerWorkflow.getId() + "' where id = '" + workflow.getId() + "'");
         try {
             testingPostgres.runUpdateStatement("update tool set checkerid = '" + checkerWorkflow.getId() + "' where id = '"
@@ -112,6 +114,7 @@ class ExtendedTRSApiIT extends BaseIT {
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("violates check constraint \"check_tool_checkerid_globally_unique\""));
         }
+        */
         testingPostgres.runUpdateStatement("update workflow set checkerid = '" + checkerWorkflow.getId() + "' where id = '" + workflow.getId() + "'");
         long workflowCount = testingPostgres.runSelectStatement("select count(*) from workflow where checkerid = " + checkerWorkflow.getId(), long.class);
         workflowCount += testingPostgres.runSelectStatement("select count(*) from tool where checkerid = " + checkerWorkflow.getId(), long.class);

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -30,12 +30,47 @@
         <addPrimaryKey columnNames="userid, entryid" constraintName="user_entry_pkey" tableName="user_entry"/>
     </changeSet>
     <changeSet id="unique_checker_ids" author="coverbeck">
-        <comment>One tool and one workflow in prod currently share the same checker workflow.  Null out any duplicate checkers.
-            When there are duplicates, prefer the workflow table, then the apptool table, for the table that "keeps" the checker.
+        <comment>One tool and one workflow in prod currently share the same checker workflow. The constraints later in this migration will
+            disallow that. Null out any duplicate checkers so the constraints can be created. When there are duplicates, prefer the
+            workflow table, then the apptool table, for the table that "keeps" the checker.
         </comment>
         <sql dbms="postgresql">
             UPDATE tool SET checkerid=NULL where checkerid in (SELECT checkerid FROM workflow UNION SELECT checkerid FROM apptool);
             UPDATE apptool SET checkerid=NULL where checkerid in (SELECT checkerid FROM workflow UNION SELECT checkerid FROM tool);
+        </sql>
+        <sql dbms="postgresql">
+            CREATE OR REPLACE FUNCTION check_apptool_checkerid_is_unique(_checkerid BIGINT) RETURNS BOOLEAN AS $$
+            BEGIN
+                RETURN
+                    NOT EXISTS(
+                        SELECT checkerid FROM workflow WHERE checkerid = _checkerid
+                        UNION SELECT checkerid FROM tool WHERE checkerid = _checkerid
+                    );
+            END
+            $$ LANGUAGE PLPGSQL;
+            CREATE OR REPLACE FUNCTION check_tool_checker_id_is_unique(_checkerid BIGINT) RETURNS BOOLEAN AS $$
+            BEGIN
+            RETURN
+                NOT EXISTS(
+                    SELECT checkerid FROM workflow WHERE checkerid = _checkerid
+                    UNION SELECT checkerid FROM apptool WHERE checkerid = _checkerid
+                );
+            END
+            $$ LANGUAGE PLPGSQL;
+            CREATE OR REPLACE FUNCTION check_workflow_checker_id_is_unique(_checkerid BIGINT) RETURNS BOOLEAN AS $$
+            BEGIN
+            RETURN
+                NOT EXISTS(
+                    SELECT checkerid FROM apptool WHERE checkerid = _checkerid
+                    UNION SELECT checkerid FROM tool WHERE checkerid = _checkerid
+                );
+            END
+            $$ LANGUAGE PLPGSQL;
+        </sql>
+        <sql dbms="postgresql">
+            ALTER TABLE apptool ADD CONSTRAINT check_apptool_checkerid_globally_unique CHECK(check_apptool_checkerid_is_unique(checkerid));
+            ALTER TABLE tool ADD CONSTRAINT check_tool_checkerid_globally_unique CHECK(check_tool_checker_id_is_unique(checkerid));
+            ALTER TABLE workflow ADD CONSTRAINT check_workflow_checkerid_globally_unique CHECK(check_workflow_checker_id_is_unique(checkerid));
         </sql>
     </changeSet>
     <changeSet author="dyuen (generated)" id="drop_old_accepted_column">

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -195,4 +195,16 @@
         </sql>
         <addNotNullConstraint tableName="lambdaevent" columnName="deliveryid"/>
     </changeSet>
+    <changeSet author="svonworl" id="removeProblematicCheckConstraints">
+        <sql dbms="postgresql">
+            ALTER TABLE apptool DROP CONSTRAINT check_apptool_checkerid_globally_unique;
+            ALTER TABLE tool DROP CONSTRAINT check_tool_checkerid_globally_unique;
+            ALTER TABLE workflow DROP CONSTRAINT check_workflow_checkerid_globally_unique;
+        </sql>
+        <sql>
+            DROP FUNCTION check_apptool_checkerid_is_unique;
+            DROP FUNCTION check_tool_checker_id_is_unique;
+            DROP FUNCTION check_workflow_checker_id_is_unique;
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -201,7 +201,7 @@
             ALTER TABLE tool DROP CONSTRAINT check_tool_checkerid_globally_unique;
             ALTER TABLE workflow DROP CONSTRAINT check_workflow_checkerid_globally_unique;
         </sql>
-        <sql>
+        <sql dbms="postgresql">
             DROP FUNCTION check_apptool_checkerid_is_unique;
             DROP FUNCTION check_tool_checker_id_is_unique;
             DROP FUNCTION check_workflow_checker_id_is_unique;

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -30,47 +30,12 @@
         <addPrimaryKey columnNames="userid, entryid" constraintName="user_entry_pkey" tableName="user_entry"/>
     </changeSet>
     <changeSet id="unique_checker_ids" author="coverbeck">
-        <comment>One tool and one workflow in prod currently share the same checker workflow. The constraints later in this migration will
-            disallow that. Null out any duplicate checkers so the constraints can be created. When there are duplicates, prefer the
-            workflow table, then the apptool table, for the table that "keeps" the checker.
+        <comment>One tool and one workflow in prod currently share the same checker workflow.  Null out any duplicate checkers.
+            When there are duplicates, prefer the workflow table, then the apptool table, for the table that "keeps" the checker.
         </comment>
         <sql dbms="postgresql">
             UPDATE tool SET checkerid=NULL where checkerid in (SELECT checkerid FROM workflow UNION SELECT checkerid FROM apptool);
             UPDATE apptool SET checkerid=NULL where checkerid in (SELECT checkerid FROM workflow UNION SELECT checkerid FROM tool);
-        </sql>
-        <sql dbms="postgresql">
-            CREATE OR REPLACE FUNCTION check_apptool_checkerid_is_unique(_checkerid BIGINT) RETURNS BOOLEAN AS $$
-            BEGIN
-                RETURN
-                    NOT EXISTS(
-                        SELECT checkerid FROM workflow WHERE checkerid = _checkerid
-                        UNION SELECT checkerid FROM tool WHERE checkerid = _checkerid
-                    );
-            END
-            $$ LANGUAGE PLPGSQL;
-            CREATE OR REPLACE FUNCTION check_tool_checker_id_is_unique(_checkerid BIGINT) RETURNS BOOLEAN AS $$
-            BEGIN
-            RETURN
-                NOT EXISTS(
-                    SELECT checkerid FROM workflow WHERE checkerid = _checkerid
-                    UNION SELECT checkerid FROM apptool WHERE checkerid = _checkerid
-                );
-            END
-            $$ LANGUAGE PLPGSQL;
-            CREATE OR REPLACE FUNCTION check_workflow_checker_id_is_unique(_checkerid BIGINT) RETURNS BOOLEAN AS $$
-            BEGIN
-            RETURN
-                NOT EXISTS(
-                    SELECT checkerid FROM apptool WHERE checkerid = _checkerid
-                    UNION SELECT checkerid FROM tool WHERE checkerid = _checkerid
-                );
-            END
-            $$ LANGUAGE PLPGSQL;
-        </sql>
-        <sql dbms="postgresql">
-            ALTER TABLE apptool ADD CONSTRAINT check_apptool_checkerid_globally_unique CHECK(check_apptool_checkerid_is_unique(checkerid));
-            ALTER TABLE tool ADD CONSTRAINT check_tool_checkerid_globally_unique CHECK(check_tool_checker_id_is_unique(checkerid));
-            ALTER TABLE workflow ADD CONSTRAINT check_workflow_checkerid_globally_unique CHECK(check_workflow_checker_id_is_unique(checkerid));
         </sql>
     </changeSet>
     <changeSet author="dyuen (generated)" id="drop_old_accepted_column">


### PR DESCRIPTION
**Description**
This PR reenables "migration caching", the scheme whereby the integration tests dump and restore the migrated database, instead of repeatedly applying the full set of migrations to the initial database, the latter being slower.

Turns out that the `CHECK` constraints added by https://github.com/dockstore/dockstore/pull/5546 to limit a checker to a single entry, invoke `FUNCTIONS` that refer to other tables.  These checks cause problems during the dump restore process, resulting in a somewhat corrupt database, which then makes some of the tests fail.  Apparently, postgresql includes `CHECK` constraints early in the database dump, under the assumption that checks only apply to the current row, causing the restore to malfunction if one of said constraints references a table which has not yet been created, for example.

Unbeknownst to us at the time, the Postgres docs state that only check constraints that refer to the current row are supported.  See the Note after Section 5.4.1: https://www.postgresql.org/docs/current/ddl-constraints.html

So, I remove the offending migrations, and reenabled migration caching.

We've created a new ticket https://ucsc-cgl.atlassian.net/browse/SEAB-5848 which covers the reimplementation of database enforcement of the 1-to-1 checker-to-entry mapping.  

**Review Instructions**
Confirm that the integration tests are running correctly, and that the database dumps appear to be created and utilized.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2412

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
