### PR TITLE
DOCK-2512: Fix pushes of annotated tags

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1879,8 +1879,14 @@ class WebhookIT extends BaseIT {
         // Existing lightweight tag with correct "after" SHA, should succeed
         handleGitHubRelease(client, repo, "refs/tags/simple-lightweight-v1", USER_2_USERNAME, "ebca52b72a5c9f9d33543648aacb10a6bc736677");
         assertEquals(3, countVersions());
-        // There should be two ignored LambdaEvents
-        assertEquals(2, new UsersApi(webClient).getUserGitHubEvents(0, 10, null, null, null).stream().filter(LambdaEvent::isIgnored).count());
+        // Branch with incorrect "after" SHA, should be ignored
+        handleGitHubRelease(client, repo, "refs/heads/dont-ever-commit-to-this-branch", USER_2_USERNAME, "ebca52b72a5c9f9d33543648aacb10a6bc736677");
+        assertEquals(3, countVersions());
+        // Branch with correct "after" SHA, should succeed
+        handleGitHubRelease(client, repo, "refs/heads/dont-ever-commit-to-this-branch", USER_2_USERNAME, "1e11133d732fe7d6e7682b6e4a99eaef5d14244c");
+        assertEquals(4, countVersions());
+        // There should be three ignored LambdaEvents
+        assertEquals(3, new UsersApi(webClient).getUserGitHubEvents(0, 10, null, null, null).stream().filter(LambdaEvent::isIgnored).count());
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1867,15 +1867,18 @@ class WebhookIT extends BaseIT {
         // Non-existent tag, should be ignored
         handleGitHubRelease(client, repo, "refs/tags/bogus", USER_2_USERNAME, "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc");
         assertEquals(0, countVersions());
-        // Existing tag with incorrect "after" SHA, should be ignored
+        // Existing annotated tag with incorrect "after" SHA, should be ignored
         handleGitHubRelease(client, repo, "refs/tags/simple-v1", USER_2_USERNAME, "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc");
         assertEquals(0, countVersions());
-        // Existing tag with correct "after" SHA, should succeed
-        handleGitHubRelease(client, repo, "refs/tags/simple-v1", USER_2_USERNAME, "ebca52b72a5c9f9d33543648aacb10a6bc736677");
+        // Existing annotated tag with correct "after" SHA, should succeed
+        handleGitHubRelease(client, repo, "refs/tags/simple-v1", USER_2_USERNAME, "ff797c7dacd8c23a8ef89864ac5c50d9378cbec1");
         assertEquals(1, countVersions());
-        // Existing tag with no "after" SHA supplied, should succeed
+        // Existing annotated tag with no "after" SHA supplied, should succeed
         handleGitHubRelease(client, repo, "refs/tags/simple-published-v1", USER_2_USERNAME);
         assertEquals(2, countVersions());
+        // Existing lightweight tag with correct "after" SHA, should succeed
+        handleGitHubRelease(client, repo, "refs/tags/simple-lightweight-v1", USER_2_USERNAME, "ebca52b72a5c9f9d33543648aacb10a6bc736677");
+        assertEquals(3, countVersions());
         // There should be two ignored LambdaEvents
         assertEquals(2, new UsersApi(webClient).getUserGitHubEvents(0, 10, null, null, null).stream().filter(LambdaEvent::isIgnored).count());
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1354,6 +1354,21 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         }
     }
 
+    public String getHash(String repositoryId, String reference) {
+        try {
+            GHRepository repo = github.getRepository(repositoryId);
+            GHRef ref = repo.getRef(reference);
+            return ref.getObject().getSha();
+        } catch (GHFileNotFoundException e) {
+            LOG.info("Could not find reference '{}' on repository '{}'", reference, repositoryId);
+            return null;
+        } catch (IOException e) {
+            LOG.error(gitUsername + ": IOException on getHash " + e.getMessage(), e);
+            throw new CustomWebApplicationException("Could not access GitHub reference", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        }
+
+    }
+
     @Override
     protected String getCommitID(String repositoryId, Version version) {
         GHRepository repo;
@@ -1410,6 +1425,7 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         }
         return null;
     }
+
 
     /**
      * Updates a user object with metadata from GitHub

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -1366,7 +1366,6 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
             LOG.error(gitUsername + ": IOException on getHash " + e.getMessage(), e);
             throw new CustomWebApplicationException("Could not access GitHub reference", HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
-
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -553,6 +553,15 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         }
     }
 
+    /**
+     * Retrieve a hash from GitHub for the specified reference.
+     * If the reference is to a branch, return the branch HEAD commit hash.
+     * If the reference is to a tag, return the hash that the tag refers to, which is either:
+     * A commit hash (if the reference is to a lightweight tag), or
+     * The tag object hash (if the reference is to an annotated tag).
+     * The returned value should match the value of the `after` hash field in a GitHub push event,
+     * if the repository has not changed since the push occurred.
+     */
     private String getCurrentHash(GitHubSourceCodeRepo repo, String repository, String reference) {
         if (StringUtils.startsWith(reference, "refs/tags/")) {
             return repo.getHash(repository, reference);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -528,7 +528,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         }
         try {
             // Retrieve the "current" head commit.
-            String currentCommit = getHeadCommit(gitHubSourceCodeRepo, repository, reference);
+            String currentCommit = getCurrentHash(gitHubSourceCodeRepo, repository, reference);
             LOG.info("afterCommit={}, currentCommit={}", afterCommit, currentCommit);
             // Process the push iff the "current" and "after" commit hashes are equal.
             // If the repo's "current" hash doesn't match the event's "after" hash, the repo has changed since the event was created.
@@ -545,7 +545,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     private boolean shouldProcessDelete(GitHubSourceCodeRepo gitHubSourceCodeRepo, String repository, String reference) {
         try {
             // Process the delete if the reference does not exist (there is no head commit).
-            return getHeadCommit(gitHubSourceCodeRepo, repository, reference) == null;
+            return getCurrentHash(gitHubSourceCodeRepo, repository, reference) == null;
         } catch (CustomWebApplicationException ex) {
             // If there's a problem determining if the delete needs processing, assume it does.
             LOG.info("CustomWebApplicationException determining whether to process delete", ex);
@@ -553,8 +553,12 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         }
     }
 
-    private String getHeadCommit(GitHubSourceCodeRepo repo, String repository, String reference) {
-        return repo.getCommitID(repository, reference);
+    private String getCurrentHash(GitHubSourceCodeRepo repo, String repository, String reference) {
+        if (StringUtils.startsWith(reference, "refs/tags/")) {
+            return repo.getHash(repository, reference);
+        } else {
+            return repo.getCommitID(repository, reference);
+        }
     }
 
     /**


### PR DESCRIPTION
**Description**
A bug in our push processing code was causing pushes of annotated tags to be ignored.  The root problem was that our "ref inspection" code compared the `after` hash in the push event to the current hash of the referenced commit.  This worked for lightweight tags, which directly link to a commit.  However, it didn't work for annotated tags, which are represented by a tag object.  In the push events corresponding to annotated tags, the `after` hash is that of the tag object itself.  So, for annotated tags, we were comparing the `after` hash to the wrong value, the comparison failed, and the pushes were ignored.

This PR solves the problem by comparing the `after` hash in tag push events to the current tag hash (which will be a commit hash if its a lightweight tag, and a tag object hash if it's an annotated tag).

Tests have been added for pushes of both lightweight and annotated tags, as well as regular branch pushes, with values that simulate what might arrive in a GitHub push event.  These are on the branch `dont-ever-commit-to-this-branch` in `dockstore-testing/simple-notebook`.  Please don't ever commit to that branch!

**Review Instructions**
Push an annotated tag of a valid workflow, and make sure it shows up on Dockstore.  Do the same for a lightweight tag to ensure that we didn't break anything.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2512
#5807

**Security and Privacy**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
