### PR TITLE
DOCK-2440: allow null values in sorting in the github apps logs table

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -89,7 +89,6 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
                 } else {
                     query.orderBy(cb.desc(sortPath), cb.desc(event.get("id")));
                 }
-                predicates.add(sortPath.isNotNull());
             }
         }
         return predicates;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -64,6 +64,7 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
                     createNotNullLikeCriteria("githubUsername", filter, cb, event),
                     createNotNullLikeCriteria("repository", filter, cb, event),
                     createNotNullLikeCriteria("type", filter, cb, event),
+                    createNotNullLikeCriteria("entryName", filter, cb, event),
                     createNotNullLikeCriteria("reference", filter, cb, event),
                     createNotNullLikeCriteria("deliveryId", filter, cb, event)
                 )


### PR DESCRIPTION
**Description**
This PR fixes the issue noted in this [comment](https://github.com/dockstore/dockstore-ui2/pull/1869#pullrequestreview-1737923105) where sorting removes null values.

Now sorting by entryName works like this.

Nulls are on top when sort order is set to ascending order
![Screenshot from 2023-11-21 12-38-22](https://github.com/dockstore/dockstore/assets/61166764/491ca9df-d47f-43d6-8a61-40b3760d41b6)

Nulls are on the bottom when sorted to descending order
![Screenshot from 2023-11-21 12-39-11](https://github.com/dockstore/dockstore/assets/61166764/6f813d5a-d02d-4416-8054-85b38e327c90)



**Review Instructions**
View your github apps logs on qa and verify that sorting by entryName column does not exclude events with missing entry names.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2440

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here.

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
