### PR TITLE
SEAB-3957: Handle search text containing special characters

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -335,6 +335,8 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
             try {
                 String include = getSearchQueryJsonIncludeKey(json);
                 if (include.length() > 0) {
+                    // A trailing .* is added by the ui when creating the request body with an autocomplete field
+                    // It gets removed here and added back later so the search recognizes it as a regex expression rather than literal characters
                     String escapedStr = include.replaceAll("\\.\\*$", "").replaceAll(SEARCH_QUERY_REGEX, "\\\\$1");
                     if (include.endsWith(".*")) {
                         escapedStr = escapedStr + ".*";

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -270,8 +270,8 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
         }
         try {
             if (!config.getEsConfiguration().getHostname().isEmpty()) {
-                query = escapeCharactersInSearchTerm(query);
-                checkSearchTermLimit(query);
+                String searchQuery = escapeCharactersInSearchTerm(query);
+                checkSearchTermLimit(searchQuery);
                 try {
                     RestClient restClient = ElasticSearchHelper.restClient();
                     Map<String, String> parameters = new HashMap<>();
@@ -282,8 +282,8 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
                     }
                     // This should be using the high-level Elasticsearch client instead
                     Request request = new Request("GET", "/" + COMMA_SEPARATED_INDEXES + "/_search");
-                    if (query != null) {
-                        request.setJsonEntity(query);
+                    if (searchQuery != null) {
+                        request.setJsonEntity(searchQuery);
                     }
                     request.addParameters(parameters);
                     org.elasticsearch.client.Response get = restClient.performRequest(request);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -335,13 +335,11 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
             try {
                 String include = getSearchQueryJsonIncludeKey(json);
                 if (include.length() > 0) {
+                    String escapedStr = include.replaceAll("\\.\\*$", "").replaceAll(SEARCH_QUERY_REGEX, "\\\\$1");
                     if (include.endsWith(".*")) {
-                        String escapedStr = include.replaceAll("\\.\\*$", "").replaceAll(SEARCH_QUERY_REGEX, "\\\\$1");
-                        json.getJSONObject("aggs").getJSONObject("autocomplete").getJSONObject("terms").put("include", escapedStr + ".*");
-                    } else {
-                        String escapedStr = include.replaceAll(SEARCH_QUERY_REGEX, "\\\\$1");
-                        json.getJSONObject("aggs").getJSONObject("autocomplete").getJSONObject("terms").put("include", escapedStr);
+                        escapedStr = escapedStr + ".*";
                     }
+                    json.getJSONObject("aggs").getJSONObject("autocomplete").getJSONObject("terms").put("include", escapedStr);
                 }
             } catch (JSONException ex) { // The request bodies all look pretty different, so it's okay for the exception to get thrown.
                 LOG.debug(SEARCH_QUERY_NOT_PARSED);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -95,6 +95,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
     public static final String TOOL_NOT_FOUND_ERROR = "Tool not found";
     public static final String VERSION_NOT_FOUND_ERROR = "Version not found";
     public static final String SEARCH_QUERY_INVALID_JSON = "Search payload request is not valid JSON";
+    public static final String SEARCH_QUERY_REGEX = "([.?+*#@&~\"{}()<>\\[\\]|\\\\])";
     private static final Logger LOG = LoggerFactory.getLogger(ToolsApiExtendedServiceImpl.class);
     private static final ToolsApiServiceImpl TOOLS_API_SERVICE_IMPL = new ToolsApiServiceImpl();
 
@@ -268,6 +269,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
         }
         try {
             if (!config.getEsConfiguration().getHostname().isEmpty()) {
+                query = escapeCharactersInSearchTerm(query);
                 checkSearchTermLimit(query);
                 try {
                     RestClient restClient = ElasticSearchHelper.restClient();
@@ -311,6 +313,42 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
         } finally {
             elasticSearchConcurrencyLimit.release(1);
         }
+    }
+
+    /**
+     * Certain characters need to be escaped in the search term ("include" key in request payload) or the request will fail
+     * See reserved characters here: https://www.elastic.co/guide/en/elasticsearch/reference/current/regexp-syntax.html#regexp-optional-operators
+     * @param query
+     * @return a query with the modified search term
+     */
+    protected static String escapeCharactersInSearchTerm(String query) {
+        if (query != null) {
+            JSONObject json;
+            try {
+                json = new JSONObject(query);
+            } catch (JSONException ex) {
+                LOG.error(SEARCH_QUERY_INVALID_JSON, ex);
+                throw new CustomWebApplicationException(SEARCH_QUERY_INVALID_JSON, HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE);
+            }
+
+            try {
+                String include = json.getJSONObject("aggs").getJSONObject("autocomplete").getJSONObject("terms").getString("include");
+                if (include.length() > 0) {
+                    if (include.endsWith(".*")) {
+                        String escapedStr = include.replaceAll("\\.\\*$", "").replaceAll(SEARCH_QUERY_REGEX, "\\\\$1");
+                        json.getJSONObject("aggs").getJSONObject("autocomplete").getJSONObject("terms").put("include", escapedStr + ".*");
+                    } else {
+                        String escapedStr = include.replaceAll(SEARCH_QUERY_REGEX, "\\\\$1");
+                        json.getJSONObject("aggs").getJSONObject("autocomplete").getJSONObject("terms").put("include", escapedStr);
+                    }
+                }
+            } catch (JSONException ex) { // The request bodies all look pretty different, so it's okay for the exception to get thrown.
+                LOG.debug("Couldn't parse search payload request.");
+            }
+
+            return json.toString();
+        }
+        return query;
     }
 
     /**

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
@@ -1,5 +1,6 @@
 package io.dockstore.webservice.resources.proposedGA4GH;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -48,6 +49,34 @@ class ToolsApiExtendedServiceImplTest {
             ToolsApiExtendedServiceImpl.checkSearchTermLimit(emptyJson);
         } catch (CustomWebApplicationException ex) {
             fail("Queries that can't be parsed for an \"include\" key or wildcards should pass");
+        }
+    }
+
+    /**
+     * Tests that ES requests with special characters in search terms pass.
+     * Only requests with the "include" key are checked for special characters.
+     * @throws IOException
+     */
+    @Test
+    void testEscapeCharactersInSearchTerm() throws IOException {
+        // Test a query without special characters in the "include" key
+        File file1 = new File(ResourceHelpers.resourceFilePath("elasticSearchQueryInclude.json"));
+        String query1 = Files.asCharSource(file1, Charsets.UTF_8).read();
+        String result1 = ToolsApiExtendedServiceImpl.escapeCharactersInSearchTerm(query1);
+        assertEquals(query1, result1);
+
+        // Test a query without special characters in the "include" key
+        File file2 = new File(ResourceHelpers.resourceFilePath("elasticSearchQueryIncludeSpecialCharacters.json"));
+        String query2 = Files.asCharSource(file2, Charsets.UTF_8).read();
+        String result2 = ToolsApiExtendedServiceImpl.escapeCharactersInSearchTerm(query2);
+        assertTrue(result2.contains("This.str\\{i\\>ng\\(has\\#special\\]char\\@acters.*"));
+
+        // Test an empty query
+        try {
+            String emptyJson = "{}";
+            String result = ToolsApiExtendedServiceImpl.escapeCharactersInSearchTerm(emptyJson);
+        } catch (CustomWebApplicationException ex) {
+            fail("Queries that can't be parsed for an \"include\" key should pass");
         }
     }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
@@ -1,6 +1,5 @@
 package io.dockstore.webservice.resources.proposedGA4GH;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -63,7 +62,7 @@ class ToolsApiExtendedServiceImplTest {
         File file1 = new File(ResourceHelpers.resourceFilePath("elasticSearchQueryInclude.json"));
         String query1 = Files.asCharSource(file1, Charsets.UTF_8).read();
         String result1 = ToolsApiExtendedServiceImpl.escapeCharactersInSearchTerm(query1);
-        assertEquals(query1, result1);
+        assertTrue(result1.contains("This is a long string This is a long string This is a long string This is a long string This is a long string This is a long string This is a long string This is a long string This is a long string This is a long string This is a long string This is a long string.*"));
 
         // Test a query without special characters in the "include" key
         File file2 = new File(ResourceHelpers.resourceFilePath("elasticSearchQueryIncludeSpecialCharacters.json"));

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
@@ -104,10 +104,10 @@ class ToolsApiExtendedServiceImplTest {
         // Test a query containing an include key
         String testString = "This is a test string";
         JSONObject testJson = new JSONObject(StringUtils.replace(query, placeholderStr, testString));
-        assertEquals(ToolsApiExtendedServiceImpl.getSearchQueryJsonIncludeKey(testJson), testString);
+        assertEquals(testString, ToolsApiExtendedServiceImpl.getSearchQueryJsonIncludeKey(testJson));
 
         // Test an empty query (no include key)
         JSONObject emptyJson = new JSONObject("{}");
-        assertEquals(ToolsApiExtendedServiceImpl.getSearchQueryJsonIncludeKey(emptyJson), "");
+        assertEquals("", ToolsApiExtendedServiceImpl.getSearchQueryJsonIncludeKey(emptyJson));
     }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
@@ -77,12 +77,12 @@ class ToolsApiExtendedServiceImplTest {
         // Test a query with special characters in the "include" key
         String query3 = StringUtils.replace(query, placeholderStr, "This.str{i>ng(has#special]char@acters.");
         String result3 = ToolsApiExtendedServiceImpl.escapeCharactersInSearchTerm(query3);
-        assertTrue(result3.contains("This.str\\{i\\>ng\\(has\\#special\\]char\\@acters\\."));
+        assertTrue(result3.contains("This\\.str\\{i\\>ng\\(has\\#special\\]char\\@acters\\."));
 
         // Test a query with special characters ending with .*
         String query4 = StringUtils.replace(query, placeholderStr, "This.str{i>ng(has#special]char@acters.*");
         String result4 = ToolsApiExtendedServiceImpl.escapeCharactersInSearchTerm(query4);
-        assertTrue(result4.contains("This.str\\{i\\>ng\\(has\\#special\\]char\\@acters.*"));
+        assertTrue(result4.contains("This\\.str\\{i\\>ng\\(has\\#special\\]char\\@acters.*"));
 
         // Test an empty query
         try {

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
@@ -77,12 +77,12 @@ class ToolsApiExtendedServiceImplTest {
         // Test a query with special characters in the "include" key
         String query3 = StringUtils.replace(query, placeholderStr, "This.str{i>ng(has#special]char@acters.");
         String result3 = ToolsApiExtendedServiceImpl.escapeCharactersInSearchTerm(query3);
-        assertTrue(result3.contains("This\\.str\\{i\\>ng\\(has\\#special\\]char\\@acters\\."));
+        assertTrue(result3.contains("This\\\\.str\\\\{i\\\\>ng\\\\(has\\\\#special\\\\]char\\\\@acters\\\\."));
 
         // Test a query with special characters ending with .*
         String query4 = StringUtils.replace(query, placeholderStr, "This.str{i>ng(has#special]char@acters.*");
         String result4 = ToolsApiExtendedServiceImpl.escapeCharactersInSearchTerm(query4);
-        assertTrue(result4.contains("This\\.str\\{i\\>ng\\(has\\#special\\]char\\@acters.*"));
+        assertTrue(result4.contains("This\\\\.str\\\\{i\\\\>ng\\\\(has\\\\#special\\\\]char\\\\@acters.*"));
 
         // Test an empty query
         try {

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
@@ -1,5 +1,6 @@
 package io.dockstore.webservice.resources.proposedGA4GH;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -10,6 +11,7 @@ import io.dropwizard.testing.ResourceHelpers;
 import java.io.File;
 import java.io.IOException;
 import org.apache.commons.lang3.StringUtils;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 class ToolsApiExtendedServiceImplTest {
@@ -85,11 +87,27 @@ class ToolsApiExtendedServiceImplTest {
         assertTrue(result4.contains("This\\\\.str\\\\{i\\\\>ng\\\\(has\\\\#special\\\\]char\\\\@acters.*"));
 
         // Test an empty query
-        try {
-            String emptyJson = "{}";
-            String result = ToolsApiExtendedServiceImpl.escapeCharactersInSearchTerm(emptyJson);
-        } catch (CustomWebApplicationException ex) {
-            fail("Queries that can't be parsed for an \"include\" key should pass");
-        }
+        String query5 = "{}";
+        String result5 = ToolsApiExtendedServiceImpl.escapeCharactersInSearchTerm(query5);
+        assertEquals(query5, result5);
+    }
+
+    /**
+     * Tests that "include" key is returned from requests
+     * @throws IOException
+     */
+    @Test
+    void testGetSearchQueryJsonIncludeKey() throws IOException {
+        File file = new File(ResourceHelpers.resourceFilePath("elasticSearchQueryIncludeWithPlaceholder.json"));
+        String query = Files.asCharSource(file, Charsets.UTF_8).read();
+
+        // Test a query containing an include key
+        String testString = "This is a test string";
+        JSONObject testJson = new JSONObject(StringUtils.replace(query, placeholderStr, testString));
+        assertEquals(ToolsApiExtendedServiceImpl.getSearchQueryJsonIncludeKey(testJson), testString);
+
+        // Test an empty query (no include key)
+        JSONObject emptyJson = new JSONObject("{}");
+        assertEquals(ToolsApiExtendedServiceImpl.getSearchQueryJsonIncludeKey(emptyJson), "");
     }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImplTest.java
@@ -93,7 +93,7 @@ class ToolsApiExtendedServiceImplTest {
     }
 
     /**
-     * Tests that "include" key is returned from requests
+     * Tests that "include" key is returned from requests.
      * @throws IOException
      */
     @Test

--- a/dockstore-webservice/src/test/resources/elasticSearchQueryIncludeSpecialCharacters.json
+++ b/dockstore-webservice/src/test/resources/elasticSearchQueryIncludeSpecialCharacters.json
@@ -1,0 +1,16 @@
+{
+    "aggs": {
+      "autocomplete": {
+        "terms": {
+          "field": "description",
+          "include": "This.str{i>ng(has#special]char@acters.*",
+          "order": {
+            "_count": "desc"
+          },
+          "size": 4
+        }
+      }
+    },
+    "size": 0
+  }
+  

--- a/dockstore-webservice/src/test/resources/elasticSearchQueryIncludeWithPlaceholder.json
+++ b/dockstore-webservice/src/test/resources/elasticSearchQueryIncludeWithPlaceholder.json
@@ -3,7 +3,7 @@
       "autocomplete": {
         "terms": {
           "field": "description",
-          "include": "This.str{i>ng(has#special]char@acters.*",
+          "include": "PLACEHOLDER",
           "order": {
             "_count": "desc"
           },


### PR DESCRIPTION
**Description**
Including certain characters (e.g., `<, [, (, {`) when typing in the search bar would fail with a 400 error, related to retrieving the auto-complete terms using the "include" key. This ticket adds a step to escape special characters in the search term before the request is made so no error is thrown.

**Review Instructions**
Go to Dockstore Search and type an input (including any of the special characters) into the search bar. No `[HTTP 400] Bad Request: Bad Request` error should appear.

**Issue**
[SEAB-3957](https://ucsc-cgl.atlassian.net/browse/SEAB-3957)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-3957]: https://ucsc-cgl.atlassian.net/browse/SEAB-3957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ