### PR TITLE
SEAB-5770: Implement GitHub App "ref inspection" scheme

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1831,10 +1831,10 @@ class WebhookIT extends BaseIT {
         String repo = "dockstore-testing/simple-notebook";
         assertEquals(0, countVersions());
         // Release from various branches with various "after" SHAs
-        // Non-existent branch, should fail
+        // Non-existent branch, should be ignored
         handleGitHubRelease(client, repo, "refs/tags/bogus", USER_2_USERNAME, "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc");
         assertEquals(0, countVersions());
-        // Existing branch with incorrect "after" SHA, should fail
+        // Existing branch with incorrect "after" SHA, should be ignored
         handleGitHubRelease(client, repo, "refs/tags/simple-v1", USER_2_USERNAME, "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc");
         assertEquals(0, countVersions());
         // Existing branch with correct "after" SHA, should succeed

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
@@ -58,8 +58,12 @@ public final class GitHubAppHelper {
         workflowsApi.handleGitHubInstallation(payload, generateXGitHubDelivery());
     }
 
+    public static void handleGitHubBranchDeletion(WorkflowsApi workflowsApi, String repository, String gitHubUsername, String gitRef, boolean passInstallationId) {
+        workflowsApi.handleGitHubBranchDeletion(repository, gitHubUsername, gitRef, generateXGitHubDelivery(), passInstallationId ? INSTALLATION_ID : null);
+    }
+
     public static void handleGitHubBranchDeletion(WorkflowsApi workflowsApi, String repository, String gitHubUsername, String gitRef) {
-        workflowsApi.handleGitHubBranchDeletion(repository, gitHubUsername, gitRef, generateXGitHubDelivery(), null); // last argument is a null installation id, which forces the branch deletion
+        handleGitHubBranchDeletion(workflowsApi, repository, gitHubUsername, gitRef, false);
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
@@ -18,7 +18,7 @@ import java.util.UUID;
  */
 public final class GitHubAppHelper {
 
-    public static final Integer INSTALLATION_ID = 1179416;
+    public static final Long INSTALLATION_ID = 1179416L;
     public static final int LAMBDA_ERROR = 418;
 
     private GitHubAppHelper() {
@@ -40,20 +40,20 @@ public final class GitHubAppHelper {
         PushPayload pushPayload = new PushPayload().ref(gitRef);
         pushPayload.setRepository(new WebhookRepository().fullName(repository));
         pushPayload.setSender(new Sender().login(gitHubUsername));
-        pushPayload.setInstallation(new Installation().id(INSTALLATION_ID.longValue()));
+        pushPayload.setInstallation(new Installation().id(INSTALLATION_ID));
         workflowsApi.handleGitHubRelease(pushPayload, generateXGitHubDelivery());
     }
 
     public static void handleGitHubInstallation(WorkflowsApi workflowsApi, List<String> repositories, String gitHubUsername) {
         InstallationRepositoriesPayload payload = new InstallationRepositoriesPayload()
                 .repositoriesAdded(repositories.stream().map(repo -> new WebhookRepository().fullName(repo)).toList());
-        payload.setInstallation(new Installation().id(INSTALLATION_ID.longValue()));
+        payload.setInstallation(new Installation().id(INSTALLATION_ID));
         payload.setSender(new Sender().login(gitHubUsername));
         workflowsApi.handleGitHubInstallation(payload, generateXGitHubDelivery());
     }
 
     public static void handleGitHubBranchDeletion(WorkflowsApi workflowsApi, String repository, String gitHubUsername, String gitRef) {
-        workflowsApi.handleGitHubBranchDeletion(repository, gitHubUsername, gitRef, generateXGitHubDelivery());
+        workflowsApi.handleGitHubBranchDeletion(repository, gitHubUsername, gitRef, generateXGitHubDelivery(), INSTALLATION_ID);
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
@@ -53,7 +53,7 @@ public final class GitHubAppHelper {
     }
 
     public static void handleGitHubBranchDeletion(WorkflowsApi workflowsApi, String repository, String gitHubUsername, String gitRef) {
-        workflowsApi.handleGitHubBranchDeletion(repository, gitHubUsername, gitRef, generateXGitHubDelivery(), INSTALLATION_ID);
+        workflowsApi.handleGitHubBranchDeletion(repository, gitHubUsername, gitRef, generateXGitHubDelivery(), null); // last argument is a null installation id, which forces the branch deletion
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
@@ -35,13 +35,19 @@ public final class GitHubAppHelper {
      * @param repository Repository path (ex. dockstore/dockstore-ui2)
      * @param gitRef Full git reference for a GitHub branch/tag. Ex. refs/heads/master or refs/tags/v1.0
      * @param gitHubUsername Username of user on GitHub who triggered action
+     * @param after commit SHA of head commit on reference
      */
-    public static void handleGitHubRelease(WorkflowsApi workflowsApi, String repository, String gitRef, String gitHubUsername) {
+    public static void handleGitHubRelease(WorkflowsApi workflowsApi, String repository, String gitRef, String gitHubUsername, String after) {
         PushPayload pushPayload = new PushPayload().ref(gitRef);
         pushPayload.setRepository(new WebhookRepository().fullName(repository));
         pushPayload.setSender(new Sender().login(gitHubUsername));
         pushPayload.setInstallation(new Installation().id(INSTALLATION_ID));
+        pushPayload.setAfter(after);
         workflowsApi.handleGitHubRelease(pushPayload, generateXGitHubDelivery());
+    }
+
+    public static void handleGitHubRelease(WorkflowsApi workflowsApi, String repository, String gitRef, String gitHubUsername) {
+        handleGitHubRelease(workflowsApi, repository, gitRef, gitHubUsername, null);
     }
 
     public static void handleGitHubInstallation(WorkflowsApi workflowsApi, List<String> repositories, String gitHubUsername) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/PushPayload.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/PushPayload.java
@@ -29,6 +29,9 @@ public class PushPayload extends Payload {
     @Schema(description = "The full git ref that was pushed", requiredMode = RequiredMode.REQUIRED, example = "refs/heads/master OR refs/tags/v1.0")
     private String ref;
 
+    // The following description is directly quoted from the above github doc
+    @Schema(description = "The SHA of the most recent commit on ref after the push", requiredMode = RequiredMode.NOT_REQUIRED, example = "6d96270004515a0486bb7f76196a72b40c55a47f")
+    private String after;
 
     public PushPayload() {
     }
@@ -39,6 +42,14 @@ public class PushPayload extends Payload {
 
     public void setRef(String ref) {
         this.ref = ref;
+    }
+
+    public String getAfter() {
+        return after;
+    }
+
+    public void setAfter(String after) {
+        this.after = after;
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1352,9 +1352,19 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
     @Override
     protected String getCommitID(String repositoryId, Version version) {
-        return getCommitID(repositoryId, version.getReference(), true);
+        try {
+            return getCommitID(repositoryId, version.getReference(), true);
+        } catch (CustomWebApplicationException ex) {
+            return null;
+        }
     }
 
+    /**
+     * Get the head commit SHA of a specified reference in a particular repository.
+     * @param repositoryId name of the repository (ex 'svonworl/test-notebooks')
+     * @param commitReference reference
+     * @param stripped if true, commitReference does not include the 'refs/{types}/' prefix
+     */
     public String getCommitID(String repositoryId, String commitReference, boolean stripped) {
         GHRepository repo;
         try {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1370,7 +1370,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             }
         } catch (IOException e) {
             LOG.error(gitUsername + ": IOException on getCommitId " + e.getMessage(), e);
-            // this is not so critical to warrant a http error code
+            throws new CustomWebApplicationException("Could not access GitHub reference", HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
         return null;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1370,7 +1370,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             }
         } catch (IOException e) {
             LOG.error(gitUsername + ": IOException on getCommitId " + e.getMessage(), e);
-            throws new CustomWebApplicationException("Could not access GitHub reference", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            throw new CustomWebApplicationException("Could not access GitHub reference", HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
         return null;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1352,23 +1352,31 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
 
     @Override
     protected String getCommitID(String repositoryId, Version version) {
+        return getCommitID(repositoryId, version.getReference(), true);
+    }
+
+    public String getCommitID(String repositoryId, String commitReference, boolean stripped) {
         GHRepository repo;
         try {
             repo = github.getRepository(repositoryId);
             GHRef[] refs = getBranchesAndTags(repo);
 
             for (GHRef ref : refs) {
-                String reference = StringUtils.removePattern(ref.getRef(), "refs/.+?/");
-                if (reference.equals(version.getReference())) {
-                    return getCommitSHA(ref, repo, reference);
+                String reference = ref.getRef();
+                String strippedReference = stripReference(reference);
+                if ((stripped ? strippedReference : reference).equals(commitReference)) {
+                    return getCommitSHA(ref, repo, strippedReference);
                 }
-
             }
         } catch (IOException e) {
             LOG.error(gitUsername + ": IOException on getCommitId " + e.getMessage(), e);
             // this is not so critical to warrant a http error code
         }
         return null;
+    }
+
+    private String stripReference(String reference) {
+        return StringUtils.removePattern(reference, "refs/.+?/");
     }
 
     private String getEmail(GHMyself myself) throws IOException {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -299,7 +299,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             GHRateLimit startRateLimit = gitHubSourceCodeRepo.getGhRateLimitQuietly();
             try {
                 if (!shouldProcessDelete(gitHubSourceCodeRepo, repository, gitReference)) {
-                    LOG.info("ignoring delete event, repository={} reference={}", repository, gitReference);
+                    LOG.info("ignoring delete event, repository={}, reference={}, deliveryId={}", repository, gitReference, deliveryId);
                     return;
                 }
             } finally {
@@ -402,7 +402,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
 
         try {
             if (!shouldProcessPush(gitHubSourceCodeRepo, repository, gitReference, afterCommit)) {
-                LOG.info("ignoring push event, repository={}, reference={}, afterCommit={}", repository, gitReference, afterCommit);
+                LOG.info("ignoring push event, repository={}, reference={}, deliveryId={}, afterCommit={}", repository, gitReference, deliveryId, afterCommit);
                 return;
             }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -299,7 +299,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             GHRateLimit startRateLimit = gitHubSourceCodeRepo.getGhRateLimitQuietly();
             try {
                 if (!shouldProcessDelete(gitHubSourceCodeRepo, repository, gitReference)) {
-                    LOG.info("ignoring delete event");
+                    LOG.info("ignoring delete event, repository={} reference={}", repository, gitReference);
                     return;
                 }
             } finally {
@@ -402,7 +402,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
 
         try {
             if (!shouldProcessPush(gitHubSourceCodeRepo, repository, gitReference, afterCommit)) {
-                LOG.info("ignoring push event, afterCommit={}", afterCommit);
+                LOG.info("ignoring push event, repository={}, reference={}, afterCommit={}", repository, gitReference, afterCommit);
                 return;
             }
 
@@ -497,12 +497,9 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             // Retrieve the "current" head commit.
             String currentCommit = getHeadCommit(gitHubSourceCodeRepo, repository, reference);
             LOG.info("afterCommit={} currentCommit={}", afterCommit, currentCommit);
-            // If the ref doesn't exist, don't process the push.
-            if (currentCommit == null) {
-                return false;
-            }
             // Process the push iff the "current" and "after" commit hashes are equal.
             // If the repo's "current" hash doesn't match the event's "after" hash, the repo has changed since the event was created.
+            // The "after" commit hash cannot be null here, so we'll return false (ignore the push) if the "current" commit hash is null (because the ref no longer exists).
             // Later, another event corresponding to the subsequent change will arrive and trigger an update.
             return Objects.equals(afterCommit, currentCommit);
         } catch (CustomWebApplicationException ex) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -2110,11 +2110,12 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         final String username = payload.getSender().getLogin();
         final String repository = payload.getRepository().getFullName();
         final String gitReference = payload.getRef();
+        final String afterCommit = payload.getAfter();
         if (LOG.isInfoEnabled()) {
             LOG.info(String.format("Branch/tag %s pushed to %s(%s)", Utilities.cleanForLogging(gitReference), Utilities.cleanForLogging(repository), Utilities.cleanForLogging(username)));
         }
 
-        githubWebhookRelease(repository, username, gitReference, installationId, deliveryId, true);
+        githubWebhookRelease(repository, username, gitReference, installationId, deliveryId, Optional.ofNullable(afterCommit), true);
     }
 
     @POST
@@ -2159,7 +2160,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                     LOG.info(String.format("Retrospectively processing branch/tag %s in %s(%s)", Utilities.cleanForLogging(gitReference), Utilities.cleanForLogging(repository),
                         Utilities.cleanForLogging(username)));
                 }
-                githubWebhookRelease(repository, username, gitReference, installationId, deliveryId, false);
+                githubWebhookRelease(repository, username, gitReference, installationId, deliveryId, Optional.empty(), false);
             }
         }
         return Response.status(HttpStatus.SC_OK).build();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -2115,7 +2115,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             LOG.info(String.format("Branch/tag %s pushed to %s(%s)", Utilities.cleanForLogging(gitReference), Utilities.cleanForLogging(repository), Utilities.cleanForLogging(username)));
         }
 
-        githubWebhookRelease(repository, username, gitReference, installationId, deliveryId, Optional.ofNullable(afterCommit), true);
+        githubWebhookRelease(repository, username, gitReference, installationId, deliveryId, afterCommit, true);
     }
 
     @POST
@@ -2160,7 +2160,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                     LOG.info(String.format("Retrospectively processing branch/tag %s in %s(%s)", Utilities.cleanForLogging(gitReference), Utilities.cleanForLogging(repository),
                         Utilities.cleanForLogging(username)));
                 }
-                githubWebhookRelease(repository, username, gitReference, installationId, deliveryId, Optional.empty(), false);
+                githubWebhookRelease(repository, username, gitReference, installationId, deliveryId, null, false);
             }
         }
         return Response.status(HttpStatus.SC_OK).build();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -2178,11 +2178,12 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         @Parameter(name = "repository", description = "Repository path (ex. dockstore/dockstore-ui2)", required = true) @QueryParam("repository") String repository,
         @Parameter(name = "username", description = "Username of user on GitHub who triggered action", required = true) @QueryParam("username") String username,
         @Parameter(name = "gitReference", description = "Full git reference for a GitHub branch/tag. Ex. refs/heads/master or refs/tags/v1.0", required = true) @QueryParam("gitReference") String gitReference,
+        @Parameter(name = "installationId", description = "GitHub App installation ID", required = false) @QueryParam("installationId") Long installationId,
         @Parameter(name = "X-GitHub-Delivery", in = ParameterIn.HEADER, description = "A GUID to identify the GitHub webhook delivery", required = true) @HeaderParam(value = "X-GitHub-Delivery")  String deliveryId) {
         if (LOG.isInfoEnabled()) {
             LOG.info(String.format("Branch/tag %s deleted from %s", Utilities.cleanForLogging(gitReference), Utilities.cleanForLogging(repository)));
         }
-        githubWebhookDelete(repository, gitReference, username, deliveryId);
+        githubWebhookDelete(repository, gitReference, username, installationId, deliveryId);
         return Response.status(HttpStatus.SC_NO_CONTENT).build();
     }
 

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -6515,6 +6515,12 @@ paths:
         required: true
         schema:
           type: string
+      - description: GitHub App installation ID
+        in: query
+        name: installationId
+        schema:
+          type: integer
+          format: int64
       - description: A GUID to identify the GitHub webhook delivery
         in: header
         name: X-GitHub-Delivery

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -10115,6 +10115,10 @@ components:
       - $ref: '#/components/schemas/Payload'
       - type: object
         properties:
+          after:
+            type: string
+            description: The SHA of the most recent commit on ref after the push
+            example: 6d96270004515a0486bb7f76196a72b40c55a47f
           ref:
             type: string
             description: The full git ref that was pushed


### PR DESCRIPTION
**Description**
This PR changes the webservice's GitHub App push and delete processing code to be more tolerant of rapid changes to a ref, by implementing a "ref inspection" scheme as proposed in ???.

The "ref inspection" scheme works by ignoring events that reference a ref that has changed since the event was created.  For example, say pushes A, B, and C happen on a ref over the span of several seconds, and result in corresponding events.  Events take several minutes to propagate to the webservice, and by the time the events arrive, the ref is in state C.  Events A and B don't represent the current state of the ref: we could process them, but since pushes [most of the time] result in a new Version that completely supercedes the old Version, it's ok to ignore them, and only process event C.

Specificly, this PR modifies the push processing code so it checks the "after" commit hash from the event, which is the SHA of the head commit after the push.  If the "after" hash matches the "current" head hash on the ref, the event corresponds to the current state of the ref, and is processed.  If the two hashes don't match, the event is ignored because it doesn't represent the ref's current state.  If there's a problem checking the two hashes, either because the "after" hash is missing, or there's a problem retrieving the "current" hash, we process the push as before...

Similarly, the delete processing code is modified so that the delete is processed if the ref does not exist.  If the ref exists, the event is ignored because it doesn't represent the ref's current state.  If there's a problem checking if the ref exists, we process the delete as before...

Since the "ref inspection" scheme only processes events that match the current state of the ref, it also has the side effect of ignoring out of order events.  Note that "fef inspection" will only works if, from the point of view of the webservice, the current ref state is always visible before the arrival of events describing the state: if the opposite was true, push events would always be ignored.
 
Sometimes, ignoring event(s) results in a different final Dockstore state than if we had processed every event.  For example, say we have a valid version on Dockstore corresponding to a ref, which is then deleted, and pushed again, this time with an invalid `.dockstore.yml`.  At the end, if we process all events, the valid version will have been deleted.  If we ignore the delete, the valid version remains.  Other similar phenomena exist.

In an ideal world, we'd have an automatic test of the full chain, wherein events originate from GitHub, move through our lambda, and then are processed by the webservice.  However, that would require a large amount of testing infrastructure.  Instead, this PR's integration tests make the some function calls that are similar to those that happen when the actual events are processed, and confirms that the correct action is taken.  Combined with some user testing on qa, we'll have a pretty good idea whether it's working correctly or not.

**Review Instructions**
Confirm that pushes and deletes to a repo in which our GitHub App has been installed are registering on Dockstore.  Inspect the logs, and confirm that most pushes and deletes are not ignored.  Over the span of days, on prod, the number of ignored events (which appear in the logs as "ignoring push event" and "ignoring delete event") should be much less than the total number of pushes and deletes.

**Issue**
A link to a github issue or SEAB- ticket (using that as a prefix)

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ ] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
