### PR TITLE
SEAB-6025: Add endpoint that retrieves an Entry by alias

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
@@ -682,7 +682,7 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
         }
 
         // Get workflow by alias
-        Workflow aliasWorkflow = workflowApi.getWorkflowByAlias("foobar");
+        io.dockstore.openapi.client.model.Entry aliasWorkflow = new io.dockstore.openapi.client.api.EntriesApi(getOpenAPIWebClient(USER_2_USERNAME, testingPostgres)).getEntryByAlias("foobar");
         assertNotNull(aliasWorkflow, "Should retrieve the workflow by alias");
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIGeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIGeneralIT.java
@@ -45,6 +45,7 @@ import io.dockstore.webservice.DockstoreWebserviceApplication;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import org.apache.http.HttpStatus;
 import org.hibernate.Session;
 import org.hibernate.context.internal.ManagedSessionContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -185,11 +186,9 @@ class OpenAPIGeneralIT extends BaseIT {
         EntriesApi entriesApi = new EntriesApi(webClient);
 
         final ApiClient anonWebClient = CommonTestUtilities.getOpenAPIWebClient(false, null, testingPostgres);
-        ContainersApi anonContainersApi = new ContainersApi(anonWebClient);
         EntriesApi anonEntriesApi = new EntriesApi(anonWebClient);
 
         final ApiClient otherUserWebClient = CommonTestUtilities.getOpenAPIWebClient(true, OTHER_USERNAME, testingPostgres);
-        ContainersApi otherUserContainersApi = new ContainersApi(otherUserWebClient);
         EntriesApi otherUserEntriesApi = new EntriesApi(otherUserWebClient);
 
         // Add tool
@@ -215,16 +214,16 @@ class OpenAPIGeneralIT extends BaseIT {
         try {
             otherUserEntriesApi.getEntryByAlias("foobar");
             fail("Should not be able to retrieve tool.");
-        } catch (ApiException ignored) {
-            assertTrue(true);
+        } catch (ApiException ex) {
+            assertEquals(HttpStatus.SC_UNAUTHORIZED, ex.getCode(), "Should fail because user cannot access tool");
         }
 
         // Cannot get unpublished tool by alias as anon user
         try {
             anonEntriesApi.getEntryByAlias("foobar");
             fail("Should not be able to retrieve tool.");
-        } catch (ApiException ignored) {
-            assertTrue(true);
+        } catch (ApiException ex) {
+            assertEquals(HttpStatus.SC_UNAUTHORIZED, ex.getCode(), "Should fail because user cannot access tool");
         }
 
         // Publish tool

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIGeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIGeneralIT.java
@@ -215,7 +215,7 @@ class OpenAPIGeneralIT extends BaseIT {
             otherUserEntriesApi.getEntryByAlias("foobar");
             fail("Should not be able to retrieve tool.");
         } catch (ApiException ex) {
-            assertEquals(HttpStatus.SC_UNAUTHORIZED, ex.getCode(), "Should fail because user cannot access tool");
+            assertEquals(HttpStatus.SC_FORBIDDEN, ex.getCode(), "Should fail because user cannot access tool");
         }
 
         // Cannot get unpublished tool by alias as anon user
@@ -223,7 +223,7 @@ class OpenAPIGeneralIT extends BaseIT {
             anonEntriesApi.getEntryByAlias("foobar");
             fail("Should not be able to retrieve tool.");
         } catch (ApiException ex) {
-            assertEquals(HttpStatus.SC_UNAUTHORIZED, ex.getCode(), "Should fail because user cannot access tool");
+            assertEquals(HttpStatus.SC_FORBIDDEN, ex.getCode(), "Should fail because user cannot access tool");
         }
 
         // Publish tool

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -22,6 +22,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Ordering;
 import io.dockstore.common.DescriptorLanguage.FileTypeCategory;
+import io.dockstore.common.EntryType;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -268,18 +269,32 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
     @ApiModel(value = "WorkflowVersionPathInfo", description = "Object that "
             + "contains the Dockstore path to the workflow and the version tag name.")
     public static final class WorkflowVersionPathInfo {
-        @ApiModelProperty(value = "Dockstore path to workflow.")
+        @ApiModelProperty(value = "Dockstore path to workflow")
         private final String fullWorkflowPath;
+        @ApiModelProperty(value = "Type of the workflow")
+        private final EntryType entryType;
+        @ApiModelProperty(value = "Metadata about the type of the workflow")
+        private final EntryTypeMetadata entryTypeMetadata;
         @ApiModelProperty(value = "Name of workflow version tag")
         private final String tagName;
 
-        public WorkflowVersionPathInfo(String fullWorkflowPath, String tagName) {
+        public WorkflowVersionPathInfo(String fullWorkflowPath, EntryType entryType, EntryTypeMetadata entryTypeMetadata, String tagName) {
             this.fullWorkflowPath = fullWorkflowPath;
+            this.entryType = entryType;
+            this.entryTypeMetadata = entryTypeMetadata;
             this.tagName = tagName;
         }
 
         public String getFullWorkflowPath() {
             return fullWorkflowPath;
+        }
+
+        public EntryType getEntryType() {
+            return entryType;
+        }
+
+        public EntryTypeMetadata getEntryTypeMetadata() {
+            return entryTypeMetadata;
         }
 
         public String getTagName() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/WorkflowVersion.java
@@ -269,13 +269,13 @@ public class WorkflowVersion extends Version<WorkflowVersion> implements Compara
     @ApiModel(value = "WorkflowVersionPathInfo", description = "Object that "
             + "contains the Dockstore path to the workflow and the version tag name.")
     public static final class WorkflowVersionPathInfo {
-        @ApiModelProperty(value = "Dockstore path to workflow")
+        @Schema(description = "Dockstore path to workflow")
         private final String fullWorkflowPath;
-        @ApiModelProperty(value = "Type of the workflow")
+        @Schema(description = "Type of the workflow")
         private final EntryType entryType;
-        @ApiModelProperty(value = "Metadata about the type of the workflow")
+        @Schema(description = "Metadata about the type of the workflow")
         private final EntryTypeMetadata entryTypeMetadata;
-        @ApiModelProperty(value = "Name of workflow version tag")
+        @Schema(description = "Name of workflow version tag")
         private final String tagName;
 
         public WorkflowVersionPathInfo(String fullWorkflowPath, EntryType entryType, EntryTypeMetadata entryTypeMetadata, String tagName) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AliasResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AliasResource.java
@@ -90,7 +90,7 @@ public class AliasResource implements AliasableResourceInterface<WorkflowVersion
         Workflow workflow = AliasHelper.getWorkflow(workflowDAO, workflowVersionId);
         workflowResource.checkCanRead(user, workflow);
 
-        return new WorkflowVersion.WorkflowVersionPathInfo(workflow.getWorkflowPath(), workflowVersion.getName());
+        return new WorkflowVersion.WorkflowVersionPathInfo(workflow.getWorkflowPath(), workflow.getEntryType(), workflow.getEntryTypeMetadata(), workflowVersion.getName());
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -1214,19 +1214,4 @@ public class DockerRepoResource
         return Response.ok().entity((StreamingOutput) output -> writeStreamAsZip(sourceFiles, output, path))
             .header("Content-Disposition", "attachment; filename=\"" + fileName + "\"").build();
     }
-
-    @GET
-    @Timed
-    @UnitOfWork(readOnly = true)
-    @Path("{alias}/aliases")
-    @Operation(operationId = "getToolByAlias", description = "Retrieves a tool by alias.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
-    @ApiOperation(value = "Retrieves a tool by alias.", notes = OPTIONAL_AUTH_MESSAGE, response = Tool.class, authorizations = {
-        @Authorization(value = JWT_SECURITY_DEFINITION_NAME)})
-    public Tool getToolByAlias(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth Optional<User> user,
-        @ApiParam(value = "Alias", required = true) @PathParam("alias") String alias) {
-        final Tool tool = this.toolDAO.findByAlias(alias);
-        checkNotNullEntry(tool);
-        checkCanRead(user, tool);
-        return tool;
-    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -242,6 +242,20 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
         topicsApi = new TopicsApi(apiClient);
     }
 
+    @GET
+    @Path("/{alias}/aliases")
+    @Timed
+    @UnitOfWork(readOnly = true)
+    @Operation(operationId = "getEntryByAlias", description = "Retrieves an entry by alias.")
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully retrieved entry", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Entry.class)))
+    public Entry getEntryByAlias(@Parameter(hidden = true, name = "user")@Auth Optional<User> user,
+            @Parameter(description = "Alias", name = "alias", in = ParameterIn.PATH, required = true) @PathParam("alias") String alias) {
+        Entry<? extends Entry, ? extends Version> entry = toolDAO.getGenericEntryByAlias(alias);
+        checkNotNullEntry(entry);
+        checkCanRead(user, entry);
+        return entry;
+    }
+
     @DELETE
     @Timed
     @UnitOfWork

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -243,12 +243,12 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
     }
 
     @GET
-    @Path("/{alias}/aliases")
     @Timed
     @UnitOfWork(readOnly = true)
-    @Operation(operationId = "getEntryByAlias", description = "Retrieves an entry by alias.")
+    @Path("/{alias}/aliases")
+    @Operation(operationId = "getEntryByAlias", description = "Retrieves an entry by alias.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully retrieved entry", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Entry.class)))
-    public Entry getEntryByAlias(@Parameter(hidden = true, name = "user")@Auth Optional<User> user,
+    public Entry getEntryByAlias(@Parameter(hidden = true, name = "user") @Auth Optional<User> user,
             @Parameter(description = "Alias", name = "alias", in = ParameterIn.PATH, required = true) @PathParam("alias") String alias) {
         Entry<? extends Entry, ? extends Version> entry = toolDAO.getGenericEntryByAlias(alias);
         checkNotNullEntry(entry);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1979,21 +1979,6 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             .header("Content-Disposition", "attachment; filename=\"" + fileName + "\"").build();
     }
 
-    @GET
-    @Timed
-    @UnitOfWork(readOnly = true)
-    @Path("{alias}/aliases")
-    @Operation(operationId = "getWorkflowByAlias", description = "Retrieves a workflow by alias.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
-    @ApiOperation(value = "Retrieves a workflow by alias.", notes = OPTIONAL_AUTH_MESSAGE, response = Workflow.class, authorizations = {
-        @Authorization(value = JWT_SECURITY_DEFINITION_NAME)})
-    public Workflow getWorkflowByAlias(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth Optional<User> user,
-        @ApiParam(value = "Alias", required = true) @PathParam("alias") String alias) {
-        final Workflow workflow = this.workflowDAO.findByAlias(alias);
-        checkNotNullEntry(workflow);
-        checkCanRead(user, workflow);
-        return workflow;
-    }
-
     @POST
     @Timed
     @UnitOfWork

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1975,27 +1975,6 @@ paths:
       - BEARER: []
       tags:
       - containers
-  /containers/{alias}/aliases:
-    get:
-      description: Retrieves a tool by alias.
-      operationId: getToolByAlias
-      parameters:
-      - in: path
-        name: alias
-        required: true
-        schema:
-          type: string
-      responses:
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DockstoreTool'
-          description: default response
-      security:
-      - BEARER: []
-      tags:
-      - containers
   /containers/{containerId}:
     delete:
       description: Delete a tool.
@@ -2959,6 +2938,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Entry'
           description: Successfully retrieved entry
+      security:
+      - BEARER: []
       tags:
       - entries
   /entries/{entryId}/exportToOrcid:
@@ -7371,27 +7352,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/WorkflowVersion'
-          description: default response
-      security:
-      - BEARER: []
-      tags:
-      - workflows
-  /workflows/{alias}/aliases:
-    get:
-      description: Retrieves a workflow by alias.
-      operationId: getWorkflowByAlias
-      parameters:
-      - in: path
-        name: alias
-        required: true
-        schema:
-          type: string
-      responses:
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Workflow'
           description: default response
       security:
       - BEARER: []

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -11876,6 +11876,10 @@ components:
     WorkflowVersionPathInfo:
       type: object
       properties:
+        entryType:
+          $ref: '#/components/schemas/EntryType'
+        entryTypeMetadata:
+          $ref: '#/components/schemas/EntryTypeMetadata'
         fullWorkflowPath:
           type: string
         tagName:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -11860,8 +11860,10 @@ components:
           $ref: '#/components/schemas/EntryTypeMetadata'
         fullWorkflowPath:
           type: string
+          description: Dockstore path to workflow
         tagName:
           type: string
+          description: Name of workflow version tag
   securitySchemes:
     BEARER:
       scheme: bearer

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -2941,6 +2941,26 @@ paths:
       - BEARER: []
       tags:
       - entries
+  /entries/{alias}/aliases:
+    get:
+      description: Retrieves an entry by alias.
+      operationId: getEntryByAlias
+      parameters:
+      - description: Alias
+        in: path
+        name: alias
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entry'
+          description: Successfully retrieved entry
+      tags:
+      - entries
   /entries/{entryId}/exportToOrcid:
     post:
       description: Export entry to ORCID. DOI is required


### PR DESCRIPTION
**Description**
This PR replaces the existing `getToolByAlias` and `getWorkflowByAlias` endpoints with a new `getEntryByAlias` endpoint, and adds some type information to the response of the `getWorkflowVersionByAlias` endpoint.  These changes facilitate some improvements to the UI's alias resolution code.

The existing tests were adapted to use the new endpoint.  Because the endpoint is new, its description only appears in `openapi.yaml`, so the primary integration test was moved to an OpenAPI-specific test class.

**Review Instructions**
Alias two different Entry types via the API, and confirm that you can retrieve each entry by its alias via the `getEntryByAlias` endpoint.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6025

**Security and Privacy**
An endpoint which examines the user's identity to control access has been added.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
