### PR TITLE
dependabot compatibility

### DIFF
--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -112,7 +112,7 @@ jobs:
           java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate --include 1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0  dockstore-integration-testing/src/test/resources/dockstore.yml
           java -jar dockstore-webservice/target/dockstore-webservice-*.jar db generate-docs dockstore-integration-testing/src/test/resources/dockstore.yml generated-docs
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: 'generated-docs'


### PR DESCRIPTION
**Description**
Looks like the deploy-pages artifact is only compatible with upload-pages-artifact v3 
https://github.com/actions/deploy-pages/releases/tag/v4.0.0
https://github.com/dockstore/dockstore/pull/5773

Looks like the build won't catch it because the deployment only happens on the develop branch


**Review Instructions**
See if the snapshot deploy develop builds successfully after merge

**Issue**
n/a

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here.

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
