### PR TITLE
Feature/debug macos

### DIFF
--- a/macos_instructions.yml
+++ b/macos_instructions.yml
@@ -27,12 +27,12 @@ actionOnlyInformation:
         runs-on: macos-latest
         steps:
           - name: Checkout dockstore/dockstore
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
             with:
               repository: dockstore/dockstore
               path: dockstore
           - name: Checkout dockstore/dockstore-ui2
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
             with:
               repository: dockstore/dockstore-ui2
               path: dockstore-ui2
@@ -94,7 +94,7 @@ setupInformation:
     - text: (cd to where you cloned the dockstore/dockstore repo)
     - code:
         run: ./mvnw clean install
-        working-directory: dockstore # Where dockstore/dockstore was cloned by actions/checkout@v3
+        working-directory: dockstore # Where dockstore/dockstore was cloned by actions/checkout@v4
     - newLine: 1
     - text: '#### Build the UI'
     - text: (cd to where you cloned the dockstore/dockstore-ui2 repo)

--- a/scripts/check_macos.sh
+++ b/scripts/check_macos.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o pipefail
 set -o nounset
-# set -o xtrace
+set -o xtrace
 
 
 # Checks that  README.md and the macos github action are up to date with macos_instructions.yml


### PR DESCRIPTION
**Description**
Follow-up for https://github.com/dockstore/dockstore/pull/5655
Turns out the checkout action upgrade broke the script that checks whether our mac os instructions are up-to-date

**Review Instructions**
Build should pass the mac os instructions check

**Issue**
n/a

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
