### PR TITLE
DOCK-2440: added sort and filter values on GitHub Apps Logs endpoints

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SubmoduleIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SubmoduleIT.java
@@ -134,7 +134,7 @@ class SubmoduleIT extends BaseIT {
         assertFalse(sourcefiles.stream().anyMatch(f -> f.getPath().contains("../wdl-common/wdl/workflows/deepvariant/deepvariant.wdl")));
         assertFalse(sourcefiles.stream().anyMatch(f -> f.getPath().contains("../wdl-common/wdl/tasks/zip_index_vcf.wdl")));
         LambdaEventsApi lambdaEventsApi = new LambdaEventsApi(webClient);
-        final List<LambdaEvent> lambdaEventsByOrganization = lambdaEventsApi.getLambdaEventsByOrganization("dockstore-testing", "0", 10, null, null, null);
+        final List<LambdaEvent> lambdaEventsByOrganization = lambdaEventsApi.getLambdaEventsByOrganization("dockstore-testing", 0, 10, null, null, null);
         assertTrue(lambdaEventsByOrganization.stream().anyMatch(e -> e.getMessage().contains("Failed to import") && e.getMessage().contains("Not found wdl-common/wdl")));
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SubmoduleIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SubmoduleIT.java
@@ -134,7 +134,7 @@ class SubmoduleIT extends BaseIT {
         assertFalse(sourcefiles.stream().anyMatch(f -> f.getPath().contains("../wdl-common/wdl/workflows/deepvariant/deepvariant.wdl")));
         assertFalse(sourcefiles.stream().anyMatch(f -> f.getPath().contains("../wdl-common/wdl/tasks/zip_index_vcf.wdl")));
         LambdaEventsApi lambdaEventsApi = new LambdaEventsApi(webClient);
-        final List<LambdaEvent> lambdaEventsByOrganization = lambdaEventsApi.getLambdaEventsByOrganization("dockstore-testing", "0", 10);
+        final List<LambdaEvent> lambdaEventsByOrganization = lambdaEventsApi.getLambdaEventsByOrganization("dockstore-testing", "0", 10, null, null, null);
         assertTrue(lambdaEventsByOrganization.stream().anyMatch(e -> e.getMessage().contains("Failed to import") && e.getMessage().contains("Not found wdl-common/wdl")));
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
@@ -178,10 +178,12 @@ class SwaggerWebhookIT extends BaseIT {
 
         assertEquals(0, lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, "0", 10, null, null, null).size(), "No events at all works");
 
-        testingPostgres.runUpdateStatement("INSERT INTO lambdaevent(dbcreatedate, message, repository, organization, deliveryid) values (CURRENT_TIMESTAMP, 'whatevs', 'repo-no-access', 'DockstoreTestUser', '1234')");
+        testingPostgres.runUpdateStatement(
+                "INSERT INTO lambdaevent(dbcreatedate, message, repository, organization, deliveryid) values (CURRENT_TIMESTAMP, 'whatevs', 'repo-no-access', 'DockstoreTestUser', '1234')");
         assertEquals(0, lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, "0", 10, null, null, null).size(), "Can't see event for repo with no access");
 
-        testingPostgres.runUpdateStatement("INSERT INTO lambdaevent(dbcreatedate, message, repository, organization, deliveryid) values (CURRENT_TIMESTAMP, 'whatevs', 'dockstore-whalesay-2', 'DockstoreTestUser', '1234')");
+        testingPostgres.runUpdateStatement(
+                "INSERT INTO lambdaevent(dbcreatedate, message, repository, organization, deliveryid) values (CURRENT_TIMESTAMP, 'whatevs', 'dockstore-whalesay-2', 'DockstoreTestUser', '1234')");
         final List<io.dockstore.openapi.client.model.LambdaEvent> events =
             lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, "0", 10, null, null, null);
         assertEquals(1, events.size(), "Can see event for repo with access, not one without");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
@@ -176,14 +176,14 @@ class SwaggerWebhookIT extends BaseIT {
         final String dockstoreTestUser = "DockstoreTestUser";
         assertTrue(userOrganizations.contains(dockstoreTestUser)); // User has access to only one repo in the org, DockstoreTestUser/dockstore-whalesay-2
 
-        assertEquals(0, lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, "0", 10).size(), "No events at all works");
+        assertEquals(0, lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, "0", 10, null, null, null).size(), "No events at all works");
 
         testingPostgres.runUpdateStatement("INSERT INTO lambdaevent(message, repository, organization, deliveryid) values ('whatevs', 'repo-no-access', 'DockstoreTestUser', '1234')");
-        assertEquals(0, lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, "0", 10).size(), "Can't see event for repo with no access");
+        assertEquals(0, lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, "0", 10, null, null, null).size(), "Can't see event for repo with no access");
 
         testingPostgres.runUpdateStatement("INSERT INTO lambdaevent(message, repository, organization, deliveryid) values ('whatevs', 'dockstore-whalesay-2', 'DockstoreTestUser', '1234')");
         final List<io.dockstore.openapi.client.model.LambdaEvent> events =
-            lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, "0", 10);
+            lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, "0", 10, null, null, null);
         assertEquals(1, events.size(), "Can see event for repo with access, not one without");
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
@@ -184,8 +184,14 @@ class SwaggerWebhookIT extends BaseIT {
 
         testingPostgres.runUpdateStatement(
                 "INSERT INTO lambdaevent(dbcreatedate, message, repository, organization, deliveryid) values (CURRENT_TIMESTAMP, 'whatevs', 'dockstore-whalesay-2', 'DockstoreTestUser', '1234')");
-        final List<io.dockstore.openapi.client.model.LambdaEvent> events =
+        List<io.dockstore.openapi.client.model.LambdaEvent> events =
             lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, 0, 10, null, null, null);
         assertEquals(1, events.size(), "Can see event for repo with access, not one without");
+
+        testingPostgres.runUpdateStatement(
+                "INSERT INTO lambdaevent(dbcreatedate, message, repository, organization, deliveryid) values (CURRENT_TIMESTAMP, 'hello', 'dockstore-whalesay-2', 'DockstoreTestUser', '1235')");
+
+        events = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, 0, 10, "hello", null, null);
+        assertEquals(1, events.size(), "Can see event with hello message, not one with whatevs due to filter");
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
@@ -176,16 +176,16 @@ class SwaggerWebhookIT extends BaseIT {
         final String dockstoreTestUser = "DockstoreTestUser";
         assertTrue(userOrganizations.contains(dockstoreTestUser)); // User has access to only one repo in the org, DockstoreTestUser/dockstore-whalesay-2
 
-        assertEquals(0, lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, "0", 10, null, null, null).size(), "No events at all works");
+        assertEquals(0, lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, 0, 10, null, null, null).size(), "No events at all works");
 
         testingPostgres.runUpdateStatement(
                 "INSERT INTO lambdaevent(dbcreatedate, message, repository, organization, deliveryid) values (CURRENT_TIMESTAMP, 'whatevs', 'repo-no-access', 'DockstoreTestUser', '1234')");
-        assertEquals(0, lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, "0", 10, null, null, null).size(), "Can't see event for repo with no access");
+        assertEquals(0, lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, 0, 10, null, null, null).size(), "Can't see event for repo with no access");
 
         testingPostgres.runUpdateStatement(
                 "INSERT INTO lambdaevent(dbcreatedate, message, repository, organization, deliveryid) values (CURRENT_TIMESTAMP, 'whatevs', 'dockstore-whalesay-2', 'DockstoreTestUser', '1234')");
         final List<io.dockstore.openapi.client.model.LambdaEvent> events =
-            lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, "0", 10, null, null, null);
+            lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, 0, 10, null, null, null);
         assertEquals(1, events.size(), "Can see event for repo with access, not one without");
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerWebhookIT.java
@@ -178,10 +178,10 @@ class SwaggerWebhookIT extends BaseIT {
 
         assertEquals(0, lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, "0", 10, null, null, null).size(), "No events at all works");
 
-        testingPostgres.runUpdateStatement("INSERT INTO lambdaevent(message, repository, organization, deliveryid) values ('whatevs', 'repo-no-access', 'DockstoreTestUser', '1234')");
+        testingPostgres.runUpdateStatement("INSERT INTO lambdaevent(dbcreatedate, message, repository, organization, deliveryid) values (CURRENT_TIMESTAMP, 'whatevs', 'repo-no-access', 'DockstoreTestUser', '1234')");
         assertEquals(0, lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, "0", 10, null, null, null).size(), "Can't see event for repo with no access");
 
-        testingPostgres.runUpdateStatement("INSERT INTO lambdaevent(message, repository, organization, deliveryid) values ('whatevs', 'dockstore-whalesay-2', 'DockstoreTestUser', '1234')");
+        testingPostgres.runUpdateStatement("INSERT INTO lambdaevent(dbcreatedate, message, repository, organization, deliveryid) values (CURRENT_TIMESTAMP, 'whatevs', 'dockstore-whalesay-2', 'DockstoreTestUser', '1234')");
         final List<io.dockstore.openapi.client.model.LambdaEvent> events =
             lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, "0", 10, null, null, null);
         assertEquals(1, events.size(), "Can see event for repo with access, not one without");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -625,7 +625,7 @@ class WebhookIT extends BaseIT {
         Set<Long> uniqueLambdaEvents = new HashSet<>();
         lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", 0, 5, null, null, null).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
         lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", 5, 5, null, null, null).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
-        lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", 15, 5, null, null, null).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
+        lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", 10, 5, null, null, null).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
         assertEquals(expectedNumEvents, uniqueLambdaEvents.size());
 
         // can also get the 16 filtering by user

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -2002,7 +2002,7 @@ class WebhookIT extends BaseIT {
     @Test
     void testLambdaEvents() {
         final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
-        final UsersApi usersApi = new io.dockstore.openapi.client.api.UsersApi(webClient);
+        final UsersApi usersApi = new UsersApi(webClient);
         final LambdaEventsApi lambdaEventsApi = new LambdaEventsApi(webClient);
         final List<String> userOrganizations = usersApi.getUserOrganizations("github.com");
         assertTrue(userOrganizations.contains("dockstoretesting")); // Org user is member of
@@ -2018,7 +2018,7 @@ class WebhookIT extends BaseIT {
 
         testingPostgres.runUpdateStatement(
                 "INSERT INTO lambdaevent(dbcreatedate, message, repository, organization, deliveryid) values (CURRENT_TIMESTAMP, 'whatevs', 'dockstore-whalesay-2', 'DockstoreTestUser', '1234')");
-        List<io.dockstore.openapi.client.model.LambdaEvent> events =
+        List<LambdaEvent> events =
                 lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTestUser, 0, 10, null, null, null);
         assertEquals(1, events.size(), "Can see event for repo with access, not one without");
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -357,21 +357,21 @@ class WebhookIT extends BaseIT {
         // Track install event
         handleGitHubInstallation(workflowsApi, List.of(DockstoreTesting.WORKFLOW_DOCKSTORE_YML), USER_2_USERNAME);
         ++numberOfWebhookInvocations;
-        List<LambdaEvent> orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10, null, null, null);
+        List<LambdaEvent> orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, 0, 10, null, null, null);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.INSTALL, true); // There should be no entry name
         assertNumberOfUniqueDeliveryIds(orgEvents, numberOfWebhookInvocations);
 
         // Release 0.1 on GitHub - one new wdl workflow
         handleGitHubRelease(workflowsApi, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, tag01, USER_2_USERNAME);
         ++numberOfWebhookInvocations;
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10, null, null, null);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, 0, 10, null, null, null);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, tag01, foobarWorkflowName, true);
         assertNumberOfUniqueDeliveryIds(orgEvents, numberOfWebhookInvocations);
 
         // Release 0.2 on GitHub - one existing wdl workflow, one new cwl workflow
         handleGitHubRelease(workflowsApi, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, tag02, USER_2_USERNAME);
         ++numberOfWebhookInvocations;
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10, null, null, null);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, 0, 10, null, null, null);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, tag02, foobarWorkflowName, true);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, tag02, foobar2WorkflowName, true);
         assertNumberOfUniqueDeliveryIds(orgEvents, numberOfWebhookInvocations);
@@ -379,7 +379,7 @@ class WebhookIT extends BaseIT {
         // Delete tag 0.2
         handleGitHubBranchDeletion(workflowsApi, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, USER_2_USERNAME, tag02);
         ++numberOfWebhookInvocations;
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10, null, null, null);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, 0, 10, null, null, null);
         // Delete events should have the names of workflows that had a version deleted
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.DELETE, tag02, foobarWorkflowName, true);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.DELETE, tag02, foobar2WorkflowName, true);
@@ -388,7 +388,7 @@ class WebhookIT extends BaseIT {
         // Release refs/heads/invalidDockstoreYml where the foobar workflow description in the .dockstore.yml is missing the 'subclass' property
         assertThrows(ApiException.class, () -> handleGitHubRelease(workflowsApi, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, branchInvalidDockstoreYml, USER_2_USERNAME));
         ++numberOfWebhookInvocations;
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10, null, null, null);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, 0, 10, null, null, null);
         // There should be two push events, one failed event for workflow 'foobar' and one successful event for workflow 'foobar2'
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, branchInvalidDockstoreYml, foobarWorkflowName, false);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, branchInvalidDockstoreYml, foobar2WorkflowName, true);
@@ -397,7 +397,7 @@ class WebhookIT extends BaseIT {
         // Release refs/heads/differentLanguagesWithSameWorkflowName where two workflows have the same workflow name
         assertThrows(ApiException.class, () -> handleGitHubRelease(workflowsApi, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, branchDifferentLanguagesWithSameWorkflowName, USER_2_USERNAME));
         ++numberOfWebhookInvocations;
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10, null, null, null);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, 0, 10, null, null, null);
         // Should only have no entry name because the error is for the whole .dockstore.yml
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, branchDifferentLanguagesWithSameWorkflowName, null, false);
         assertNumberOfUniqueDeliveryIds(orgEvents, numberOfWebhookInvocations);
@@ -406,7 +406,7 @@ class WebhookIT extends BaseIT {
         final String tag10 = "refs/tags/1.0";
         handleGitHubRelease(workflowsApi, DockstoreTesting.TEST_WORKFLOWS_AND_TOOLS, tag10, USER_2_USERNAME);
         ++numberOfWebhookInvocations;
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 15, null, null, null);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, 0, 15, null, null, null);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, tag10, "", true);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, tag10, "md5sum", true);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUBLISH, tag10, "", true);
@@ -416,7 +416,7 @@ class WebhookIT extends BaseIT {
         final String invalidToolNameBranch = "refs/heads/invalidToolName";
         assertThrows(ApiException.class, () -> handleGitHubRelease(workflowsApi, DockstoreTesting.TEST_WORKFLOWS_AND_TOOLS, invalidToolNameBranch, USER_2_USERNAME));
         ++numberOfWebhookInvocations;
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 15, null, null, null);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, 0, 15, null, null, null);
         // There should be two push events, one successful event for the workflow and one failed event for the tool
         final String workflowName = "";
         final String toolName = "md5sum/with/slashes";
@@ -582,11 +582,11 @@ class WebhookIT extends BaseIT {
         assertTrue(events.stream().anyMatch(lambdaEvent -> Objects.equals(14L, lambdaEvent.getId())), "Should have event with ID 14");
 
         // Test the organization events endpoint
-        List<LambdaEvent> orgEvents = lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "0", 20, null, null, null);
+        List<LambdaEvent> orgEvents = lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", 0, 20, null, null, null);
         assertEquals(16, orgEvents.size(), "There should be 16 events");
 
         // Test pagination
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "2", 2, null, null, null);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", 2, 2, null, null, null);
         assertEquals(2, orgEvents.size(), "There should be 2 events (id 13 and 14)");
         assertTrue(orgEvents.stream().anyMatch(lambdaEvent -> Objects.equals(13L, lambdaEvent.getId())), "Should have event with ID 13");
         assertTrue(orgEvents.stream().anyMatch(lambdaEvent -> Objects.equals(14L, lambdaEvent.getId())), "Should have event with ID 14");
@@ -594,13 +594,13 @@ class WebhookIT extends BaseIT {
         // Change organization to test filter
         testingPostgres.runUpdateStatement("UPDATE lambdaevent SET repository = 'workflow-dockstore-yml', organization = 'DockstoreTestUser3' WHERE id = '1'");
 
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "0", 20, null, null, null);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", 0, 20, null, null, null);
         assertEquals(15, orgEvents.size(), "There should now be 15 events");
 
         handlePaginationTesting(lambdaEventsApi);
 
         try {
-            lambdaEventsApi.getLambdaEventsByOrganization("IAmMadeUp", "0", 10, null, null, null);
+            lambdaEventsApi.getLambdaEventsByOrganization("IAmMadeUp", 0, 10, null, null, null);
             fail("Should not reach this statement");
         } catch (ApiException ex) {
             assertEquals(HttpStatus.SC_UNAUTHORIZED, ex.getCode(), "Should fail because user cannot access org.");
@@ -623,9 +623,9 @@ class WebhookIT extends BaseIT {
 
         // test pagination, should  be three pages of five events and the total size should match the total count
         Set<Long> uniqueLambdaEvents = new HashSet<>();
-        lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "0", 5, null, null, null).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
-        lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "5", 5, null, null, null).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
-        lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "10", 5, null, null, null).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
+        lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", 0, 5, null, null, null).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
+        lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", 5, 5, null, null, null).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
+        lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", 15, 5, null, null, null).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
         assertEquals(expectedNumEvents, uniqueLambdaEvents.size());
 
         // can also get the 16 filtering by user

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -180,7 +180,7 @@ class WebhookIT extends BaseIT {
             handleGitHubRelease(workflowClient, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, "refs/heads/sameWorkflowName-CWL", USER_2_USERNAME);
             fail("should have thrown");
         } catch (ApiException ex) {
-            List<LambdaEvent> events = usersApi.getUserGitHubEvents(0, 10);
+            List<LambdaEvent> events = usersApi.getUserGitHubEvents(0, 10, null, null, null);
             LambdaEvent event = events.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).findFirst().get();
             String message = event.getMessage().toLowerCase();
             assertTrue(message.contains("descriptor language"));
@@ -300,7 +300,7 @@ class WebhookIT extends BaseIT {
         final ApiClient webClientAdminUser = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
         LambdaEventsApi lambdaEventsApi = new LambdaEventsApi(webClientAdminUser);
 
-        List<LambdaEvent> lambdaEvents = lambdaEventsApi.getUserLambdaEvents(userid, 0, 100);
+        List<LambdaEvent> lambdaEvents = lambdaEventsApi.getUserLambdaEvents(userid, 0, 100, null, null, null);
         assertEquals(1, lambdaEvents.size());
         assertEquals("refs/tags/1.0", lambdaEvents.get(0).getReference());
     }
@@ -357,21 +357,21 @@ class WebhookIT extends BaseIT {
         // Track install event
         handleGitHubInstallation(workflowsApi, List.of(DockstoreTesting.WORKFLOW_DOCKSTORE_YML), USER_2_USERNAME);
         ++numberOfWebhookInvocations;
-        List<LambdaEvent> orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10);
+        List<LambdaEvent> orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10, null, null, null);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.INSTALL, true); // There should be no entry name
         assertNumberOfUniqueDeliveryIds(orgEvents, numberOfWebhookInvocations);
 
         // Release 0.1 on GitHub - one new wdl workflow
         handleGitHubRelease(workflowsApi, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, tag01, USER_2_USERNAME);
         ++numberOfWebhookInvocations;
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10, null, null, null);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, tag01, foobarWorkflowName, true);
         assertNumberOfUniqueDeliveryIds(orgEvents, numberOfWebhookInvocations);
 
         // Release 0.2 on GitHub - one existing wdl workflow, one new cwl workflow
         handleGitHubRelease(workflowsApi, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, tag02, USER_2_USERNAME);
         ++numberOfWebhookInvocations;
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10, null, null, null);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, tag02, foobarWorkflowName, true);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, tag02, foobar2WorkflowName, true);
         assertNumberOfUniqueDeliveryIds(orgEvents, numberOfWebhookInvocations);
@@ -379,7 +379,7 @@ class WebhookIT extends BaseIT {
         // Delete tag 0.2
         handleGitHubBranchDeletion(workflowsApi, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, USER_2_USERNAME, tag02);
         ++numberOfWebhookInvocations;
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10, null, null, null);
         // Delete events should have the names of workflows that had a version deleted
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.DELETE, tag02, foobarWorkflowName, true);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.DELETE, tag02, foobar2WorkflowName, true);
@@ -388,7 +388,7 @@ class WebhookIT extends BaseIT {
         // Release refs/heads/invalidDockstoreYml where the foobar workflow description in the .dockstore.yml is missing the 'subclass' property
         assertThrows(ApiException.class, () -> handleGitHubRelease(workflowsApi, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, branchInvalidDockstoreYml, USER_2_USERNAME));
         ++numberOfWebhookInvocations;
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10, null, null, null);
         // There should be two push events, one failed event for workflow 'foobar' and one successful event for workflow 'foobar2'
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, branchInvalidDockstoreYml, foobarWorkflowName, false);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, branchInvalidDockstoreYml, foobar2WorkflowName, true);
@@ -397,7 +397,7 @@ class WebhookIT extends BaseIT {
         // Release refs/heads/differentLanguagesWithSameWorkflowName where two workflows have the same workflow name
         assertThrows(ApiException.class, () -> handleGitHubRelease(workflowsApi, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, branchDifferentLanguagesWithSameWorkflowName, USER_2_USERNAME));
         ++numberOfWebhookInvocations;
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 10, null, null, null);
         // Should only have no entry name because the error is for the whole .dockstore.yml
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, branchDifferentLanguagesWithSameWorkflowName, null, false);
         assertNumberOfUniqueDeliveryIds(orgEvents, numberOfWebhookInvocations);
@@ -406,7 +406,7 @@ class WebhookIT extends BaseIT {
         final String tag10 = "refs/tags/1.0";
         handleGitHubRelease(workflowsApi, DockstoreTesting.TEST_WORKFLOWS_AND_TOOLS, tag10, USER_2_USERNAME);
         ++numberOfWebhookInvocations;
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 15);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 15, null, null, null);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, tag10, "", true);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, tag10, "md5sum", true);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUBLISH, tag10, "", true);
@@ -416,7 +416,7 @@ class WebhookIT extends BaseIT {
         final String invalidToolNameBranch = "refs/heads/invalidToolName";
         assertThrows(ApiException.class, () -> handleGitHubRelease(workflowsApi, DockstoreTesting.TEST_WORKFLOWS_AND_TOOLS, invalidToolNameBranch, USER_2_USERNAME));
         ++numberOfWebhookInvocations;
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 15);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, "0", 15, null, null, null);
         // There should be two push events, one successful event for the workflow and one failed event for the tool
         final String workflowName = "";
         final String toolName = "md5sum/with/slashes";
@@ -563,30 +563,30 @@ class WebhookIT extends BaseIT {
                 "Should not have a 0.2 version.");
 
         // Add version that doesn't exist
-        long failedCount = usersApi.getUserGitHubEvents(0, 10).stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count();
+        long failedCount = usersApi.getUserGitHubEvents(0, 10, null, null, null).stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count();
         try {
             handleGitHubRelease(client, DockstoreTestUser2.WORKFLOW_DOCKSTORE_YML, "refs/heads/idonotexist", USER_2_USERNAME);
             fail("Should fail and not reach this point");
         } catch (ApiException ex) {
-            assertEquals(failedCount + 1, usersApi.getUserGitHubEvents(0, 10).stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count(), "There should be one more unsuccessful event than before");
+            assertEquals(failedCount + 1, usersApi.getUserGitHubEvents(0, 10, null, null, null).stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count(), "There should be one more unsuccessful event than before");
         }
 
         // There should be 13 successful lambda events
-        List<LambdaEvent> events = usersApi.getUserGitHubEvents(0, 20);
+        List<LambdaEvent> events = usersApi.getUserGitHubEvents(0, 20, null, null, null);
         assertEquals(13, events.stream().filter(LambdaEvent::isSuccess).count(), "There should be 13 successful events");
 
         // Test pagination for user github events
-        events = usersApi.getUserGitHubEvents(2, 2);
+        events = usersApi.getUserGitHubEvents(2, 2, null, null, null);
         assertEquals(2, events.size(), "There should be 2 events (id 13 and 14)");
         assertTrue(events.stream().anyMatch(lambdaEvent -> Objects.equals(13L, lambdaEvent.getId())), "Should have event with ID 13");
         assertTrue(events.stream().anyMatch(lambdaEvent -> Objects.equals(14L, lambdaEvent.getId())), "Should have event with ID 14");
 
         // Test the organization events endpoint
-        List<LambdaEvent> orgEvents = lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "0", 20);
+        List<LambdaEvent> orgEvents = lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "0", 20, null, null, null);
         assertEquals(16, orgEvents.size(), "There should be 16 events");
 
         // Test pagination
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "2", 2);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "2", 2, null, null, null);
         assertEquals(2, orgEvents.size(), "There should be 2 events (id 13 and 14)");
         assertTrue(orgEvents.stream().anyMatch(lambdaEvent -> Objects.equals(13L, lambdaEvent.getId())), "Should have event with ID 13");
         assertTrue(orgEvents.stream().anyMatch(lambdaEvent -> Objects.equals(14L, lambdaEvent.getId())), "Should have event with ID 14");
@@ -594,13 +594,13 @@ class WebhookIT extends BaseIT {
         // Change organization to test filter
         testingPostgres.runUpdateStatement("UPDATE lambdaevent SET repository = 'workflow-dockstore-yml', organization = 'DockstoreTestUser3' WHERE id = '1'");
 
-        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "0", 20);
+        orgEvents = lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "0", 20, null, null, null);
         assertEquals(15, orgEvents.size(), "There should now be 15 events");
 
         handlePaginationTesting(lambdaEventsApi);
 
         try {
-            lambdaEventsApi.getLambdaEventsByOrganization("IAmMadeUp", "0", 10);
+            lambdaEventsApi.getLambdaEventsByOrganization("IAmMadeUp", "0", 10, null, null, null);
             fail("Should not reach this statement");
         } catch (ApiException ex) {
             assertEquals(HttpStatus.SC_UNAUTHORIZED, ex.getCode(), "Should fail because user cannot access org.");
@@ -623,9 +623,9 @@ class WebhookIT extends BaseIT {
 
         // test pagination, should  be three pages of five events and the total size should match the total count
         Set<Long> uniqueLambdaEvents = new HashSet<>();
-        lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "0", 5).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
-        lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "5", 5).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
-        lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "10", 5).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
+        lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "0", 5, null, null, null).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
+        lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "5", 5, null, null, null).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
+        lambdaEventsApi.getLambdaEventsByOrganization("DockstoreTestUser2", "10", 5, null, null, null).stream().map(LambdaEvent::getId).forEach(uniqueLambdaEvents::add);
         assertEquals(expectedNumEvents, uniqueLambdaEvents.size());
 
         // can also get the 16 filtering by user
@@ -728,7 +728,7 @@ class WebhookIT extends BaseIT {
             handleGitHubRelease(workflowsApi, DockstoreTestUser2.WORKFLOW_DOCKSTORE_YML, "refs/heads/invalidWorkflowName", USER_2_USERNAME);
         } catch (ApiException ex) {
             assertEquals(LAMBDA_ERROR, ex.getCode(), "Should not be able to add a workflow with an invalid name");
-            List<LambdaEvent> failEvents = usersApi.getUserGitHubEvents(0, 10);
+            List<LambdaEvent> failEvents = usersApi.getUserGitHubEvents(0, 10, null, null, null);
             assertEquals(1, failEvents.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count(), "There should be 1 unsuccessful event");
             assertTrue(failEvents.get(0).getMessage().contains(ValidationConstants.ENTRY_NAME_REGEX_MESSAGE));
         }
@@ -851,7 +851,7 @@ class WebhookIT extends BaseIT {
             fail("should have thrown");
         } catch (ApiException ex) {
             // Confirm that the release failed and was logged correctly.
-            List<LambdaEvent> events = usersApi.getUserGitHubEvents(0, 10);
+            List<LambdaEvent> events = usersApi.getUserGitHubEvents(0, 10, null, null, null);
             assertEquals(1, events.size(), "There should be one event");
             assertEquals(0, events.stream().filter(LambdaEvent::isSuccess).count(), "There should be no successful events");
             assertTrue(events.get(0).getMessage().contains(WDLHandler.ERROR_PARSING_WORKFLOW_YOU_MAY_HAVE_A_RECURSIVE_IMPORT), "Event message should indicate the problem");
@@ -1218,7 +1218,7 @@ class WebhookIT extends BaseIT {
         assertTrue(getLatestLambdaEventMessage(0, usersApi).contains("testParameterFilets"), "Refers to misspelled property");
 
         // There should be 4 successful lambda events
-        List<LambdaEvent> events = usersApi.getUserGitHubEvents(0, 10);
+        List<LambdaEvent> events = usersApi.getUserGitHubEvents(0, 10, null, null, null);
         assertEquals(4, events.stream().filter(LambdaEvent::isSuccess).count(), "There should be 4 successful events");
 
         final int versionCountBeforeInvalidDockstoreYml = getFoobar1Workflow(client).getWorkflowVersions().size();
@@ -1227,14 +1227,14 @@ class WebhookIT extends BaseIT {
             handleGitHubRelease(client, DockstoreTestUser2.WORKFLOW_DOCKSTORE_YML, "refs/heads/invalidDockstoreYml", USER_2_USERNAME);
             fail("Should not reach this statement");
         } catch (ApiException ex) {
-            List<LambdaEvent> failEvents = usersApi.getUserGitHubEvents(0, 10);
+            List<LambdaEvent> failEvents = usersApi.getUserGitHubEvents(0, 10, null, null, null);
             assertEquals(1, failEvents.stream().filter(lambdaEvent -> !lambdaEvent.isSuccess()).count(), "There should be 1 unsuccessful event");
             assertEquals(versionCountBeforeInvalidDockstoreYml, getFoobar1Workflow(client).getWorkflowVersions().size(), "Number of versions should be the same");
         }
     }
 
     private LambdaEvent getLatestLambdaEvent(Integer offset, UsersApi usersApi) {
-        return usersApi.getUserGitHubEvents(offset, 1).get(0);
+        return usersApi.getUserGitHubEvents(offset, 1, null, null, null).get(0);
     }
 
     private String getLatestLambdaEventMessage(Integer offset, UsersApi usersApi) {
@@ -1798,7 +1798,7 @@ class WebhookIT extends BaseIT {
         assertTrue(ex.getMessage().toLowerCase().contains("could not be processed"));
         assertEquals(0, countWorkflows());
         assertEquals(0, countTools());
-        List<LambdaEvent> failedLambdaEvents = usersApi.getUserGitHubEvents(0, 10).stream()
+        List<LambdaEvent> failedLambdaEvents = usersApi.getUserGitHubEvents(0, 10, null, null, null).stream()
                 .filter(event -> !event.isSuccess())
                 .toList();
         assertEquals(4, failedLambdaEvents.size(), "There should be four failed events");
@@ -1877,7 +1877,7 @@ class WebhookIT extends BaseIT {
         handleGitHubRelease(client, repo, "refs/tags/simple-published-v1", USER_2_USERNAME);
         assertEquals(2, countVersions());
         // There should be two ignored LambdaEvents
-        assertEquals(2, new UsersApi(webClient).getUserGitHubEvents(0, 10).stream().filter(LambdaEvent::isIgnored).count());
+        assertEquals(2, new UsersApi(webClient).getUserGitHubEvents(0, 10, null, null, null).stream().filter(LambdaEvent::isIgnored).count());
     }
 
     /**
@@ -1908,7 +1908,7 @@ class WebhookIT extends BaseIT {
         handleGitHubBranchDeletion(client, existingRepo, USER_2_USERNAME, "refs/heads/main", false);
         assertEquals(versionCount - 2, countVersions());
         // There should be two ignored LambdaEvents
-        assertEquals(2, new UsersApi(webClient).getUserGitHubEvents(0, 10).stream().filter(LambdaEvent::isIgnored).count());
+        assertEquals(2, new UsersApi(webClient).getUserGitHubEvents(0, 10, null, null, null).stream().filter(LambdaEvent::isIgnored).count());
     }
 
     private void addNotebookAndVersion(String organization, String repo, String ref) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -60,11 +60,11 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
             predicates.add(
                 // ensure we deal with null values and then do like queries on those non-null values
                 cb.or(
-                    createNotNullLikeCriteria("message", filter, cb, event), //
-                    createNotNullLikeCriteria("githubUsername", filter, cb, event), //
-                    createNotNullLikeCriteria("repository", filter, cb, event), //
-                    createNotNullLikeCriteria("type", filter, cb, event), //
-                    createNotNullLikeCriteria("reference", filter, cb, event), //
+                    createNotNullLikeCriteria("message", filter, cb, event),
+                    createNotNullLikeCriteria("githubUsername", filter, cb, event),
+                    createNotNullLikeCriteria("repository", filter, cb, event),
+                    createNotNullLikeCriteria("type", filter, cb, event),
+                    createNotNullLikeCriteria("reference", filter, cb, event),
                     createNotNullLikeCriteria("deliveryId", filter, cb, event)
                 )
             );
@@ -84,9 +84,7 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
 
             } else {
                 Path<Object> sortPath = event.get(sortCol);
-                if (!Strings.isNullOrEmpty(sortOrder) && "desc".equalsIgnoreCase(sortOrder)) {
-                    query.orderBy(cb.desc(sortPath), cb.desc(event.get("id")));
-                } else if (!Strings.isNullOrEmpty(sortOrder) && "asc".equalsIgnoreCase(sortOrder)) {
+                if ("asc".equalsIgnoreCase(sortOrder)) {
                     query.orderBy(cb.asc(sortPath), cb.desc(event.get("id")));
                 } else {
                     query.orderBy(cb.desc(sortPath), cb.desc(event.get("id")));
@@ -125,8 +123,7 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
 
         query.select(event);
 
-        int primitiveOffset = (offset != null) ? offset : 0;
-        TypedQuery<LambdaEvent> typedQuery = currentSession().createQuery(query).setFirstResult(primitiveOffset).setMaxResults(limit);
+        TypedQuery<LambdaEvent> typedQuery = currentSession().createQuery(query).setFirstResult(offset).setMaxResults(limit);
         return typedQuery.getResultList();
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -118,8 +118,8 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
         CriteriaQuery<LambdaEvent> query = criteriaQuery();
         Root<LambdaEvent> event = query.from(LambdaEvent.class);
 
-        List<Predicate> initialPredicate = processQuery(filter, sortCol, sortOrder, cb, query, event);
-        setupFindByUserQuery(user, cb, query, initialPredicate, event);
+        List<Predicate> initialPredicates = processQuery(filter, sortCol, sortOrder, cb, query, event);
+        setupFindByUserQuery(user, cb, query, initialPredicates, event);
 
         query.select(event);
 
@@ -163,8 +163,8 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
         CriteriaQuery<LambdaEvent> query = criteriaQuery();
         Root<LambdaEvent> event = query.from(LambdaEvent.class);
 
-        List<Predicate> initialPredicate = processQuery(filter, sortCol, sortOrder, cb, query, event);
-        setupFindByOrganizationQuery(organization, repositories, cb, query, initialPredicate, event);
+        List<Predicate> initialPredicates = processQuery(filter, sortCol, sortOrder, cb, query, event);
+        setupFindByOrganizationQuery(organization, repositories, cb, query, initialPredicates, event);
         query.select(event);
 
         TypedQuery<LambdaEvent> typedQuery = currentSession().createQuery(query).setFirstResult(offset).setMaxResults(limit);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -1,22 +1,34 @@
 package io.dockstore.webservice.jdbi;
 
+import static io.dockstore.webservice.jdbi.EntryDAO.INVALID_SORTCOL_MESSAGE;
+
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Strings;
+import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.LambdaEvent;
 import io.dockstore.webservice.core.User;
 import io.dropwizard.hibernate.AbstractDAO;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.metamodel.Attribute;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.apache.http.HttpStatus;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EntryDAO.class);
+
     public LambdaEventDAO(SessionFactory factory) {
         super(factory);
     }
@@ -39,6 +51,44 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
         session.flush();
     }
 
+    private List<Predicate> processQuery(String filter, String sortCol, String sortOrder, CriteriaBuilder cb, CriteriaQuery query, Root<LambdaEvent> event) {
+        List<Predicate> predicates = new ArrayList<>();
+        if (!Strings.isNullOrEmpty(filter)) {
+            predicates.add(
+                    // ensure we deal with null values and then do like queries on those non-null values
+                    cb.or(cb.and(cb.isNotNull(event.get("message")), cb.like(cb.upper(event.get("message")), "%" + filter.toUpperCase() + "%")), //
+                            cb.and(cb.isNotNull(event.get("githubUsername")), cb.like(cb.upper(event.get("githubUsername")), "%" + filter.toUpperCase() + "%")), //
+                            cb.and(cb.isNotNull(event.get("repository")), cb.like(cb.upper(event.get("repository")), "%" + filter.toUpperCase() + "%")), //
+                            cb.and(cb.isNotNull(event.get("type")), cb.like(cb.upper(event.get("type")), "%" + filter.toUpperCase() + "%")), //
+                            cb.and(cb.isNotNull(event.get("reference")), cb.like(cb.upper(event.get("reference")), "%" + filter.toUpperCase() + "%")), //
+                            cb.and(cb.isNotNull(event.get("deliveryId")), cb.like(cb.upper(event.get("deliveryId")), "%" + filter.toUpperCase() + "%"))));
+        }
+
+        if (!Strings.isNullOrEmpty(sortCol)) {
+            boolean hasSortCol = event.getModel()
+                    .getAttributes()
+                    .stream()
+                    .map(Attribute::getName)
+                    .anyMatch(sortCol::equals);
+
+            if (!hasSortCol) {
+                LOG.error(INVALID_SORTCOL_MESSAGE);
+                throw new CustomWebApplicationException(INVALID_SORTCOL_MESSAGE,
+                        HttpStatus.SC_BAD_REQUEST);
+
+            } else {
+                Path<Object> sortPath = event.get(sortCol);
+                if (!Strings.isNullOrEmpty(sortOrder) && "desc".equalsIgnoreCase(sortOrder)) {
+                    query.orderBy(cb.desc(sortPath), cb.desc(event.get("id")));
+                } else {
+                    query.orderBy(cb.asc(sortPath), cb.desc(event.get("id")));
+                }
+                predicates.add(sortPath.isNotNull());
+            }
+        }
+        return predicates;
+    }
+
     public List<LambdaEvent> findByRepository(String repository) {
         Query<LambdaEvent> query = namedTypedQuery("io.dockstore.webservice.core.LambdaEvent.findByRepository")
                 .setParameter("repository", repository);
@@ -57,15 +107,15 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
         return list(query);
     }
 
-    public List<LambdaEvent> findByUser(User user, Integer offset, Integer limit) {
+    public List<LambdaEvent> findByUser(User user, Integer offset, Integer limit, String filter, String sortCol, String sortOrder) {
         CriteriaBuilder cb = currentSession().getCriteriaBuilder();
         CriteriaQuery<LambdaEvent> query = criteriaQuery();
         Root<LambdaEvent> event = query.from(LambdaEvent.class);
 
-        setupFindByUserQuery(user, cb, query, event);
+        List<Predicate> initialPredicate = processQuery(filter, sortCol, sortOrder, cb, query, event);
+        setupFindByUserQuery(user, cb, query, initialPredicate, event);
 
         query.select(event);
-        query.orderBy(cb.desc(event.get("id")));
 
         int primitiveOffset = (offset != null) ? offset : 0;
         TypedQuery<LambdaEvent> typedQuery = currentSession().createQuery(query).setFirstResult(primitiveOffset).setMaxResults(limit);
@@ -77,17 +127,19 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
      * @param user filter for lambda events
      * @return count of lambda events
      */
-    public long countByUser(User user) {
+    public long countByUser(User user, String filter) {
         CriteriaBuilder cb = currentSession().getCriteriaBuilder();
         CriteriaQuery<Long> query = cb.createQuery(Long.class);
         Root<LambdaEvent> event = query.from(LambdaEvent.class);
+
+        List<Predicate> initialPredicate = processQuery(filter, "", "", cb, query, event);
+        setupFindByUserQuery(user, cb, query, initialPredicate, event);
         query.select(cb.count(event));
-        setupFindByUserQuery(user, cb, query, event);
+
         return currentSession().createQuery(query).getSingleResult();
     }
 
-    private void setupFindByUserQuery(User user, CriteriaBuilder cb, CriteriaQuery<?> query, Root<?> event) {
-        List<Predicate> predicates = new ArrayList<>();
+    private void setupFindByUserQuery(User user, CriteriaBuilder cb, CriteriaQuery<?> query, List<Predicate> predicates, Root<?> event) {
         predicates.add(cb.equal(event.get("user"), user));
         query.where(predicates.toArray(new Predicate[]{}));
     }
@@ -101,14 +153,14 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
      * @param repositories
      * @return
      */
-    public List<LambdaEvent> findByOrganization(String organization, String offset, Integer limit, Optional<List<String>> repositories) {
+    public List<LambdaEvent> findByOrganization(String organization, String offset, Integer limit, String filter, String sortCol, String sortOrder, Optional<List<String>> repositories) {
         CriteriaBuilder cb = currentSession().getCriteriaBuilder();
         CriteriaQuery<LambdaEvent> query = criteriaQuery();
         Root<LambdaEvent> event = query.from(LambdaEvent.class);
 
-        setupFindByOrganizationQuery(organization, repositories, cb, query, event);
+        List<Predicate> initialPredicate = processQuery(filter, sortCol, sortOrder, cb, query, event);
+        setupFindByOrganizationQuery(organization, repositories, cb, query, initialPredicate, event);
         query.select(event);
-        query.orderBy(cb.desc(event.get("id")));
 
         int primitiveOffset = Integer.parseInt(MoreObjects.firstNonNull(offset, "0"));
         TypedQuery<LambdaEvent> typedQuery = currentSession().createQuery(query).setFirstResult(primitiveOffset).setMaxResults(limit);
@@ -121,18 +173,20 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
      * @param repositories optional list of repositories
      * @return count of lambda events
      */
-    public long countByOrganization(String organization, Optional<List<String>> repositories) {
+    public long countByOrganization(String organization, Optional<List<String>> repositories, String filter) {
         CriteriaBuilder cb = currentSession().getCriteriaBuilder();
         CriteriaQuery<Long> query = cb.createQuery(Long.class);
         Root<LambdaEvent> event = query.from(LambdaEvent.class);
+
+        List<Predicate> initialPredicate = processQuery(filter, "", "", cb, query, event);
+        setupFindByOrganizationQuery(organization, repositories, cb, query, initialPredicate, event);
         query.select(cb.count(event));
-        setupFindByOrganizationQuery(organization, repositories, cb, query, event);
+
         return currentSession().createQuery(query).getSingleResult();
     }
 
     private void setupFindByOrganizationQuery(String organization, Optional<List<String>> repositories, CriteriaBuilder cb,
-            CriteriaQuery<?> query, Root<?> event) {
-        List<Predicate> predicates = new ArrayList<>();
+                                              CriteriaQuery<?> query, List<Predicate> predicates, Root<?> event) {
         predicates.add(cb.equal(event.get("organization"), organization));
         repositories.ifPresent(repos -> predicates.add(event.get("repository").in(repos)));
         query.where(predicates.toArray(new Predicate[]{}));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -65,7 +65,7 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
                     createNotNullLikeCriteria("repository", filter, cb, event), //
                     createNotNullLikeCriteria("type", filter, cb, event), //
                     createNotNullLikeCriteria("reference", filter, cb, event), //
-                    createNotNullLikeCriteria("deliveryid", filter, cb, event)
+                    createNotNullLikeCriteria("deliveryId", filter, cb, event)
                 )
             );
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(EntryDAO.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LambdaEventDAO.class);
 
     public LambdaEventDAO(SessionFactory factory) {
         super(factory);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -1,5 +1,6 @@
 package io.dockstore.webservice.resources;
 
+import static io.dockstore.webservice.resources.ResourceConstants.MAX_PAGINATION_LIMIT;
 import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_LIMIT;
 import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_LIMIT_TEXT;
 import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_OFFSET_TEXT;
@@ -25,6 +26,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.Max;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -67,7 +69,7 @@ public class LambdaEventResource {
     public List<LambdaEvent> getLambdaEventsByOrganization(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,
             @PathParam("organization") String organization,
             @Parameter(description = PAGINATION_OFFSET_TEXT) @QueryParam("offset") @DefaultValue("0") int offset,
-            @Parameter(description = PAGINATION_LIMIT_TEXT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") int limit,
+            @Parameter(description = PAGINATION_LIMIT_TEXT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") @Max(MAX_PAGINATION_LIMIT) int limit,
             @DefaultValue("") @QueryParam("filter") String filter,
             @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
             @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
@@ -95,7 +97,7 @@ public class LambdaEventResource {
     public List<LambdaEvent> getUserLambdaEvents(@Parameter(hidden = true, name = "user")@Auth User authUser,
            @PathParam("userid") long userid,
            @Parameter(description = PAGINATION_OFFSET_TEXT) @QueryParam("offset") @DefaultValue("0") int offset,
-           @Parameter(description = PAGINATION_LIMIT_TEXT) @QueryParam("limit") @DefaultValue("1000") int limit,
+           @Parameter(description = PAGINATION_LIMIT_TEXT) @QueryParam("limit") @DefaultValue(PAGINATION_LIMIT)  @Max(MAX_PAGINATION_LIMIT) int limit,
            @DefaultValue("") @QueryParam("filter") String filter,
            @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
            @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -64,7 +64,7 @@ public class LambdaEventResource {
     @SuppressWarnings("checkstyle:parameternumber")
     public List<LambdaEvent> getLambdaEventsByOrganization(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,
             @PathParam("organization") String organization,
-            @QueryParam("offset") @DefaultValue("0") String offset,
+            @QueryParam("offset") @DefaultValue("0") Integer offset,
             @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
             @DefaultValue("") @QueryParam("filter") String filter,
             @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -1,8 +1,6 @@
 package io.dockstore.webservice.resources;
 
 import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_LIMIT;
-import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_LIMIT_TEXT;
-import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_OFFSET_TEXT;
 
 import com.codahale.metrics.annotation.Timed;
 import io.dockstore.webservice.CustomWebApplicationException;
@@ -63,10 +61,14 @@ public class LambdaEventResource {
     @Path("/{organization}")
     @Operation(operationId = "getLambdaEventsByOrganization", description = "Get all of the Lambda Events for the given GitHub organization.", security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "See OpenApi for details")
+    @SuppressWarnings("checkstyle:parameternumber")
     public List<LambdaEvent> getLambdaEventsByOrganization(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,
-            @ApiParam(value = "organization", required = true) @PathParam("organization") String organization,
-            @ApiParam(value = PAGINATION_OFFSET_TEXT) @QueryParam("offset") @DefaultValue("0") String offset,
-            @ApiParam(value = PAGINATION_LIMIT_TEXT, allowableValues = "range[1,100]", defaultValue = PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
+            @PathParam("organization") String organization,
+            @QueryParam("offset") @DefaultValue("0") String offset,
+            @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
+            @DefaultValue("") @QueryParam("filter") String filter,
+            @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
+            @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
             @Context HttpServletResponse response) {
         final User authUser = userDAO.findById(user.getId());
         final List<Token> githubTokens = tokenDAO.findGithubByUserId(authUser.getId());
@@ -75,9 +77,9 @@ public class LambdaEventResource {
         }
         final Token githubToken = githubTokens.get(0);
         final Optional<List<String>> authorizedRepos = authorizedRepos(organization, githubToken);
-        response.addHeader(X_TOTAL_COUNT, String.valueOf(lambdaEventDAO.countByOrganization(organization, authorizedRepos)));
+        response.addHeader(X_TOTAL_COUNT, String.valueOf(lambdaEventDAO.countByOrganization(organization, authorizedRepos, filter)));
         response.addHeader(ACCESS_CONTROL_EXPOSE_HEADERS, X_TOTAL_COUNT);
-        return lambdaEventDAO.findByOrganization(organization, offset, limit, authorizedRepos);
+        return lambdaEventDAO.findByOrganization(organization, offset, limit, filter, sortCol, sortOrder, authorizedRepos);
     }
 
     @GET
@@ -87,18 +89,22 @@ public class LambdaEventResource {
     @Path("/user/{userid}")
     @Operation(operationId = "getUserLambdaEvents", description = "Get all of the Lambda Events for the given user.",
             security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME))
+    @SuppressWarnings("checkstyle:parameternumber")
     public List<LambdaEvent> getUserLambdaEvents(@Parameter(hidden = true, name = "user")@Auth User authUser,
            @PathParam("userid") long userid,
            @QueryParam("offset") @DefaultValue("0") Integer offset,
            @QueryParam("limit") @DefaultValue("1000") Integer limit,
+           @DefaultValue("") @QueryParam("filter") String filter,
+           @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
+           @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
            @Context HttpServletResponse response) {
         final User user = userDAO.findById(userid);
         if (user == null) {
             throw new CustomWebApplicationException("User not found.", HttpStatus.SC_NOT_FOUND);
         }
-        response.addHeader(LambdaEventResource.X_TOTAL_COUNT, String.valueOf(lambdaEventDAO.countByUser(user)));
+        response.addHeader(LambdaEventResource.X_TOTAL_COUNT, String.valueOf(lambdaEventDAO.countByUser(user, filter)));
         response.addHeader(LambdaEventResource.ACCESS_CONTROL_EXPOSE_HEADERS, LambdaEventResource.X_TOTAL_COUNT);
-        return lambdaEventDAO.findByUser(user, offset, limit);
+        return lambdaEventDAO.findByUser(user, offset, limit, filter, sortCol, sortOrder);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -1,6 +1,8 @@
 package io.dockstore.webservice.resources;
 
 import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_LIMIT;
+import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_LIMIT_TEXT;
+import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_OFFSET_TEXT;
 
 import com.codahale.metrics.annotation.Timed;
 import io.dockstore.webservice.CustomWebApplicationException;
@@ -64,8 +66,8 @@ public class LambdaEventResource {
     @SuppressWarnings("checkstyle:parameternumber")
     public List<LambdaEvent> getLambdaEventsByOrganization(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User user,
             @PathParam("organization") String organization,
-            @QueryParam("offset") @DefaultValue("0") Integer offset,
-            @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
+            @Parameter(description = PAGINATION_OFFSET_TEXT) @QueryParam("offset") @DefaultValue("0") int offset,
+            @Parameter(description = PAGINATION_LIMIT_TEXT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") int limit,
             @DefaultValue("") @QueryParam("filter") String filter,
             @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
             @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
@@ -92,8 +94,8 @@ public class LambdaEventResource {
     @SuppressWarnings("checkstyle:parameternumber")
     public List<LambdaEvent> getUserLambdaEvents(@Parameter(hidden = true, name = "user")@Auth User authUser,
            @PathParam("userid") long userid,
-           @QueryParam("offset") @DefaultValue("0") Integer offset,
-           @QueryParam("limit") @DefaultValue("1000") Integer limit,
+           @Parameter(description = PAGINATION_OFFSET_TEXT) @QueryParam("offset") @DefaultValue("0") int offset,
+           @Parameter(description = PAGINATION_LIMIT_TEXT) @QueryParam("limit") @DefaultValue("1000") int limit,
            @DefaultValue("") @QueryParam("filter") String filter,
            @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
            @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceConstants.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceConstants.java
@@ -38,6 +38,7 @@ public final class ResourceConstants {
     public static final String JWT_SECURITY_DEFINITION_NAME = "BEARER";
     public static final String APPEASE_SWAGGER_PATCH = "This is here to appease Swagger. It requires PATCH methods to have a body, even if it is empty. Please leave it empty.";
     public static final String PAGINATION_LIMIT = "100";
+    public static final long MAX_PAGINATION_LIMIT = 100;
     public static final int VERSION_PAGINATION_LIMIT = 200;
     public static final String PAGINATION_LIMIT_TEXT = "Amount of records to return in a given page, limited to " + PAGINATION_LIMIT;
     public static final String PAGINATION_OFFSET_TEXT = "Start index of paging. Pagination results can be based on numbers or other values chosen by the registry implementor (for example, SHA values). If this exceeds the current result set return an empty set.  If not specified in the request, this will start at the beginning of the results.";

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -1194,10 +1194,13 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiOperation(value = "See OpenApi for details")
     public List<LambdaEvent> getUserGitHubEvents(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
             @QueryParam("offset") Integer offset,
-            @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit) {
+            @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
+            @DefaultValue("") @QueryParam("filter") String filter,
+            @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
+            @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder) {
         final User user = userDAO.findById(authUser.getId());
         checkNotNullUser(user);
-        return lambdaEventDAO.findByUser(user, offset, limit);
+        return lambdaEventDAO.findByUser(user, offset, limit, filter, sortCol, sortOrder);
     }
 
     @GET

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3982,8 +3982,9 @@ paths:
       - in: query
         name: offset
         schema:
-          type: string
-          default: "0"
+          type: integer
+          format: int32
+          default: 0
       - in: query
         name: limit
         schema:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3929,13 +3929,18 @@ paths:
         schema:
           type: integer
           format: int64
-      - in: query
+      - description: "Start index of paging. Pagination results can be based on numbers\
+          \ or other values chosen by the registry implementor (for example, SHA values).\
+          \ If this exceeds the current result set return an empty set.  If not specified\
+          \ in the request, this will start at the beginning of the results."
+        in: query
         name: offset
         schema:
           type: integer
           format: int32
           default: 0
-      - in: query
+      - description: "Amount of records to return in a given page, limited to 100"
+        in: query
         name: limit
         schema:
           type: integer
@@ -3979,13 +3984,18 @@ paths:
         required: true
         schema:
           type: string
-      - in: query
+      - description: "Start index of paging. Pagination results can be based on numbers\
+          \ or other values chosen by the registry implementor (for example, SHA values).\
+          \ If this exceeds the current result set return an empty set.  If not specified\
+          \ in the request, this will start at the beginning of the results."
+        in: query
         name: offset
         schema:
           type: integer
           format: int32
           default: 0
-      - in: query
+      - description: "Amount of records to return in a given page, limited to 100"
+        in: query
         name: limit
         schema:
           type: integer

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3941,6 +3941,21 @@ paths:
           type: integer
           format: int32
           default: 1000
+      - in: query
+        name: filter
+        schema:
+          type: string
+          default: ""
+      - in: query
+        name: sortCol
+        schema:
+          type: string
+          default: dbCreateDate
+      - in: query
+        name: sortOrder
+        schema:
+          type: string
+          default: desc
       responses:
         default:
           content:
@@ -3975,6 +3990,21 @@ paths:
           type: integer
           format: int32
           default: 100
+      - in: query
+        name: filter
+        schema:
+          type: string
+          default: ""
+      - in: query
+        name: sortCol
+        schema:
+          type: string
+          default: dbCreateDate
+      - in: query
+        name: sortOrder
+        schema:
+          type: string
+          default: desc
       responses:
         default:
           content:
@@ -5504,6 +5534,21 @@ paths:
           type: integer
           format: int32
           default: 100
+      - in: query
+        name: filter
+        schema:
+          type: string
+          default: ""
+      - in: query
+        name: sortCol
+        schema:
+          type: string
+          default: dbCreateDate
+      - in: query
+        name: sortOrder
+        schema:
+          type: string
+          default: desc
       responses:
         "200":
           content:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3945,7 +3945,8 @@ paths:
         schema:
           type: integer
           format: int32
-          default: 1000
+          default: 100
+          maximum: 100
       - in: query
         name: filter
         schema:
@@ -4001,6 +4002,7 @@ paths:
           type: integer
           format: int32
           default: 100
+          maximum: 100
       - in: query
         name: filter
         schema:


### PR DESCRIPTION
**Description**
This PR is the webservice portion of DOCK-2440. It adds sort and filter functionalities to `getLambdaEventsByOrganization` and `getUserLambdaEvents` such that the UI PR can use those parameters to implement pagination.

**Review Instructions**
Review tests pass.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2440

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here.

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
