### PR TITLE
Fix duplicate validator versions in get aggregated metrics response for "ALL" platform

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/metrics/MetricsIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/metrics/MetricsIT.java
@@ -48,8 +48,8 @@ import io.dockstore.webservice.jdbi.WorkflowDAO;
 import io.dockstore.webservice.jdbi.WorkflowVersionDAO;
 import java.time.Instant;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
@@ -211,7 +211,7 @@ class MetricsIT extends BaseIT {
         miniwdlValidatorVersionInfo.setNumberOfRuns(5);
         miniwdlValidatorVersionInfo.setPassingRate(100d);
         ValidatorInfo miniwdlValidatorInfo = new ValidatorInfo();
-        miniwdlValidatorInfo.setValidatorVersions(List.of(miniwdlValidatorVersionInfo));
+        miniwdlValidatorInfo.setValidatorVersions(Set.of(miniwdlValidatorVersionInfo));
         miniwdlValidatorInfo.setMostRecentVersionName(miniwdlValidatorVersionInfo.getName());
         miniwdlValidatorInfo.setNumberOfRuns(miniwdlValidatorVersionInfo.getNumberOfRuns());
         miniwdlValidatorInfo.setPassingRate(miniwdlValidatorVersionInfo.getPassingRate());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/ValidatorInfo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/ValidatorInfo.java
@@ -32,8 +32,8 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.CreationTimestamp;
@@ -58,7 +58,7 @@ public class ValidatorInfo {
     @Cascade({ CascadeType.DETACH, CascadeType.SAVE_UPDATE })
     @JoinTable(name = "validator_versions", joinColumns = @JoinColumn(name = "validatorinfoid", referencedColumnName = "id", columnDefinition = "bigint"), inverseJoinColumns = @JoinColumn(name = "validatorversioninfoid", referencedColumnName = "id", columnDefinition = "bigint"))
     @ApiModelProperty(value = "A list containing validation info for the most recent execution of the validator tool versions")
-    private List<ValidatorVersionInfo> validatorVersions = new ArrayList<>();
+    private Set<ValidatorVersionInfo> validatorVersions = new HashSet<>();
 
     @NotNull
     @Column(nullable = false)
@@ -119,11 +119,11 @@ public class ValidatorInfo {
         this.numberOfRuns = numberOfRuns;
     }
 
-    public List<ValidatorVersionInfo> getValidatorVersions() {
+    public Set<ValidatorVersionInfo> getValidatorVersions() {
         return validatorVersions;
     }
 
-    public void setValidatorVersions(List<ValidatorVersionInfo> validatorVersions) {
+    public void setValidatorVersions(Set<ValidatorVersionInfo> validatorVersions) {
         this.validatorVersions = validatorVersions;
     }
 }

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -353,4 +353,7 @@
             UPDATE enduser SET platformpartner=NULL where platformpartner='false';
         </sql>
     </changeSet>
+    <changeSet author="ktran (generated)" id="addValidatorVersionsPrimaryKey">
+        <addPrimaryKey columnNames="validatorinfoid, validatorversioninfoid" constraintName="validator_versions_pkey" tableName="validator_versions"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -11506,6 +11506,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ValidatorVersionInfo'
+          uniqueItems: true
       required:
       - mostRecentVersionName
       - numberOfRuns


### PR DESCRIPTION
**Description**
Noticed in staging that some workflows have duplicate validation metrics for the ALL platform, like https://staging.dockstore.org/workflows/github.com/AnalysisCommons/genesis_wdl/genesis_GWAS:v1_5?tab=metrics. I checked the DB and there's not actually duplicate rows for the validation versions. I'm not entirely sure what query is being performed that causes that, but making `validationVersions` a set fixed the problem (tested locally).

**Review Instructions**
There shouldn't be duplicate validator versions in https://staging.dockstore.org/workflows/github.com/AnalysisCommons/genesis_wdl/genesis_GWAS:v1_5?tab=metrics for All platforms.

**Issue**
[SEAB-6183](https://ucsc-cgl.atlassian.net/browse/SEAB-6183)

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here.

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-6183]: https://ucsc-cgl.atlassian.net/browse/SEAB-6183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ