### PR TITLE
DOCK-2441: remove global security property to remove unneeded auth padlocks

### DIFF
--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -30,8 +30,6 @@ servers:
 - description: Nightly build server
   url: https://dev.dockstore.net/api
   variables: {}
-security:
-- BEARER: []
 tags:
 - description: "Create, update list aliases for accessing entries"
   name: aliases

--- a/dockstore-webservice/src/main/templates/io/dockstore/webservice/resources/Description.java
+++ b/dockstore-webservice/src/main/templates/io/dockstore/webservice/resources/Description.java
@@ -59,7 +59,6 @@ import jakarta.ws.rs.ext.Provider;
         @Tag(name = "hosted", description = ResourceConstants.HOSTED),
         @Tag(name = "users", description = ResourceConstants.USERS),
         @Tag(name = "metadata", description = ResourceConstants.METADATA)},
-    security = {@SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME)},
     servers = {@Server(url = "/api", description = "Current server when hosted on AWS"), @Server(url = "/", description = "When working locally"), @Server(url = "https://dockstore.org/api", description = "Production server"), @Server(url = "https://staging.dockstore.org/api", description = "Staging server"), @Server(url = "https://dev.dockstore.net/api", description = "Nightly build server")},
     info = @Info(description = Description.DESCRIPTION, version = "1.15.0-SNAPSHOT", title = "Dockstore API", contact = @Contact(name = Description.NAME, email = Description.EMAIL, url = Description.CONTACT_URL), license = @License(name = Description.APACHE_LICENSE_VERSION_2_0, url = Description.LICENSE_LOCATION), termsOfService = Description.TOS_LOCATION)
 )


### PR DESCRIPTION
**Description**
The global security property seems to be added during the [dropwizard 4.0 update](https://github.com/dockstore/dockstore/pull/5483). This change made QA show auth padlocks in all endpoints (including the ones that didn't require authentication).

This PR removes that global security property as it also isn't in prod/staging.

Before fix:
![Screenshot from 2023-11-10 15-54-36](https://github.com/dockstore/dockstore/assets/61166764/1b7e182f-6c96-4d21-9f15-25722fe3b297)

After fix (note the padlocks are not present for the unneeded endpoints)
![Screenshot from 2023-11-10 15-49-52](https://github.com/dockstore/dockstore/assets/61166764/fcae0a4c-91c3-40ad-947d-5a9637feb30c)


**Review Instructions**
Go to https://qa.dockstore.org/api/static/swagger-ui/index.html#/categories/getCategories and verify the padlock is not there

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2441

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here.

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
