### PR TITLE
SEAB-5195: Automatically set default version if appropriate

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -681,37 +681,36 @@ class WebhookIT extends BaseIT {
     }
 
     @Test
-    private void testAutomaticDefaultVersionMustMatchGitHubDefault() {
+    void testAutomaticDefaultVersionMustMatchGitHubDefault() {
         final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi client = new WorkflowsApi(webClient);
-        handleGitHubRelease(client, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, "manualTopic", USER_2_USERNAME);
+        handleGitHubRelease(client, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, "refs/heads/manualTopic", USER_2_USERNAME);
         Workflow workflow = getFoobarWorkflowDockstoreTesting(client);
         assertNull(workflow.getDefaultVersion());
         assertEquals(1, workflow.getWorkflowVersions().size());
-        handleGitHubRelease(client, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, "master", USER_2_USERNAME);
+        handleGitHubRelease(client, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, "refs/heads/master", USER_2_USERNAME);
         workflow = getFoobarWorkflowDockstoreTesting(client);
         assertEquals("master", workflow.getDefaultVersion());
         assertEquals(2, workflow.getWorkflowVersions().size());
     }
 
     @Test
-    private void testAutomaticDefaultVersionWontOverrideExistingDefault() {
+    void testAutomaticDefaultVersionWontOverrideExistingDefault() {
         final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi client = new WorkflowsApi(webClient);
         // This release should not automatically set the default version, because the branch name doesn't
         // match the GitHub default.
-        handleGitHubRelease(client, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, "manualTopic", USER_2_USERNAME);
+        handleGitHubRelease(client, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, "refs/heads/manualTopic", USER_2_USERNAME);
         Workflow workflow = getFoobarWorkflowDockstoreTesting(client);
         assertNull(workflow.getDefaultVersion());
         assertEquals(1, workflow.getWorkflowVersions().size());
         // Manually set the default version.
-        workflow.setDefaultVersion("manualTopic");
-        client.updateWorkflow(workflow.getId(), workflow);
+        client.updateDefaultVersion1(workflow.getId(), "manualTopic");
         workflow = getFoobarWorkflowDockstoreTesting(client);
         assertEquals("manualTopic", workflow.getDefaultVersion());
         // This release should not set the default version, because although the branch name matches,
         // the default version is already set.
-        handleGitHubRelease(client, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, "master", USER_2_USERNAME);
+        handleGitHubRelease(client, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, "refs/heads/master", USER_2_USERNAME);
         workflow = getFoobarWorkflowDockstoreTesting(client);
         assertEquals("manualTopic", workflow.getDefaultVersion());
         assertEquals(2, workflow.getWorkflowVersions().size());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -668,11 +668,15 @@ class WebhookIT extends BaseIT {
         Workflow workflow2 = getFoobar2Workflow(client);
         assertNull(workflow2.getDefaultVersion());
         Workflow workflow = getFoobar1Workflow(client);
+        // The default version should be set to the version named "master" because the branch "master" has
+        // been registered, and the source GitHub repo default branch is set to "master".  For more info, see:
+        // https://github.com/dockstore/dockstore/pull/5829
         assertEquals("master", workflow.getDefaultVersion());
         handleGitHubRelease(client, DockstoreTestUser2.WORKFLOW_DOCKSTORE_YML, "refs/tags/0.4", USER_2_USERNAME);
         workflow2 = getFoobar2Workflow(client);
         assertEquals("0.4", workflow2.getDefaultVersion(), "The new tag says the latest tag should be the default version");
         workflow = getFoobar1Workflow(client);
+        // See above comment.
         assertEquals("master", workflow.getDefaultVersion());
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -1076,7 +1076,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     private void setToDefaultVersionIfAppropriate(GitHubSourceCodeRepo gitHubSourceCodeRepo, String repositoryId, Workflowish wf, Workflow workflow, WorkflowVersion version) {
         // If the default version isn't set, the latest tag is not the default, the version is a branch,
         // and the version's name is the same as the GitHub repo's default branch name, use this version
-        /// as the workflow's default version.
+        // as the workflow's default version.
         if (workflow.getActualDefaultVersion() == null
             && !Objects.equals(wf.getLatestTagAsDefault(), Boolean.TRUE)
             && Objects.equals(version.getReferenceType(), Version.ReferenceType.BRANCH)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -1077,10 +1077,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         // If the default version isn't set, the latest tag is not the default, the version is a branch,
         // and the version's name is the same as the GitHub repo's default branch name, use this version
         /// as the workflow's default version.
-        if (workflow.getActualDefaultVersion() == null &&
-            !Objects.equals(wf.getLatestTagAsDefault(), Boolean.TRUE) &&
-            Objects.equals(version.getReferenceType(), Version.ReferenceType.BRANCH) &&
-            Objects.equals(version.getName(), gitHubSourceCodeRepo.getDefaultBranch(repositoryId))
+        if (workflow.getActualDefaultVersion() == null
+            && !Objects.equals(wf.getLatestTagAsDefault(), Boolean.TRUE)
+            && Objects.equals(version.getReferenceType(), Version.ReferenceType.BRANCH)
+            && Objects.equals(version.getName(), gitHubSourceCodeRepo.getDefaultBranch(repositoryId))
         ) {
             workflow.setActualDefaultVersion(version);
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -1082,6 +1082,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             && Objects.equals(version.getReferenceType(), Version.ReferenceType.BRANCH)
             && Objects.equals(version.getName(), gitHubSourceCodeRepo.getDefaultBranch(repositoryId))
         ) {
+            LOG.info("default version set to GitHub default branch " + version.getName());
             workflow.setActualDefaultVersion(version);
         }
     }


### PR DESCRIPTION
**Description**
This PR modifies the webservice to automatically set the default version for a `.dockstore.yml`-based entry to the version being processed in the release webhook, if the following are true:

1. the entry's default version is not set
2. `.dockstore.yml` does not specify that the latest tag should be the default
3. the version being processed corresponds to a branch
4. the version's name matches the GitHub default branch name

This will set the default branch for most users, with a minimum of code and overhead.

This PR also includes some light refactoring.

**Review Instructions**
On qa, create a new repo containing a workflow and register it on Dockstore.  After the Dockstore entry appears, confirm that the default version is set to the GitHub default branch.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5195

**Security and Privacy**

No concerns.

- [x] Security and Privacy assessed

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
