### PR TITLE
SEAB-6022: Fix updateWorkflow endpoint for Services and Notebooks

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Notebook.java
@@ -72,8 +72,11 @@ public class Notebook extends Workflow {
     }
 
     @Override
-    public void setParentEntry(Entry parentEntry) {
-        throw new UnsupportedOperationException("cannot add a checker workflow to a Notebook");
+    public void setParentEntry(Entry<?, ?> parentEntry) {
+        if (parentEntry == null) {
+            return;
+        }
+        throw new UnsupportedOperationException("Notebook cannot be a checker workflow");
     }
 
     @Override
@@ -83,7 +86,10 @@ public class Notebook extends Workflow {
 
     @Override
     public void setIsChecker(boolean isChecker) {
-        throw new UnsupportedOperationException("cannot add a checker workflow to a Notebook");
+        if (!isChecker) {
+            return;
+        }
+        throw new UnsupportedOperationException("Notebook cannot be a checker workflow");
     }
 
     @Transient

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Service.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Service.java
@@ -72,7 +72,10 @@ public class Service extends Workflow {
 
     @Override
     public void setParentEntry(Entry<?, ?> parentEntry) {
-        throw new UnsupportedOperationException("cannot add a checker workflow to a Service");
+        if (parentEntry == null) {
+            return;
+        }
+        throw new UnsupportedOperationException("Service cannot be a checker workflow");
     }
 
     @Override
@@ -82,7 +85,10 @@ public class Service extends Workflow {
 
     @Override
     public void setIsChecker(boolean isChecker) {
-        throw new UnsupportedOperationException("cannot add a checker workflow to a Service");
+        if (!isChecker) {
+            return;
+        }
+        throw new UnsupportedOperationException("Service cannot be a checker workflow");
     }
 
     @Transient


### PR DESCRIPTION
**Description**
This PR fixes the `updateWorkflow` endpoint so that Services and Notebooks can be updated.  Previously, a notebook/service update failed with a 400 because the notebook/service implementations of `setParentEntry` and `setIsChecker` were wrong.  This PR copies the correct implementations from `AppTool`, and adds a test to confirm that a notebook can be updated.

Next time we do a big refactor of our integration tests, we might consider creating tests which are parameterized by entry type, and test each common operation on an instance of each type.  For example, you might have a base OperationsIT that housed the base test methods, which would call an abstract factory method to determine the entry to be tested, which could be subclassed for each entry type (NotebookOperationsIT, WorkflowOperationsIT, etc...).  Adding a test for a new type would be as simple as creating another subclass.  This would help to keep similar defects from slipping through...

**Review Instructions**
Confirm that you can update the topic of a notebook on qa.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6022

**Security and Privacy**
None.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
