### PR TITLE
Decode metrics S3 key components 

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/S3ClientHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/S3ClientHelper.java
@@ -125,7 +125,8 @@ public final class S3ClientHelper {
     }
 
     public static String getVersionName(String key) {
-        return getElementFromKey(key, VERSION_NAME_INDEX);
+        // Get encoded version name from S3 key and return the decoded version name
+        return URLDecoder.decode(getElementFromKey(key, VERSION_NAME_INDEX), StandardCharsets.UTF_8);
     }
 
     /**
@@ -134,7 +135,8 @@ public final class S3ClientHelper {
      * @return
      */
     public static String getMetricsPlatform(String key) {
-        return getElementFromKey(key, METRICS_PLATFORM_INDEX);
+        // Get encoded platform name from S3 key and return the decoded platform name
+        return URLDecoder.decode(getElementFromKey(key, METRICS_PLATFORM_INDEX), StandardCharsets.UTF_8);
     }
 
     /**
@@ -144,7 +146,8 @@ public final class S3ClientHelper {
      */
     public static String getFileName(String key) {
         final String[] keyComponents = splitKey(key);
-        return keyComponents[keyComponents.length - 1];
+        // Get encoded file name from S3 key and return the decoded file name
+        return URLDecoder.decode(keyComponents[keyComponents.length - 1], StandardCharsets.UTF_8);
     }
 
     /**


### PR DESCRIPTION
**Description**
When we create the S3 key for the metrics objects to send to S3, we encode the version name, platform, and file name. However, the helper classes that retrieve these components do not decode them. This results in inconsistencies when retrieving metrics from S3 using the [getMetricsData helper methods](https://github.com/dockstore/dockstore/blob/0fcd0cd4b1d97137d554d24bdd71c8ed29534e9f/dockstore-common/src/main/java/io/dockstore/common/metrics/MetricsDataS3Client.java#L117) because it's expecting a decoded version name. Instead, it receives an encoded one, and it further encodes it, resulting in an S3 key that doesn't exist.

The metrics aggregator is affected by this, causing it to not aggregate S3 directories where the encoded version name has a `%2F` (a decoded slash) because when the aggregator calls the `getMetricsData` function with this encoded version name, it encodes the `%s` into a `%25`, resulting in a key with a version name of `%252F` which doesn't exist in the bucket. It appears this only affects the DNAstack metrics that I ingested in this [comment](https://github.com/dockstore/dockstore-support/pull/478#issuecomment-1899142807) (note how there were 67 platform metrics skipped).

**Review Instructions**
There should be no skipped metrics when running the `aggregate-metrics` command while going through the [release steps for ingesting Terra metrics](https://github.com/dockstore/dockstore-deploy/wiki/1.15-staging#ingesting-terra-metrics).

**Issue**
[SEAB-5963](https://ucsc-cgl.atlassian.net/browse/SEAB-5963) - discovered while running through the release steps for ingesting terra metrics locally

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here.

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-5963]: https://ucsc-cgl.atlassian.net/browse/SEAB-5963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ