### PR TITLE
DOCK-1195: Populate versions in archive/unarchive endpoint response

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -274,6 +274,7 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
         @ApiParam(value = "Entry to archive.", required = true) @PathParam("id") Long id) {
         Entry<?, ?> entry = toolDAO.getGenericEntryById(id);
         updateArchived(true, user, entry);
+        Hibernate.initialize(entry.getWorkflowVersions());
         return entry;
     }
 
@@ -287,6 +288,7 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
         @ApiParam(value = "Entry to unarchive.", required = true) @PathParam("id") Long id) {
         Entry<?, ?> entry = toolDAO.getGenericEntryById(id);
         updateArchived(false, user, entry);
+        Hibernate.initialize(entry.getWorkflowVersions());
         return entry;
     }
 


### PR DESCRIPTION
**Description**
Recently, we added webservice endpoints to archive/unarchive entries.  These endpoints respond with the updated Entry, but they neglect to populate its Versions, so after updating the backing state with the returned Entry, the UI crashes, because when it retrieves the list of Versions from the Entry, it gets a null.

This PR changes the endpoints to populate the Versions in the returned Entry.

**Review Instructions**
Confirm that there is a list of Versions in the archive/unarchive endpoint Entry response.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-1195
https://github.com/dockstore/dockstore/issues/3199

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
