### PR TITLE
DOCK-2468: Improve error message when .dockstore.yml contains a scalar where a list is expected

### DIFF
--- a/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/yaml/DockstoreYamlTest.java
@@ -555,4 +555,16 @@ class DockstoreYamlTest {
             assertTrue(ex.getMessage().toLowerCase().contains("subclass"));
         }
     }
+
+    @Test
+    void testScalarWhereListExpected() throws DockstoreYamlHelper.DockstoreYamlException {
+        final String prelude = "version: 1.2\nworkflows:\n - primaryDescriptorPath: /abc.wdl\n   subclass: wdl\n   testParameterFiles: ";
+        DockstoreYamlHelper.readDockstoreYaml(prelude + "[ /some/file.txt ]", true);
+        try {
+            DockstoreYamlHelper.readDockstoreYaml(prelude + "/some/file.txt", true);
+            fail("Should not succeed because the `testParameterFiles` property should be a list");
+        } catch (DockstoreYamlHelper.DockstoreYamlException ex) {
+            assertTrue(ex.getMessage().contains(DockstoreYamlHelper.BETTER_NO_SINGLE_ARGUMENT_CONSTRUCTOR_YAML_EXCEPTION_MESSAGE));
+        }
+    }
 }


### PR DESCRIPTION
**Description**
This PR improves the error message that appears in the GitHub App logs when a single string is supplied to a `.dockstore.yml` property that requires a list.  Previously, the message was:
```
No single argument constructor found for interface java.util.List
```
This PR changes it to something intelligible.

Before deciding on the above solution, I tried to make the parser accept a string where a list was expected, but after a number of hours, stopped.  I can't eliminate the possibility that we could somehow inject some code into SnakeYaml to make it happen, but there's no obvious public hooks, and it appears that we'd be fiddling with its innards to a degree that, IMHO, the danger would outweigh the benefits.  Similarly, we could parse to an intermediate YAML node representation, modify the appropriate scalar property settings to lists, convert back to YAML, then parse as we currently do, but we'd risk mangling our line number information and introducing other issues.  We could do something similar by preprocessing with regexps, similar risks.

This PR is a minimally-invasive solution that probably makes the situation good enough.  There are other ways to make SnakeYaml throw exceptions containing inscrutable messages, but they happen with low enough frequency that it's probably not worth addressing at this point.  If we wanted to make those better, a PR to SnakeYaml might be the most efficient approach.  Or, parsing to an intermediate YAML node representation, then using our own code to build the objects, would give us more control.

**Review Instructions**
Push a `.dockstore.yml` that sets a property to a single string value, instead of the expected list.  Wait five minutes, then confirm that the new message appears in the GitHub App logs.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2468
#5683

**Security and Privacy**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
