### PR TITLE
SEAB-6225/4825: Add Liquibase lock and Elasticsearch consistency checks

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/MetadataResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/MetadataResourceIT.java
@@ -25,8 +25,13 @@ import io.dockstore.client.cli.BaseIT;
 import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.openapi.client.ApiClient;
 import io.dockstore.openapi.client.ApiException;
+import io.dockstore.openapi.client.api.ContainersApi;
 import io.dockstore.openapi.client.api.MetadataApi;
+import io.dockstore.openapi.client.api.WorkflowsApi;
+import io.dockstore.openapi.client.model.DockstoreTool;
 import io.dockstore.openapi.client.model.HealthCheckResult;
+import io.dockstore.openapi.client.model.PublishRequest;
+import io.dockstore.openapi.client.model.Workflow;
 import io.dropwizard.testing.DropwizardTestSupport;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -42,8 +47,37 @@ class MetadataResourceIT extends BaseIT {
         CommonTestUtilities.dropAndRecreateNoTestData(SUPPORT, CommonTestUtilities.PUBLIC_CONFIG_PATH);
     }
 
+    void sleep(long milliseconds) {
+        try {
+            Thread.sleep(milliseconds);
+        } catch (Exception e) {
+            // This space intentionally left blank.
+        }
+    }
+
+    void makeElasticsearchConsistent() {
+
+        ApiClient apiClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        ContainersApi containersApi = new ContainersApi(apiClient);
+        WorkflowsApi workflowsApi = new WorkflowsApi(apiClient);
+
+        // Retrieve all the published entries
+        List<DockstoreTool> tools = containersApi.allPublishedContainers(null, null, null, null, null);
+        List<Workflow> workflows = workflowsApi.allPublishedWorkflows(null, null, null, null, null, false, null);
+
+        // Unpublish the entries
+        PublishRequest unpublishRequest = CommonTestUtilities.createOpenAPIPublishRequest(false);
+        tools.forEach(tool -> containersApi.publish(tool.getId(), unpublishRequest));
+        workflows.forEach(workflow -> workflowsApi.publish1(workflow.getId(), unpublishRequest));
+
+        // Give the ES server a few seconds to deindex everything
+        sleep(5000);
+    }
+
     @Test
     void testCheckHealth() {
+        makeElasticsearchConsistent();
+
         ApiClient anonymousApiClient = getAnonymousOpenAPIWebClient();
         MetadataApi metadataApi = new MetadataApi(anonymousApiClient);
 
@@ -53,7 +87,9 @@ class MetadataResourceIT extends BaseIT {
             results = metadataApi.checkHealth(null);
             // Not asserting size because there seems to be an JdbiHealthCheck present when running tests
             healthCheckNames = results.stream().map(HealthCheckResult::getHealthCheckName).collect(Collectors.toList());
-            assertTrue(healthCheckNames.contains("hibernate") && healthCheckNames.contains("deadlocks") && healthCheckNames.contains("connectionPool"));
+            for (String name: List.of("hibernate", "deadlocks", "connectionPool", "liquibaseLock", "elasticsearchConsistency")) {
+                assertTrue(healthCheckNames.contains(name), String.format("health check names should include '%s'", name));
+            }
         } catch (ApiException e) {
             fail("Health checks should not fail");
         }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/MetadataResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/MetadataResourceIT.java
@@ -70,12 +70,13 @@ class MetadataResourceIT extends BaseIT {
         tools.forEach(tool -> containersApi.publish(tool.getId(), unpublishRequest));
         workflows.forEach(workflow -> workflowsApi.publish1(workflow.getId(), unpublishRequest));
 
-        // Give the ES server a few seconds to deindex everything
+        // Give the ES server a few seconds to deindex anything that was there
         sleep(5000);
     }
 
     @Test
-    void testCheckHealth() {
+    void testCheckHealth() throws Exception {
+        CommonTestUtilities.restartElasticsearch();
         makeElasticsearchConsistent();
 
         ApiClient anonymousApiClient = getAnonymousOpenAPIWebClient();

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/MetadataResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/MetadataResourceIT.java
@@ -39,7 +39,6 @@ import java.util.stream.Collectors;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -65,7 +64,7 @@ class MetadataResourceIT extends BaseIT {
         RestHighLevelClient client = ElasticSearchHelper.restHighLevelClient();
         DeleteByQueryRequest request = new DeleteByQueryRequest("tools", "workflows", "notebooks");
         request.setQuery(QueryBuilders.matchAllQuery());
-        BulkByScrollResponse response = client.deleteByQuery(request, RequestOptions.DEFAULT);
+        client.deleteByQuery(request, RequestOptions.DEFAULT);
         // Give the ES server a few seconds to finish any internal updates.
         sleep(5000);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -122,6 +122,7 @@ import io.dockstore.webservice.resources.EventResource;
 import io.dockstore.webservice.resources.HostedToolResource;
 import io.dockstore.webservice.resources.HostedWorkflowResource;
 import io.dockstore.webservice.resources.LambdaEventResource;
+import io.dockstore.webservice.resources.LiquibaseLockHealthCheck;
 import io.dockstore.webservice.resources.MetadataResource;
 import io.dockstore.webservice.resources.NotificationResource;
 import io.dockstore.webservice.resources.OrganizationResource;
@@ -512,6 +513,8 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         environment.lifecycle().addServerLifecycleListener(server -> {
             final ConnectionPoolHealthCheck connectionPoolHealthCheck = new ConnectionPoolHealthCheck(configuration.getDataSourceFactory().getMaxSize(), environment.metrics().getGauges());
             environment.healthChecks().register("connectionPool", connectionPoolHealthCheck);
+            final LiquibaseLockHealthCheck liquibaseLockHealthCheck = new LiquibaseLockHealthCheck(hibernate.getSessionFactory());
+            environment.healthChecks().register("liquibaseLock", liquibaseLockHealthCheck);
             metadataResource.setHealthCheckRegistry(environment.healthChecks());
         });
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -516,7 +516,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             environment.healthChecks().register("connectionPool", connectionPoolHealthCheck);
             final LiquibaseLockHealthCheck liquibaseLockHealthCheck = new LiquibaseLockHealthCheck(hibernate.getSessionFactory());
             environment.healthChecks().register("liquibaseLock", liquibaseLockHealthCheck);
-            final ElasticsearchConsistencyHealthCheck elasticsearchConsistencyHealthCheck = new ElasticsearchConsistencyHealthCheck(hibernate.getSessionFactory(), bioWorkflowDAO, toolDAO, appToolDAO, notebookDAO);
+            final ElasticsearchConsistencyHealthCheck elasticsearchConsistencyHealthCheck = new ElasticsearchConsistencyHealthCheck(hibernate.getSessionFactory(), toolDAO, bioWorkflowDAO, appToolDAO, notebookDAO);
             environment.healthChecks().register("elasticsearchConsistency", elasticsearchConsistencyHealthCheck);
             metadataResource.setHealthCheckRegistry(environment.healthChecks());
         });

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -410,7 +410,8 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         LOG.info("Cache directory for OkHttp is: " + cache.directory().getAbsolutePath());
         LOG.info("This is our custom logger saying that we're about to load authenticators");
         // setup authentication to allow session access in authenticators, see https://github.com/dropwizard/dropwizard/pull/1361
-        SimpleAuthenticator authenticator = new UnitOfWorkAwareProxyFactory(getHibernate())
+        UnitOfWorkAwareProxyFactory unitOfWorkAwareProxyFactory = new UnitOfWorkAwareProxyFactory(getHibernate());
+        SimpleAuthenticator authenticator = unitOfWorkAwareProxyFactory
                 .create(SimpleAuthenticator.class, new Class[] { TokenDAO.class, UserDAO.class }, new Object[] { tokenDAO, userDAO });
         CachingAuthenticator<String, User> cachingAuthenticator = new CachingAuthenticator<>(environment.metrics(), authenticator,
                 configuration.getAuthenticationCachePolicy());
@@ -515,15 +516,15 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         environment.lifecycle().addServerLifecycleListener(server -> {
             final ConnectionPoolHealthCheck connectionPoolHealthCheck = new ConnectionPoolHealthCheck(configuration.getDataSourceFactory().getMaxSize(), environment.metrics().getGauges());
             environment.healthChecks().register("connectionPool", connectionPoolHealthCheck);
-            final LiquibaseLockHealthCheck liquibaseLockHealthCheck = new UnitOfWorkAwareProxyFactory(getHibernate()).create(
+            final LiquibaseLockHealthCheck liquibaseLockHealthCheck = unitOfWorkAwareProxyFactory.create(
                 LiquibaseLockHealthCheck.class,
                 new Class[] { SessionFactory.class },
                 new Object[] { hibernate.getSessionFactory() });
             environment.healthChecks().register("liquibaseLock", liquibaseLockHealthCheck);
-            final ElasticsearchConsistencyHealthCheck elasticsearchConsistencyHealthCheck = new UnitOfWorkAwareProxyFactory(getHibernate()).create(
+            final ElasticsearchConsistencyHealthCheck elasticsearchConsistencyHealthCheck = unitOfWorkAwareProxyFactory.create(
                 ElasticsearchConsistencyHealthCheck.class,
-                new Class[] { SessionFactory.class, ToolDAO.class, BioWorkflowDAO.class, AppToolDAO.class, NotebookDAO.class },
-                new Object[] { hibernate.getSessionFactory(), toolDAO, bioWorkflowDAO, appToolDAO, notebookDAO });
+                new Class[] { ToolDAO.class, BioWorkflowDAO.class, AppToolDAO.class, NotebookDAO.class },
+                new Object[] { toolDAO, bioWorkflowDAO, appToolDAO, notebookDAO });
             environment.healthChecks().register("elasticsearchConsistency", elasticsearchConsistencyHealthCheck);
             metadataResource.setHealthCheckRegistry(environment.healthChecks());
         });

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -117,6 +117,7 @@ import io.dockstore.webservice.resources.CollectionResource;
 import io.dockstore.webservice.resources.ConnectionPoolHealthCheck;
 import io.dockstore.webservice.resources.DockerRepoResource;
 import io.dockstore.webservice.resources.DockerRepoTagResource;
+import io.dockstore.webservice.resources.ElasticsearchConsistencyHealthCheck;
 import io.dockstore.webservice.resources.EntryResource;
 import io.dockstore.webservice.resources.EventResource;
 import io.dockstore.webservice.resources.HostedToolResource;
@@ -515,6 +516,8 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             environment.healthChecks().register("connectionPool", connectionPoolHealthCheck);
             final LiquibaseLockHealthCheck liquibaseLockHealthCheck = new LiquibaseLockHealthCheck(hibernate.getSessionFactory());
             environment.healthChecks().register("liquibaseLock", liquibaseLockHealthCheck);
+            final ElasticsearchConsistencyHealthCheck elasticsearchConsistencyHealthCheck = new ElasticsearchConsistencyHealthCheck(hibernate.getSessionFactory(), bioWorkflowDAO, toolDAO, appToolDAO, notebookDAO);
+            environment.healthChecks().register("elasticsearchConsistency", elasticsearchConsistencyHealthCheck);
             metadataResource.setHealthCheckRegistry(environment.healthChecks());
         });
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticsearchConsistencyHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticsearchConsistencyHealthCheck.java
@@ -24,6 +24,7 @@ import io.dockstore.webservice.jdbi.BioWorkflowDAO;
 import io.dockstore.webservice.jdbi.EntryDAO;
 import io.dockstore.webservice.jdbi.NotebookDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
+import io.dropwizard.hibernate.UnitOfWork;
 import java.io.IOException;
 import org.apache.http.HttpStatus;
 import org.elasticsearch.client.RequestOptions;
@@ -67,16 +68,14 @@ public class ElasticsearchConsistencyHealthCheck extends HealthCheck  {
         return dao.countAllPublished(null, null, null, null, null, null, null, false);
     }
 
+    @UnitOfWork
     @Override
     protected Result check() throws Exception {
 
         // Retrieve database entry counts.
-        Session session = sessionFactory.openSession();
-        ManagedSessionContext.bind(session);
         long dbWorkflowCount = countAllPublishedNonCheckers(bioWorkflowDAO);
         long dbToolCount = countAllPublishedNonCheckers(toolDAO) + countAllPublishedNonCheckers(appToolDAO);
         long dbNotebookCount = countAllPublishedNonCheckers(notebookDAO);
-        session.close();
 
         // Retrieve Elasticsearch document counts.
         long esWorkflowCount = countElasticsearchDocuments("workflows");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticsearchConsistencyHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticsearchConsistencyHealthCheck.java
@@ -63,7 +63,7 @@ public class ElasticsearchConsistencyHealthCheck extends HealthCheck  {
     @Override
     protected Result check() throws Exception {
 
-        // Retrieve database entry counts.
+        // Retrieve database entry counts.  Checkers aren't indexed on Elasticsearch so don't include them.
         long dbWorkflowCount = countAllPublishedNonCheckers(bioWorkflowDAO);
         long dbToolCount = countAllPublishedNonCheckers(toolDAO) + countAllPublishedNonCheckers(appToolDAO);
         long dbNotebookCount = countAllPublishedNonCheckers(notebookDAO);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticsearchConsistencyHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticsearchConsistencyHealthCheck.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2024 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package io.dockstore.webservice.resources;
 
 import com.codahale.metrics.health.HealthCheck;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticsearchConsistencyHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticsearchConsistencyHealthCheck.java
@@ -31,11 +31,8 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.CountRequest;
 import org.elasticsearch.client.core.CountResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ElasticsearchConsistencyHealthCheck extends HealthCheck  {
-    private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchConsistencyHealthCheck.class);
     private ToolDAO toolDAO;
     private BioWorkflowDAO bioWorkflowDAO;
     private AppToolDAO appToolDAO;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticsearchConsistencyHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticsearchConsistencyHealthCheck.java
@@ -1,0 +1,84 @@
+package io.dockstore.webservice.resources;
+
+import com.codahale.metrics.health.HealthCheck;
+import io.dockstore.webservice.helpers.ElasticSearchHelper;
+import io.dockstore.webservice.jdbi.AppToolDAO;
+import io.dockstore.webservice.jdbi.BioWorkflowDAO;
+import io.dockstore.webservice.jdbi.EntryDAO;
+import io.dockstore.webservice.jdbi.NotebookDAO;
+import io.dockstore.webservice.jdbi.ToolDAO;
+import java.io.IOException;
+import java.util.Date;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.core.CountRequest;
+import org.elasticsearch.client.core.CountResponse;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.context.internal.ManagedSessionContext;
+import org.hibernate.query.Query;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ElasticsearchConsistencyHealthCheck extends HealthCheck  {
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchConsistencyHealthCheck.class);
+    private final SessionFactory sessionFactory;
+    private BioWorkflowDAO bioWorkflowDAO;
+    private ToolDAO toolDAO;
+    private AppToolDAO appToolDAO;
+    private NotebookDAO notebookDAO;
+
+    public ElasticsearchConsistencyHealthCheck(SessionFactory sessionFactory,
+        BioWorkflowDAO bioWorkflowDAO, ToolDAO toolDAO, AppToolDAO appToolDAO, NotebookDAO notebookDAO) {
+        this.sessionFactory = sessionFactory;
+        this.bioWorkflowDAO = bioWorkflowDAO;
+        this.toolDAO = toolDAO;
+        this.appToolDAO = appToolDAO;
+        this.notebookDAO = notebookDAO;
+    }
+
+    private long countElasticsearchIndex(String index) throws IOException {
+        RestHighLevelClient client = ElasticSearchHelper.restHighLevelClient();
+        CountRequest countRequest = new CountRequest(index);
+        CountResponse countResponse = client.count(countRequest, RequestOptions.DEFAULT);
+        // TODO Check for failures.
+        return countResponse.getCount();
+    }
+
+    private long countAllPublishedNonCheckers(EntryDAO<?> dao) {
+        return dao.countAllPublished(null, null, null, null, null, null, null, false);
+    }
+
+    @Override
+    protected Result check() throws Exception {
+
+        // Retrieve database entry counts.
+        Session session = sessionFactory.openSession();
+        ManagedSessionContext.bind(session);
+        long dbWorkflowCount = countAllPublishedNonCheckers(bioWorkflowDAO);
+        long dbToolCount = countAllPublishedNonCheckers(toolDAO) + countAllPublishedNonCheckers(appToolDAO);
+        long dbNotebookCount = countAllPublishedNonCheckers(notebookDAO);
+        session.close();
+
+        // Retrieve Elasticsearch index counts.
+        long esWorkflowCount = countElasticsearchIndex("workflows");
+        long esToolCount = countElasticsearchIndex("tools");
+        long esNotebookCount = countElasticsearchIndex("notebooks");
+
+        // Compare and return the appropriate result.
+        String counts = String.format("esWorkflowCount=%d, dbWorkflowCount=%d, esToolCount=%d, dbToolCount=%d, esNotebookCount=%d, dbNotebookCount=%d",
+            esWorkflowCount,  dbWorkflowCount,
+            esToolCount,  dbToolCount,
+            esNotebookCount,  dbNotebookCount);
+            
+        if (esWorkflowCount == dbWorkflowCount
+            && esToolCount == dbToolCount
+            && esNotebookCount == dbNotebookCount) {
+            LOG.info("Elasticsearch is consistent, " + counts);
+            return Result.healthy();
+        } else {
+            LOG.error("Elasticsearch is not consistent, " + counts);
+            return Result.unhealthy("Elasticsearch is not consistent");
+        }
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticsearchConsistencyHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticsearchConsistencyHealthCheck.java
@@ -31,23 +31,17 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.CountRequest;
 import org.elasticsearch.client.core.CountResponse;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
-import org.hibernate.context.internal.ManagedSessionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ElasticsearchConsistencyHealthCheck extends HealthCheck  {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchConsistencyHealthCheck.class);
-    private final SessionFactory sessionFactory;
     private ToolDAO toolDAO;
     private BioWorkflowDAO bioWorkflowDAO;
     private AppToolDAO appToolDAO;
     private NotebookDAO notebookDAO;
 
-    public ElasticsearchConsistencyHealthCheck(SessionFactory sessionFactory,
-        ToolDAO toolDAO, BioWorkflowDAO bioWorkflowDAO, AppToolDAO appToolDAO, NotebookDAO notebookDAO) {
-        this.sessionFactory = sessionFactory;
+    public ElasticsearchConsistencyHealthCheck(ToolDAO toolDAO, BioWorkflowDAO bioWorkflowDAO, AppToolDAO appToolDAO, NotebookDAO notebookDAO) {
         this.toolDAO = toolDAO;
         this.bioWorkflowDAO = bioWorkflowDAO;
         this.appToolDAO = appToolDAO;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticsearchConsistencyHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ElasticsearchConsistencyHealthCheck.java
@@ -8,7 +8,6 @@ import io.dockstore.webservice.jdbi.EntryDAO;
 import io.dockstore.webservice.jdbi.NotebookDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import java.io.IOException;
-import java.util.Date;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.CountRequest;
@@ -16,28 +15,27 @@ import org.elasticsearch.client.core.CountResponse;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
-import org.hibernate.query.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ElasticsearchConsistencyHealthCheck extends HealthCheck  {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchConsistencyHealthCheck.class);
     private final SessionFactory sessionFactory;
-    private BioWorkflowDAO bioWorkflowDAO;
     private ToolDAO toolDAO;
+    private BioWorkflowDAO bioWorkflowDAO;
     private AppToolDAO appToolDAO;
     private NotebookDAO notebookDAO;
 
     public ElasticsearchConsistencyHealthCheck(SessionFactory sessionFactory,
-        BioWorkflowDAO bioWorkflowDAO, ToolDAO toolDAO, AppToolDAO appToolDAO, NotebookDAO notebookDAO) {
+        ToolDAO toolDAO, BioWorkflowDAO bioWorkflowDAO, AppToolDAO appToolDAO, NotebookDAO notebookDAO) {
         this.sessionFactory = sessionFactory;
-        this.bioWorkflowDAO = bioWorkflowDAO;
         this.toolDAO = toolDAO;
+        this.bioWorkflowDAO = bioWorkflowDAO;
         this.appToolDAO = appToolDAO;
         this.notebookDAO = notebookDAO;
     }
 
-    private long countElasticsearchIndex(String index) throws IOException {
+    private long countElasticsearchDocuments(String index) throws IOException {
         RestHighLevelClient client = ElasticSearchHelper.restHighLevelClient();
         CountRequest countRequest = new CountRequest(index);
         CountResponse countResponse = client.count(countRequest, RequestOptions.DEFAULT);
@@ -60,17 +58,17 @@ public class ElasticsearchConsistencyHealthCheck extends HealthCheck  {
         long dbNotebookCount = countAllPublishedNonCheckers(notebookDAO);
         session.close();
 
-        // Retrieve Elasticsearch index counts.
-        long esWorkflowCount = countElasticsearchIndex("workflows");
-        long esToolCount = countElasticsearchIndex("tools");
-        long esNotebookCount = countElasticsearchIndex("notebooks");
+        // Retrieve Elasticsearch document counts.
+        long esWorkflowCount = countElasticsearchDocuments("workflows");
+        long esToolCount = countElasticsearchDocuments("tools");
+        long esNotebookCount = countElasticsearchDocuments("notebooks");
 
         // Compare and return the appropriate result.
         String counts = String.format("esWorkflowCount=%d, dbWorkflowCount=%d, esToolCount=%d, dbToolCount=%d, esNotebookCount=%d, dbNotebookCount=%d",
             esWorkflowCount,  dbWorkflowCount,
             esToolCount,  dbToolCount,
             esNotebookCount,  dbNotebookCount);
-            
+
         if (esWorkflowCount == dbWorkflowCount
             && esToolCount == dbToolCount
             && esNotebookCount == dbNotebookCount) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LiquibaseLockHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LiquibaseLockHealthCheck.java
@@ -22,7 +22,6 @@ import io.dropwizard.hibernate.UnitOfWork;
 import java.util.Date;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.context.internal.ManagedSessionContext;
 import org.hibernate.query.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LiquibaseLockHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LiquibaseLockHealthCheck.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2024 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package io.dockstore.webservice.resources;
 
 import com.codahale.metrics.health.HealthCheck;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LiquibaseLockHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LiquibaseLockHealthCheck.java
@@ -11,6 +11,8 @@ import org.slf4j.LoggerFactory;
 
 public class LiquibaseLockHealthCheck extends HealthCheck  {
     private static final Logger LOG = LoggerFactory.getLogger(LiquibaseLockHealthCheck.class);
+    private static final long MILLISECONDS_PER_SECOND = 1000L;
+    private static final long HELD_TOO_LONG_SECONDS = 600L;
     private final SessionFactory sessionFactory;
 
     public LiquibaseLockHealthCheck(SessionFactory sessionFactory) {
@@ -32,9 +34,9 @@ public class LiquibaseLockHealthCheck extends HealthCheck  {
         }
 
         if (result instanceof Date grantedDate) {
-            long heldSeconds = (new Date().getTime() - grantedDate.getTime()) / 1000L;
+            long heldSeconds = (new Date().getTime() - grantedDate.getTime()) / MILLISECONDS_PER_SECOND;
             LOG.info(String.format("Liquibase lock was granted at %s, held for %d seconds", grantedDate, heldSeconds));
-            if (heldSeconds > 600L) {
+            if (heldSeconds > HELD_TOO_LONG_SECONDS) {
                 LOG.error("Liquibase lock held too long");
                 return Result.unhealthy("Liquibase lock held too long");
             } else {
@@ -42,7 +44,7 @@ public class LiquibaseLockHealthCheck extends HealthCheck  {
             }
         }
 
-        LOG.error("Unexpected result from liquibase query"); 
+        LOG.error("Unexpected result from liquibase query");
         return Result.unhealthy("Unexpected result from liquibase query");
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LiquibaseLockHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LiquibaseLockHealthCheck.java
@@ -1,0 +1,48 @@
+package io.dockstore.webservice.resources;
+
+import com.codahale.metrics.health.HealthCheck;
+import java.util.Date;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.context.internal.ManagedSessionContext;
+import org.hibernate.query.Query;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LiquibaseLockHealthCheck extends HealthCheck  {
+    private static final Logger LOG = LoggerFactory.getLogger(LiquibaseLockHealthCheck.class);
+    private final SessionFactory sessionFactory;
+
+    public LiquibaseLockHealthCheck(SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+
+    @Override
+    protected Result check() throws Exception {
+
+        Session session = sessionFactory.openSession();
+        ManagedSessionContext.bind(session);
+        Query query = session.createNativeQuery("select lockgranted from databasechangeloglock");
+        Object result = query.getSingleResult();
+        session.close();
+
+        if (result == null) {
+            LOG.info("Liquibase lock is free");
+            return Result.healthy();
+        }
+
+        if (result instanceof Date grantedDate) {
+            long heldSeconds = (new Date().getTime() - grantedDate.getTime()) / 1000L;
+            LOG.info(String.format("Liquibase lock was granted at %s, held for %d seconds", grantedDate, heldSeconds));
+            if (heldSeconds > 600L) {
+                LOG.error("Liquibase lock was held too long");
+                return Result.unhealthy("Liquibase lock was held too long");
+            } else {
+                return Result.healthy();
+            }
+        }
+
+        LOG.error("Unexpected result from liquibase query"); 
+        return Result.unhealthy("Unexpected result from liquibase query");
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LiquibaseLockHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LiquibaseLockHealthCheck.java
@@ -29,22 +29,18 @@ public class LiquibaseLockHealthCheck extends HealthCheck  {
         session.close();
 
         if (result == null) {
-            LOG.info("Liquibase lock is free");
             return Result.healthy();
         }
 
         if (result instanceof Date grantedDate) {
             long heldSeconds = (new Date().getTime() - grantedDate.getTime()) / MILLISECONDS_PER_SECOND;
-            LOG.info(String.format("Liquibase lock was granted at %s, held for %d seconds", grantedDate, heldSeconds));
             if (heldSeconds > HELD_TOO_LONG_SECONDS) {
-                LOG.error("Liquibase lock held too long");
-                return Result.unhealthy("Liquibase lock held too long");
+                return Result.unhealthy(String.format("Liquibase lock held too long: granted at %s, held for %d seconds", grantedDate, heldSeconds));
             } else {
                 return Result.healthy();
             }
         }
 
-        LOG.error("Unexpected result from liquibase query");
         return Result.unhealthy("Unexpected result from liquibase query");
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LiquibaseLockHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LiquibaseLockHealthCheck.java
@@ -18,6 +18,7 @@
 package io.dockstore.webservice.resources;
 
 import com.codahale.metrics.health.HealthCheck;
+import io.dropwizard.hibernate.UnitOfWork;
 import java.util.Date;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -36,14 +37,13 @@ public class LiquibaseLockHealthCheck extends HealthCheck  {
         this.sessionFactory = sessionFactory;
     }
 
+    @UnitOfWork
     @Override
     protected Result check() throws Exception {
 
-        Session session = sessionFactory.openSession();
-        ManagedSessionContext.bind(session);
+        Session session = sessionFactory.getCurrentSession();
         Query query = session.createNativeQuery("select lockgranted from databasechangeloglock");
         Object result = query.getSingleResult();
-        session.close();
 
         if (result == null) {
             return Result.healthy();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LiquibaseLockHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LiquibaseLockHealthCheck.java
@@ -35,8 +35,8 @@ public class LiquibaseLockHealthCheck extends HealthCheck  {
             long heldSeconds = (new Date().getTime() - grantedDate.getTime()) / 1000L;
             LOG.info(String.format("Liquibase lock was granted at %s, held for %d seconds", grantedDate, heldSeconds));
             if (heldSeconds > 600L) {
-                LOG.error("Liquibase lock was held too long");
-                return Result.unhealthy("Liquibase lock was held too long");
+                LOG.error("Liquibase lock held too long");
+                return Result.unhealthy("Liquibase lock held too long");
             } else {
                 return Result.healthy();
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -99,11 +99,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
@@ -119,7 +117,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.hibernate.SessionFactory;
-import org.hibernate.query.Query;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.kohsuke.github.GHRelease;
@@ -130,7 +127,6 @@ import org.kohsuke.github.PagedIterable;
 import org.kohsuke.github.extras.okhttp3.OkHttpGitHubConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.event.Level;
 
 /**
  * @author dyuen
@@ -154,7 +150,6 @@ public class MetadataResource {
     private final DockstoreWebserviceConfiguration config;
     private final SitemapListener sitemapListener;
     private final RSSListener rssListener;
-    private final SessionFactory sessionFactory;
 
     private HealthCheckRegistry healthCheckRegistry;
 
@@ -170,7 +165,6 @@ public class MetadataResource {
         this.notebookDAO = new NotebookDAO(sessionFactory);
         this.sitemapListener = PublicStateManager.getInstance().getSitemapListener();
         this.rssListener = PublicStateManager.getInstance().getRSSListener();
-        this.sessionFactory = sessionFactory;
     }
 
     public void setHealthCheckRegistry(HealthCheckRegistry healthCheckRegistry) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -505,6 +505,7 @@ public class MetadataResource {
                     .map(result -> new HealthCheckResult(result.getKey(), result.getValue().isHealthy()))
                     .collect(Collectors.toSet());
         } else {
+            // Alarms may depend on the syntax of this logging statement, so make sure to check if you change it.
             results.entrySet().stream()
                     .filter(result -> !result.getValue().isHealthy())
                     .forEach(result -> LOG.error("Health check '{}' failed with error: {}", result.getKey(), result.getValue().getMessage()));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -510,7 +510,7 @@ public class MetadataResource {
                     .forEach(result -> LOG.error("Health check '{}' failed with error: {}", result.getKey(), result.getValue().getMessage()));
             String failedHealthCheckNames = results.entrySet().stream()
                     .filter(result -> !result.getValue().isHealthy())
-                    .map(result -> String.format("'%s'", result))
+                    .map(result -> String.format("'%s'", result.getKey()))
                     .collect(Collectors.joining(", "));
             throw new CustomWebApplicationException(String.format("Health checks failed: %s", failedHealthCheckNames), HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -523,35 +523,6 @@ public class MetadataResource {
     }
 
     @GET
-    @Timed
-    @UnitOfWork(readOnly = true)
-    @Path("/liquibase")
-    @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Successful response if there are no Liquibase issues", description = "Successful response if there are no Liquibase issues, NO authentication")
-    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "No current issues", content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = HealthCheckResult.class))))
-    @ApiResponse(responseCode = HttpStatus.SC_INTERNAL_SERVER_ERROR + "", description = "There are one or more Liquibase issues")
-    public Response monitor() {
-        Query query = sessionFactory.getCurrentSession().createNativeQuery("select lockgranted from databasechangeloglock");
-        Object result = query.getSingleResult();
-        if (result == null) {
-            LOG.info("Liquibase lock free");
-            return Response.ok().build();
-        }
-        if (result instanceof Date grantedDate) {
-            long heldSeconds = (new Date().getTime() - grantedDate.getTime()) / 1000L;
-            LOG.info(String.format("Liquibase lock granted at %s, held for %d seconds", grantedDate, heldSeconds));
-            if (heldSeconds > 600L) {
-                LOG.error("Liquibase lock held too long");
-                return Response.status(HttpStatus.SC_INTERNAL_SERVER_ERROR).build();
-            } else {
-                return Response.ok().build();
-            }
-        }
-        // unexpected response
-        throw new CustomWebApplicationException("Unexpected result from liquibase query", HttpStatus.SC_INTERNAL_SERVER_ERROR);
-    }
-
-    @GET
     @Path("/config.json")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Configuration for UI clients of the API", description = "Configuration, NO authentication")

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -4298,24 +4298,6 @@ paths:
       summary: Successful response if the health checks succeed
       tags:
       - metadata
-  /metadata/liquibase:
-    get:
-      description: "Successful response if there are no Liquibase issues, NO authentication"
-      operationId: monitor
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthCheckResult'
-          description: No current issues
-        "500":
-          description: There are one or more Liquibase issues
-      summary: Successful response if there are no Liquibase issues
-      tags:
-      - metadata
   /metadata/okHttpCachePerformance:
     get:
       description: "Get measures of cache performance, NO authentication"

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -4298,6 +4298,24 @@ paths:
       summary: Successful response if the health checks succeed
       tags:
       - metadata
+  /metadata/liquibase:
+    get:
+      description: "Successful response if there are no Liquibase issues, NO authentication"
+      operationId: monitor
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthCheckResult'
+          description: No current issues
+        "500":
+          description: There are one or more Liquibase issues
+      summary: Successful response if there are no Liquibase issues
+      tags:
+      - metadata
   /metadata/okHttpCachePerformance:
     get:
       description: "Get measures of cache performance, NO authentication"


### PR DESCRIPTION
**Description**
This PR adds health checks to the webservice that detect when:
* the Liquibase migration lock has been held for too long.
* the number of published non-checker tools, workflows, and notebooks does not match the number of documents in the corresponding Elasticsearch indexes.

Kathy convinced me that these are indeed health checks, so they're run and reported via the existing `/metadata/health` endpoint and associated machinery.  They do differ from some of the existing health checks: although they signal a condition that's not entirely healthy, their failure indicates a non-fatal condition, and the webservice should continue to run, it need not be stopped/replaced/etc.  That's ok, because currently, our monitoring software only replaces the webservice task when the `connectionPool` health check fails.

We calculate how long the Liquibase lock has been held by comparing the current time against when it was last granted, per the database table.  If the lock has been held more than 10 minutes, we declare it held too long.

Initially, I tried to manage the required `Sessions` "manually" via `SessionFactory.openSession` and `ManagedSessionContext.bind`.
However, for unknown reasons, this screwed up other Sessions in subsequent unrelated requests, causing them to malfunction with `IllegalStateExceptions` etc.  So, instead, I used `UnitOfWorkAwareProxyFactory` to wrap the `check()` methods, which is cleaner and worked as advertised.  I cribbed the subsequently-rejected manual session management code from https://github.com/dockstore/dockstore/blob/develop/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java#L526, so its continued presence worries me a little.

When a health check fails, the resource method logs an `ERROR` level message containing the health check name.  We use this log entry to create a Cloudwatch alarm in companion PR https://github.com/dockstore/dockstore-deploy/pull/762

**Review Instructions**
Trigger the exceptional conditions on qa and confirm that the alarms happen.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6225
https://ucsc-cgl.atlassian.net/browse/SEAB-4825

**Security and Privacy**

No unusual concerns.

- [ ] Security and Privacy assessed

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
