### PR TITLE
enforce entryname is null or nonempty for lambda events - sorting issue

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -407,9 +407,9 @@ class WebhookIT extends BaseIT {
         handleGitHubRelease(workflowsApi, DockstoreTesting.TEST_WORKFLOWS_AND_TOOLS, tag10, USER_2_USERNAME);
         ++numberOfWebhookInvocations;
         orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, 0, 15, null, null, null);
-        assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, tag10, "", true);
+        assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, tag10, null, true);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, tag10, "md5sum", true);
-        assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUBLISH, tag10, "", true);
+        assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUBLISH, tag10, null, true);
         assertNumberOfUniqueDeliveryIds(orgEvents, numberOfWebhookInvocations);
 
         // Release refs/heads/invalidToolName. There is one successful workflow and one failed tool with an invalid name
@@ -418,7 +418,7 @@ class WebhookIT extends BaseIT {
         ++numberOfWebhookInvocations;
         orgEvents = lambdaEventsApi.getLambdaEventsByOrganization(dockstoreTesting, 0, 15, null, null, null);
         // There should be two push events, one successful event for the workflow and one failed event for the tool
-        final String workflowName = "";
+        final String workflowName = null;
         final String toolName = "md5sum/with/slashes";
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, invalidToolNameBranch, workflowName, true);
         assertEntryNameInNewestLambdaEvent(orgEvents, LambdaEvent.TypeEnum.PUSH, invalidToolNameBranch, toolName, false);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LambdaEvent.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LambdaEvent.java
@@ -186,6 +186,10 @@ public class LambdaEvent {
     }
 
     public void setEntryName(String entryName) {
+        if (entryName.isBlank()) {
+            this.entryName = null;
+            return;
+        }
         this.entryName = entryName;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LambdaEvent.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LambdaEvent.java
@@ -186,7 +186,7 @@ public class LambdaEvent {
     }
 
     public void setEntryName(String entryName) {
-        if (entryName.isBlank()) {
+        if (entryName != null && entryName.isBlank()) {
             this.entryName = null;
             return;
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -10,7 +10,6 @@ import io.dropwizard.hibernate.AbstractDAO;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
@@ -22,8 +21,6 @@ import org.apache.http.HttpStatus;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
-import org.hibernate.query.sqm.NullPrecedence;
-import org.hibernate.query.sqm.tree.select.SqmSortSpecification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,17 +86,9 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
             } else {
                 Path<Object> sortPath = event.get(sortCol);
                 if ("asc".equalsIgnoreCase(sortOrder)) {
-                    Order asc = cb.asc(sortPath);
-                    if (asc instanceof SqmSortSpecification) {
-                        ((SqmSortSpecification) asc).nullPrecedence(NullPrecedence.LAST);
-                    }
-                    query.orderBy(asc, cb.desc(event.get("id")));
+                    query.orderBy(cb.asc(sortPath), cb.desc(event.get("id")));
                 } else {
-                    Order desc = cb.desc(sortPath);
-                    if (desc instanceof SqmSortSpecification) {
-                        ((SqmSortSpecification) desc).nullPrecedence(NullPrecedence.LAST);
-                    }
-                    query.orderBy(desc, cb.desc(event.get("id")));
+                    query.orderBy(cb.desc(sortPath), cb.desc(event.get("id")));
                 }
             }
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/LambdaEventDAO.java
@@ -10,6 +10,7 @@ import io.dropwizard.hibernate.AbstractDAO;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
@@ -21,6 +22,8 @@ import org.apache.http.HttpStatus;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
+import org.hibernate.query.sqm.NullPrecedence;
+import org.hibernate.query.sqm.tree.select.SqmSortSpecification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,9 +89,17 @@ public class LambdaEventDAO extends AbstractDAO<LambdaEvent> {
             } else {
                 Path<Object> sortPath = event.get(sortCol);
                 if ("asc".equalsIgnoreCase(sortOrder)) {
-                    query.orderBy(cb.asc(sortPath), cb.desc(event.get("id")));
+                    Order asc = cb.asc(sortPath);
+                    if (asc instanceof SqmSortSpecification) {
+                        ((SqmSortSpecification) asc).nullPrecedence(NullPrecedence.LAST);
+                    }
+                    query.orderBy(asc, cb.desc(event.get("id")));
                 } else {
-                    query.orderBy(cb.desc(sortPath), cb.desc(event.get("id")));
+                    Order desc = cb.desc(sortPath);
+                    if (desc instanceof SqmSortSpecification) {
+                        ((SqmSortSpecification) desc).nullPrecedence(NullPrecedence.LAST);
+                    }
+                    query.orderBy(desc, cb.desc(event.get("id")));
                 }
             }
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -743,11 +743,11 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     }
 
     private String computeWorkflowName(Workflowish workflow) {
-        return workflow.getName() == null ? "" : workflow.getName();
+        return workflow.getName();
     }
 
     private String computeWorkflowName(Workflow workflow) {
-        return workflow.getWorkflowName() == null ? "" : workflow.getWorkflowName();
+        return workflow.getWorkflowName();
     }
 
     private String generateMessageFromException(Exception ex) {

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -300,4 +300,16 @@
             <column name="topicai" type="varchar(150 BYTE)"/>
         </addColumn>
     </changeSet>
+    <changeSet id="lambdaEntryNameConvertEmptyStringToNull" author="dyuen">
+        <update schemaName="public"
+                tableName="lambdaevent">
+            <column name="entryname"/>
+            <where>entryname = ''</where>
+        </update>
+    </changeSet>
+    <changeSet id="lambdaEntryNameNotEmptyConstraint" author="dyuen" >
+        <sql dbms="postgresql">
+            ALTER TABLE lambdaevent add constraint lambdaevent_entryname_notempty check (entryname &lt;&gt; '')
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -306,8 +306,6 @@
             <column name="entryname"/>
             <where>entryname = ''</where>
         </update>
-    </changeSet>
-    <changeSet id="lambdaEntryNameNotEmptyConstraint" author="dyuen" >
         <sql dbms="postgresql">
             ALTER TABLE lambdaevent add constraint lambdaevent_entryname_notempty check (entryname &lt;&gt; '')
         </sql>


### PR DESCRIPTION
**Description**
Was a confusing issue, so at first it looked like nulls were not being sorted consistently. 
Added a hack relying on hibernate to configure sorting of nulls, then reverted it (kept it in the commit history in case it becomes useful later)

After more experimentation, turns out the issue is we have both empty string entryname and null entryname lambda events but they look the same in the ui and sort differently which is confusing 
Enforcing that only null entrynames should exist like with workflows for consistency and since there are a lot more of them
In a blast from the past, this is basically a newer version of https://github.com/dockstore/dockstore/pull/1063

From qa dump 
```
webservice_test=# select count(*) from lambdaevent where entryname is null;
 count  
--------
 497633
(1 row)

webservice_test=# select count(*) from lambdaevent where entryname = '';
 count 
-------
    37
(1 row)

webservice_test=# select count(*) from workflow where workflowname is null;
 count 
-------
  2579
(1 row)

webservice_test=# select count(*) from workflow where workflowname = '';
 count 
-------
     0
```


**Review Instructions**
Sort by workflow name in github app logs, should look more consistent if you have a mix of entrynames and no entrynames. 
Test only after accompanying ui PR is merged

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6060

**Security and Privacy**

None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
