### PR TITLE
SEAB-6100: Reduce memory consumption of TRS tools get

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -473,6 +473,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         ToolsApiServiceImpl.setNotebookDAO(notebookDAO);
         ToolsApiServiceImpl.setFileDAO(fileDAO);
         ToolsApiServiceImpl.setVersionDAO(versionDAO);
+        ToolsApiServiceImpl.setSessionFactory(hibernate.getSessionFactory());
         ToolsApiServiceImpl.setConfig(configuration);
         ToolsApiServiceImpl.setAuthorizer(authorizer);
 

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -47,7 +47,6 @@ import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowVersion;
 import io.dockstore.webservice.helpers.EntryVersionHelper;
-import io.dockstore.webservice.helpers.TransactionHelper;
 import io.dockstore.webservice.jdbi.AppToolDAO;
 import io.dockstore.webservice.jdbi.BioWorkflowDAO;
 import io.dockstore.webservice.jdbi.EntryDAO;
@@ -99,7 +98,6 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.hibernate.SessionFactory;
-import org.hibernate.stat.SessionStatistics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -381,18 +379,15 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
 
         List<io.openapi.model.Tool> results = new ArrayList<>();
 
-        List<Long> ids = all.stream().map(Entry::getId).toList();
-        for (long entryId: ids) {
+        for (long entryId: all.stream().map(Entry::getId).toList()) {
             sessionFactory.getCurrentSession().clear();
+            Entry<?, ?> c = toolDAO.getGenericEntryById(entryId);
             // if passing, for each container that matches the criteria, convert to standardised format and return
-            Entry c = toolDAO.getGenericEntryById(entryId);
             io.openapi.model.Tool tool = ToolsImplCommon.convertEntryToTool(c, config);
             if (tool != null) {
                 results.add(tool);
             }
         }
-        SessionStatistics statistics = sessionFactory.getCurrentSession().getStatistics();
-        LOG.error("STATS collections=" + statistics.getCollectionCount() + " entities=" + statistics.getEntityCount());
 
         final String scheme = config.getExternalConfig().getScheme();
         final String hostname = config.getExternalConfig().getHostname();


### PR DESCRIPTION
**Description**
In December 2023, the prod webservice ran out of memory, at least partially due to excessive memory consumption by the `/ga4gh/trs/v2/tools` endpoint.

This PR reduces the memory consumption of the underlying `toolsGet` method.  Originally, within, the Hibernate `Session` accumulated all of the entities which were retrieved while satisfying the request.  This PR changes the code to clear the `Session` before each entry is processed, reducing the peak `Session` memory consumption to that of the largest entry (rather than the total of all entries).

A side effect of this fix is that the total number of database requests issued by my test query approximately doubles (from 1049 to 2029), at least partially because, after this change, there aren't other workflows in the `Session` to batch-fetch properties into.   On my local install, the wall clock request-to-response time increased from 23 to 26 seconds.  The changes might be more pronounced in AWS deploys, since the database is temporally more-distant from the webservice.  I don't think there'll be a huge difference, but we won't know for sure until we deploy...

See this slack discussion for more details: https://ucsc-gi.slack.com/archives/C05EZH3RVNY/p1701994562751399

Almost certainly, there is a more elegant way to reduce the memory consumption of `toolsGet`, this PR is intended as a safe stopgap solution.

**Review Instructions**
On staging, sequentially probe the `/ga4gh/trs/v2/tools` endpoint with a `limit` of 100, varying the `offset` until you find a setting that takes more than 10 seconds to respond.  Then, issue ten of that query simultaneously, and confirm that the webservice does not run out of memory and die.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6100

**Security and Privacy**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
