### PR TITLE
clean-up zenodo reference to wrong repo

### DIFF
--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -132,12 +132,6 @@ POM as their parent.
                 <version>0.9.12</version>
             </dependency>
             <dependency>
-                <groupId>io.dockstore</groupId>
-                <artifactId>zenodo-client-generated</artifactId>
-                <version>0.3</version>
-            </dependency>
-
-            <dependency>
               <groupId>org.apache.httpcomponents</groupId>
               <artifactId>httpcore-osgi</artifactId>
               <version>4.4.4</version>


### PR DESCRIPTION
**Description**
Supporting PR for zenodo clean-up and removal

**Review Instructions**
Build should pass after merging pretty much (there should be no functional change)

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6049

**Security and Privacy**

No change

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
