### PR TITLE
add tests and fix 500s - weird registries and languages

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
@@ -133,7 +133,7 @@ public abstract class GA4GHIT {
      */
     @Test
     void testToolsIdVersionsVersionIdTypeDescriptorWeirdLanguage() {
-        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/fuzzstring/descriptor", HttpStatus.SC_BAD_REQUEST);
+        checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/fuzzstring/descriptor", HttpStatus.SC_BAD_REQUEST);
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHIT.java
@@ -129,6 +129,14 @@ public abstract class GA4GHIT {
     abstract void testToolsIdVersionsVersionIdTypeDescriptor() throws Exception;
 
     /**
+     * This tests the /tools/{id}/versions/{version-id}/{type}/descriptor endpoint
+     */
+    @Test
+    void testToolsIdVersionsVersionIdTypeDescriptorWeirdLanguage() {
+        Response response = checkedResponse(baseURL + "tools/quay.io%2Ftest_org%2Ftest6/versions/fakeName/fuzzstring/descriptor", HttpStatus.SC_BAD_REQUEST);
+    }
+
+    /**
      * This tests the /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path} endpoint
      */
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiCRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiCRUDClientIT.java
@@ -120,6 +120,29 @@ class OpenApiCRUDClientIT extends BaseIT {
         assertEquals(workflows.size() + tools.size(), allStuff.size());
     }
 
+    @Test
+    void testGA4GHWeirdFiltering() {
+        ApiClient webClient = new ApiClient();
+        File configFile = FileUtils.getFile("src", "test", "resources", "config");
+        INIConfiguration parseConfig = Utilities.parseConfig(configFile.getAbsolutePath());
+        webClient.setBasePath(parseConfig.getString(Constants.WEBSERVICE_BASE_PATH));
+        Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(webClient);
+        List<Tool> weirdStuff = ga4Ghv20Api
+            .toolsGet(null, null, null, null, "fuzzString", null, null, null, null, null, null, null, Integer.MAX_VALUE);
+        assertTrue(weirdStuff.isEmpty());
+        ApiException returnException = assertThrows(ApiException.class, () -> ga4Ghv20Api
+            .toolsGet(null, null, null, null, null, null, null, null, null, null, null, "fuzzString", Integer.MAX_VALUE));
+        assertTrue(returnException.getCode() == HttpStatus.SC_BAD_REQUEST);
+        assertTrue(weirdStuff.isEmpty());
+        returnException = assertThrows(ApiException.class, () -> ga4Ghv20Api
+            .toolsGet(null, null, null, "fuzzString", null, null, null, null, null, null, null, null, Integer.MAX_VALUE));
+        assertTrue(returnException.getCode() == HttpStatus.SC_BAD_REQUEST);
+        assertTrue(weirdStuff.isEmpty());
+        weirdStuff = ga4Ghv20Api
+            .toolsGet(null, null, "fuzzString", null, null, null, null, null, null, null, null, null, Integer.MAX_VALUE);
+        assertTrue(weirdStuff.isEmpty());
+    }
+
 
     @Test
     void testGA4GHBigPaging() throws IOException {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiCRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenApiCRUDClientIT.java
@@ -132,11 +132,11 @@ class OpenApiCRUDClientIT extends BaseIT {
         assertTrue(weirdStuff.isEmpty());
         ApiException returnException = assertThrows(ApiException.class, () -> ga4Ghv20Api
             .toolsGet(null, null, null, null, null, null, null, null, null, null, null, "fuzzString", Integer.MAX_VALUE));
-        assertTrue(returnException.getCode() == HttpStatus.SC_BAD_REQUEST);
+        assertEquals(HttpStatus.SC_BAD_REQUEST, returnException.getCode());
         assertTrue(weirdStuff.isEmpty());
         returnException = assertThrows(ApiException.class, () -> ga4Ghv20Api
             .toolsGet(null, null, null, "fuzzString", null, null, null, null, null, null, null, null, Integer.MAX_VALUE));
-        assertTrue(returnException.getCode() == HttpStatus.SC_BAD_REQUEST);
+        assertEquals(HttpStatus.SC_BAD_REQUEST, returnException.getCode());
         assertTrue(weirdStuff.isEmpty());
         weirdStuff = ga4Ghv20Api
             .toolsGet(null, null, "fuzzString", null, null, null, null, null, null, null, null, null, Integer.MAX_VALUE);

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -299,6 +299,9 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
     @Override
     public Response toolsIdVersionsVersionIdTypeDescriptorGet(String id, DescriptorTypeWithPlain type, String versionId, SecurityContext securityContext, ContainerRequestContext value,
         Optional<User> user) {
+        if (type == null) {
+            return Response.status(Status.BAD_REQUEST).build();
+        }
         final Optional<DescriptorLanguage.FileType> fileType = DescriptorLanguage.getOptionalFileType(type.toString());
         if (fileType.isEmpty()) {
             return Response.status(Status.NOT_FOUND).build();
@@ -362,7 +365,11 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
 
         int offsetInteger = 0;
         if (offset != null) {
-            offsetInteger = Integer.parseInt(offset);
+            try {
+                offsetInteger = Integer.parseInt(offset);
+            } catch (NumberFormatException e) {
+                return Response.status(getExtendedStatus(Status.BAD_REQUEST, "Bad offset")).build();
+            }
             offsetInteger = Math.max(offsetInteger, 0);
         }
         // note, there's a subtle change in definition here, TRS uses offset to indicate the page number, JPA uses index in the result set


### PR DESCRIPTION
**Description**
Expose a few 500s based on fuzzing results and then fix them. 

**Review Instructions**
Could try out weird languages and registries against the TRS API and get non-500s

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6171

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
