### PR TITLE
Fix silly zenodo api change

### DIFF
--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -134,7 +134,7 @@ POM as their parent.
             <dependency>
                 <groupId>io.dockstore</groupId>
                 <artifactId>zenodo-client-generated</artifactId>
-                <version>0.2</version>
+                <version>0.3</version>
             </dependency>
 
             <dependency>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
@@ -160,7 +160,7 @@ public final class ZenodoHelper {
 
         Deposit publishedDeposit = publishDepositOnZenodo(actionsApi, depositionID);
 
-        String conceptDoiUrl = publishedDeposit.getLinks().get("conceptdoi");
+        String conceptDoiUrl = publishedDeposit.getLinks().get("parent_doi");
 
         String conceptDoi = extractDoiFromDoiUrl(conceptDoiUrl);
 


### PR DESCRIPTION
**Description**
Mimics the silly patch in https://github.com/dockstore/zenodo-client/pull/27
(i.e. zenodo renamed a property we rely on) 

In a confusing twist, it seems like we have two zenodo clients, one used for testing only and one used by the webservice. It looks like the one I updated was the former, hence no change in the generated pom.xml files in this PR. 
Follow-up is https://ucsc-cgl.atlassian.net/browse/SEAB-6049

**Review Instructions**
Try to request a DOI on staging.dockstore.org, see if there is a null pointer exception and whether we process the concept DOI properly

**Issue**
https://github.com/dockstore/dockstore/issues/5740

**Security and Privacy**

None known 

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
