### PR TITLE
Separate execution metrics by status

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
@@ -77,6 +77,7 @@ import io.dockstore.openapi.client.model.ExecutionsRequestBody;
 import io.dockstore.openapi.client.model.ExecutionsResponseBody;
 import io.dockstore.openapi.client.model.MemoryMetric;
 import io.dockstore.openapi.client.model.Metrics;
+import io.dockstore.openapi.client.model.MetricsByStatus;
 import io.dockstore.openapi.client.model.PrivilegeRequest;
 import io.dockstore.openapi.client.model.PrivilegeRequest.PlatformPartnerEnum;
 import io.dockstore.openapi.client.model.RunExecution;
@@ -293,7 +294,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         validationExecution.setDateExecuted(Instant.now().toString());
 
         AggregatedExecution aggregatedExecution = new AggregatedExecution().executionId(generateExecutionId());
-        aggregatedExecution.setExecutionStatusCount(new ExecutionStatusMetric().count(Map.of(SUCCESSFUL.name(), 1)));
+        aggregatedExecution.setExecutionStatusCount(new ExecutionStatusMetric().count(Map.of(SUCCESSFUL.name(), new MetricsByStatus().executionStatusCount(1))));
 
         ExecutionsRequestBody executionsRequestBody = new ExecutionsRequestBody()
                 .runExecutions(runExecutions)
@@ -489,9 +490,9 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         workflowsApi.publish1(workflow.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
 
         ExecutionStatusMetric executionStatusMetric = new ExecutionStatusMetric()
-                .count(Map.of(SUCCESSFUL.name(), 1,
-                        FAILED_SEMANTIC_INVALID.name(), 1,
-                        ABORTED.name(), 2));
+                .count(Map.of(SUCCESSFUL.name(), new MetricsByStatus().executionStatus(MetricsByStatus.ExecutionStatusEnum.SUCCESSFUL).executionStatusCount(1),
+                        FAILED_SEMANTIC_INVALID.name(), new MetricsByStatus().executionStatus(MetricsByStatus.ExecutionStatusEnum.FAILED_SEMANTIC_INVALID).executionStatusCount(1),
+                        ABORTED.name(), new MetricsByStatus().executionStatus(MetricsByStatus.ExecutionStatusEnum.ABORTED).executionStatusCount(2)));
         final double min = 1.0;
         final double max = 3.0;
         final double average = 2.0;
@@ -501,21 +502,21 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
                 .maximum(max)
                 .average(average)
                 .numberOfDataPointsForAverage(numberOfDataPointsForAverage);
+        executionStatusMetric.getCount().get(SUCCESSFUL.name()).setExecutionTime(executionTimeMetric);
         CpuMetric cpuMetric = new CpuMetric()
                 .minimum(min)
                 .maximum(max)
                 .average(average)
                 .numberOfDataPointsForAverage(numberOfDataPointsForAverage);
+        executionStatusMetric.getCount().get(SUCCESSFUL.name()).setCpu(cpuMetric);
         MemoryMetric memoryMetric = new MemoryMetric()
                 .minimum(min)
                 .maximum(max)
                 .average(average)
                 .numberOfDataPointsForAverage(numberOfDataPointsForAverage);
+        executionStatusMetric.getCount().get(SUCCESSFUL.name()).setMemory(memoryMetric);
         Metrics metrics = new Metrics()
-                .executionStatusCount(executionStatusMetric)
-                .executionTime(executionTimeMetric)
-                .cpu(cpuMetric)
-                .memory(memoryMetric);
+                .executionStatusCount(executionStatusMetric);
 
         // Put run metrics for platform 1
         extendedGa4GhApi.aggregatedMetricsPut(metrics, platform1, workflowId, workflowVersionId);
@@ -532,23 +533,24 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         assertEquals(2, platform1Metrics.getExecutionStatusCount().getNumberOfAbortedExecutions());
         assertFalse(platform1Metrics.getExecutionStatusCount().getCount().containsKey(FAILED_RUNTIME_INVALID.name()), "Should not contain this because no executions had this status");
         // Verify execution time
-        assertEquals(min, platform1Metrics.getExecutionTime().getMinimum());
-        assertEquals(max, platform1Metrics.getExecutionTime().getMaximum());
-        assertEquals(average, platform1Metrics.getExecutionTime().getAverage());
-        assertEquals(numberOfDataPointsForAverage, platform1Metrics.getExecutionTime().getNumberOfDataPointsForAverage());
-        assertEquals(ExecutionTimeStatisticMetric.UNIT, platform1Metrics.getExecutionTime().getUnit());
+        MetricsByStatus platform1SuccessfulMetrics = platform1Metrics.getExecutionStatusCount().getCount().get(SUCCESSFUL.name());
+        assertEquals(min, platform1SuccessfulMetrics.getExecutionTime().getMinimum());
+        assertEquals(max, platform1SuccessfulMetrics.getExecutionTime().getMaximum());
+        assertEquals(average, platform1SuccessfulMetrics.getExecutionTime().getAverage());
+        assertEquals(numberOfDataPointsForAverage, platform1SuccessfulMetrics.getExecutionTime().getNumberOfDataPointsForAverage());
+        assertEquals(ExecutionTimeStatisticMetric.UNIT, platform1SuccessfulMetrics.getExecutionTime().getUnit());
         // Verify CPU
-        assertEquals(min, platform1Metrics.getCpu().getMinimum());
-        assertEquals(max, platform1Metrics.getCpu().getMaximum());
-        assertEquals(average, platform1Metrics.getCpu().getAverage());
-        assertEquals(numberOfDataPointsForAverage, platform1Metrics.getCpu().getNumberOfDataPointsForAverage());
+        assertEquals(min, platform1SuccessfulMetrics.getCpu().getMinimum());
+        assertEquals(max, platform1SuccessfulMetrics.getCpu().getMaximum());
+        assertEquals(average, platform1SuccessfulMetrics.getCpu().getAverage());
+        assertEquals(numberOfDataPointsForAverage, platform1SuccessfulMetrics.getCpu().getNumberOfDataPointsForAverage());
         assertNull(null, "CPU has no units");
         // Verify memory
-        assertEquals(min, platform1Metrics.getMemory().getMinimum());
-        assertEquals(max, platform1Metrics.getMemory().getMaximum());
-        assertEquals(average, platform1Metrics.getMemory().getAverage());
-        assertEquals(numberOfDataPointsForAverage, platform1Metrics.getMemory().getNumberOfDataPointsForAverage());
-        assertEquals(MemoryStatisticMetric.UNIT, platform1Metrics.getMemory().getUnit());
+        assertEquals(min, platform1SuccessfulMetrics.getMemory().getMinimum());
+        assertEquals(max, platform1SuccessfulMetrics.getMemory().getMaximum());
+        assertEquals(average, platform1SuccessfulMetrics.getMemory().getAverage());
+        assertEquals(numberOfDataPointsForAverage, platform1SuccessfulMetrics.getMemory().getNumberOfDataPointsForAverage());
+        assertEquals(MemoryStatisticMetric.UNIT, platform1SuccessfulMetrics.getMemory().getUnit());
 
         // Put metrics for platform1 again to verify that the old metrics are deleted from the DB and there are no orphans
         extendedGa4GhApi.aggregatedMetricsPut(metrics, platform1, workflowId, workflowVersionId);
@@ -635,7 +637,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         workflow = workflowsApi.refresh1(workflow.getId(), false);
         workflowsApi.publish1(workflow.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
 
-        ExecutionStatusMetric executionStatusMetric = new ExecutionStatusMetric().count(Map.of(SUCCESSFUL.name(), 1));
+        ExecutionStatusMetric executionStatusMetric = new ExecutionStatusMetric().count(Map.of(SUCCESSFUL.name(), new MetricsByStatus().executionStatus(MetricsByStatus.ExecutionStatusEnum.SUCCESSFUL).executionStatusCount(1)));
         Metrics metrics = new Metrics().executionStatusCount(executionStatusMetric);
 
         // Test that a non-admin/non-curator user can't put aggregated metrics
@@ -654,7 +656,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         verifyMetricsDataList(id, versionId, 1);
         // Test that a platform partner can post aggregated metrics
         AggregatedExecution aggregatedExecution = new AggregatedExecution().executionId(generateExecutionId());
-        aggregatedExecution.setExecutionStatusCount(new ExecutionStatusMetric().count(Map.of(SUCCESSFUL.name(), 5)));
+        aggregatedExecution.setExecutionStatusCount(new ExecutionStatusMetric().count(Map.of(SUCCESSFUL.name(), new MetricsByStatus().executionStatus(MetricsByStatus.ExecutionStatusEnum.SUCCESSFUL).executionStatusCount(5))));
         List<AggregatedExecution> aggregatedMetrics = List.of(aggregatedExecution);
         otherExtendedGa4GhApi.executionMetricsPost(new ExecutionsRequestBody().aggregatedExecutions(aggregatedMetrics), platform, id, versionId, "foo");
         verifyMetricsDataList(id, versionId, 2);
@@ -698,7 +700,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         String versionId = "master";
         String platform = Partner.TERRA.name();
 
-        ExecutionStatusMetric executionStatusMetric = new ExecutionStatusMetric().count(Map.of(SUCCESSFUL.name(), 1));
+        ExecutionStatusMetric executionStatusMetric = new ExecutionStatusMetric().count(Map.of(SUCCESSFUL.name(), new MetricsByStatus().executionStatus(MetricsByStatus.ExecutionStatusEnum.SUCCESSFUL).executionStatusCount(1)));
         Metrics metrics = new Metrics().executionStatusCount(executionStatusMetric);
         // Test malformed ID
         ApiException exception = assertThrows(ApiException.class, () -> extendedGa4GhApi.aggregatedMetricsPut(metrics, platform, "malformedId", "malformedVersionId"));
@@ -764,7 +766,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         final AggregatedExecution expectedAggregatedMetrics = new AggregatedExecution()
                 .executionId(generateExecutionId())
                 .additionalAggregatedMetrics(Map.of("cpu_utilization", 50.0));
-        expectedAggregatedMetrics.setExecutionStatusCount(new ExecutionStatusMetric().count(Map.of(SUCCESSFUL.name(), 5)));
+        expectedAggregatedMetrics.setExecutionStatusCount(new ExecutionStatusMetric().count(Map.of(SUCCESSFUL.name(), new MetricsByStatus().executionStatus(MetricsByStatus.ExecutionStatusEnum.SUCCESSFUL).executionStatusCount(5))));
         extendedGa4GhApi.executionMetricsPost(new ExecutionsRequestBody().aggregatedExecutions(List.of(expectedAggregatedMetrics)), platform1, workflowId, workflowVersionId, description);
         verifyMetricsDataList(workflowId, workflowVersionId, platform1, ownerUserId, description, 1);
         ExecutionsRequestBody executionsRequestBody = extendedGa4GhApi.executionGet(workflowId, workflowVersionId, platform1, expectedAggregatedMetrics.getExecutionId());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/metrics/MetricsIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/metrics/MetricsIT.java
@@ -47,7 +47,6 @@ import io.dockstore.webservice.jdbi.MetricsDAO;
 import io.dockstore.webservice.jdbi.WorkflowDAO;
 import io.dockstore.webservice.jdbi.WorkflowVersionDAO;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.hibernate.Session;
@@ -149,34 +148,29 @@ class MetricsIT extends BaseIT {
         Metrics metrics = new Metrics();
 
         ExecutionStatusCountMetric executionStatusCountMetric = new ExecutionStatusCountMetric();
-        Map<ExecutionStatusCountMetric.ExecutionStatus, Integer> executionStatusCount = new HashMap<>();
         // Add 10 successful workflow runs
-        executionStatusCount.put(SUCCESSFUL, 10);
-        executionStatusCountMetric.setCount(executionStatusCount);
+        executionStatusCountMetric.putCount(SUCCESSFUL, 10);
         metrics.setExecutionStatusCount(executionStatusCountMetric);
         assertEquals(10, metrics.getExecutionStatusCount().getNumberOfExecutions());
         assertEquals(10, metrics.getExecutionStatusCount().getNumberOfSuccessfulExecutions());
         assertEquals(0, metrics.getExecutionStatusCount().getNumberOfFailedExecutions());
         assertEquals(0, metrics.getExecutionStatusCount().getNumberOfAbortedExecutions());
         // Add 1 failed workflow run that was runtime invalid
-        executionStatusCount.put(FAILED_RUNTIME_INVALID, 1);
-        executionStatusCountMetric.setCount(executionStatusCount);
+        executionStatusCountMetric.putCount(FAILED_RUNTIME_INVALID, 1);
         metrics.setExecutionStatusCount(executionStatusCountMetric);
         assertEquals(11, metrics.getExecutionStatusCount().getNumberOfExecutions());
         assertEquals(10, metrics.getExecutionStatusCount().getNumberOfSuccessfulExecutions());
         assertEquals(1, metrics.getExecutionStatusCount().getNumberOfFailedExecutions());
         assertEquals(0, metrics.getExecutionStatusCount().getNumberOfAbortedExecutions());
         // Add 1 failed workflow run that was semantically invalid
-        executionStatusCount.put(FAILED_SEMANTIC_INVALID, 1);
-        executionStatusCountMetric.setCount(executionStatusCount);
+        executionStatusCountMetric.putCount(FAILED_SEMANTIC_INVALID, 1);
         metrics.setExecutionStatusCount(executionStatusCountMetric);
         assertEquals(12, metrics.getExecutionStatusCount().getNumberOfExecutions());
         assertEquals(10, metrics.getExecutionStatusCount().getNumberOfSuccessfulExecutions());
         assertEquals(2, metrics.getExecutionStatusCount().getNumberOfFailedExecutions());
         assertEquals(0, metrics.getExecutionStatusCount().getNumberOfAbortedExecutions());
         // Add 1 aborted workflow run
-        executionStatusCount.put(ABORTED, 1);
-        executionStatusCountMetric.setCount(executionStatusCount);
+        executionStatusCountMetric.putCount(ABORTED, 1);
         metrics.setExecutionStatusCount(executionStatusCountMetric);
         assertEquals(13, metrics.getExecutionStatusCount().getNumberOfExecutions());
         assertEquals(10, metrics.getExecutionStatusCount().getNumberOfSuccessfulExecutions());
@@ -186,21 +180,21 @@ class MetricsIT extends BaseIT {
         // Add aggregated information about execution time for the workflow runs.
         // The minimum execution time was 1 minute, the maximum was 5 minutes, and the average was 3 minutes. 10 data points were used to calculate the average
         ExecutionTimeStatisticMetric executionTimeStatisticMetric = new ExecutionTimeStatisticMetric(60.0, 300.0, 180.12, 10);
-        metrics.setExecutionTime(executionTimeStatisticMetric);
+        executionStatusCountMetric.getMetricsByStatus(SUCCESSFUL).setExecutionTime(executionTimeStatisticMetric);
 
         // Add aggregated information about the CPU used for the workflow runs.
         // The minimum CPU used was 1, the maximum was 4, and the average was 2. 10 data points were used to calculate the average
         CpuStatisticMetric cpuStatisticMetric = new CpuStatisticMetric(1.0, 4.0, 2.0, 10);
-        metrics.setCpu(cpuStatisticMetric);
+        executionStatusCountMetric.getMetricsByStatus(SUCCESSFUL).setCpu(cpuStatisticMetric);
 
         // Add aggregated information about the memory used for the workflow runs.
         // The minimum CPU used was 1GB, the maximum was 4GB, and the average was 2G. 10 data points were used to calculate the average
         MemoryStatisticMetric memoryStatisticMetric = new MemoryStatisticMetric(1.0, 4.0, 2.5, 10);
-        metrics.setMemory(memoryStatisticMetric);
+        executionStatusCountMetric.getMetricsByStatus(SUCCESSFUL).setMemory(memoryStatisticMetric);
 
         // Add aggregated information about the cost of the workflow run
         CostStatisticMetric costStatisticMetric = new CostStatisticMetric(1.00, 4.00, 2.50, 10);
-        metrics.setCost(costStatisticMetric);
+        executionStatusCountMetric.getMetricsByStatus(SUCCESSFUL).setCost(costStatisticMetric);
 
         // Add aggregated information about validation
         // Add a successful miniwdl validation

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -75,6 +75,7 @@ import io.dockstore.webservice.core.metrics.ExecutionStatusCountMetric;
 import io.dockstore.webservice.core.metrics.ExecutionTimeStatisticMetric;
 import io.dockstore.webservice.core.metrics.MemoryStatisticMetric;
 import io.dockstore.webservice.core.metrics.Metrics;
+import io.dockstore.webservice.core.metrics.MetricsByStatus;
 import io.dockstore.webservice.core.metrics.ValidationStatusCountMetric;
 import io.dockstore.webservice.core.metrics.ValidatorInfo;
 import io.dockstore.webservice.core.metrics.ValidatorVersionInfo;
@@ -235,7 +236,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             Organization.class, Notification.class, OrganizationUser.class, Event.class, Collection.class, Validation.class, BioWorkflow.class, Service.class, VersionMetadata.class, Image.class, Checksum.class, LambdaEvent.class,
             ParsedInformation.class, EntryVersion.class, DeletedUsername.class, CloudInstance.class, Author.class, OrcidAuthor.class,
             AppTool.class, Category.class, FullWorkflowPath.class, Notebook.class, SourceFileMetadata.class, Metrics.class, CpuStatisticMetric.class, MemoryStatisticMetric.class, ExecutionTimeStatisticMetric.class, CostStatisticMetric.class,
-            CountMetric.class, ExecutionStatusCountMetric.class, ValidationStatusCountMetric.class, ValidatorInfo.class, ValidatorVersionInfo.class) {
+            CountMetric.class, ExecutionStatusCountMetric.class, ValidationStatusCountMetric.class, ValidatorInfo.class, ValidatorVersionInfo.class, MetricsByStatus.class) {
         @Override
         public DataSourceFactory getDataSourceFactory(DockstoreWebserviceConfiguration configuration) {
             return configuration.getDataSourceFactory();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/ExecutionStatusCountMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/ExecutionStatusCountMetric.java
@@ -36,7 +36,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
-import jakarta.persistence.MapKey;
+import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.MapKeyEnumerated;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -53,9 +53,9 @@ public class ExecutionStatusCountMetric extends CountMetric<ExecutionStatusCount
 
     @NotEmpty
     @MapKeyEnumerated(EnumType.STRING)
-    @MapKey(name = "executionStatus")
-    @ApiModelProperty(value = "A map containing the count for each key")
-    @Schema(description = "A map containing the count for each key", requiredMode = RequiredMode.REQUIRED)
+    @MapKeyColumn(name = "executionStatus")
+    @ApiModelProperty(value = "A map containing the metrics for each execution status")
+    @Schema(description = "A map containing the metrics for each execution status", requiredMode = RequiredMode.REQUIRED)
     @OneToMany(fetch = FetchType.EAGER, orphanRemoval = true, cascade = CascadeType.ALL)
     @JoinTable(name = "execution_status_count", joinColumns = @JoinColumn(name = "executionstatusid", referencedColumnName = "id", columnDefinition = "bigint"), inverseJoinColumns = @JoinColumn(name = "metricsbystatusid", referencedColumnName = "id", columnDefinition = "bigint"))
     private Map<ExecutionStatus, MetricsByStatus> count = new EnumMap<>(ExecutionStatus.class);
@@ -92,9 +92,9 @@ public class ExecutionStatusCountMetric extends CountMetric<ExecutionStatusCount
     }
 
     public void calculateNumberOfExecutions() {
-        this.numberOfSuccessfulExecutions = count.getOrDefault(SUCCESSFUL, new MetricsByStatus(SUCCESSFUL)).getExecutionStatusCount();
-        this.numberOfFailedExecutions = count.getOrDefault(FAILED, new MetricsByStatus(FAILED)).getExecutionStatusCount() + count.getOrDefault(FAILED_SEMANTIC_INVALID, new MetricsByStatus(FAILED_SEMANTIC_INVALID)).getExecutionStatusCount() + count.getOrDefault(FAILED_RUNTIME_INVALID, new MetricsByStatus(FAILED_RUNTIME_INVALID)).getExecutionStatusCount();
-        this.numberOfAbortedExecutions = count.getOrDefault(ABORTED, new MetricsByStatus(ABORTED)).getExecutionStatusCount();
+        this.numberOfSuccessfulExecutions = count.getOrDefault(SUCCESSFUL, new MetricsByStatus(0)).getExecutionStatusCount();
+        this.numberOfFailedExecutions = count.getOrDefault(FAILED, new MetricsByStatus(0)).getExecutionStatusCount() + count.getOrDefault(FAILED_SEMANTIC_INVALID, new MetricsByStatus(0)).getExecutionStatusCount() + count.getOrDefault(FAILED_RUNTIME_INVALID, new MetricsByStatus(0)).getExecutionStatusCount();
+        this.numberOfAbortedExecutions = count.getOrDefault(ABORTED, new MetricsByStatus(0)).getExecutionStatusCount();
     }
 
     public void setCount(Map<ExecutionStatus, MetricsByStatus> count) {
@@ -102,13 +102,13 @@ public class ExecutionStatusCountMetric extends CountMetric<ExecutionStatusCount
         calculateNumberOfExecutions();
     }
 
-    public void putCount(MetricsByStatus metricsByStatus) {
-        this.count.put(metricsByStatus.getExecutionStatus(), metricsByStatus);
+    public void putCount(ExecutionStatus executionStatus, MetricsByStatus metricsByStatus) {
+        this.count.put(executionStatus, metricsByStatus);
         calculateNumberOfExecutions();
     }
 
     public void putCount(ExecutionStatus executionStatus, int executionStatusCount) {
-        putCount(new MetricsByStatus(executionStatus, executionStatusCount));
+        putCount(executionStatus, new MetricsByStatus(executionStatusCount));
     }
 
     public MetricsByStatus getMetricsByStatus(ExecutionStatus executionStatus) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/ExecutionStatusCountMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/ExecutionStatusCountMetric.java
@@ -104,6 +104,7 @@ public class ExecutionStatusCountMetric extends CountMetric<ExecutionStatusCount
 
     public void putCount(MetricsByStatus metricsByStatus) {
         this.count.put(metricsByStatus.getExecutionStatus(), metricsByStatus);
+        calculateNumberOfExecutions();
     }
 
     public void putCount(ExecutionStatus executionStatus, int executionStatusCount) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/Metrics.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/Metrics.java
@@ -56,34 +56,6 @@ public class Metrics {
 
     @Valid
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "executiontime", referencedColumnName = "id")
-    @ApiModelProperty(value = "Aggregated execution time metrics in seconds")
-    @Schema(description = "Aggregated execution time metrics in seconds")
-    private ExecutionTimeStatisticMetric executionTime;
-
-    @Valid
-    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "memory", referencedColumnName = "id")
-    @ApiModelProperty(value = "Aggregated memory metrics in GB")
-    @Schema(description = "Aggregated memory metrics in GB")
-    private MemoryStatisticMetric memory;
-
-    @Valid
-    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "cpu", referencedColumnName = "id")
-    @ApiModelProperty(value = "Aggregated CPU metrics")
-    @Schema(description = "Aggregated CPU metrics")
-    private CpuStatisticMetric cpu;
-
-    @Valid
-    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "cost", referencedColumnName = "id")
-    @ApiModelProperty(value = "Aggregated cost metrics in USD")
-    @Schema(description = "Aggregated cost metrics in USD")
-    private CostStatisticMetric cost;
-
-    @Valid
-    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "validationstatus", referencedColumnName = "id")
     @ApiModelProperty(value = "Aggregated validation status metrics")
     @Schema(description = "Aggregated validation status metrics")
@@ -103,10 +75,6 @@ public class Metrics {
     public Metrics() {
     }
 
-    public Metrics(ExecutionStatusCountMetric executionStatusCount) {
-        this.executionStatusCount = executionStatusCount;
-    }
-
     public long getId() {
         return id;
     }
@@ -121,38 +89,6 @@ public class Metrics {
 
     public void setExecutionStatusCount(ExecutionStatusCountMetric executionStatusCount) {
         this.executionStatusCount = executionStatusCount;
-    }
-
-    public ExecutionTimeStatisticMetric getExecutionTime() {
-        return executionTime;
-    }
-
-    public void setExecutionTime(ExecutionTimeStatisticMetric executionTime) {
-        this.executionTime = executionTime;
-    }
-
-    public MemoryStatisticMetric getMemory() {
-        return memory;
-    }
-
-    public void setMemory(MemoryStatisticMetric memory) {
-        this.memory = memory;
-    }
-
-    public CpuStatisticMetric getCpu() {
-        return cpu;
-    }
-
-    public void setCpu(CpuStatisticMetric cpu) {
-        this.cpu = cpu;
-    }
-
-    public CostStatisticMetric getCost() {
-        return cost;
-    }
-
-    public void setCost(CostStatisticMetric cost) {
-        this.cost = cost;
     }
 
     public ValidationStatusCountMetric getValidationStatus() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/MetricsByStatus.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/MetricsByStatus.java
@@ -17,15 +17,12 @@
 
 package io.dockstore.webservice.core.metrics;
 
-import io.dockstore.webservice.core.metrics.ExecutionStatusCountMetric.ExecutionStatus;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -44,11 +41,6 @@ public class MetricsByStatus {
     @ApiModelProperty(value = "Implementation specific ID for the metrics in this webservice")
     @Schema(description = "Implementation specific ID for the metrics in this webservice")
     private long id;
-
-    @Enumerated(EnumType.STRING)
-    @NotNull
-    @Schema(description = "The status of the executions that these metrics were aggregated from", requiredMode = RequiredMode.REQUIRED)
-    private ExecutionStatus executionStatus;
 
     @Column(nullable = false)
     @NotNull
@@ -87,13 +79,8 @@ public class MetricsByStatus {
 
     }
 
-    public MetricsByStatus(ExecutionStatus executionStatus, int executionStatusCount) {
-        this.executionStatus = executionStatus;
+    public MetricsByStatus(int executionStatusCount) {
         this.executionStatusCount = executionStatusCount;
-    }
-
-    public MetricsByStatus(ExecutionStatus executionStatus) {
-        this(executionStatus, 0);
     }
 
     public long getId() {
@@ -102,14 +89,6 @@ public class MetricsByStatus {
 
     public void setId(long id) {
         this.id = id;
-    }
-
-    public ExecutionStatus getExecutionStatus() {
-        return executionStatus;
-    }
-
-    public void setExecutionStatus(ExecutionStatus executionStatus) {
-        this.executionStatus = executionStatus;
     }
 
     public int getExecutionStatusCount() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/MetricsByStatus.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/MetricsByStatus.java
@@ -17,7 +17,6 @@
 
 package io.dockstore.webservice.core.metrics;
 
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.persistence.CascadeType;
@@ -38,7 +37,6 @@ import jakarta.validation.constraints.NotNull;
 public class MetricsByStatus {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @ApiModelProperty(value = "Implementation specific ID for the metrics in this webservice")
     @Schema(description = "Implementation specific ID for the metrics in this webservice")
     private long id;
 
@@ -49,30 +47,26 @@ public class MetricsByStatus {
 
     @Valid
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "executiontime", referencedColumnName = "id")
-    @ApiModelProperty(value = "Aggregated execution time metrics in seconds")
-    @Schema(description = "Aggregated execution time metrics in seconds")
+    @JoinColumn(name = "executiontimeid", referencedColumnName = "id")
+    @Schema(description = "Aggregated execution time metrics in seconds for the status")
     private ExecutionTimeStatisticMetric executionTime;
 
     @Valid
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "memory", referencedColumnName = "id")
-    @ApiModelProperty(value = "Aggregated memory metrics in GB")
-    @Schema(description = "Aggregated memory metrics in GB")
+    @JoinColumn(name = "memoryid", referencedColumnName = "id")
+    @Schema(description = "Aggregated memory metrics in GB for the status")
     private MemoryStatisticMetric memory;
 
     @Valid
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "cpu", referencedColumnName = "id")
-    @ApiModelProperty(value = "Aggregated CPU metrics")
-    @Schema(description = "Aggregated CPU metrics")
+    @JoinColumn(name = "cpuid", referencedColumnName = "id")
+    @Schema(description = "Aggregated CPU metrics for the status")
     private CpuStatisticMetric cpu;
 
     @Valid
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "cost", referencedColumnName = "id")
-    @ApiModelProperty(value = "Aggregated cost metrics in USD")
-    @Schema(description = "Aggregated cost metrics in USD")
+    @JoinColumn(name = "costid", referencedColumnName = "id")
+    @Schema(description = "Aggregated cost metrics in USD for the status")
     private CostStatisticMetric cost;
 
     public MetricsByStatus() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/MetricsByStatus.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/MetricsByStatus.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2024 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.dockstore.webservice.core.metrics;
+
+import io.dockstore.webservice.core.metrics.ExecutionStatusCountMetric.ExecutionStatus;
+import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+@Entity
+@Table(name = "metrics_by_status")
+@Schema(name = "MetricsByStatus", description = "Aggregated metrics grouped by execution status")
+public class MetricsByStatus {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @ApiModelProperty(value = "Implementation specific ID for the metrics in this webservice")
+    @Schema(description = "Implementation specific ID for the metrics in this webservice")
+    private long id;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    @Schema(description = "The status of the executions that these metrics were aggregated from", requiredMode = RequiredMode.REQUIRED)
+    private ExecutionStatus executionStatus;
+
+    @Column(nullable = false)
+    @NotNull
+    @Schema(description = "The number of executions for the status", requiredMode = RequiredMode.REQUIRED)
+    private int executionStatusCount;
+
+    @Valid
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "executiontime", referencedColumnName = "id")
+    @ApiModelProperty(value = "Aggregated execution time metrics in seconds")
+    @Schema(description = "Aggregated execution time metrics in seconds")
+    private ExecutionTimeStatisticMetric executionTime;
+
+    @Valid
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "memory", referencedColumnName = "id")
+    @ApiModelProperty(value = "Aggregated memory metrics in GB")
+    @Schema(description = "Aggregated memory metrics in GB")
+    private MemoryStatisticMetric memory;
+
+    @Valid
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "cpu", referencedColumnName = "id")
+    @ApiModelProperty(value = "Aggregated CPU metrics")
+    @Schema(description = "Aggregated CPU metrics")
+    private CpuStatisticMetric cpu;
+
+    @Valid
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "cost", referencedColumnName = "id")
+    @ApiModelProperty(value = "Aggregated cost metrics in USD")
+    @Schema(description = "Aggregated cost metrics in USD")
+    private CostStatisticMetric cost;
+
+    public MetricsByStatus() {
+
+    }
+
+    public MetricsByStatus(ExecutionStatus executionStatus, int executionStatusCount) {
+        this.executionStatus = executionStatus;
+        this.executionStatusCount = executionStatusCount;
+    }
+
+    public MetricsByStatus(ExecutionStatus executionStatus) {
+        this(executionStatus, 0);
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public ExecutionStatus getExecutionStatus() {
+        return executionStatus;
+    }
+
+    public void setExecutionStatus(ExecutionStatus executionStatus) {
+        this.executionStatus = executionStatus;
+    }
+
+    public int getExecutionStatusCount() {
+        return executionStatusCount;
+    }
+
+    public void setExecutionStatusCount(int executionStatusCount) {
+        this.executionStatusCount = executionStatusCount;
+    }
+
+    public ExecutionTimeStatisticMetric getExecutionTime() {
+        return executionTime;
+    }
+
+    public void setExecutionTime(ExecutionTimeStatisticMetric executionTime) {
+        this.executionTime = executionTime;
+    }
+
+    public MemoryStatisticMetric getMemory() {
+        return memory;
+    }
+
+    public void setMemory(MemoryStatisticMetric memory) {
+        this.memory = memory;
+    }
+
+    public CpuStatisticMetric getCpu() {
+        return cpu;
+    }
+
+    public void setCpu(CpuStatisticMetric cpu) {
+        this.cpu = cpu;
+    }
+
+    public CostStatisticMetric getCost() {
+        return cost;
+    }
+
+    public void setCost(CostStatisticMetric cost) {
+        this.cost = cost;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/RunExecution.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/RunExecution.java
@@ -20,6 +20,7 @@ package io.dockstore.webservice.core.metrics;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dockstore.webservice.core.metrics.ExecutionStatusCountMetric.ExecutionStatus;
 import io.dockstore.webservice.core.metrics.constraints.ISO8601ExecutionTime;
+import io.dockstore.webservice.core.metrics.constraints.ValidClientExecutionStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotNull;
@@ -31,8 +32,9 @@ import jakarta.validation.constraints.NotNull;
 public class RunExecution extends Execution {
 
     @NotNull
+    @ValidClientExecutionStatus
     @JsonProperty(required = true)
-    @Schema(description = "The status of the execution", requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "The status of the execution", requiredMode = RequiredMode.REQUIRED, example = "SUCCESSFUL")
     private ExecutionStatus executionStatus;
 
     @ISO8601ExecutionTime

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/constraints/ValidClientExecutionStatus.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/constraints/ValidClientExecutionStatus.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.dockstore.webservice.core.metrics.constraints;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines the `ValidClientExecutionStatus` constraint annotation, which
+ * checks that the execution status is meant for client use.
+ */
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidClientExecutionStatusValidator.class)
+public @interface ValidClientExecutionStatus {
+    String INVALID_EXECUTION_STATUS_MESSAGE = "cannot be ALL";
+
+    String message() default INVALID_EXECUTION_STATUS_MESSAGE;
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/constraints/ValidClientExecutionStatusValidator.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/constraints/ValidClientExecutionStatusValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.dockstore.webservice.core.metrics.constraints;
+
+import io.dockstore.webservice.core.metrics.ExecutionStatusCountMetric.ExecutionStatus;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * Validates that the execution status is meant for client use.
+ */
+public class ValidClientExecutionStatusValidator implements ConstraintValidator<ValidClientExecutionStatus, ExecutionStatus> {
+
+    @Override
+    public boolean isValid(final ExecutionStatus executionStatus, final ConstraintValidatorContext context) {
+        return executionStatus != ExecutionStatus.ALL; // ALL is only meant to be used internally
+    }
+}

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -364,10 +364,10 @@
             <column name="executionstatuscount" type="INTEGER">
                 <constraints nullable="false"/>
             </column>
-            <column name="cost" type="BIGINT"/>
-            <column name="cpu" type="BIGINT"/>
-            <column name="executiontime" type="BIGINT"/>
-            <column name="memory" type="BIGINT"/>
+            <column name="costid" type="BIGINT"/>
+            <column name="cpuid" type="BIGINT"/>
+            <column name="executiontimeid" type="BIGINT"/>
+            <column name="memoryid" type="BIGINT"/>
         </createTable>
         <addColumn tableName="execution_status_count">
             <column name="metricsbystatusid" type="int8">
@@ -377,10 +377,10 @@
 
         <addUniqueConstraint columnNames="metricsbystatusid" constraintName="unique_metricsbystatus_executionstatuscount" tableName="execution_status_count"/>
         <addForeignKeyConstraint baseColumnNames="metricsbystatusid" baseTableName="execution_status_count" constraintName="fk_metricsbystatusid_executionstatuscount" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="metrics_by_status"/>
-        <addForeignKeyConstraint baseColumnNames="executiontime" baseTableName="metrics_by_status" constraintName="fk_executiontime_metricsbystatus" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="execution_time_metric"/>
-        <addForeignKeyConstraint baseColumnNames="memory" baseTableName="metrics_by_status" constraintName="fk_memory_metricsbystatus" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="memory_metric"/>
-        <addForeignKeyConstraint baseColumnNames="cpu" baseTableName="metrics_by_status" constraintName="fk_cpu_metricsbystatus" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="cpu_metric"/>
-        <addForeignKeyConstraint baseColumnNames="cost" baseTableName="metrics_by_status" constraintName="fk_cost_metricsbystatus" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="cost_metric"/>
+        <addForeignKeyConstraint baseColumnNames="executiontimeid" baseTableName="metrics_by_status" constraintName="fk_executiontimeid_metricsbystatus" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="execution_time_metric"/>
+        <addForeignKeyConstraint baseColumnNames="memoryid" baseTableName="metrics_by_status" constraintName="fk_memoryid_metricsbystatus" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="memory_metric"/>
+        <addForeignKeyConstraint baseColumnNames="cpuid" baseTableName="metrics_by_status" constraintName="fk_cpuid_metricsbystatus" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="cpu_metric"/>
+        <addForeignKeyConstraint baseColumnNames="costid" baseTableName="metrics_by_status" constraintName="fk_costid_metricsbystatus" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="cost_metric"/>
 
         <sql dbms="postgresql">
             <comment>Delete all metrics that have a null metricsbystatusid column in execution_status_count</comment>

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -356,4 +356,78 @@
     <changeSet author="ktran (generated)" id="addValidatorVersionsPrimaryKey">
         <addPrimaryKey columnNames="validatorinfoid, validatorversioninfoid" constraintName="validator_versions_pkey" tableName="validator_versions"/>
     </changeSet>
+    <changeSet author="ktran (generated)" id="separateMetricsByStatus">
+        <createTable tableName="metrics_by_status">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="metrics_by_status_pkey"/>
+            </column>
+            <column name="executionstatus" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="executionstatuscount" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cost" type="BIGINT"/>
+            <column name="cpu" type="BIGINT"/>
+            <column name="executiontime" type="BIGINT"/>
+            <column name="memory" type="BIGINT"/>
+        </createTable>
+        <addColumn tableName="execution_status_count">
+            <column name="metricsbystatusid" type="int8">
+                <!-- not null constraint is added after migrating existing data -->
+            </column>
+        </addColumn>
+
+        <addUniqueConstraint columnNames="metricsbystatusid" constraintName="unique_metricsbystatus_executionstatuscount" tableName="execution_status_count"/>
+        <addForeignKeyConstraint baseColumnNames="metricsbystatusid" baseTableName="execution_status_count" constraintName="fk_metricsbystatusid_executionstatuscount" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="metrics_by_status"/>
+        <addForeignKeyConstraint baseColumnNames="executiontime" baseTableName="metrics_by_status" constraintName="fk_executiontime_metricsbystatus" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="execution_time_metric"/>
+        <addForeignKeyConstraint baseColumnNames="memory" baseTableName="metrics_by_status" constraintName="fk_memory_metricsbystatus" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="memory_metric"/>
+        <addForeignKeyConstraint baseColumnNames="cpu" baseTableName="metrics_by_status" constraintName="fk_cpu_metricsbystatus" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="cpu_metric"/>
+        <addForeignKeyConstraint baseColumnNames="cost" baseTableName="metrics_by_status" constraintName="fk_cost_metricsbystatus" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="cost_metric"/>
+
+        <sql dbms="postgresql">
+            <comment>Delete all metrics that have a null metricsbystatusid column in execution_status_count</comment>
+            <!-- Temporary table that contains metrics that have an execution status metric, but a null metricsbystatusid column -->
+            CREATE TEMPORARY TABLE metricstodelete
+            AS
+            WITH executionstatusmetrics AS (
+            SELECT metrics.id AS metricsid, executionstatusid, executionstatus, count, executiontime, cpu, memory, cost, validationstatus
+            FROM execution_status_count
+            INNER JOIN execution_status ON execution_status_count.executionstatusid = execution_status.id
+            INNER JOIN metrics ON execution_status.id = metrics.executionstatuscount
+            WHERE metrics.executionstatuscount IS NOT NULL AND execution_status_count.metricsbystatusid IS NULL
+            )
+            SELECT * FROM executionstatusmetrics;
+
+            <!-- Delete run execution metrics that are present in the metricstodelete table -->
+            DELETE FROM execution_status_count WHERE execution_status_count.executionstatusid IN (SELECT executionstatusid FROM metricstodelete);
+            UPDATE metrics SET executionstatuscount = NULL, executiontime = NULL, cpu = NULL, memory = NULL, cost = NULL WHERE metrics.id IN (SELECT metricsid FROM metricstodelete);
+            DELETE FROM execution_status WHERE execution_status.id IN (SELECT executionstatusid FROM metricstodelete);
+            DELETE FROM execution_time_metric WHERE execution_time_metric.id IN (SELECT executiontime FROM metricstodelete);
+            DELETE FROM cpu_metric WHERE cpu_metric.id IN (SELECT cpu FROM metricstodelete);
+            DELETE FROM memory_metric WHERE memory_metric.id IN (SELECT memory FROM metricstodelete);
+            DELETE FROM cost_metric WHERE cost_metric.id IN (SELECT cost FROM metricstodelete);
+
+            <!-- Don't delete metrics that still have a validationstatus metric -->
+            DELETE FROM version_metrics WHERE version_metrics.metricsid IN (SELECT metricsid FROM metricstodelete WHERE validationstatus IS NULL);
+            DELETE FROM metrics WHERE metrics.id IN (SELECT metricsid FROM metricstodelete) AND metrics.validationstatus IS NULL;
+        </sql>
+
+        <dropPrimaryKey tableName="execution_status_count"/>
+        <addPrimaryKey columnNames="executionstatusid, metricsbystatusid" constraintName="execution_status_count_pkey" tableName="execution_status_count"/>
+
+        <!-- Need to add not null constraint after deleting rows with a null metricsbystatusid -->
+        <addNotNullConstraint tableName="execution_status_count" columnName="metricsbystatusid"/>
+
+        <dropForeignKeyConstraint baseTableName="metrics" constraintName="fk_cost_metrics"/>
+        <dropForeignKeyConstraint baseTableName="metrics" constraintName="fk_cpu_metrics"/>
+        <dropForeignKeyConstraint baseTableName="metrics" constraintName="fk_executiontime_metrics"/>
+        <dropForeignKeyConstraint baseTableName="metrics" constraintName="fk_memory_metrics"/>
+        <dropColumn columnName="cost" tableName="metrics"/>
+        <dropColumn columnName="count" tableName="execution_status_count"/>
+        <dropColumn columnName="cpu" tableName="metrics"/>
+        <dropColumn columnName="executiontime" tableName="metrics"/>
+        <dropColumn columnName="memory" tableName="metrics"/>
+        <dropColumn columnName="executionstatus" tableName="execution_status_count"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.15.0.xml
@@ -361,9 +361,6 @@
             <column autoIncrement="true" name="id" type="BIGINT">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="metrics_by_status_pkey"/>
             </column>
-            <column name="executionstatus" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
             <column name="executionstatuscount" type="INTEGER">
                 <constraints nullable="false"/>
             </column>
@@ -414,7 +411,7 @@
         </sql>
 
         <dropPrimaryKey tableName="execution_status_count"/>
-        <addPrimaryKey columnNames="executionstatusid, metricsbystatusid" constraintName="execution_status_count_pkey" tableName="execution_status_count"/>
+        <addPrimaryKey columnNames="executionstatusid, executionstatus" constraintName="execution_status_count_pkey" tableName="execution_status_count"/>
 
         <!-- Need to add not null constraint after deleting rows with a null metricsbystatusid -->
         <addNotNullConstraint tableName="execution_status_count" columnName="metricsbystatusid"/>
@@ -428,6 +425,5 @@
         <dropColumn columnName="cpu" tableName="metrics"/>
         <dropColumn columnName="executiontime" tableName="metrics"/>
         <dropColumn columnName="memory" tableName="metrics"/>
-        <dropColumn columnName="executionstatus" tableName="execution_status_count"/>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -9561,14 +9561,8 @@ components:
         count:
           type: object
           additionalProperties:
-            type: integer
-            format: int32
-            description: A map containing the count for each key
+            $ref: '#/components/schemas/MetricsByStatus'
           description: A map containing the count for each key
-          example:
-            FAILED_RUNTIME_INVALID: 1
-            FAILED_SEMANTIC_INVALID: 1
-            SUCCESSFUL: 5
         id:
           type: integer
           format: int64
@@ -10056,12 +10050,39 @@ components:
       type: object
       description: Aggregated metrics associated with entry versions
       properties:
+        executionStatusCount:
+          $ref: '#/components/schemas/ExecutionStatusMetric'
+        id:
+          type: integer
+          format: int64
+          description: Implementation specific ID for the metrics in this webservice
+        validationStatus:
+          $ref: '#/components/schemas/ValidationStatusMetric'
+      required:
+      - executionStatusCount
+    MetricsByStatus:
+      type: object
+      description: Aggregated metrics grouped by execution status
+      properties:
         cost:
           $ref: '#/components/schemas/CostMetric'
         cpu:
           $ref: '#/components/schemas/CpuMetric'
+        executionStatus:
+          type: string
+          description: The status of the executions that these metrics were aggregated
+            from
+          enum:
+          - ALL
+          - SUCCESSFUL
+          - FAILED
+          - FAILED_SEMANTIC_INVALID
+          - FAILED_RUNTIME_INVALID
+          - ABORTED
         executionStatusCount:
-          $ref: '#/components/schemas/ExecutionStatusMetric'
+          type: integer
+          format: int32
+          description: The number of executions for the status
         executionTime:
           $ref: '#/components/schemas/ExecutionTimeMetric'
         id:
@@ -10070,9 +10091,8 @@ components:
           description: Implementation specific ID for the metrics in this webservice
         memory:
           $ref: '#/components/schemas/MemoryMetric'
-        validationStatus:
-          $ref: '#/components/schemas/ValidationStatusMetric'
       required:
+      - executionStatus
       - executionStatusCount
     Notebook:
       type: object
@@ -10410,11 +10430,13 @@ components:
             type: string
             description: The status of the execution
             enum:
+            - ALL
             - SUCCESSFUL
             - FAILED
             - FAILED_SEMANTIC_INVALID
             - FAILED_RUNTIME_INVALID
             - ABORTED
+            example: SUCCESSFUL
           executionTime:
             type: string
             description: The total time it took for the execution to complete in ISO

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -9562,7 +9562,7 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/MetricsByStatus'
-          description: A map containing the count for each key
+          description: A map containing the metrics for each execution status
         id:
           type: integer
           format: int64
@@ -10068,17 +10068,6 @@ components:
           $ref: '#/components/schemas/CostMetric'
         cpu:
           $ref: '#/components/schemas/CpuMetric'
-        executionStatus:
-          type: string
-          description: The status of the executions that these metrics were aggregated
-            from
-          enum:
-          - ALL
-          - SUCCESSFUL
-          - FAILED
-          - FAILED_SEMANTIC_INVALID
-          - FAILED_RUNTIME_INVALID
-          - ABORTED
         executionStatusCount:
           type: integer
           format: int32
@@ -10092,7 +10081,6 @@ components:
         memory:
           $ref: '#/components/schemas/MemoryMetric'
       required:
-      - executionStatus
       - executionStatusCount
     Notebook:
       type: object


### PR DESCRIPTION
**Description**
Corresponding PRs:
- https://github.com/dockstore/dockstore-ui2/pull/1930
- https://github.com/dockstore/dockstore-support/pull/482

This PR separates the execution metrics by status by moving the execution metrics (execution time, cpu, memory, cost) from `Metrics` to `MetricsByStatus` so that `ExecutionStatusCountMetric` can have a Map of `ExecutionStatus` to `MetricsByStatus`. This allows users to view metrics that are grouped by execution status. Additionally, there is an `ALL` status that displays metrics that are aggregated across executions of all statuses.

The migration I wrote deletes existing execution status count metrics in the database. We only have 12 execution status metrics in prod which are the AGC ones that we uploaded and we plan to re-ingest them anyway for 1.15 so deleting was much easier than trying to migrate to the existing schema given how little execution metrics we have in prod and who uploaded them.

**Review Instructions**
See https://github.com/dockstore/dockstore-ui2/pull/1930

**Issue**
[SEAB-6199](https://ucsc-cgl.atlassian.net/browse/SEAB-6199)

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here.

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-6199]: https://ucsc-cgl.atlassian.net/browse/SEAB-6199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ