### PR TITLE
SEAB-5913: Avoid indexing .dockstore.yml, improve es tokenization

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -18,6 +18,7 @@ package io.dockstore.webservice.helpers.statelisteners;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.core.Author;
@@ -424,7 +425,13 @@ public class ElasticListener implements StateListenerInterface {
             if (workflowVersion == defaultVersion) {
                 detachedVersion.setDescriptionAndDescriptionSource(workflowVersion.getDescription(), workflowVersion.getDescriptionSource());
                 SortedSet<SourceFile> sourceFiles = workflowVersion.getSourceFiles();
-                sourceFiles.forEach(sourceFile -> detachedVersion.addSourceFile(SourceFile.copy(sourceFile)));
+                // Copy the sourcefiles to the detached version, except for .dockstore.yml, which contains the names
+                // of all entries in the repo, thus clouding the search results for multi-entry repos
+                sourceFiles.forEach(sourceFile -> {
+                    if (sourceFile.getType() != DescriptorLanguage.FileType.DOCKSTORE_YML) {
+                        detachedVersion.addSourceFile(SourceFile.copy(sourceFile));
+                    }
+                });
             }
             detachedVersions.add(detachedVersion);
         });

--- a/dockstore-webservice/src/main/resources/queries/mapping_notebook.json
+++ b/dockstore-webservice/src/main/resources/queries/mapping_notebook.json
@@ -18,6 +18,13 @@
             "stopwords": [ "https", "http", "see", "from", "use", "usage", "more", "can", "reads", "website", "count" ]
           }
         },
+        "char_filter": {
+          "underscores_to_spaces": {
+            "type": "pattern_replace",
+            "pattern": "_",
+            "replacement": " "
+          }
+        },
         "analyzer": {
           "didYouMean": {
             "filter": [
@@ -40,7 +47,8 @@
               "unique_stem"
             ],
             "char_filter": [
-              "html_strip"
+              "html_strip",
+              "underscores_to_spaces"
             ]
           }
         }

--- a/dockstore-webservice/src/main/resources/queries/mapping_tool.json
+++ b/dockstore-webservice/src/main/resources/queries/mapping_tool.json
@@ -18,6 +18,13 @@
             "stopwords": [ "https", "http", "see", "from", "use", "usage", "more", "can", "reads", "website", "count" ]
           }
         },
+        "char_filter": {
+          "underscores_to_spaces": {
+            "type": "pattern_replace",
+            "pattern": "_",
+            "replacement": " "
+          }
+        },
         "analyzer": {
           "didYouMean": {
             "filter": [
@@ -40,7 +47,8 @@
               "unique_stem"
             ],
             "char_filter": [
-              "html_strip"
+              "html_strip",
+              "underscores_to_spaces"
             ]
           }
         }

--- a/dockstore-webservice/src/main/resources/queries/mapping_workflow.json
+++ b/dockstore-webservice/src/main/resources/queries/mapping_workflow.json
@@ -18,6 +18,13 @@
             "stopwords": [ "https", "http", "see", "from", "use", "usage", "more", "can", "reads", "website", "count" ]
           }
         },
+        "char_filter": {
+          "underscores_to_spaces": {
+            "type": "pattern_replace",
+            "pattern": "_",
+            "replacement": " "
+          }
+        },
         "analyzer": {
           "didYouMean": {
             "filter": [
@@ -40,7 +47,8 @@
               "unique_stem"
             ],
             "char_filter": [
-              "html_strip"
+              "html_strip",
+              "underscores_to_spaces"
             ]
           }
         }


### PR DESCRIPTION
**Description**
This PR is a companion to https://github.com/dockstore/dockstore-ui2/pull/1847 and makes two small changes to the webservice to improve search quality:
1. Adds a char filter to the ES analyzer which maps underscores, which ES doen't by default consider a token break, to spaces, which it does.  For example, this makes the string "samtools_index" parse as the two-word phrase "samtools" + "index", improving hit relevance when searching for that word pair.
2. `ElasticListener` no longer indexes `.dockstore.yml`, preventing it from clouding the search results for entries from multi-entry repos.  `.dockstore.yml` contains information about all entries in the repo, such as names, and if it is indexed, a search for any name will return all entries described within.  For example, given a `.dockstore.yml` describing workflows named "foo" and "bar", if `.dockstore.yml` is indexed, a keyword search for "foo" will return both, as will a search for "bar".

**Review Instructions**
Review using instructions from https://github.com/dockstore/dockstore-ui2/pull/1847

**Issue**
 https://ucsc-cgl.atlassian.net/browse/SEAB-5913

**Security and Privacy**

No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
