### PR TITLE
Review tables for dbcreatedate and dbupdatedate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,52 +54,51 @@ workflows:
           <<: *common_filters
           requires:
             - build
-# REMOVE THIS BEFORE SUBMITTING FOR REVIEW!
-#      - workflow-integration-tests:
-#          <<: *common_filters
-#          requires:
-#            - build
-#          context: sonarcloud
-#      - bitbucket-tests:
-#          <<: *common_filters
-#          requires:
-#            - build
-#      - language-parsing-tests:
-#          <<: *common_filters
-#          requires:
-#            - build
-#      - localstack-tests:
-#          <<: *common_filters
-#          requires:
-#            - build
-#      - tool-integration-tests:
-#          <<: *common_filters
-#          requires:
-#            - build
-#      - integration-tests:
-#          <<: *common_filters
-#          requires:
-#            - build
-#      - regression-integration-tests:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - /^release.*$/
-#          requires:
-#            - build
-#      - sonar-cloud:
-#          <<: *common_filters
-#          requires:
-#            - unit_test
-#            - workflow-integration-tests
-#            - bitbucket-tests
-#            - language-parsing-tests
-#            - localstack-tests
-#            - tool-integration-tests
-#            - integration-tests
-#            - regression-integration-tests
-#          context: sonarcloud
+      - workflow-integration-tests:
+          <<: *common_filters
+          requires:
+            - build
+          context: sonarcloud
+      - bitbucket-tests:
+          <<: *common_filters
+          requires:
+            - build
+      - language-parsing-tests:
+          <<: *common_filters
+          requires:
+            - build
+      - localstack-tests:
+          <<: *common_filters
+          requires:
+            - build
+      - tool-integration-tests:
+          <<: *common_filters
+          requires:
+            - build
+      - integration-tests:
+          <<: *common_filters
+          requires:
+            - build
+      - regression-integration-tests:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release.*$/
+          requires:
+            - build
+      - sonar-cloud:
+          <<: *common_filters
+          requires:
+            - unit_test
+            - workflow-integration-tests
+            - bitbucket-tests
+            - language-parsing-tests
+            - localstack-tests
+            - tool-integration-tests
+            - integration-tests
+            - regression-integration-tests
+          context: sonarcloud
 jobs:
   regression-integration-tests:
     executor: machine_integration_test_exec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,51 +54,52 @@ workflows:
           <<: *common_filters
           requires:
             - build
-      - workflow-integration-tests:
-          <<: *common_filters
-          requires:
-            - build
-          context: sonarcloud
-      - bitbucket-tests:
-          <<: *common_filters
-          requires:
-            - build
-      - language-parsing-tests:
-          <<: *common_filters
-          requires:
-            - build
-      - localstack-tests:
-          <<: *common_filters
-          requires:
-            - build
-      - tool-integration-tests:
-          <<: *common_filters
-          requires:
-            - build
-      - integration-tests:
-          <<: *common_filters
-          requires:
-            - build
-      - regression-integration-tests:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release.*$/
-          requires:
-            - build
-      - sonar-cloud:
-          <<: *common_filters
-          requires:
-            - unit_test
-            - workflow-integration-tests
-            - bitbucket-tests
-            - language-parsing-tests
-            - localstack-tests
-            - tool-integration-tests
-            - integration-tests
-            - regression-integration-tests
-          context: sonarcloud
+# REMOVE THIS BEFORE SUBMITTING FOR REVIEW!
+#      - workflow-integration-tests:
+#          <<: *common_filters
+#          requires:
+#            - build
+#          context: sonarcloud
+#      - bitbucket-tests:
+#          <<: *common_filters
+#          requires:
+#            - build
+#      - language-parsing-tests:
+#          <<: *common_filters
+#          requires:
+#            - build
+#      - localstack-tests:
+#          <<: *common_filters
+#          requires:
+#            - build
+#      - tool-integration-tests:
+#          <<: *common_filters
+#          requires:
+#            - build
+#      - integration-tests:
+#          <<: *common_filters
+#          requires:
+#            - build
+#      - regression-integration-tests:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - /^release.*$/
+#          requires:
+#            - build
+#      - sonar-cloud:
+#          <<: *common_filters
+#          requires:
+#            - unit_test
+#            - workflow-integration-tests
+#            - bitbucket-tests
+#            - language-parsing-tests
+#            - localstack-tests
+#            - tool-integration-tests
+#            - integration-tests
+#            - regression-integration-tests
+#          context: sonarcloud
 jobs:
   regression-integration-tests:
     executor: machine_integration_test_exec

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/FullWorkflowPath.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/FullWorkflowPath.java
@@ -25,6 +25,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.io.Serializable;
+import java.sql.Timestamp;
 
 /**
  * Workflow is broken into three different subclasses: BioWorkflow, Service, and AppTool. All three are in separate tables in our database and there is a unique
@@ -42,6 +43,10 @@ public class FullWorkflowPath implements Serializable {
     @Column(name = "id", unique = true, nullable = false)
     @ApiModelProperty(value = "Implementation specific ID for the full workflow path in this web service.")
     private long id;
+
+    // database timestamps
+    @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
+    private Timestamp dbCreateDate;
 
     @Column(columnDefinition = "text")
     @ApiModelProperty(value = "This is the name of the workflow, not needed when only one workflow in a repo")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Alias.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Alias.java
@@ -31,8 +31,10 @@ public class Alias implements Serializable {
     @Column(columnDefinition = "text")
     public String content = "";
 
-    // database timestamp -- no update timestamp because they don't work with @Embdeddable objects. SEAB-3083
+    // database timestamps
     @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
     private Timestamp dbCreateDate;
 
+    @Column()
+    private Timestamp dbUpdateDate;
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Alias.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Alias.java
@@ -35,6 +35,6 @@ public class Alias implements Serializable {
     @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
     private Timestamp dbCreateDate;
 
-    @Column()
-    private Timestamp dbUpdateDate;
+    // There is no dbupdatedate because it doesn't work with @Embeddable nor @ElementCollection
+
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Alias.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Alias.java
@@ -31,10 +31,8 @@ public class Alias implements Serializable {
     @Column(columnDefinition = "text")
     public String content = "";
 
-    // database timestamps
+    // database timestamp -- no update timestamp because they don't work with @Embdeddable objects. SEAB-3083
     @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
     private Timestamp dbCreateDate;
 
-    @Column()
-    private Timestamp dbUpdateDate;
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Language.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Language.java
@@ -27,10 +27,7 @@ public class Language implements Serializable {
     @Schema(type = "integer", format = "int64")
     private Timestamp dbCreateDate;
 
-    @Column()
-    @ApiModelProperty(dataType = "long")
-    @Schema(type = "integer", format = "int64")
-    private Timestamp dbUpdateDate;
+    // There is no dbupdatedate because it doesn't work with @Embeddable nor @ElementCollection
 
     public DescriptorLanguage getLanguage() {
         return language;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/OrcidPutCode.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/OrcidPutCode.java
@@ -13,12 +13,9 @@ public class OrcidPutCode implements Serializable {
     @Column(columnDefinition = "text")
     public String orcidPutCode;
 
-    // database timestamps
+    // database timestamp -- no update timestamp because they don't work with @Embdeddable objects. SEAB-3083
     @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
     private Timestamp dbCreateDate;
-
-    @Column()
-    private Timestamp dbUpdateDate;
 
     public OrcidPutCode() {}
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/OrcidPutCode.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/OrcidPutCode.java
@@ -17,8 +17,7 @@ public class OrcidPutCode implements Serializable {
     @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
     private Timestamp dbCreateDate;
 
-    @Column()
-    private Timestamp dbUpdateDate;
+    // There is no dbupdatedate because it doesn't work with @Embeddable nor @ElementCollection
 
     public OrcidPutCode() {}
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/OrcidPutCode.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/OrcidPutCode.java
@@ -13,9 +13,12 @@ public class OrcidPutCode implements Serializable {
     @Column(columnDefinition = "text")
     public String orcidPutCode;
 
-    // database timestamp -- no update timestamp because they don't work with @Embdeddable objects. SEAB-3083
+    // database timestamps
     @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
     private Timestamp dbCreateDate;
+
+    @Column()
+    private Timestamp dbUpdateDate;
 
     public OrcidPutCode() {}
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ParsedInformation.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ParsedInformation.java
@@ -22,11 +22,15 @@ public class ParsedInformation {
     private boolean hasHTTPImports = false;
     private boolean hasLocalImports = false;
 
-    // database timestamp -- no update timestamp because they don't work with @Embdeddable objects. SEAB-3083
     @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
     @ApiModelProperty(dataType = "long")
     @Schema(type = "integer", format = "int64")
     private Timestamp dbCreateDate;
+
+    @Column()
+    @ApiModelProperty(dataType = "long")
+    @Schema(type = "integer", format = "int64")
+    private Timestamp dbUpdateDate;
 
     public DescriptorLanguage getDescriptorLanguage() {
         return descriptorLanguage;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ParsedInformation.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ParsedInformation.java
@@ -22,15 +22,11 @@ public class ParsedInformation {
     private boolean hasHTTPImports = false;
     private boolean hasLocalImports = false;
 
+    // database timestamp -- no update timestamp because they don't work with @Embdeddable objects. SEAB-3083
     @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
     @ApiModelProperty(dataType = "long")
     @Schema(type = "integer", format = "int64")
     private Timestamp dbCreateDate;
-
-    @Column()
-    @ApiModelProperty(dataType = "long")
-    @Schema(type = "integer", format = "int64")
-    private Timestamp dbUpdateDate;
 
     public DescriptorLanguage getDescriptorLanguage() {
         return descriptorLanguage;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ParsedInformation.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/ParsedInformation.java
@@ -27,10 +27,7 @@ public class ParsedInformation {
     @Schema(type = "integer", format = "int64")
     private Timestamp dbCreateDate;
 
-    @Column()
-    @ApiModelProperty(dataType = "long")
-    @Schema(type = "integer", format = "int64")
-    private Timestamp dbUpdateDate;
+    // There is no dbupdatedate because it doesn't work with @Embeddable nor @ElementCollection
 
     public DescriptorLanguage getDescriptorLanguage() {
         return descriptorLanguage;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -343,9 +343,11 @@ public class SourceFile implements Comparable<SourceFile> {
         @Column(columnDefinition = "text")
         public String platformVersion = null;
 
-        // database timestamp -- no update timestamp because they don't work with @Embdeddable objects. SEAB-3083
+        // database timestamps
         @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
         private Timestamp dbCreateDate;
 
+        @Column()
+        private Timestamp dbUpdateDate;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -347,7 +347,6 @@ public class SourceFile implements Comparable<SourceFile> {
         @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
         private Timestamp dbCreateDate;
 
-        @Column()
-        private Timestamp dbUpdateDate;
+        // There is no dbupdatedate because it doesn't work with @Embeddable nor @ElementCollection
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -343,11 +343,9 @@ public class SourceFile implements Comparable<SourceFile> {
         @Column(columnDefinition = "text")
         public String platformVersion = null;
 
-        // database timestamps
+        // database timestamp -- no update timestamp because they don't work with @Embdeddable objects. SEAB-3083
         @Column(updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT NOW()")
         private Timestamp dbCreateDate;
 
-        @Column()
-        private Timestamp dbUpdateDate;
     }
 }

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -300,4 +300,12 @@
             <column name="topicai" type="varchar(150 BYTE)"/>
         </addColumn>
     </changeSet>
+    <changeSet id="dropUnusedDbUpdateDate" author="coverbeck">
+        <dropColumn tableName="collection_alias" columnName="dbupdatedate"/>
+        <dropColumn tableName="entry_alias" columnName="dbupdatedate"/>
+        <dropColumn tableName="entry_orcidputcode" columnName="dbupdatedate"/>
+        <dropColumn tableName="organization_alias" columnName="dbupdatedate"/>
+        <dropColumn tableName="sourcefile_verified" columnName="dbupdatedate"/>
+        <dropColumn tableName="parsed_information" columnName="dbupdatedate"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -304,5 +304,12 @@
         <addColumn tableName="fullworkflowpath">
             <column name="dbcreatedate" type="TIMESTAMP WITHOUT TIME ZONE" defaultValueComputed="now()"/>
         </addColumn>
+        <dropColumn tableName="cloudinstance_supportedlanguages" columnName="dbupdatedate"/>
+        <dropColumn tableName="parsed_information" columnName="dbupdatedate"/>
+        <dropColumn tableName="sourcefile_verified" columnName="dbupdatedate"/>
+        <dropColumn tableName="entry_orcidputcode" columnName="dbupdatedate"/>
+        <dropColumn tableName="version_metadata_orcidputcode" columnName="dbupdatedate"/>
+        <dropColumn tableName="entry_alias" columnName="dbupdatedate"/>
+        <dropColumn tableName="organization_alias" columnName="dbupdatedate"/>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -300,12 +300,9 @@
             <column name="topicai" type="varchar(150 BYTE)"/>
         </addColumn>
     </changeSet>
-    <changeSet id="dropUnusedDbUpdateDate" author="coverbeck">
-        <dropColumn tableName="collection_alias" columnName="dbupdatedate"/>
-        <dropColumn tableName="entry_alias" columnName="dbupdatedate"/>
-        <dropColumn tableName="entry_orcidputcode" columnName="dbupdatedate"/>
-        <dropColumn tableName="organization_alias" columnName="dbupdatedate"/>
-        <dropColumn tableName="sourcefile_verified" columnName="dbupdatedate"/>
-        <dropColumn tableName="parsed_information" columnName="dbupdatedate"/>
+    <changeSet id="dbdates" author="coverbeck">
+        <addColumn tableName="fullworkflowpath">
+            <column name="dbcreatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+        </addColumn>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -302,7 +302,7 @@
     </changeSet>
     <changeSet id="dbdates" author="coverbeck">
         <addColumn tableName="fullworkflowpath">
-            <column name="dbcreatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="dbcreatedate" type="TIMESTAMP WITHOUT TIME ZONE" defaultValueComputed="now()"/>
         </addColumn>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -311,5 +311,7 @@
         <dropColumn tableName="version_metadata_orcidputcode" columnName="dbupdatedate"/>
         <dropColumn tableName="entry_alias" columnName="dbupdatedate"/>
         <dropColumn tableName="organization_alias" columnName="dbupdatedate"/>
+        <dropColumn tableName="collection_alias" columnName="dbupdatedate"/>
+        <dropColumn tableName="workflowversion_alias" columnName="dbupdatedate"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**Description**
TLDR; this PR adds dbcreatedate to one table. :) 

***Details***

The ticket was to review all tables to ensure they had dbcreatedate and dbupdatedate, and that both fields were populating correctly in all those tables. Table-by-table details are in SEAB-3083, but broadly this is what I discovered:

* I couldn't add the `@UpdateTimestamp` annotation to the dbupdatedate for `@Embeddable` entities. Dockstore just wouldn't start up. See [here](https://en.wikibooks.org/wiki/Java_Persistence/ElementCollection). I initially had a commit that removed the dbupdatedate column property for embeddables, but then I realized that could force us to have downtime when we deploy 1.15; if we remove the column during the 1.15 deploy, and 1.14 is still serving requests, 1.14 would error.
* Join tables don't have dbcreate nor dbupdate columns, and I couldn't figure out a way to add them. And I don't know that it's worth it.
* `@ElementCollection` also have issues with the two timestamp annotations.
* After looking at every table, I believe the only changed needed was to add dbcreatedate to one entity/table, fullworkflowpath. That table is an outlier, populated by a trigger and doesn't do updates, just inserts, so I left off dbupdatedate.


**Review Instructions**
1. Create a new workflow one day in qa
2. The next day, download the QA DB, and verify that the dbcreatedate column is set for the new row in the table `fullworkflowpath`.

**Issue**
SEAB-3083

**Security and Privacy**

None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
