### PR TITLE
Restore disabled BitBucket test

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGitHubBasicIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGitHubBasicIT.java
@@ -34,7 +34,6 @@ import io.swagger.client.api.UsersApi;
 import io.swagger.client.model.DockstoreTool;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGitHubBasicIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGitHubBasicIT.java
@@ -77,7 +77,6 @@ class BitBucketGitHubBasicIT extends BaseIT {
      * Tests that refresh all works, also that refreshing without a quay.io token should not destroy tools
      */
     @Test
-    @Disabled("Quay.io failing, see https://ucsc-cgl.atlassian.net/browse/SEAB-6023")
     void testRefresh() {
         ApiClient client = getWebClient(USER_1_USERNAME, testingPostgres);
         UsersApi usersApi = new UsersApi(client);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGitHubBasicIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGitHubBasicIT.java
@@ -57,6 +57,7 @@ class BitBucketGitHubBasicIT extends BaseIT {
     public final SystemOut systemOut = new SystemOut();
     @SystemStub
     public final SystemErr systemErr = new SystemErr();
+    protected static final String DOCKSTORE_TEST_USER_QUAY_NAMESPACE = "dockstoretestuser"; // Case-sensitive for quay! See SEAB-6023
 
     @BeforeEach
     @Override
@@ -82,7 +83,7 @@ class BitBucketGitHubBasicIT extends BaseIT {
 
         final long startToolCount = testingPostgres.runSelectStatement("select count(*) from tool", long.class);
         // should have 0 tools to start with
-        usersApi.refreshToolsByOrganization((long)1, "DockstoreTestUser", "quayandbitbucket");
+        usersApi.refreshToolsByOrganization((long)1, DOCKSTORE_TEST_USER_QUAY_NAMESPACE, "quayandbitbucket");
         // should have a certain number of tools based on github contents
         final long secondToolCount = testingPostgres.runSelectStatement("select count(*) from tool", long.class);
         assertTrue(startToolCount <= secondToolCount && secondToolCount > 1);
@@ -92,7 +93,7 @@ class BitBucketGitHubBasicIT extends BaseIT {
 
         // refresh
         try {
-            usersApi.refreshToolsByOrganization((long)1, "DockstoreTestUser", "quayandbitbucket");
+            usersApi.refreshToolsByOrganization((long)1, DOCKSTORE_TEST_USER_QUAY_NAMESPACE, "quayandbitbucket");
             fail("Refresh should fail");
         } catch (ApiException e) {
             assertTrue(e.getMessage().contains("Please add a Quay.io token"), "Should see error message since user has Quay tools but no Quay token.");


### PR DESCRIPTION
**Description**
Restore the disabled BitBucket test, and change Quay.io namespace parameter to lower case.

There is a link to a RedHat article in SEAB-6023, so see that for more details, but quay.io switched to a case-sensitive database. The quay.io organization is `dockstoretestuser`, all lower-case, but we were passing `DockstoreTestUser`, mixed-case, in the API request. Until their DB change, the mixed-case name was working; after the DB change, it stopped working.

Note: I swapped characters in the branch name :(

**Review Instructions**
Not reviewable, integration tests should be passing and the PR can't be merged if they aren't.

**Issue**
SEAB-6023

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here.

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
