### PR TITLE
SEAB-6220: Add testing resource

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -126,6 +126,7 @@ import io.dockstore.webservice.resources.MetadataResource;
 import io.dockstore.webservice.resources.NotificationResource;
 import io.dockstore.webservice.resources.OrganizationResource;
 import io.dockstore.webservice.resources.ServiceResource;
+import io.dockstore.webservice.resources.TestingResource;
 import io.dockstore.webservice.resources.TokenResource;
 import io.dockstore.webservice.resources.ToolTesterResource;
 import io.dockstore.webservice.resources.UserResource;
@@ -454,6 +455,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         environment.jersey().register(new ToolTesterResource(configuration));
         environment.jersey().register(new CloudInstanceResource(getHibernate().getSessionFactory()));
         environment.jersey().register(new CategoryResource(getHibernate().getSessionFactory()));
+        environment.jersey().register(new TestingResource(configuration));
 
         // disable odd extra endpoints showing up
         final SwaggerConfiguration swaggerConfiguration = new SwaggerConfiguration().prettyPrint(true);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -455,7 +455,9 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         environment.jersey().register(new ToolTesterResource(configuration));
         environment.jersey().register(new CloudInstanceResource(getHibernate().getSessionFactory()));
         environment.jersey().register(new CategoryResource(getHibernate().getSessionFactory()));
-        environment.jersey().register(new TestingResource(configuration));
+        if (!configuration.getExternalConfig().computeIsProduction()) {
+            environment.jersey().register(new TestingResource(configuration));
+        }
 
         // disable odd extra endpoints showing up
         final SwaggerConfiguration swaggerConfiguration = new SwaggerConfiguration().prettyPrint(true);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceConstants.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ResourceConstants.java
@@ -35,6 +35,7 @@ public final class ResourceConstants {
     public static final String CURATION = "List and modify notifications for users of Dockstore";
     public static final String NIHDATACOMMONS = "Needed for SmartAPI compatibility apparantly, might be cargo cult behaviour";
     public static final String LAMBDAEVENTS = "Query lambda events triggered by GitHub Apps";
+    public static final String TESTING = "Perform testing-related operations";
     public static final String JWT_SECURITY_DEFINITION_NAME = "BEARER";
     public static final String APPEASE_SWAGGER_PATCH = "This is here to appease Swagger. It requires PATCH methods to have a body, even if it is empty. Please leave it empty.";
     public static final String PAGINATION_LIMIT = "100";

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TestingResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TestingResource.java
@@ -1,0 +1,98 @@
+/*
+ *    Copyright 2024 OICR, UCSC
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.dockstore.webservice.resources;
+
+import static io.dockstore.webservice.resources.ResourceConstants.JWT_SECURITY_DEFINITION_NAME;
+
+import io.dockstore.common.HttpStatusMessageConstants;
+import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.DockstoreWebserviceConfiguration;
+import io.swagger.annotations.Api;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.security.SecuritySchemes;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Path("/testing")
+@Api("testing")
+@SecuritySchemes({ @SecurityScheme(type = SecuritySchemeType.HTTP, name = JWT_SECURITY_DEFINITION_NAME, scheme = "bearer") })
+@Tag(name = "testing", description = ResourceConstants.TESTING)
+public class TestingResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestingResource.class);
+    private static final int MAXIMUM_MEMORY_CHUNK_SIZE = 16 * 1024 * 1024;
+    private static final long MILLISECONDS_PER_SECOND = 1000L;
+
+    private final DockstoreWebserviceConfiguration config;
+
+    public TestingResource(DockstoreWebserviceConfiguration config) {
+        this.config = config;
+    }
+
+    @POST
+    @Path("/consume/memory/{byteCount}/{durationSeconds}")
+    @RolesAllowed("admin")
+    @Operation(summary = "Consume the specified amount of heap memory for the specified duration.", description = "Consume the specified amount of heap memory for the specified duration.")
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "A description of what was done")
+    @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = HttpStatusMessageConstants.BAD_REQUEST)
+    public String consumeResource(@PathParam("byteCount") long byteCount, @PathParam("durationSeconds") long durationSeconds) {
+        checkEnvironment();
+
+        String actionMessage = String.format("consuming %d bytes of memory for %d seconds", byteCount, durationSeconds);
+        LOG.info(actionMessage);
+
+        List<byte[]> chunks = new ArrayList<>();
+        while (byteCount > 0) {
+            byte[] chunk = new byte[(int)Math.min(byteCount, MAXIMUM_MEMORY_CHUNK_SIZE)];
+            chunks.add(chunk);
+            byteCount -= chunk.length;
+        }
+
+        sleepSeconds(durationSeconds);
+
+        String doneMessage = "done " + actionMessage;
+        LOG.info(doneMessage);
+        return doneMessage;
+    }
+
+    private void checkEnvironment() {
+        // Throw if we're running in production, ensuring that these endpoints cannot be used to crash it.
+        if (config.getExternalConfig().computeIsProduction()) {
+            throw new CustomWebApplicationException("endpoint cannot be invoked in production", HttpStatus.SC_BAD_REQUEST);
+        }
+    }
+
+    private void sleepSeconds(long seconds) {
+        try {
+            Thread.sleep(seconds * MILLISECONDS_PER_SECOND);
+        } catch (InterruptedException e) {
+            // This space intentionally left blank.
+        }
+    }
+}
+

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TestingResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TestingResource.java
@@ -22,6 +22,7 @@ import io.dockstore.common.HttpStatusMessageConstants;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.swagger.annotations.Api;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -40,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 @Path("/testing")
 @Api("testing")
+@Hidden
 @SecuritySchemes({ @SecurityScheme(type = SecuritySchemeType.HTTP, name = JWT_SECURITY_DEFINITION_NAME, scheme = "bearer") })
 @Tag(name = "testing", description = ResourceConstants.TESTING)
 public class TestingResource {

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -79,8 +79,6 @@ tags:
   name: metadata
 - description: Query lambda events triggered by GitHub Apps
   name: lambdaEvents
-- description: Perform testing-related operations
-  name: testing
 paths:
   /aliases/workflow-versions/{alias}:
     get:
@@ -5476,31 +5474,6 @@ paths:
       summary: Retrieve a collection by name.
       tags:
       - organizations
-  /testing/consume/memory/{byteCount}/{durationSeconds}:
-    post:
-      description: Consume the specified amount of heap memory for the specified duration.
-      operationId: consumeResource
-      parameters:
-      - in: path
-        name: byteCount
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - in: path
-        name: durationSeconds
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        "200":
-          description: A description of what was done
-        "400":
-          description: Bad request
-      summary: Consume the specified amount of heap memory for the specified duration.
-      tags:
-      - testing
   /toolTester/logs:
     get:
       operationId: getToolTesterLog

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -79,6 +79,8 @@ tags:
   name: metadata
 - description: Query lambda events triggered by GitHub Apps
   name: lambdaEvents
+- description: Perform testing-related operations
+  name: testing
 paths:
   /aliases/workflow-versions/{alias}:
     get:
@@ -5474,6 +5476,31 @@ paths:
       summary: Retrieve a collection by name.
       tags:
       - organizations
+  /testing/consume/memory/{byteCount}/{durationSeconds}:
+    post:
+      description: Consume the specified amount of heap memory for the specified duration.
+      operationId: consumeResource
+      parameters:
+      - in: path
+        name: byteCount
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - in: path
+        name: durationSeconds
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: A description of what was done
+        "400":
+          description: Bad request
+      summary: Consume the specified amount of heap memory for the specified duration.
+      tags:
+      - testing
   /toolTester/logs:
     get:
       operationId: getToolTesterLog


### PR DESCRIPTION
**Description**
This PR adds a `TestingResource`, initially containing a single endpoint that will make testing the `OutOfMemoryError` alarm easier.

A quote from my related Slack message:

> It's terrific that we've made it harder to crash the webservice, but the flipside is that it's more difficult to test things like alarms that only go off when bad things happen.  A mechanism whereby we can induce various exceptional conditions by consuming resources might be useful.  Perhaps in the form of some endpoints, accessible to admins/curators and only active in non-production environments, that'll run N cpu-intensive threads for S seconds, write a file of Z bytes to disk, or consume X amount of memory, etc etc 

Yes, sometimes, to consume resources, we can do the equivalent by running a non-JVM process in the container.  But there are scenarios where that doesn't work, like triggering CPU load within the app server itself, eating up part of the internal database pool, etc.  And, an endpoint-based solution is more controllable and easier to use.  

The new endpoint will attempt to consume the specified amount of heap memory for the specified duration.  If it OOMs while trying to consume the memory, either the JVM was launched with the `-XX:+ExitOnOutOfMemoryError` and dies with the `Terminating due to`... message, or the typical exception request termination process occurs.  In the case that the JVM doesn't exit on OOM, it is possible to engineer the endpoint to ignore `OutOfMemoryErrors` and try to suck up every last available byte.  However, this isn't very useful, because the result is that the app server threads proceed to die as they themselves OOM, and everything becomes unstable and/or locked up.

You could also invoke this endpoint to add memory pressure, without triggering an OOM outright.  This might be useful when we improve our scaling logic.

The endpoint can only be invoked by an admin, and on prod, it will refuse to consume resources, thus avoiding the possibility of accidentally invoking it and crashing the webservice.

Later, we can add endpoints for other types of resource consumption, like spawning N cpu-bound threads, occupying N slots of the database pool, filling the filesystem by N bytes, or whatever else we think is useful.
  
**Review Instructions**
Use this endpoint to trigger an OOM on qa.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6220

**Security and Privacy**
No concerns. 

- [ ] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
