### PR TITLE
add zenodo patch

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
@@ -98,6 +98,7 @@ public final class ZenodoHelper {
                 depositMetadata.prereserveDoi(false);
                 // Retrieve the DOI so we can use it to create a Dockstore alias
                 // to the workflow; we will add that alias as a Zenodo related identifier
+                // TODO clean this after https://github.com/dockstore/swagger-java-zenodo-client/pull/20/files is merged and released
                 Map<String, String> doiMap = (Map<String, String>)newDeposit.getMetadata().getPrereserveDoi();
                 Map.Entry<String, String> doiEntry = doiMap.entrySet().iterator().next();
                 String doi = doiEntry.getValue();
@@ -129,6 +130,7 @@ public final class ZenodoHelper {
                 depositMetadata = returnDeposit.getMetadata();
                 // Retrieve the DOI so we can use it to create a Dockstore alias
                 // to the workflow; we will add that alias as a Zenodo related identifier
+                // TODO clean this after https://github.com/dockstore/swagger-java-zenodo-client/pull/20/files is merged and released
                 Map<String, String> doiMap = (Map<String, String>)depositMetadata.getPrereserveDoi();
                 Map.Entry<String, String> doiEntry = doiMap.entrySet().iterator().next();
                 String doi = doiEntry.getValue();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
@@ -129,7 +129,9 @@ public final class ZenodoHelper {
                 depositMetadata = returnDeposit.getMetadata();
                 // Retrieve the DOI so we can use it to create a Dockstore alias
                 // to the workflow; we will add that alias as a Zenodo related identifier
-                String doi = depositMetadata.getDoi();
+                Map<String, String> doiMap = (Map<String, String>)depositMetadata.getPrereserveDoi();
+                Map.Entry<String, String> doiEntry = doiMap.entrySet().iterator().next();
+                String doi = doiEntry.getValue();
                 doiAlias = createAliasUsingDoi(doi);
                 setMetadataRelatedIdentifiers(depositMetadata,  dockstoreGA4GHBaseUrl,
                         dockstoreUrl, workflowUrl, workflow, workflowVersion, doiAlias);


### PR DESCRIPTION
**Description**
Safer version of https://github.com/dockstore/swagger-java-zenodo-client/pull/20 without needing to update the zenodo client version. Retrieve the doi when adding a new version of a doi the same way as we do when initially creating a concept doi
(Looks like zenodo has removed many of the depositmetadata fields that used to be returned in their api update)

**Review Instructions**
Login to staging and issue two or three DOIs for the same workflow or notebook using different versions of it.
Note: you can test locally by hooking up the webservice to zenodo. The trick is you may need to manually transfer the oauth code since zenodo only accepts https or localhost but some of us are using a localhost with a specific name 

**Issue**
Variant of https://github.com/dockstore/dockstore/issues/5792

Follow-ups needed:
* ticket to ensure zenodo exports are not carried between prod and staging (and qa) since zenodo ids are not accessible between their sandbox and prod environments, weird bugs can ensue https://ucsc-cgl.atlassian.net/browse/SEAB-6191
* Clean-up obsolete fields from swagger zenodo api https://ucsc-cgl.atlassian.net/browse/SEAB-6192

**Security and Privacy**
None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
