### PR TITLE
DOCK-2415 follow-up: add notnull to test parameters

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlNotebook.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlNotebook.java
@@ -155,7 +155,7 @@ public class YamlNotebook implements Workflowish {
         this.authors = authors;
     }
 
-    public List<@AbsolutePath String> getTestParameterFiles() {
+    public List<@NotNull @AbsolutePath String> getTestParameterFiles() {
         return testParameterFiles;
     }
 

--- a/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/yaml/YamlWorkflow.java
@@ -115,7 +115,7 @@ public class YamlWorkflow implements Workflowish {
         this.authors = authors;
     }
 
-    public List<@AbsolutePath String> getTestParameterFiles() {
+    public List<@NotNull @AbsolutePath String> getTestParameterFiles() {
         return testParameterFiles;
     }
 


### PR DESCRIPTION
**Description**
Accidentally missed this comment on my last PR. https://github.com/dockstore/dockstore/pull/5641#discussion_r1323350670


**Review Instructions**
Review that the added `@NotNull` works properly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2415

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
