### PR TITLE
search workflow version as well as default version for authors

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
@@ -36,6 +36,7 @@ import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -299,18 +300,29 @@ public final class ZenodoHelper {
      * @param depositMetadata Metadata for the workflow version
      * @param workflow    workflow for which DOI is registered
      */
-    static void setMetadataCreator(DepositMetadata depositMetadata, Workflow workflow) {
-        final Stream<Author> authors = workflow.getAuthors().stream().map(ZenodoHelper::fromDockstoreAuthor);
-        final Stream<Author> orcidAuthors = workflow.getOrcidAuthors().stream()
+    static void setMetadataCreator(DepositMetadata depositMetadata, Workflow workflow, WorkflowVersion workflowVersion) {
+        // prefer authors from the specific workflow version
+        final Set<Author> setOfAuthors = new HashSet<>(getAuthors(workflowVersion.getAuthors(), workflowVersion.getOrcidAuthors()));
+        /// but use the default if necessary
+        if (setOfAuthors.isEmpty()) {
+            final List<Author> zenodoAuthors = getAuthors(workflow.getAuthors(), workflow.getOrcidAuthors());
+            setOfAuthors.addAll(zenodoAuthors);
+        }
+
+        if (setOfAuthors.isEmpty()) {
+            throw new CustomWebApplicationException(AT_LEAST_ONE_AUTHOR_IS_REQUIRED_TO_PUBLISH_TO_ZENODO, HttpStatus.SC_BAD_REQUEST);
+        }
+        depositMetadata.setCreators(setOfAuthors.stream().toList());
+    }
+
+    private static List<Author> getAuthors(Set<io.dockstore.webservice.core.Author> inputAuthors, Set<OrcidAuthor> inputOrcidAuthors) {
+        final Stream<Author> authors = inputAuthors.stream().map(ZenodoHelper::fromDockstoreAuthor);
+        final Stream<Author> orcidAuthors = inputOrcidAuthors.stream()
                 .map(OrcidAuthor::getOrcid)
                 .map(orcidId -> ORCIDHelper.getOrcidAuthorInformation(orcidId, null))
                 .flatMap(Optional::stream)
                 .map(ZenodoHelper::fromOrcidAuthorInfo);
-        final List<Author> zenodoAuthors = Stream.concat(authors, orcidAuthors).toList();
-        if (zenodoAuthors.isEmpty()) {
-            throw new CustomWebApplicationException(AT_LEAST_ONE_AUTHOR_IS_REQUIRED_TO_PUBLISH_TO_ZENODO, HttpStatus.SC_BAD_REQUEST);
-        }
-        depositMetadata.setCreators(zenodoAuthors);
+        return Stream.concat(authors, orcidAuthors).toList();
     }
 
     private static Author fromDockstoreAuthor(io.dockstore.webservice.core.Author dockstoreAuthor) {
@@ -372,7 +384,7 @@ public final class ZenodoHelper {
 
         setMetadataKeywords(depositMetadata, workflow);
 
-        setMetadataCreator(depositMetadata, workflow);
+        setMetadataCreator(depositMetadata, workflow, workflowVersion);
 
         setMetadataCommunities(depositMetadata);
     }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
@@ -1,29 +1,29 @@
 package io.dockstore.webservice.helpers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import alleycats.std.map;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
 import io.dockstore.webservice.CustomWebApplicationException;
-import io.dockstore.webservice.core.Author;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowVersion;
 import io.swagger.zenodo.client.ApiClient;
 import io.swagger.zenodo.client.api.PreviewApi;
+import io.swagger.zenodo.client.model.Author;
 import io.swagger.zenodo.client.model.DepositMetadata;
+import java.util.HashSet;
 import java.util.Map;
-import org.junit.jupiter.api.Disabled;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class ZenodoHelperTest {
 
     @Test
-    @Disabled("looks like sandbox is down, still listed at https://developers.zenodo.org/#testing ")
     void testBasicFunctionality() {
         ApiClient zenodoClient = new ApiClient();
         String zenodoUrlApi = "https://sandbox.zenodo.org/api";
@@ -32,7 +32,39 @@ class ZenodoHelperTest {
         final Map map = (Map) previewApi.listLicenses();
         // this is just a basic sanity check, the licenses api is one of the apis that does not require an access token, but it returns what
         // looks like an elasticsearch object, this does not match the documentation. Ironically, we have this too for search. 
-        assertTrue(map.size() > 0);
+        assertFalse(map.isEmpty());
+    }
+
+    @Test
+    void testAuthorHashSetSanity() {
+        // this tests that the zenodo classes used in zenodo helper have sane hashcodes and equals methods
+        final String awesomeUniversity = "awesomeUniversity";
+        final String someGuy = "Some guy";
+        Author author1 = new Author();
+        author1.setAffiliation("awesomeUniversity");
+        author1.setName("Some guy");
+        Author author2 = new Author();
+        author2.setAffiliation("mediocreUniversity");
+        author2.setName("Some other guy");
+        Author author3 = new Author();
+        author3.setAffiliation(awesomeUniversity);
+        author3.setName(someGuy);
+        Set<Author> authorSet = new HashSet<>();
+        authorSet.add(author1);
+        authorSet.add(author2);
+        authorSet.add(author3);
+        assertEquals(2, authorSet.size());
+        Author oAuthor1 = new Author();
+        oAuthor1.setOrcid("xxx-xxxx-1234-1234");
+        String orcid = "XXX-xxx-4321-4321";
+        Author oAuthor2 = new Author();
+        oAuthor2.setOrcid(orcid);
+        Author oAuthor3 = new Author();
+        oAuthor3.setOrcid(orcid);
+        authorSet.add(oAuthor1);
+        authorSet.add(oAuthor2);
+        authorSet.add(oAuthor3);
+        assertEquals(4, authorSet.size());
     }
 
     @Test
@@ -104,7 +136,7 @@ class ZenodoHelperTest {
         final DepositMetadata depositMetadata = new DepositMetadata();
         final BioWorkflow bioWorkflow = new BioWorkflow();
         final WorkflowVersion workflowVersion = new WorkflowVersion();
-        final Author author = new Author();
+        final io.dockstore.webservice.core.Author author = new io.dockstore.webservice.core.Author();
         final String joeBlow = "Joe Blow";
         author.setName(joeBlow);
         workflowVersion.addAuthor(author);

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
@@ -92,7 +92,7 @@ class ZenodoHelperTest {
         final WorkflowVersion workflowVersion = new WorkflowVersion();
         bioWorkflow.getWorkflowVersions().add(workflowVersion);
         try {
-            ZenodoHelper.setMetadataCreator(depositMetadata, bioWorkflow);
+            ZenodoHelper.setMetadataCreator(depositMetadata, bioWorkflow, workflowVersion);
             fail("Should have failed");
         } catch (CustomWebApplicationException ex) {
             assertEquals(ZenodoHelper.AT_LEAST_ONE_AUTHOR_IS_REQUIRED_TO_PUBLISH_TO_ZENODO, ex.getMessage());
@@ -110,7 +110,7 @@ class ZenodoHelperTest {
         workflowVersion.addAuthor(author);
         bioWorkflow.getWorkflowVersions().add(workflowVersion);
         bioWorkflow.setActualDefaultVersion(workflowVersion);
-        ZenodoHelper.setMetadataCreator(depositMetadata, bioWorkflow);
+        ZenodoHelper.setMetadataCreator(depositMetadata, bioWorkflow, workflowVersion);
         assertEquals(joeBlow, depositMetadata.getCreators().get(0).getName());
     }
 


### PR DESCRIPTION
**Description**
Look through a workflow versions authors as well as the default version when publishing to zenodo to avoid not having an author for the zenodo export

**Review Instructions**
Publish a few zenodo exports with workflows with a default version (with no authors in the specific version) or vice versa
See if the data is correct on zenodo 
(I tested locally against zenodo prod but worth checking on staging)

**Issue**
https://github.com/dockstore/dockstore/issues/5791

**Security and Privacy**
None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
