### PR TITLE
SEAB-5951: Notebook "launch to GitHub Codespace" support

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/DescriptorLanguage.java
@@ -84,7 +84,7 @@ public enum DescriptorLanguage {
     JUPYTER("jupyter", "Jupyter .ipynb notebook", FileType.DOCKSTORE_JUPYTER, FileType.DOCKSTORE_NOTEBOOK_TEST_FILE, false, false, Set.of("ipynb"), false, false, Set.of(NOTEBOOK)) {
         @Override
         public boolean isRelevantFileType(FileType type) {
-            return super.isRelevantFileType(type) || type == FileType.DOCKSTORE_NOTEBOOK_REES || type == FileType.DOCKSTORE_NOTEBOOK_OTHER;
+            return super.isRelevantFileType(type) || type == FileType.DOCKSTORE_NOTEBOOK_REES || type == FileType.DOCKSTORE_NOTEBOOK_DEVCONTAINER || type == FileType.DOCKSTORE_NOTEBOOK_OTHER;
         }
     };
 
@@ -259,7 +259,7 @@ public enum DescriptorLanguage {
         DOCKSTORE_SERVICE_YML(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_SERVICE_TEST_JSON(FileTypeCategory.TEST_FILE), DOCKSTORE_SERVICE_OTHER(FileTypeCategory.OTHER),
         DOCKSTORE_GXFORMAT2(FileTypeCategory.GENERIC_DESCRIPTOR), GXFORMAT2_TEST_FILE(FileTypeCategory.TEST_FILE),
         DOCKSTORE_SWL(FileTypeCategory.GENERIC_DESCRIPTOR), SWL_TEST_JSON(FileTypeCategory.TEST_FILE),
-        DOCKSTORE_JUPYTER(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_NOTEBOOK_REES(FileTypeCategory.CONFIGURATION_FILE), DOCKSTORE_NOTEBOOK_TEST_FILE(FileTypeCategory.TEST_FILE), DOCKSTORE_NOTEBOOK_OTHER(FileTypeCategory.OTHER);
+        DOCKSTORE_JUPYTER(FileTypeCategory.PRIMARY_DESCRIPTOR), DOCKSTORE_NOTEBOOK_REES(FileTypeCategory.CONFIGURATION_FILE), DOCKSTORE_NOTEBOOK_DEVCONTAINER(FileTypeCategory.CONFIGURATION_FILE), DOCKSTORE_NOTEBOOK_TEST_FILE(FileTypeCategory.TEST_FILE), DOCKSTORE_NOTEBOOK_OTHER(FileTypeCategory.OTHER);
         // DOCKSTORE-2428 - demo how to add new workflow language
 
         private final FileTypeCategory category;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
@@ -86,7 +86,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -245,7 +245,7 @@ class NotebookIT extends BaseIT {
     }
 
     private long countFileType(List<SourceFile> sourceFiles, DescriptorLanguage.FileType type) {
-        return sourceFiles.stream().filter(file -> file.getType().equals(type)).count();
+        return sourceFiles.stream().filter(file -> type.name().equals(file.getType().getValue())).count();
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -232,7 +232,7 @@ class NotebookIT extends BaseIT {
 
     @Test
     void testRegisterAllDevcontainersNotebook() {
-        List<SourceFile> files = registerSimpleRepoAndGetSourceFiles("simple", "refs/heads/all-devcontainers");
+        List<SourceFile> files = registerSimpleRepoAndGetSourceFiles("simple", "refs/tags/all-devcontainers-v1");
         assertEquals(Set.of("/.devcontainer.json", "/.devcontainer/devcontainer.json", "/.devcontainer/a/devcontainer.json", "/.devcontainer/b/devcontainer.json", "/notebook.ipynb", "/.dockstore.yml"),
             getAbsolutePaths(files));
         assertEquals(4, countFileType(files, DOCKSTORE_NOTEBOOK_DEVCONTAINER));

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -16,6 +16,7 @@
 
 package io.dockstore.webservice;
 
+import static io.dockstore.common.DescriptorLanguage.FileType.DOCKSTORE_NOTEBOOK_DEVCONTAINER;
 import static io.dockstore.webservice.Constants.DOCKSTORE_YML_PATH;
 import static io.dockstore.webservice.Constants.LAMBDA_FAILURE;
 import static io.dockstore.webservice.helpers.GitHubAppHelper.handleGitHubRelease;
@@ -209,33 +210,42 @@ class NotebookIT extends BaseIT {
 
     @Test
     void testRegisterRootDevcontainerNotebook() {
-        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/heads/root-devcontainer");
-        assertTrue(paths.contains("/.devcontainer.json"));
+        List<SourceFile> files = registerSimpleRepoAndGetSourceFiles("simple", "refs/tags/root-devcontainer-v1");
+        assertEquals(Set.of("/.devcontainer.json", "/notebook.ipynb", ".dockstore.yml"), getAbsolutePaths(files));
+        assertEquals(1, countFileType(files, DOCKSTORE_NOTEBOOK_DEVCONTAINER));
     }
 
     @Test
     void testRegisterDotdirDevcontainerNotebook() {
-        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/heads/dotdir-devcontainer");
-        assertTrue(paths.contains("/.devcontainer/devcontainer.json"));
+        List<SourceFile> files = registerSimpleRepoAndGetSourceFiles("simple", "refs/tags/dotdir-devcontainer-v1");
+        assertEquals(Set.of("/.devcontainer/devcontainer.json", "/notebook.ipynb", ".dockstore.yml"), getAbsolutePaths(files));
+        assertEquals(1, countFileType(files, DOCKSTORE_NOTEBOOK_DEVCONTAINER));
     }
 
     @Test
     void testRegisterDotdirFolderDevcontainersNotebook() {
-        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/heads/dotdir-folder-devcontainers");
-        assertTrue(paths.contains("/.devcontainer/a/devcontainer.json"));
-        assertTrue(paths.contains("/.devcontainer/b/devcontainer.json"));
-        assertFalse(paths.contains("/.devcontainer/c.txt"));
+        List<SourceFile> files = registerSimpleRepoAndGetSourceFiles("simple", "refs/tags/dotdir-folder-devcontainers-v1");
+        assertEquals(Set.of("/.devcontainer/a/devcontainer.json", "/.devcontainer/b/devcontainer.json", "/notebook.ipynb", ".dockstore.yml"),
+            getAbsolutePaths(files));
+        assertEquals(2, countFileType(files, DOCKSTORE_NOTEBOOK_DEVCONTAINER));
     }
 
-    private List<String> registerSimpleRepoAndGetSourceFilePaths(String name, String ref) {
+    private List<SourceFile> registerSimpleRepoAndGetSourceFiles(String name, String ref) {
         ApiClient apiClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(apiClient);
         handleGitHubRelease(workflowsApi, simpleRepo, ref, USER_2_USERNAME);
         String path = simpleRepoPath + "/" + name;
         Workflow notebook = workflowsApi.getWorkflowByPath(path, WorkflowSubClass.NOTEBOOK, "versions");
         WorkflowVersion version = notebook.getWorkflowVersions().get(0);
-        List<SourceFile> sourceFiles = workflowsApi.getWorkflowVersionsSourcefiles(notebook.getId(), version.getId(), null);
-        return sourceFiles.stream().map(SourceFile::getAbsolutePath).toList();
+        return workflowsApi.getWorkflowVersionsSourcefiles(notebook.getId(), version.getId(), null);
+    }
+
+    private Set<String> getAbsolutePaths(List<SourceFile> sourceFiles) {
+        return sourceFiles.stream().map(SourceFile::getAbsolutePath).collect(Collectors.toSet());
+    }
+
+    private long countFileType(List<SourceFile> sourceFiles, DescriptorLanguage.FileType type) {
+        return sourceFiles.stream().filter(file -> file.getType().equals(type)).count();
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -215,13 +215,13 @@ class NotebookIT extends BaseIT {
 
     @Test
     void testRegisterSubdirDevcontainerNotebook() {
-        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/branches/subdir-devcontainer");
+        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/branches/dotdir-devcontainer");
         assertTrue(paths.contains("/.devcontainer/devcontainer.json"));
     }
 
     @Test
     void testRegisterSubsubdirDevcontainerNotebook() {
-        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/branches/subsubdir-devcontainers");
+        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/branches/dotdir-folder-devcontainers");
         assertTrue(paths.contains("/.devcontainer/a/devcontainer.json"));
         assertTrue(paths.contains("/.devcontainer/b/devcontainer.json"));
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -211,21 +211,21 @@ class NotebookIT extends BaseIT {
     @Test
     void testRegisterRootDevcontainerNotebook() {
         List<SourceFile> files = registerSimpleRepoAndGetSourceFiles("simple", "refs/tags/root-devcontainer-v1");
-        assertEquals(Set.of("/.devcontainer.json", "/notebook.ipynb", ".dockstore.yml"), getAbsolutePaths(files));
+        assertEquals(Set.of("/.devcontainer.json", "/notebook.ipynb", "/.dockstore.yml"), getAbsolutePaths(files));
         assertEquals(1, countFileType(files, DOCKSTORE_NOTEBOOK_DEVCONTAINER));
     }
 
     @Test
     void testRegisterDotdirDevcontainerNotebook() {
         List<SourceFile> files = registerSimpleRepoAndGetSourceFiles("simple", "refs/tags/dotdir-devcontainer-v1");
-        assertEquals(Set.of("/.devcontainer/devcontainer.json", "/notebook.ipynb", ".dockstore.yml"), getAbsolutePaths(files));
+        assertEquals(Set.of("/.devcontainer/devcontainer.json", "/notebook.ipynb", "/.dockstore.yml"), getAbsolutePaths(files));
         assertEquals(1, countFileType(files, DOCKSTORE_NOTEBOOK_DEVCONTAINER));
     }
 
     @Test
     void testRegisterDotdirFolderDevcontainersNotebook() {
         List<SourceFile> files = registerSimpleRepoAndGetSourceFiles("simple", "refs/tags/dotdir-folder-devcontainers-v1");
-        assertEquals(Set.of("/.devcontainer/a/devcontainer.json", "/.devcontainer/b/devcontainer.json", "/notebook.ipynb", ".dockstore.yml"),
+        assertEquals(Set.of("/.devcontainer/a/devcontainer.json", "/.devcontainer/b/devcontainer.json", "/notebook.ipynb", "/.dockstore.yml"),
             getAbsolutePaths(files));
         assertEquals(2, countFileType(files, DOCKSTORE_NOTEBOOK_DEVCONTAINER));
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -230,6 +230,14 @@ class NotebookIT extends BaseIT {
         assertEquals(2, countFileType(files, DOCKSTORE_NOTEBOOK_DEVCONTAINER));
     }
 
+    @Test
+    void testRegisterAllDevcontainersNotebook() {
+        List<SourceFile> files = registerSimpleRepoAndGetSourceFiles("simple", "refs/heads/all-devcontainers");
+        assertEquals(Set.of("/.devcontainer.json", "/.devcontainer/devcontainer.json", "/.devcontainer/a/devcontainer.json", "/.devcontainer/b/devcontainer.json", "/notebook.ipynb", "/.dockstore.yml"),
+            getAbsolutePaths(files));
+        assertEquals(4, countFileType(files, DOCKSTORE_NOTEBOOK_DEVCONTAINER));
+    }
+
     private List<SourceFile> registerSimpleRepoAndGetSourceFiles(String name, String ref) {
         ApiClient apiClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(apiClient);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -209,19 +209,19 @@ class NotebookIT extends BaseIT {
 
     @Test
     void testRegisterRootDevcontainerNotebook() {
-        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/branches/root-devcontainer");
+        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/heads/root-devcontainer");
         assertTrue(paths.contains("/.devcontainer.json"));
     }
 
     @Test
     void testRegisterSubdirDevcontainerNotebook() {
-        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/branches/dotdir-devcontainer");
+        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/heads/dotdir-devcontainer");
         assertTrue(paths.contains("/.devcontainer/devcontainer.json"));
     }
 
     @Test
     void testRegisterSubsubdirDevcontainerNotebook() {
-        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/branches/dotdir-folder-devcontainers");
+        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/heads/dotdir-folder-devcontainers");
         assertTrue(paths.contains("/.devcontainer/a/devcontainer.json"));
         assertTrue(paths.contains("/.devcontainer/b/devcontainer.json"));
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -214,16 +214,17 @@ class NotebookIT extends BaseIT {
     }
 
     @Test
-    void testRegisterSubdirDevcontainerNotebook() {
+    void testRegisterDotdirDevcontainerNotebook() {
         List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/heads/dotdir-devcontainer");
         assertTrue(paths.contains("/.devcontainer/devcontainer.json"));
     }
 
     @Test
-    void testRegisterSubsubdirDevcontainerNotebook() {
+    void testRegisterDotdirFolderDevcontainersNotebook() {
         List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/heads/dotdir-folder-devcontainers");
         assertTrue(paths.contains("/.devcontainer/a/devcontainer.json"));
         assertTrue(paths.contains("/.devcontainer/b/devcontainer.json"));
+        assertFalse(paths.contains("/.devcontainer/c.txt"));
     }
 
     private List<String> registerSimpleRepoAndGetSourceFilePaths(String name, String ref) {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -208,6 +208,36 @@ class NotebookIT extends BaseIT {
     }
 
     @Test
+    void testRegisterRootDevcontainerNotebook() {
+        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/branches/root-devcontainer");
+        assertTrue(paths.contains("/.devcontainer.json"));
+    }
+
+    @Test
+    void testRegisterSubdirDevcontainerNotebook() {
+        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/branches/subdir-devcontainer");
+        assertTrue(paths.contains("/.devcontainer/devcontainer.json"));
+    }
+
+    @Test
+    void testRegisterSubsubdirDevcontainerNotebook() {
+        List<String> paths = registerSimpleRepoAndGetSourceFilePaths("simple", "refs/branches/subsubdir-devcontainers");
+        assertTrue(paths.contains("/.devcontainer/a/devcontainer.json"));
+        assertTrue(paths.contains("/.devcontainer/b/devcontainer.json"));
+    }
+
+    private List<String> registerSimpleRepoAndGetSourceFilePaths(String name, String ref) {
+        ApiClient apiClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowsApi = new WorkflowsApi(apiClient);
+        handleGitHubRelease(workflowsApi, simpleRepo, ref, USER_2_USERNAME);
+        String path = simpleRepoPath + "/" + name;
+        Workflow notebook = workflowsApi.getWorkflowByPath(path, WorkflowSubClass.NOTEBOOK, "versions");
+        WorkflowVersion version = notebook.getWorkflowVersions().get(0);
+        List<SourceFile> sourceFiles = workflowsApi.getWorkflowVersionsSourcefiles(notebook.getId(), version.getId(), null);
+        return sourceFiles.stream().map(SourceFile::getAbsolutePath).toList();
+    }
+
+    @Test
     void testUserNotebooks() {
         ApiClient apiClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(apiClient);

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -2532,6 +2532,7 @@ paths:
             - SWL_TEST_JSON
             - DOCKSTORE_JUPYTER
             - DOCKSTORE_NOTEBOOK_REES
+            - DOCKSTORE_NOTEBOOK_DEVCONTAINER
             - DOCKSTORE_NOTEBOOK_TEST_FILE
             - DOCKSTORE_NOTEBOOK_OTHER
       responses:
@@ -3080,6 +3081,7 @@ paths:
                   - SWL_TEST_JSON
                   - DOCKSTORE_JUPYTER
                   - DOCKSTORE_NOTEBOOK_REES
+                  - DOCKSTORE_NOTEBOOK_DEVCONTAINER
                   - DOCKSTORE_NOTEBOOK_TEST_FILE
                   - DOCKSTORE_NOTEBOOK_OTHER
                 uniqueItems: true
@@ -8274,6 +8276,7 @@ paths:
             - SWL_TEST_JSON
             - DOCKSTORE_JUPYTER
             - DOCKSTORE_NOTEBOOK_REES
+            - DOCKSTORE_NOTEBOOK_DEVCONTAINER
             - DOCKSTORE_NOTEBOOK_TEST_FILE
             - DOCKSTORE_NOTEBOOK_OTHER
       responses:
@@ -10249,6 +10252,7 @@ components:
           - SWL_TEST_JSON
           - DOCKSTORE_JUPYTER
           - DOCKSTORE_NOTEBOOK_REES
+          - DOCKSTORE_NOTEBOOK_DEVCONTAINER
           - DOCKSTORE_NOTEBOOK_TEST_FILE
           - DOCKSTORE_NOTEBOOK_OTHER
         verifiedBySource:
@@ -11097,6 +11101,7 @@ components:
           - SWL_TEST_JSON
           - DOCKSTORE_JUPYTER
           - DOCKSTORE_NOTEBOOK_REES
+          - DOCKSTORE_NOTEBOOK_DEVCONTAINER
           - DOCKSTORE_NOTEBOOK_TEST_FILE
           - DOCKSTORE_NOTEBOOK_OTHER
         valid:


### PR DESCRIPTION
**Description**
This PR modifies the webservice to read the devcontainer file(s) that are usually present in a repo that's intended to be launched in a GitHub Codespace.

When a repo is opened in a codespace, GitHub could inspect the repo to infer the type/contents (hey, there's an `ipynb` file, so this must be a notebook, fire up the notebook support), but it doesn't.  Instead, it reads the devcontainer file(s) from the repo, which specify the [optional] image that will run in the Codespace container, any vscode extensions that will be started, command to run, files to open, etc.   The devcontainer spec:

https://containers.dev/

Specifically, this PR adds a new file type `DOCKSTORE_NOTEBOOK_DEVCONTAINER`, and modifies the Jupyter language handler to find and read devcontainer files as SourceFiles of that type.

The intention is that the UI will use this information to advise the user at launch time.  For example, when a notebook repo is launched to a codespace but there's not devcontainer in the repo, the notebook will not automatically load.  If we can determine this at "launch to codespace" time, we can inform the user and tell them what to do ("click on X/Y/Z when the interface loads", "add this suggested devcontainer", etc)...

Possibly, in the future, the launch process for non-GitHub platforms could also inspect the devcontainer to determine which image to use, etc.
 
**Review Instructions**
Clone/create a repo that contains a devcontainer file, register it in qa, and confirm that the devcontainer `SourceFile` appears and has the correct type when you retrieve it via the appropriate endpoint. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5951

**Security and Privacy**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
