### PR TITLE
Add blurb to PR template to cover privacy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,8 +11,14 @@ Many tickets will likely be between these two extremes, so some judgement may be
 **Issue**
 A link to a github issue or SEAB- ticket (using that as a prefix)
 
-**Security**
+**Security and Privacy**
+
 If there are any concerns that require extra attention from the security team, highlight them here.
+
+e.g. Does this change...
+* Any user data we collect, or data location?
+* Access control, authentication or authorization?
+* Encryption features?
 
 Please make sure that you've checked the following before submitting your pull request. Thanks!
 


### PR DESCRIPTION
**Description**

Small change to PR template that will help us demonstrate adherence to controls from 800-53rev5 that address privacy.

**Review Instructions**

The example list is not meant to be exhaustive, but should help instruct when a change might affect privacy.

**Issue**

https://ucsc-cgl.atlassian.net/browse/SEAB-5880

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
