### PR TITLE
DOCK-2463: Fix "No descriptor found" sourcefile bug

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -270,6 +270,7 @@ public class SourceFile implements Comparable<SourceFile> {
      * Thus, an absolute path and an absolute path missing the leading
      * slash will match, as will paths that are the same string,
      * whether absolute or relative.
+     * Relates to https://ucsc-cgl.atlassian.net/browse/SEAB-5945
      */
     @JsonIgnore
     public boolean isSamePath(String otherPath) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -273,10 +273,10 @@ public class SourceFile implements Comparable<SourceFile> {
      */
     @JsonIgnore
     public boolean isSamePath(String otherPath) {
-        return otherPath != null && toAbsolutePath(getPath()).equalsIgnoreCase(toAbsolutePath(otherPath));
+        return otherPath != null && addLeadingSlash(getPath()).equalsIgnoreCase(addLeadingSlash(otherPath));
     }
 
-    private static String toAbsolutePath(String path) {
+    private static String addLeadingSlash(String path) {
         return path.startsWith("/") ? path : "/" + path;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -263,6 +263,23 @@ public class SourceFile implements Comparable<SourceFile> {
         return dbUpdateDate;
     }
 
+    /**
+     * Determine if the specified path matches the sourcefile path.
+     * The paths will match if, after adding a leading slash when it
+     * is missing, the resulting strings are equal, case insensitive.
+     * Thus, an absolute path and an absolute path missing the leading
+     * slash will match, as will paths that are the same string,
+     * whether absolute or relative.
+     */
+    @JsonIgnore
+    public boolean isSamePath(String otherPath) {
+        return otherPath != null && toAbsolutePath(getPath()).equalsIgnoreCase(toAbsolutePath(otherPath));
+    }
+
+    private static String toAbsolutePath(String path) {
+        return path.startsWith("/") ? path : "/" + path;
+    }
+
     // removed overridden hashcode and equals, resulted in issue due to https://hibernate.atlassian.net/browse/HHH-3799
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -342,7 +342,7 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
 
         for (SourceFile file: sourceFiles) {
             if (file.getType() == fileType) {
-                boolean isPrimary = file.getPath().equalsIgnoreCase(primaryPath);
+                boolean isPrimary = file.isSamePath(primaryPath);
                 resultMap.put(file.getPath(), ImmutablePair.of(file, new FileDescription(isPrimary)));
             }
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -228,6 +228,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             String fileKey = file.getType().toString() + file.getAbsolutePath();
             SourceFile existingFile = existingFileMap.get(fileKey);
             if (existingFileMap.containsKey(fileKey)) {
+                existingFile.setPath(file.getPath());
                 existingFile.setContent(file.getContent());
                 existingFile.getMetadata().setTypeVersion(file.getMetadata().getTypeVersion());
             } else {


### PR DESCRIPTION
**Description**
This PR is a hotfix for the "No descriptor found" bug as described in https://ucsc-cgl.atlassian.net/browse/DOCK-2463

The bug happens because:
* We recycle `SourceFiles` when a version is updated. https://github.com/dockstore/dockstore/blob/a1466b82f42cc90fb375f09d82728b5ce7f653be/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java#L227-L233
* `.dockstore.yml` in the existing version was updated to add the leading slash to the primary descriptor path.
* Upon the push of the updated version, the primary descriptor's `SourceFile` was recycled.
* The recycling code didn't update the primary descriptor `SourceFile`'s raw path (returned by `getPath`).  It remained the original path, without the slash.
* However, the new primary descriptor path was stored as the workflow path in the updated version.
* And so, the code that identifies the primary descriptor began to fail, because `projected_admixture.wdl` is not equal to `/projected_admixture.wdl` https://github.com/dockstore/dockstore/blob/a1466b82f42cc90fb375f09d82728b5ce7f653be/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java#L345

This PR tweaks the webservice so it:
1. Updates the raw path in a recycled `SourceFile`.  With this change, a broken version can be pushed to fix this/related bugs. 
2. Uses a comparison to determine the primary descriptor which can handle a missing leading slash, so that paths relative to root (without the leading slash) and absolute paths (with the leading slash) match.  This change fixes the "No descriptor found" problem" in existing versions afflicted by this bug.

Some thoughts:
* It is very important that this change make it into 1.15, otherwise when users make the update to absolute paths, their entries will suffer the same fate.
* The webservice should store and use absolute paths internally whenever possible.
* I'm on the fence as to whether there's other varieties of this bug lurking in the webservice.  At first, I though maybe the test file code might be broken, but I believe we mark/identify test files differently, so maybe not.  And, since this is a hotfix, and the code we're touching is fairly sensitive, I'm loath to make extensive changes.  Should we dig further, or should we not?  Tough call.

**Review Instructions**
Confirm that you can retrieve the primary descriptor from the previously-afflicted workflow, ala `curl "http://localhost:4200/api/workflows/21183/primaryDescriptor?tag=main&language=WDL"`

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2463
https://github.com/dockstore/dockstore/issues/5673

**Security and Privacy**
None.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
