### PR TITLE
add total count and tests - lambda events

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -39,6 +39,7 @@ import io.dockstore.webservice.DockstoreWebserviceApplication;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.core.Token;
 import io.dockstore.webservice.jdbi.TokenDAO;
+import io.dockstore.webservice.resources.LambdaEventResource;
 import io.dropwizard.core.Application;
 import io.dropwizard.testing.DropwizardTestSupport;
 import io.swagger.client.ApiClient;
@@ -741,7 +742,7 @@ public final class CommonTestUtilities {
         Response response = request.property(ClientProperties.READ_TIMEOUT, 0).get();
         assertEquals(HttpStatus.SC_OK, response.getStatus());
         MultivaluedMap<String, Object> headers = response.getHeaders();
-        Object xTotalCount = headers.getFirst("X-total-count");
+        Object xTotalCount = headers.getFirst(LambdaEventResource.X_TOTAL_COUNT);
         assertEquals(String.valueOf(expectedValue), xTotalCount);
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -716,10 +716,23 @@ public final class CommonTestUtilities {
         return Optional.empty();
     }
 
+    /**
+     * Call an endpoint given a jersey client and check that a total count header is returned, no auth
+     * @param jerseyClient jersey client
+     * @param path endpoint to test
+     * @param expectedValue expected total count
+     */
     public static void testXTotalCount(Client jerseyClient, String path, int expectedValue) {
         testXTotalCount(jerseyClient, path, expectedValue, null);
     }
 
+    /**
+     * Call an endpoint given a jersey client and check that a total count header is returned, with auth
+     * @param jerseyClient jersey client
+     * @param path endpoint to test
+     * @param expectedValue expected total count
+     * @param bearerToken authorization
+     */
     public static void testXTotalCount(Client jerseyClient, String path, int expectedValue, String bearerToken) {
         final Invocation.Builder request = jerseyClient.target(path).request();
         if (bearerToken != null) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -73,7 +73,7 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
     }
 
     /**
-     * Count lambda events filtered by a user
+     * Count lambda events filtered by a user.
      * @param user filter for lambda events
      * @return count of lambda events
      */
@@ -116,7 +116,7 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
     }
 
     /**
-     * Count lambda events filtered by an organization and a list of repositories
+     * Count lambda events filtered by an organization and a list of repositories.
      * @param organization organization
      * @param repositories optional list of repositories
      * @return count of lambda events

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -62,16 +62,29 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
         CriteriaQuery<LambdaEvent> query = criteriaQuery();
         Root<LambdaEvent> event = query.from(LambdaEvent.class);
 
-        List<Predicate> predicates = new ArrayList<>();
-        predicates.add(cb.equal(event.get("user"), user));
-        query.orderBy(cb.desc(event.get("id")));
-        query.where(predicates.toArray(new Predicate[]{}));
+        setupFindByUserQuery(user, cb, query, event);
 
         query.select(event);
+        query.orderBy(cb.desc(event.get("id")));
 
         int primitiveOffset = (offset != null) ? offset : 0;
         TypedQuery<LambdaEvent> typedQuery = currentSession().createQuery(query).setFirstResult(primitiveOffset).setMaxResults(limit);
         return typedQuery.getResultList();
+    }
+
+    public long countByUser(User user) {
+        CriteriaBuilder cb = currentSession().getCriteriaBuilder();
+        CriteriaQuery<Long> query = cb.createQuery(Long.class);
+        Root<LambdaEvent> event = query.from(LambdaEvent.class);
+        query.select(cb.count(event));
+        setupFindByUserQuery(user, cb, query, event);
+        return currentSession().createQuery(query).getSingleResult();
+    }
+
+    private void setupFindByUserQuery(User user, CriteriaBuilder cb, CriteriaQuery<?> query, Root<?> event) {
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(cb.equal(event.get("user"), user));
+        query.where(predicates.toArray(new Predicate[]{}));
     }
 
     /**
@@ -88,16 +101,29 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
         CriteriaQuery<LambdaEvent> query = criteriaQuery();
         Root<LambdaEvent> event = query.from(LambdaEvent.class);
 
-        List<Predicate> predicates = new ArrayList<>();
-        predicates.add(cb.equal(event.get("organization"), organization));
-        repositories.ifPresent(repos -> predicates.add(event.get("repository").in(repos)));
-        query.orderBy(cb.desc(event.get("id")));
-        query.where(predicates.toArray(new Predicate[]{}));
-
+        setupFindByOrganizationQuery(organization, repositories, cb, query, event);
         query.select(event);
+        query.orderBy(cb.desc(event.get("id")));
 
         int primitiveOffset = Integer.parseInt(MoreObjects.firstNonNull(offset, "0"));
         TypedQuery<LambdaEvent> typedQuery = currentSession().createQuery(query).setFirstResult(primitiveOffset).setMaxResults(limit);
         return typedQuery.getResultList();
+    }
+
+    public long countByOrganization(String organization, Optional<List<String>> repositories) {
+        CriteriaBuilder cb = currentSession().getCriteriaBuilder();
+        CriteriaQuery<Long> query = cb.createQuery(Long.class);
+        Root<LambdaEvent> event = query.from(LambdaEvent.class);
+        query.select(cb.count(event));
+        setupFindByOrganizationQuery(organization, repositories, cb, query, event);
+        return currentSession().createQuery(query).getSingleResult();
+    }
+
+    private void setupFindByOrganizationQuery(String organization, Optional<List<String>> repositories, CriteriaBuilder cb,
+            CriteriaQuery<?> query, Root<?> event) {
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(cb.equal(event.get("organization"), organization));
+        repositories.ifPresent(repos -> predicates.add(event.get("repository").in(repos)));
+        query.where(predicates.toArray(new Predicate[]{}));
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -72,6 +72,11 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
         return typedQuery.getResultList();
     }
 
+    /**
+     * Count lambda events filtered by a user
+     * @param user filter for lambda events
+     * @return count of lambda events
+     */
     public long countByUser(User user) {
         CriteriaBuilder cb = currentSession().getCriteriaBuilder();
         CriteriaQuery<Long> query = cb.createQuery(Long.class);
@@ -110,6 +115,12 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
         return typedQuery.getResultList();
     }
 
+    /**
+     * Count lambda events filtered by an organization and a list of repositories
+     * @param organization organization
+     * @param repositories optional list of repositories
+     * @return count of lambda events
+     */
     public long countByOrganization(String organization, Optional<List<String>> repositories) {
         CriteriaBuilder cb = currentSession().getCriteriaBuilder();
         CriteriaQuery<Long> query = cb.createQuery(Long.class);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -796,8 +796,8 @@ public class DockerRepoResource
         List<Tool> tools = toolDAO.findAllPublished(offset, maxLimit, filter, sortCol, sortOrder);
         filterContainersForHiddenTags(tools);
         stripContent(tools);
-        response.addHeader("X-total-count", String.valueOf(toolDAO.countAllPublished(Optional.of(filter))));
-        response.addHeader("Access-Control-Expose-Headers", "X-total-count");
+        response.addHeader(LambdaEventResource.X_TOTAL_COUNT, String.valueOf(toolDAO.countAllPublished(Optional.of(filter))));
+        response.addHeader(LambdaEventResource.ACCESS_CONTROL_EXPOSE_HEADERS, LambdaEventResource.X_TOTAL_COUNT);
         return tools;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -45,6 +45,8 @@ import org.hibernate.SessionFactory;
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "lambdaEvents", description = ResourceConstants.LAMBDAEVENTS)
 public class LambdaEventResource {
+    public static final String X_TOTAL_COUNT = "X-total-count";
+    public static final String ACCESS_CONTROL_EXPOSE_HEADERS = "Access-Control-Expose-Headers";
     private final LambdaEventDAO lambdaEventDAO;
     private final UserDAO userDAO;
     private final TokenDAO tokenDAO;
@@ -73,8 +75,8 @@ public class LambdaEventResource {
         }
         final Token githubToken = githubTokens.get(0);
         final Optional<List<String>> authorizedRepos = authorizedRepos(organization, githubToken);
-        response.addHeader("X-total-count", String.valueOf(lambdaEventDAO.countByOrganization(organization, authorizedRepos)));
-        response.addHeader("Access-Control-Expose-Headers", "X-total-count");
+        response.addHeader(X_TOTAL_COUNT, String.valueOf(lambdaEventDAO.countByOrganization(organization, authorizedRepos)));
+        response.addHeader(ACCESS_CONTROL_EXPOSE_HEADERS, X_TOTAL_COUNT);
         return lambdaEventDAO.findByOrganization(organization, offset, limit, authorizedRepos);
     }
 
@@ -94,8 +96,8 @@ public class LambdaEventResource {
         if (user == null) {
             throw new CustomWebApplicationException("User not found.", HttpStatus.SC_NOT_FOUND);
         }
-        response.addHeader("X-total-count", String.valueOf(lambdaEventDAO.countByUser(user)));
-        response.addHeader("Access-Control-Expose-Headers", "X-total-count");
+        response.addHeader(LambdaEventResource.X_TOTAL_COUNT, String.valueOf(lambdaEventDAO.countByUser(user)));
+        response.addHeader(LambdaEventResource.ACCESS_CONTROL_EXPOSE_HEADERS, LambdaEventResource.X_TOTAL_COUNT);
         return lambdaEventDAO.findByUser(user, offset, limit);
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -24,12 +24,14 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +64,8 @@ public class LambdaEventResource {
     public List<LambdaEvent> getLambdaEventsByOrganization(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,
             @ApiParam(value = "organization", required = true) @PathParam("organization") String organization,
             @ApiParam(value = PAGINATION_OFFSET_TEXT) @QueryParam("offset") @DefaultValue("0") String offset,
-            @ApiParam(value = PAGINATION_LIMIT_TEXT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit) {
+            @ApiParam(value = PAGINATION_LIMIT_TEXT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
+            @Context HttpServletResponse response) {
         final User authUser = userDAO.findById(user.getId());
         final List<Token> githubTokens = tokenDAO.findGithubByUserId(authUser.getId());
         if (githubTokens.isEmpty()) {
@@ -70,6 +73,8 @@ public class LambdaEventResource {
         }
         final Token githubToken = githubTokens.get(0);
         final Optional<List<String>> authorizedRepos = authorizedRepos(organization, githubToken);
+        response.addHeader("X-total-count", String.valueOf(lambdaEventDAO.countByOrganization(organization, authorizedRepos)));
+        response.addHeader("Access-Control-Expose-Headers", "X-total-count");
         return lambdaEventDAO.findByOrganization(organization, offset, limit, authorizedRepos);
     }
 
@@ -83,11 +88,14 @@ public class LambdaEventResource {
     public List<LambdaEvent> getUserLambdaEvents(@Parameter(hidden = true, name = "user")@Auth User authUser,
            @PathParam("userid") long userid,
            @QueryParam("offset") @DefaultValue("0") Integer offset,
-           @QueryParam("limit") @DefaultValue("1000") Integer limit) {
+           @QueryParam("limit") @DefaultValue("1000") Integer limit,
+           @Context HttpServletResponse response) {
         final User user = userDAO.findById(userid);
         if (user == null) {
             throw new CustomWebApplicationException("User not found.", HttpStatus.SC_NOT_FOUND);
         }
+        response.addHeader("X-total-count", String.valueOf(lambdaEventDAO.countByUser(user)));
+        response.addHeader("Access-Control-Expose-Headers", "X-total-count");
         return lambdaEventDAO.findByUser(user, offset, limit);
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
@@ -344,8 +344,8 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
             + PAGINATION_LIMIT, name = "limit", in = ParameterIn.QUERY, schema = @Schema(minimum = "1", maximum = "100"), required = true) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
         @Context HttpServletResponse response) {
         getOrganizationByIdOptionalAuth(user, id);
-        response.addHeader("X-total-count", String.valueOf(eventDAO.countAllEventsForOrganization(id)));
-        response.addHeader("Access-Control-Expose-Headers", "X-total-count");
+        response.addHeader(LambdaEventResource.X_TOTAL_COUNT, String.valueOf(eventDAO.countAllEventsForOrganization(id)));
+        response.addHeader(LambdaEventResource.ACCESS_CONTROL_EXPOSE_HEADERS, LambdaEventResource.X_TOTAL_COUNT);
         List<Event> eventsForOrganization = eventDAO.findEventsForOrganization(id, offset, limit);
         for (Event event : eventsForOrganization) {
             Hibernate.initialize(event.getInitiatorUser());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -20,6 +20,7 @@ import static io.dockstore.common.DescriptorLanguage.CWL;
 import static io.dockstore.common.DescriptorLanguage.WDL;
 import static io.dockstore.webservice.Constants.OPTIONAL_AUTH_MESSAGE;
 import static io.dockstore.webservice.core.WorkflowMode.DOCKSTORE_YML;
+import static io.dockstore.webservice.resources.LambdaEventResource.X_TOTAL_COUNT;
 import static io.dockstore.webservice.resources.ResourceConstants.JWT_SECURITY_DEFINITION_NAME;
 import static io.dockstore.webservice.resources.ResourceConstants.VERSION_PAGINATION_LIMIT;
 
@@ -826,8 +827,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         filterContainersForHiddenTags(workflows);
         stripContent(workflows);
         EntryDAO entryDAO = services ? serviceEntryDAO : bioWorkflowDAO;
-        response.addHeader("X-total-count", String.valueOf(entryDAO.countAllPublished(Optional.of(filter), workflowClass)));
-        response.addHeader("Access-Control-Expose-Headers", "X-total-count");
+        response.addHeader(LambdaEventResource.X_TOTAL_COUNT, String.valueOf(entryDAO.countAllPublished(Optional.of(filter), workflowClass)));
+        response.addHeader(LambdaEventResource.ACCESS_CONTROL_EXPOSE_HEADERS, X_TOTAL_COUNT);
         return workflows;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -20,7 +20,6 @@ import static io.dockstore.common.DescriptorLanguage.CWL;
 import static io.dockstore.common.DescriptorLanguage.WDL;
 import static io.dockstore.webservice.Constants.OPTIONAL_AUTH_MESSAGE;
 import static io.dockstore.webservice.core.WorkflowMode.DOCKSTORE_YML;
-import static io.dockstore.webservice.resources.LambdaEventResource.X_TOTAL_COUNT;
 import static io.dockstore.webservice.resources.ResourceConstants.JWT_SECURITY_DEFINITION_NAME;
 import static io.dockstore.webservice.resources.ResourceConstants.VERSION_PAGINATION_LIMIT;
 
@@ -828,7 +827,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         stripContent(workflows);
         EntryDAO entryDAO = services ? serviceEntryDAO : bioWorkflowDAO;
         response.addHeader(LambdaEventResource.X_TOTAL_COUNT, String.valueOf(entryDAO.countAllPublished(Optional.of(filter), workflowClass)));
-        response.addHeader(LambdaEventResource.ACCESS_CONTROL_EXPOSE_HEADERS, X_TOTAL_COUNT);
+        response.addHeader(LambdaEventResource.ACCESS_CONTROL_EXPOSE_HEADERS, LambdaEventResource.X_TOTAL_COUNT);
         return workflows;
     }
 


### PR DESCRIPTION
**Description**
Add total count header to allow for pagination of github lambda events. 
i.e. pagination of any type of entity usually requires an endpoint that takes page size and offset (already exists) and a total count (sometimes which requires filters to match) which is added via this PR

**Review Instructions**
Primarily supports a future UI ticket to do lambda event pagination (github app logs). 
Will probably be easiest to wait till that UI ticket and page through github app logs, ensuring that each page is a new REST request with different offset values (and results)

**Issue**
Back-end portion of https://github.com/dockstore/dockstore/issues/5617 with tests

**Security and Privacy**

None known

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
