### PR TITLE
DOCK-2477: Accept pairs of internal hyphens/underscores in entry names

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/ValidationConstants.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/ValidationConstants.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
  */
 public final class ValidationConstants {
 
-    public static final String ENTRY_NAME_REGEX = "[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*+";
+    public static final String ENTRY_NAME_REGEX = "[a-zA-Z0-9]++([-_]{1,2}+[a-zA-Z0-9]++)*+";
     public static final Pattern ENTRY_NAME_PATTERN = Pattern.compile(ENTRY_NAME_REGEX);
     public static final String ENTRY_NAME_REGEX_MESSAGE = "must only consist of alphanumerics and internal underscores and hyphens";
     public static final int ENTRY_NAME_LENGTH_MIN = 1;

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/StringInputValidationHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/StringInputValidationHelperTest.java
@@ -37,6 +37,13 @@ class StringInputValidationHelperTest {
         }
 
         try {
+            StringInputValidationHelper.checkEntryName(BioWorkflow.class, "foo---bar");
+            fail("Entry name with three successive hyphens should fail validation.");
+        } catch (CustomWebApplicationException ex) {
+            assertTrue(ex.getMessage().contains("Invalid workflow name"));
+        }
+
+        try {
             StringInputValidationHelper.checkEntryName(Service.class, "_foo_");
             fail("Entry name with external underscores should fail validation.");
         } catch (CustomWebApplicationException ex) {
@@ -62,6 +69,12 @@ class StringInputValidationHelperTest {
             StringInputValidationHelper.checkEntryName(BioWorkflow.class, "foo-bar_1");
         } catch (CustomWebApplicationException ex) {
             fail("Name with alphanumeric characters, internal hyphens and internal underscores should pass validation");
+        }
+
+        try {
+            StringInputValidationHelper.checkEntryName(BioWorkflow.class, "foo--bar__1");
+        } catch (CustomWebApplicationException ex) {
+            fail("Name with alphanumeric characters, pairs of internal hyphens and internal underscores should pass validation");
         }
     }
 }


### PR DESCRIPTION
**Description**
This PR changes the webservice to allow two consecutive internal hyphens/underscores in Entry names.  Runs of three or more hyphens or underscores are still rejected, because we probably don't want entry names like `foo___________bar`.

Whilst changing the responsible regular expression, I converted all of the quantifiers to be possessive, because there's no need for backtracking during matching.  https://docs.oracle.com/javase/tutorial/essential/regex/quant.html
This will slightly improve performance and reduce the chance that the regexp could be used for a DOS attack.

The message that describes the requirements for an entry name (`ENTRY_NAME_REGEX_MESSAGE`) covers both the old and new criteria, so it doesn't need to change.

**Review Instructions**
Register a valid entry with a name that contains two consecutive internal hyphens/underscores, and confirm the entry was successfully registered.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2477
#5715

**Security and Privacy**

No concerns.

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
