### PR TITLE
SEAB-6096: Add version Event on tagged GitHub release

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -681,13 +681,13 @@ class NotebookIT extends BaseIT {
 
         String tagRef = "refs/tags/simple-v1";
         String branchRef = "refs/heads/simple";
-        String eventName = "ADD_VERSION_TO_ENTRY";
+        String eventType = "ADD_VERSION_TO_ENTRY";
 
-        long aCount = countEvents(eventName);
+        long aCount = countEvents(eventType);
         handleGitHubRelease(workflowsApi, simpleRepo, tagRef, USER_2_USERNAME);
-        long bCount = countEvents(eventName);
+        long bCount = countEvents(eventType);
         handleGitHubRelease(workflowsApi, simpleRepo, branchRef, USER_2_USERNAME);
-        long cCount = countEvents(eventName);
+        long cCount = countEvents(eventType);
 
         assertEquals(aCount + 1, bCount, "a tagged release should produce an ADD_VERSION_TO_ENTRY Event");
         assertEquals(bCount, cCount, "an untagged release should not produce an ADD_VERSION_TO_ENTRY Event");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -678,13 +678,19 @@ class NotebookIT extends BaseIT {
     void testTagEventCreation() {
         ApiClient apiClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(apiClient);
-        String ref = "refs/tags/simple-v1";
 
-        long beforeCount = countEvents("ADD_VERSION_TO_ENTRY");
-        handleGitHubRelease(workflowsApi, simpleRepo, ref, USER_2_USERNAME);
-        long afterCount = countEvents("ADD_VERSION_TO_ENTRY");
+        String tagRef = "refs/tags/simple-v1";
+        String branchRef = "refs/heads/simple";
+        String eventName = "ADD_VERSION_TO_ENTRY";
 
-        assertTrue(beforeCount + 1 == afterCount, "a tagged release should produce an ADD_VERSION_TO_ENTRY Event");
+        long aCount = countEvents(eventName);
+        handleGitHubRelease(workflowsApi, simpleRepo, tagRef, USER_2_USERNAME);
+        long bCount = countEvents(eventName);
+        handleGitHubRelease(workflowsApi, simpleRepo, branchRef, USER_2_USERNAME);
+        long cCount = countEvents(eventName);
+
+        assertEquals(aCount + 1, bCount, "a tagged release should produce an ADD_VERSION_TO_ENTRY Event");
+        assertEquals(bCount, cCount, "an untagged release should not produce an ADD_VERSION_TO_ENTRY Event");
     }
 
     private Organization createTestOrganization(String name, boolean categorizer) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -654,6 +654,9 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                         Workflow workflow = createOrGetWorkflow(workflowType, repository, user, workflowName, wf, gitHubSourceCodeRepo);
                         WorkflowVersion version = addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, defaultVersion, yamlAuthors);
 
+                        // Create some events.
+                        eventDAO.createAddTagToEntryEvent(user, workflow, version);
+
                         LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, username, LambdaEvent.LambdaEventType.PUSH, true, deliveryId, computeWorkflowName(wf));
                         setEventMessage(lambdaEvent, createValidationsMessage(workflow, version));
                         lambdaEventDAO.create(lambdaEvent);


### PR DESCRIPTION
**Description**
A couple of months ago, as I prepped for a demo, I added a tag to a repo upon which our GitHub App was previously installed.  The intention was to create a corresponding `ADD_VERSION_TO_ENTRY` event, which should happen when a tagged branch is registered in Dockstore.  However, no such event was created...

To determine why, I inspected the webservice's github push processing code, and found that it didn't invoke any code that would create an event when a tag was pushed.  The manual registration code creates the event as expected, via a call to `eventDAO.createAddTagToEntryEvent`.

So, I added a `createAddTagToEntryEvent` call to the github push processing code and a test that confirms that an `ADD_VERSION_TO_ENTRY` event is created (or not) in the appropriate circumstances.

To avoid bugs like this, we might strive to avoid duplicate code.  For example, the webservice could contain a single method that creates a new Workflow version, which all registration schemes (manual + webhook + hosted) use, thus eliminating the possibility that we'd forget to do something on one of multiple code paths.

I targeted this to `develop`, but it's probably safe enough to add to 1.15 if we so decide.

**Review Instructions**
Install our GitHub app on a repo that contains a valid Entry and `.dockstore.yml`, push a tag, wait a few minutes, and confirm that a corresponding `ADD_VERSION_TO_ENTRY` appears in the profile of the Dockstore user that pushed.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6096

**Security and Privacy**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
