### PR TITLE
DOCK-2442: Fix sluggish events endpoint

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -41,14 +41,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 @NamedQueries({
     // workaround for https://ucsc-cgl.atlassian.net/browse/SEAB-5057
     // the clauses that look like "(e.version is null or (e.version in (select id from WorkflowVersion) or e.version in (select id from Tag)))" can be removed once the version ids are consistent
-    @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByEntryIds", query = "SELECT e FROM Event e where ((e.tool.id in :entryIDs) OR (e.workflow.id in :entryIDs) OR (e.apptool.id in :entryIDs) OR (e.service.id in :entryIDs) OR (e.notebook.id in :entryIDs)) and (e.version is null or (e.version in (select id from WorkflowVersion) or e.version in (select id from Tag))) ORDER by e.id desc"),
     @NamedQuery(name = "io.dockstore.webservice.core.Event.deleteByEntryId", query = "DELETE from Event e where e.tool.id = :entryId OR e.workflow.id = :entryId OR e.apptool.id = :entryId OR e.service.id = :entryId OR e.notebook.id = :entryId"),
     @NamedQuery(name = "io.dockstore.webservice.core.Event.deleteByOrganizationId", query = "DELETE from Event e WHERE e.organization.id = :organizationId"),
-    @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByUserId", query = "SELECT e FROM Event e where e.user.id = :userId and (e.version is null or (e.version in (select id from WorkflowVersion) or e.version in (select id from Tag))) ORDER BY e.id DESC"),
-    @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByInitiatorUserId", query = "SELECT e FROM Event e where e.initiatorUser.id = :initiatorUser and (e.version is null or (e.version in (select id from WorkflowVersion) or e.version in (select id from Tag))) ORDER BY e.id DESC"),
-    @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByEntryId", query = "SELECT e FROM Event e where (e.workflow.id = :entryId OR e.tool.id = :entryId OR e.apptool.id = :entryId OR e.service.id = :serviceId OR e.notebook.id = :entryId) and (e.version is null or (e.version in (select id from WorkflowVersion) or e.version in (select id from Tag))) ORDER BY e.id DESC"),
-    @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllForOrganization", query = "SELECT e FROM Event e WHERE e.organization.id = :organizationId and (e.version is null or (e.version in (select id from WorkflowVersion) or e.version in (select id from Tag))) ORDER BY e.id DESC"),
-    @NamedQuery(name = "io.dockstore.webservice.core.Event.findAllByOrganizationIds", query = "SELECT e FROM Event e WHERE e.organization.id in :organizationIDs and (e.version is null or (e.version in (select id from WorkflowVersion) or e.version in (select id from Tag))) ORDER BY e.id DESC"),
     @NamedQuery(name = "io.dockstore.webservice.core.Event.countAllForOrganization", query = "SELECT COUNT(*) FROM Event eve WHERE eve.organization.id = :organizationId")
 })
 public class Event {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -24,6 +24,9 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import java.sql.Timestamp;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.FilterJoinTable;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.UpdateTimestamp;
 
 /**
@@ -64,6 +67,7 @@ public class Event {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "organizationId", referencedColumnName = "id", columnDefinition = "bigint")
+    @FilterJoinTable(name = "omitCategorizers", condition = ":categorizer = false")
     @ApiModelProperty(value = "Organization that the event is acting on.", position = 2)
     private Organization organization;
 
@@ -110,6 +114,7 @@ public class Event {
 
     @ManyToOne
     @JoinColumn(name = "versionId", referencedColumnName = "id")
+    @NotFound(action = NotFoundAction.IGNORE)
     @ApiModelProperty(value = "Version associated with the event.", position = 8)
     @JsonFilter(SLIM_VERSION_FILTER)
     private Version version;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -24,7 +24,6 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import java.sql.Timestamp;
 import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.FilterJoinTable;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -67,7 +66,6 @@ public class Event {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "organizationId", referencedColumnName = "id", columnDefinition = "bigint")
-    @FilterJoinTable(name = "omitCategorizers", condition = ":categorizer = false")
     @ApiModelProperty(value = "Organization that the event is acting on.", position = 2)
     private Organization organization;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EventResource.java
@@ -58,6 +58,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
 import org.hibernate.Hibernate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Avoid adding Swagger annotations to this, only use OpenAPI 3.0 annotations when possible.
@@ -76,6 +78,7 @@ public class EventResource {
     private static final String DESCRIPTION = "Requires authentication.";
     private final EventDAO eventDAO;
     private final UserDAO userDAO;
+    private static final Logger LOG = LoggerFactory.getLogger(EventResource.class);
 
     public EventResource(EventDAO eventDAO, UserDAO userDAO) {
         this.eventDAO = eventDAO;
@@ -99,7 +102,9 @@ public class EventResource {
                                  @NotNull @QueryParam("eventSearchType") EventSearchType eventSearchType,
                                  @Min(1) @Max(MAX_LIMIT) @DefaultValue(PAGINATION_DEFAULT_STRING) @ApiParam(defaultValue = PAGINATION_DEFAULT_STRING, allowableValues = PAGINATION_RANGE) @Parameter(schema = @Schema(maximum = "100", minimum = "1")) @QueryParam("limit") Integer limit,
                                  @QueryParam("offset") @DefaultValue("0") Integer offset) {
+        LOG.error("A");
         User userWithSession = this.userDAO.findById(user.getId());
+        LOG.error("B");
         return getEventsForUser(userWithSession, userWithSession, eventSearchType, limit, offset);
     }
 
@@ -153,8 +158,11 @@ public class EventResource {
             return allByOrganizationIdsOrEntryIds;
         }
         case PROFILE -> {
+            LOG.error("0");
             List<Event> eventsByUserID = this.eventDAO.findEventsForInitiatorUser(loggedInUser, user.getId(), offset, limit);
+            LOG.error("1");
             eagerLoadEventEntries(eventsByUserID);
+            LOG.error("2");
             return eventsByUserID;
         }
         case SELF_ORGANIZATIONS -> {


### PR DESCRIPTION
**Description**
This is a draft PR that attempts to solve some of our `Event`-related issues with a partial rewrite of `EventDAO`.  I'm looking for high-level feedback on the techniques/solutions, the code is not yet polished...

The performance problem which spurred this work is described in https://ucsc-cgl.atlassian.net/browse/DOCK-2442
Essentially, a simple request to an `/events` endpoint to retrieve aofarrel's 10 latest events was taking 5+ seconds to respond.
`curl -s 'https://qa.dockstore.org/api/events/31191?eventSearchType=PROFILE'`

Upon investigation, I found that the webservice was retrieving all of aofarrels events (more than 2000!), filtering the category-related events, and implementing paging logic, in code.  This took a long time and fired off many related database queries.  There didn't really seem to be an easy way to patch the problem, so I opted for the rewrite.

Essentially, I changed the DAO methods that retrieve lists of Events to use the same underlying method, which constructs a `CriteriaQuery` and runs it, so that the paging and category filtering occurs on the database side.  This greatly improves the performance of the above query, which improves to a round trip time of about 150ms on my local box.  Additionally, it makes it very easy to add new types of queries, change the paging logic, modify access control, etc..

In a `CriteriaQuery`, it may be difficult to replicate the SQL which filters dangling versions that we added to triage the problem described in:
https://ucsc-cgl.atlassian.net/browse/SEAB-5057

To that end, I investigated a different solution, which removes the SQL and adds a `NotFound` annotation to `Event.version`, which tells Hibernate to continue if it can't link the version id and set the field to null, rather than throw.  Maybe it's ok if such events show up in the UI, which we label appropriately ("User x added a version which has been updated or deleted."), or maybe we call a DAO method that removes the unlinked version events at strategic points in the webservice?

**Review Instructions**
Describe if this ticket needs review and if so, how one may go about it in qa and/or staging environments.
For example, a ticket based on Security Hub, Snyk, or Dependabot may not need review since those services 
will generate new warnings if the issue has not been resolved properly. On the other hand, an infrastructure
ticket that results in visible changes to the end-user will definitely require review. 
Many tickets will likely be between these two extremes, so some judgement may be required.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2442

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here.

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ ] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
