### PR TITLE
SEAB-5951: Add GitHub codespace import URL property to UI config

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
@@ -769,6 +769,7 @@ public class DockstoreWebserviceConfiguration extends Configuration {
         private String elwaziImportUrl;
         private String colabImportUrl;
         private String mybinderImportUrl;
+        private String gitHubCodespaceImportUrl;
 
         private String gitHubAuthUrl;
         private String gitHubRedirectPath;
@@ -876,6 +877,14 @@ public class DockstoreWebserviceConfiguration extends Configuration {
 
         public void setMybinderImportUrl(String mybinderImportUrl) {
             this.mybinderImportUrl = mybinderImportUrl;
+        }
+
+        public String getGitHubCodespaceImportUrl() {
+            return gitHubCodespaceImportUrl;
+        }
+
+        public void setGitHubCodespaceImportUrl(String gitHubCodespaceImportUrl) {
+            this.gitHubCodespaceImportUrl = gitHubCodespaceImportUrl;
         }
 
         public String getGitHubAuthUrl() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
@@ -769,7 +769,7 @@ public class DockstoreWebserviceConfiguration extends Configuration {
         private String elwaziImportUrl;
         private String colabImportUrl;
         private String mybinderImportUrl;
-        private String gitHubCodespaceImportUrl;
+        private String gitHubCodespacesImportUrl;
 
         private String gitHubAuthUrl;
         private String gitHubRedirectPath;
@@ -879,12 +879,12 @@ public class DockstoreWebserviceConfiguration extends Configuration {
             this.mybinderImportUrl = mybinderImportUrl;
         }
 
-        public String getGitHubCodespaceImportUrl() {
-            return gitHubCodespaceImportUrl;
+        public String getGitHubCodespacesImportUrl() {
+            return gitHubCodespacesImportUrl;
         }
 
-        public void setGitHubCodespaceImportUrl(String gitHubCodespaceImportUrl) {
-            this.gitHubCodespaceImportUrl = gitHubCodespaceImportUrl;
+        public void setGitHubCodespacesImportUrl(String gitHubCodespacesImportUrl) {
+            this.gitHubCodespacesImportUrl = gitHubCodespacesImportUrl;
         }
 
         public String getGitHubAuthUrl() {

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -8658,6 +8658,8 @@ components:
           type: string
         gitHubAuthUrl:
           type: string
+        gitHubCodespaceImportUrl:
+          type: string
         gitHubRedirectPath:
           type: string
         gitHubScope:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -8658,7 +8658,7 @@ components:
           type: string
         gitHubAuthUrl:
           type: string
-        gitHubCodespaceImportUrl:
+        gitHubCodespacesImportUrl:
           type: string
         gitHubRedirectPath:
           type: string


### PR DESCRIPTION
**Description**
This PR adds the GitHub codespace import URL property to the UI config, so we can vary it, if desired.

**Review Instructions**
Confirm that the property `gitHubCodespacesImportUrl` now appears in `openapi.yaml`.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5951

**Security and Privacy**
None.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
