### PR TITLE
SEAB-6002: Enable search in notebook EntryTypeMetadata

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/EntryTypeMetadata.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/EntryTypeMetadata.java
@@ -19,15 +19,15 @@ public class EntryTypeMetadata {
     private static final String NONE = "";
 
     public static final EntryTypeMetadata TOOL =
-        new EntryTypeMetadata(EntryType.TOOL, "tool", "tools", "containers", true, "", true, "tools", true, ElasticListener.TOOLS_INDEX);
+        new EntryTypeMetadata(EntryType.TOOL, "tool", "tools", "containers", true, "", true, ElasticListener.TOOLS_INDEX, true, ElasticListener.TOOLS_INDEX);
     public static final EntryTypeMetadata WORKFLOW =
-        new EntryTypeMetadata(EntryType.WORKFLOW, "workflow", "workflows", "workflows", true, ToolsImplCommon.WORKFLOW_PREFIX + "/", true, "workflows", true, ElasticListener.WORKFLOWS_INDEX);
+        new EntryTypeMetadata(EntryType.WORKFLOW, "workflow", "workflows", "workflows", true, ToolsImplCommon.WORKFLOW_PREFIX + "/", true, ElasticListener.WORKFLOWS_INDEX, true, ElasticListener.WORKFLOWS_INDEX);
     public static final EntryTypeMetadata SERVICE =
         new EntryTypeMetadata(EntryType.SERVICE, "service", "services", "services", true, ToolsImplCommon.SERVICE_PREFIX + "/", false, NONE, false, NONE);
     public static final EntryTypeMetadata APPTOOL =
-        new EntryTypeMetadata(EntryType.APPTOOL, "tool", "tools", "containers", true, "", true, "tools", true, ElasticListener.TOOLS_INDEX);
+        new EntryTypeMetadata(EntryType.APPTOOL, "tool", "tools", "containers", true, "", true, ElasticListener.TOOLS_INDEX, true, ElasticListener.TOOLS_INDEX);
     public static final EntryTypeMetadata NOTEBOOK =
-        new EntryTypeMetadata(EntryType.NOTEBOOK, "notebook", "notebooks", "notebooks", true, ToolsImplCommon.NOTEBOOK_PREFIX + "/", true, "notebooks", true, ElasticListener.NOTEBOOKS_INDEX);
+        new EntryTypeMetadata(EntryType.NOTEBOOK, "notebook", "notebooks", "notebooks", true, ToolsImplCommon.NOTEBOOK_PREFIX + "/", true, ElasticListener.NOTEBOOKS_INDEX, true, ElasticListener.NOTEBOOKS_INDEX);
 
     private final EntryType type;
     private final String term;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/EntryTypeMetadata.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/EntryTypeMetadata.java
@@ -27,7 +27,7 @@ public class EntryTypeMetadata {
     public static final EntryTypeMetadata APPTOOL =
         new EntryTypeMetadata(EntryType.APPTOOL, "tool", "tools", "containers", true, "", true, "tools", true, ElasticListener.TOOLS_INDEX);
     public static final EntryTypeMetadata NOTEBOOK =
-        new EntryTypeMetadata(EntryType.NOTEBOOK, "notebook", "notebooks", "notebooks", true, ToolsImplCommon.NOTEBOOK_PREFIX + "/", false, NONE, true, ElasticListener.NOTEBOOKS_INDEX);
+        new EntryTypeMetadata(EntryType.NOTEBOOK, "notebook", "notebooks", "notebooks", true, ToolsImplCommon.NOTEBOOK_PREFIX + "/", true, "notebooks", true, ElasticListener.NOTEBOOKS_INDEX);
 
     private final EntryType type;
     private final String term;


### PR DESCRIPTION
**Description**
This PR sets `EntryTypeMetadata.searchSupported` and `EntryTypeMetadata.searchEntryType` properly for notebooks, so that any code that uses them will function correctly.  Also, for all entry types that support search, we set `EntryTypeMetadata.searchEntryType` to the name of the corresponding ES index, since that's the naming scheme, currently.

**Review Instructions**
View the response from the endpoint that lists the `EntryTypeMetadata`, and confirm that the notebook `EntryTypeMetadata.searchSupported` and `EntryTypeMetadata.searchEntryType` are set to `true` and `notebooks`, respectively.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6002

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
