### PR TITLE
run with ea

### DIFF
--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -34,6 +34,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-cbor</artifactId>
+      <version>2.15.2</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-oauth2</artifactId>
       <version>v2-rev151-1.25.0</version>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -1107,6 +1107,8 @@
                                 <usedDependency>io.jsonwebtoken:jjwt-impl</usedDependency>
                                 <usedDependency>io.jsonwebtoken:jjwt-api</usedDependency>
                                 <usedDependency>io.jsonwebtoken:jjwt-jackson</usedDependency>
+				<!-- used when running with assertions https://github.com/dockstore/dockstore/issues/5654  --> 
+				<usedDependency>com.fasterxml.jackson.dataformat:jackson-dataformat-cbor</usedDependency>
                             </usedDependencies>
                         </configuration>
                     </execution>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>jackson-datatype-hibernate5-jakarta</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-cbor</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-oauth2</artifactId>
         </dependency>

--- a/macos_instructions.yml
+++ b/macos_instructions.yml
@@ -27,12 +27,12 @@ actionOnlyInformation:
         runs-on: macos-latest
         steps:
           - name: Checkout dockstore/dockstore
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
             with:
               repository: dockstore/dockstore
               path: dockstore
           - name: Checkout dockstore/dockstore-ui2
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
             with:
               repository: dockstore/dockstore-ui2
               path: dockstore-ui2
@@ -94,7 +94,7 @@ setupInformation:
     - text: (cd to where you cloned the dockstore/dockstore repo)
     - code:
         run: ./mvnw clean install
-        working-directory: dockstore # Where dockstore/dockstore was cloned by actions/checkout@v3
+        working-directory: dockstore # Where dockstore/dockstore was cloned by actions/checkout@v4
     - newLine: 1
     - text: '#### Build the UI'
     - text: (cd to where you cloned the dockstore/dockstore-ui2 repo)

--- a/scripts/check_macos.sh
+++ b/scripts/check_macos.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o pipefail
 set -o nounset
-# set -o xtrace
+set -o xtrace
 
 
 # Checks that  README.md and the macos github action are up to date with macos_instructions.yml


### PR DESCRIPTION
**Description**
Allows the webservice to run with assertions on (-ea)

**Review Instructions**
Run web service with assertions on
Looks like 
![Screenshot from 2023-09-13 10-38-51](https://github.com/dockstore/dockstore/assets/1730679/432c3928-4299-49c6-a784-cd5b7cbe27f8)

**Issue**
https://github.com/dockstore/dockstore/issues/5654

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
