### PR TITLE
Make athena life easier - duration in seconds

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
@@ -101,7 +101,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -937,8 +939,11 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         expectedWorkflowExecutions.forEach(expectedWorkflowExecution -> {
             List<RunExecution> actualWorkflowExecutions = getExecution(extendedGa4GhApi, trsId, versionId, platform, expectedWorkflowExecution.getExecutionId()).getRunExecutions();
             assertEquals(1, actualWorkflowExecutions.size());
-            assertTrue(expectedWorkflowExecutions.contains(actualWorkflowExecutions.get(0)));
-            assertTrue(actualWorkflowExecutions.stream().allMatch(f -> f.getExecutionTimeSeconds() != null));
+            Assertions.assertThat(expectedWorkflowExecutions).usingElementComparatorIgnoringFields("executionTimeSeconds").containsOnly(actualWorkflowExecutions.get(0));
+            assertTrue(actualWorkflowExecutions.stream().allMatch(f -> f.getExecutionTimeSeconds() != null && f.getExecutionTimeSeconds() > 0),
+                () -> "executionTimes are showing up as " + actualWorkflowExecutions.stream().map(
+                    RunExecution::getExecutionTimeSeconds).collect(
+                    Collectors.toSet()));
         });
     }
 
@@ -950,7 +955,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         expectedTaskExecutions.forEach(expectedTaskExecutionsSet -> {
             List<TaskExecutions> actualTaskExecution = getExecution(extendedGa4GhApi, trsId, versionId, platform, expectedTaskExecutionsSet.getExecutionId()).getTaskExecutions();
             assertEquals(1, actualTaskExecution.size());
-            assertTrue(expectedTaskExecutions.contains(actualTaskExecution.get(0)));
+            Assertions.assertThat(expectedTaskExecutions).usingElementComparatorIgnoringFields("executionTimeSeconds").containsOnly(actualTaskExecution.get(0));
         });
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
@@ -93,6 +93,7 @@ import io.dockstore.openapi.client.model.WorkflowVersion;
 import io.dockstore.webservice.core.metrics.ExecutionTimeStatisticMetric;
 import io.dockstore.webservice.core.metrics.MemoryStatisticMetric;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -103,8 +104,8 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -132,6 +133,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
     private static final String DOCKSTORE_WORKFLOW_CNV_PATH = SourceControl.GITHUB + "/" + DOCKSTORE_WORKFLOW_CNV_REPO;
     private static final Gson GSON = new Gson();
     private static final Logger LOGGER = LoggerFactory.getLogger(ExtendedMetricsTRSOpenApiIT.class);
+    public static final String MINUTES_EXECUTION = "5";
 
     private static String bucketName;
     private static String s3EndpointOverride;
@@ -464,7 +466,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         verifyRunExecutionMetricsDataContent(List.of(workflowExecution), extendedGa4GhApi, workflowId, workflowVersionId, platform1);
 
         // Update the workflow execution so that it has execution time
-        workflowExecution.setExecutionTime("PT5M"); // 5 mins
+        workflowExecution.setExecutionTime("PT" + MINUTES_EXECUTION + "M"); // 5 mins
         workflowExecution.setExecutionStatus(ExecutionStatusEnum.FAILED_RUNTIME_INVALID); // Attempt to update the execution status. This should not be updated because it's not an optional field
         ExecutionsResponseBody responseBody = extendedGa4GhApi.executionMetricsUpdate(new ExecutionsRequestBody().runExecutions(List.of(workflowExecution)), platform1, workflowId, workflowVersionId, description);
         assertEquals(1, responseBody.getExecutionResponses().size());
@@ -472,7 +474,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         verifyMetricsDataList(workflowId, workflowVersionId, platform1, ownerUserId, description, 11); // There should still be 11 files
         ExecutionsRequestBody execution = extendedGa4GhApi.executionGet(workflowId, workflowVersionId, platform1, executionId);
         RunExecution updatedWorkflowExecutionFromS3 = execution.getRunExecutions().get(0);
-        assertEquals("PT5M", updatedWorkflowExecutionFromS3.getExecutionTime(), "Execution time should've been updated");
+        assertEquals("PT" + MINUTES_EXECUTION + "M", updatedWorkflowExecutionFromS3.getExecutionTime(), "Execution time should've been updated");
         assertEquals(ExecutionStatusEnum.SUCCESSFUL, updatedWorkflowExecutionFromS3.getExecutionStatus(), "Execution status should not change");
 
         // Try to update an execution that doesn't exist
@@ -782,7 +784,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         ExecutionsRequestBody executionsRequestBody = extendedGa4GhApi.executionGet(workflowId, workflowVersionId, platform1, expectedAggregatedMetrics.getExecutionId());
         assertEquals(1, executionsRequestBody.getAggregatedExecutions().size());
         AggregatedExecution aggregatedMetrics = executionsRequestBody.getAggregatedExecutions().get(0);
-        assertEquals(5, aggregatedMetrics.getExecutionStatusCount().getNumberOfSuccessfulExecutions());
+        Assertions.assertEquals(MINUTES_EXECUTION, aggregatedMetrics.getExecutionStatusCount().getNumberOfSuccessfulExecutions());
         assertEquals(0, aggregatedMetrics.getExecutionStatusCount().getNumberOfFailedExecutions());
         assertEquals(50.0, aggregatedMetrics.getAdditionalAggregatedMetrics().get("cpu_utilization"), "Should be able to submit additional aggregated metrics");
 
@@ -939,23 +941,51 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         expectedWorkflowExecutions.forEach(expectedWorkflowExecution -> {
             List<RunExecution> actualWorkflowExecutions = getExecution(extendedGa4GhApi, trsId, versionId, platform, expectedWorkflowExecution.getExecutionId()).getRunExecutions();
             assertEquals(1, actualWorkflowExecutions.size());
-            Assertions.assertThat(expectedWorkflowExecutions).usingElementComparatorIgnoringFields("executionTimeSeconds,taskExecutions").containsOnly(actualWorkflowExecutions.get(0));
-            assertTrue(actualWorkflowExecutions.stream().allMatch(f -> f.getExecutionTimeSeconds() != null && f.getExecutionTimeSeconds() > 0),
-                () -> "executionTimes are showing up as " + actualWorkflowExecutions.stream().map(
-                    RunExecution::getExecutionTimeSeconds).collect(
-                    Collectors.toSet()));
+            // mimic server calculation client-side
+            if (expectedWorkflowExecution.getExecutionTime() != null) {
+                overrideExpectation(expectedWorkflowExecution);
+            }
+            assertTrue(expectedWorkflowExecutions.contains(actualWorkflowExecutions.get(0)));
+            if (expectedWorkflowExecution.getExecutionTime() != null) {
+                assertTrue(actualWorkflowExecutions.stream().allMatch(f -> f.getExecutionTimeSeconds() != null && f.getExecutionTimeSeconds() > 0),
+                    () -> "executionTimes are showing up as " + actualWorkflowExecutions.stream().map(
+                        RunExecution::getExecutionTimeSeconds).collect(
+                        Collectors.toSet()));
+            }
         });
     }
 
+    /**
+     * The executionTimeSeconds is calculated server side but is read-only, so we change our expectation
+     *
+     * @param expectedWorkflowExecution
+     */
+    private static void overrideExpectation(RunExecution expectedWorkflowExecution) {
+        Field f1;
+        try {
+            f1 = expectedWorkflowExecution.getClass().getDeclaredField("executionTimeSeconds");
+            f1.setAccessible(true);
+            f1.set(expectedWorkflowExecution, (Long.parseLong(MINUTES_EXECUTION) * 60));
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void overrideExpectation(TaskExecutions taskExecutions) {
+        taskExecutions.getTaskExecutions().forEach(ExtendedMetricsTRSOpenApiIT::overrideExpectation);
+    }
+
     private int getNumberOfExecutions(ExecutionsRequestBody executionsRequestBody) {
-        return executionsRequestBody.getRunExecutions().size() + executionsRequestBody.getTaskExecutions().size() + executionsRequestBody.getValidationExecutions().size() + executionsRequestBody.getAggregatedExecutions().size();
+        return executionsRequestBody.getRunExecutions().size() + executionsRequestBody.getTaskExecutions().size() + executionsRequestBody.getValidationExecutions().size()
+            + executionsRequestBody.getAggregatedExecutions().size();
     }
 
     private void verifyTaskExecutionMetricsDataContent(List<TaskExecutions> expectedTaskExecutions, ExtendedGa4GhApi extendedGa4GhApi, String trsId, String versionId, String platform) {
         expectedTaskExecutions.forEach(expectedTaskExecutionsSet -> {
             List<TaskExecutions> actualTaskExecution = getExecution(extendedGa4GhApi, trsId, versionId, platform, expectedTaskExecutionsSet.getExecutionId()).getTaskExecutions();
             assertEquals(1, actualTaskExecution.size());
-            Assertions.assertThat(expectedTaskExecutions).usingElementComparatorIgnoringFields("executionTimeSeconds").containsOnly(actualTaskExecution.get(0));
+            overrideExpectation(expectedTaskExecutionsSet);
+            assertTrue(expectedTaskExecutions.contains(actualTaskExecution.get(0)));
         });
     }
 
@@ -981,12 +1011,12 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
             execution.setExecutionId(generateExecutionId()); // Set a random execution ID
             execution.setExecutionStatus(RunExecution.ExecutionStatusEnum.SUCCESSFUL);
             execution.setDateExecuted(Instant.now().toString());
-            execution.setExecutionTime("PT5M");
+            execution.setExecutionTime("PT" + MINUTES_EXECUTION + "M");
             execution.setCpuRequirements(2);
             execution.setMemoryRequirementsGB(2.0);
             execution.setCost(new Cost().value(9.99));
             execution.setRegion("us-central1");
-            Map<String, Object> additionalProperties = Map.of("schema.org:totalTime", "PT5M");
+            Map<String, Object> additionalProperties = Map.of("schema.org:totalTime", "PT" + MINUTES_EXECUTION + "M");
             execution.setAdditionalProperties(additionalProperties);
             executions.add(execution);
         }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
@@ -938,6 +938,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
             List<RunExecution> actualWorkflowExecutions = getExecution(extendedGa4GhApi, trsId, versionId, platform, expectedWorkflowExecution.getExecutionId()).getRunExecutions();
             assertEquals(1, actualWorkflowExecutions.size());
             assertTrue(expectedWorkflowExecutions.contains(actualWorkflowExecutions.get(0)));
+            assertTrue(actualWorkflowExecutions.stream().allMatch(f -> f.getExecutionTimeSeconds() != null));
         });
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
@@ -105,7 +105,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
@@ -784,7 +784,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         ExecutionsRequestBody executionsRequestBody = extendedGa4GhApi.executionGet(workflowId, workflowVersionId, platform1, expectedAggregatedMetrics.getExecutionId());
         assertEquals(1, executionsRequestBody.getAggregatedExecutions().size());
         AggregatedExecution aggregatedMetrics = executionsRequestBody.getAggregatedExecutions().get(0);
-        Assertions.assertEquals(MINUTES_EXECUTION, aggregatedMetrics.getExecutionStatusCount().getNumberOfSuccessfulExecutions());
+        assertEquals(5, aggregatedMetrics.getExecutionStatusCount().getNumberOfSuccessfulExecutions());
         assertEquals(0, aggregatedMetrics.getExecutionStatusCount().getNumberOfFailedExecutions());
         assertEquals(50.0, aggregatedMetrics.getAdditionalAggregatedMetrics().get("cpu_utilization"), "Should be able to submit additional aggregated metrics");
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
@@ -939,7 +939,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         expectedWorkflowExecutions.forEach(expectedWorkflowExecution -> {
             List<RunExecution> actualWorkflowExecutions = getExecution(extendedGa4GhApi, trsId, versionId, platform, expectedWorkflowExecution.getExecutionId()).getRunExecutions();
             assertEquals(1, actualWorkflowExecutions.size());
-            Assertions.assertThat(expectedWorkflowExecutions).usingElementComparatorIgnoringFields("executionTimeSeconds").containsOnly(actualWorkflowExecutions.get(0));
+            Assertions.assertThat(expectedWorkflowExecutions).usingElementComparatorIgnoringFields("executionTimeSeconds,taskExecutions").containsOnly(actualWorkflowExecutions.get(0));
             assertTrue(actualWorkflowExecutions.stream().allMatch(f -> f.getExecutionTimeSeconds() != null && f.getExecutionTimeSeconds() > 0),
                 () -> "executionTimes are showing up as " + actualWorkflowExecutions.stream().map(
                     RunExecution::getExecutionTimeSeconds).collect(

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/RunExecution.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/RunExecution.java
@@ -47,7 +47,7 @@ public class RunExecution extends Execution {
 
     @JsonProperty
     @PositiveOrZero
-    @Schema(description = "In seconds, automatically calculated from executionTime and dateExecuted", example = "30")
+    @Schema(description = "In seconds, automatically calculated from executionTime and dateExecuted", example = "30", accessMode = Schema.AccessMode.READ_ONLY)
     private Long executionTimeSeconds;
 
     @JsonProperty

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/RunExecution.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/RunExecution.java
@@ -26,6 +26,7 @@ import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.time.Duration;
+import java.time.format.DateTimeParseException;
 
 /**
  * This is an object to encapsulate workflow run execution metrics data in an entity. Does not need to be stored in the database.
@@ -91,7 +92,11 @@ public class RunExecution extends Execution {
     public void setExecutionTime(String executionTime) {
         this.executionTime = executionTime;
         // make life easier on AWS athena, also store duration in seconds
-        this.executionTimeSeconds = Duration.parse(executionTime).getSeconds();
+        try {
+            this.executionTimeSeconds = Duration.parse(executionTime).getSeconds();
+        } catch (DateTimeParseException e) {
+            // ignore, expecting this to be caught by `ISO8601ExecutionTime` anyway
+        }
     }
 
     public Double getMemoryRequirementsGB() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/RunExecution.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/RunExecution.java
@@ -47,7 +47,7 @@ public class RunExecution extends Execution {
 
     @JsonProperty
     @PositiveOrZero
-    @Schema(description = "In seconds, automatically calculated from executionTime and dateExecuted", example = "30", accessMode = Schema.AccessMode.READ_ONLY)
+    @Schema(description = "In seconds, automatically calculated from executionTime and dateExecuted", example = "30")
     private Long executionTimeSeconds;
 
     @JsonProperty

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -10430,6 +10430,13 @@ components:
             description: The total time it took for the execution to complete in ISO
               8601 duration format
             example: PT30S
+          executionTimeSeconds:
+            type: integer
+            format: int64
+            description: "In seconds, automatically calculated from executionTime\
+              \ and dateExecuted"
+            example: 30
+            readOnly: true
           memoryRequirementsGB:
             type: number
             format: double

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -10436,6 +10436,7 @@ components:
             description: "In seconds, automatically calculated from executionTime\
               \ and dateExecuted"
             example: 30
+            readOnly: true
           memoryRequirementsGB:
             type: number
             format: double

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -10436,7 +10436,6 @@ components:
             description: "In seconds, automatically calculated from executionTime\
               \ and dateExecuted"
             example: 30
-            readOnly: true
           memoryRequirementsGB:
             type: number
             format: double

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/QuayImageRegistryTest.java
@@ -91,7 +91,7 @@ class QuayImageRegistryTest {
     @Test
     void testGetQuayTag() throws ApiException {
         final String repo = "calico/node";
-        final String tag = "master";
+        final String tag = "v3.28.0-0.dev-493-gad6e818087f8";
         QuayImageRegistry quayImageRegistry = new QuayImageRegistry();
         Optional<QuayTag> quayTag = quayImageRegistry.getQuayTag(repo, tag);
         assertTrue(quayTag.isPresent());


### PR DESCRIPTION
**Description**
Turns out AWS Athena is kinda terrible at  ISO 8601 duration, it can handle ISO 8601 times and dates, but not durations. 
There are a few work arounds, but just providing the time in seconds should just make our lives easier long term if we go down this route. 

**Review Instructions**
Can ingest a metric using the Swagger API in staging and get it back again, with a server-side duration calculated time in seconds 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6313

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
