### PR TITLE
SEAB-2476: Fix nextflow 500 error in getContent()

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -636,10 +636,10 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
                     continue;
                 }
                 GroovySourceAST containerAST = getFirstAstWithKeyword(processAST, "container", false);
-                String containerName = ObjectUtils.firstNonNull(
-                    getText(getFirstChild(getNextSibling(containerAST))),
-                    getText(getNextSibling(containerAST)),
-                    defaultContainer);
+                // A "container" directive parses as a "container" node followed by an ELIST sibling
+                // The first child of the ELIST contains the container name (image reference)
+                // https://www.nextflow.io/docs/latest/process.html#containeroptions
+                String containerName = ObjectUtils.firstNonNull(getText(getFirstChild(getNextSibling(containerAST))), defaultContainer);
 
                 if (containerName != null) {
                     if (containerName.startsWith("$")) { // Parameterized container name
@@ -657,27 +657,15 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
     }
 
     private AST getNextSibling(AST ast) {
-        if (ast != null) {
-            return ast.getNextSibling();
-        } else {
-            return null;
-        }
+        return (ast != null) ? ast.getNextSibling() : null;
     }
 
     private AST getFirstChild(AST ast) {
-        if (ast != null) {
-            return ast.getFirstChild();
-        } else {
-            return null;
-        }
+        return (ast != null) ? ast.getFirstChild() : null;
     }
 
     private String getText(AST ast) {
-        if (ast != null) {
-            return ast.getText();
-        } else {
-            return null;
-        }
+        return (ast != null) ? ast.getText() : null;
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/NextflowHandler.java
@@ -53,6 +53,7 @@ import java.util.stream.Stream;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.codehaus.groovy.antlr.GroovySourceAST;
@@ -635,12 +636,10 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
                     continue;
                 }
                 GroovySourceAST containerAST = getFirstAstWithKeyword(processAST, "container", false);
-                String containerName;
-                if (containerAST != null) {
-                    containerName = containerAST.getNextSibling().getFirstChild().getText();
-                } else {
-                    containerName = defaultContainer;
-                }
+                String containerName = ObjectUtils.firstNonNull(
+                    getText(getFirstChild(getNextSibling(containerAST))),
+                    getText(getNextSibling(containerAST)),
+                    defaultContainer);
 
                 if (containerName != null) {
                     if (containerName.startsWith("$")) { // Parameterized container name
@@ -655,6 +654,30 @@ public class NextflowHandler extends AbstractLanguageHandler implements Language
             LOG.warn("could not parse", e);
         }
         return map;
+    }
+
+    private AST getNextSibling(AST ast) {
+        if (ast != null) {
+            return ast.getNextSibling();
+        } else {
+            return null;
+        }
+    }
+
+    private AST getFirstChild(AST ast) {
+        if (ast != null) {
+            return ast.getFirstChild();
+        } else {
+            return null;
+        }
+    }
+
+    private String getText(AST ast) {
+        if (ast != null) {
+            return ast.getText();
+        } else {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
**Description**
This PR changes the code in `NextflowHandler` that extracts the container name to fail gracefully if the syntax is wrong.

The previous code was throwing a `NullPointerException` when attempting to extract the container name from the following malformed Nextflow `container` directive in the `circos.nf` file of https://dockstore.org/workflows/github.com/erinyoung/roundabout:main?tab=info:
```
container = 'quay.io/biocontainers/circos:0.69.8--hdfd78af_1'
```

The Nextflow standard defines the `container` directive as the `container` keyword followed by a one-element-long list of expressions: https://www.nextflow.io/docs/latest/process.html#container:
```
container 'quay.io/biocontainers/circos:0.69.8--hdfd78af_1'
```
Note that there's no equals sign.

The offending construct is parsed as an assignment, which results in a differently-structured AST.  We could handle it, too, but I'm loath to do so, the syntax is wrong.  Seems like a slippery slope to try to handle bad syntax, things can be mangled in an infinite number of ways...

After this fix, rather than erroring out, the code skips over the erroneous construct and generates the best tool table and DAG it can, given the remaining information:

<img width="978" alt="image" src="https://github.com/dockstore/dockstore/assets/88108675/30d1b904-59e2-4193-8630-1f6f3b166e31">

**Review Instructions**
Navigate to, click on the "Tools" tab, and confirm that a mostly-complete tool table is generated.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2476
#5714

**Security and Privacy**
No concerns.

If there are any concerns that require extra attention from the security team, highlight them here.

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ ] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
