### PR TITLE
SEAB-6170: "weird tags and ids" fuzzing bug fixes

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AuthenticatedResourceInterface.java
@@ -176,6 +176,16 @@ public interface AuthenticatedResourceInterface {
     }
 
     /**
+     * Check if the specified value is not null.
+     * If not, throw a {@link CustomWebApplicationException}.
+     * @param value value to be checked
+     * @param nullMessage message to be used in thrown Exception
+     */
+    default void checkNotNull(Object value, String nullMessage) {
+        throwIf(value == null, nullMessage, HttpStatus.SC_BAD_REQUEST);
+    }
+
+    /**
      * Check if the specified user owns an entry.
      * If not, throw a {@link CustomWebApplicationException}.
      */

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -76,6 +76,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
@@ -951,9 +952,8 @@ public class DockerRepoResource
     @ApiOperation(value = "Get a list of secondary descriptor files.", tags = {
         "containers"}, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {@Authorization(value = JWT_SECURITY_DEFINITION_NAME)})
     public List<SourceFile> secondaryDescriptors(@Parameter(hidden = true, name = "user") @Auth Optional<User> user,
-        @Parameter(description = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
-        @Parameter(description = "Descriptor language", required = true) @QueryParam("language") DescriptorLanguage language) {
-        checkNotNull(language, "Descriptor language is required");
+        @Parameter(description = "Tool id") @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
+        @Parameter(description = "Descriptor language") @NotNull @QueryParam("language") DescriptorLanguage language) {
         final FileType fileType = language.getFileType();
         return getAllSecondaryFiles(containerId, tag, fileType, user, fileDAO, versionDAO);
     }
@@ -966,9 +966,8 @@ public class DockerRepoResource
     @ApiOperation(value = "Get the corresponding test parameter files.", tags = {
         "containers"}, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {@Authorization(value = JWT_SECURITY_DEFINITION_NAME)})
     public List<SourceFile> getTestParameterFiles(@Parameter(hidden = true, name = "user") @Auth Optional<User> user,
-        @Parameter(description = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
-        @Parameter(description = "Descriptor Type", required = true) @QueryParam("descriptorType") DescriptorLanguage descriptorLanguage) {
-        checkNotNull(descriptorLanguage, "Descriptor Type is required");
+        @Parameter(description = "Tool id") @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
+        @Parameter(description = "Descriptor Type") @NotNull @QueryParam("descriptorType") DescriptorLanguage descriptorLanguage) {
         final FileType testParameterType = descriptorLanguage.getTestParamType();
         return getAllSourceFiles(containerId, tag, testParameterType, user, fileDAO, versionDAO);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -949,7 +949,9 @@ public class DockerRepoResource
     @ApiOperation(value = "Get a list of secondary descriptor files.", tags = {
         "containers"}, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {@Authorization(value = JWT_SECURITY_DEFINITION_NAME)})
     public List<SourceFile> secondaryDescriptors(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth Optional<User> user,
-        @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag, @QueryParam("language") DescriptorLanguage language) {
+        @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
+        @ApiParam(value = "Descriptor language", required = true) @QueryParam("language") DescriptorLanguage language) {
+        checkNotNullParameter(language, "Language is required");
         final FileType fileType = language.getFileType();
         return getAllSecondaryFiles(containerId, tag, fileType, user, fileDAO, versionDAO);
     }
@@ -964,8 +966,15 @@ public class DockerRepoResource
     public List<SourceFile> getTestParameterFiles(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
         @ApiParam(value = "Descriptor Type", required = true) @QueryParam("descriptorType") DescriptorLanguage descriptorLanguage) {
+        checkNotNullParameter(descriptorLanguage, "DescriptorLanguage is required");
         final FileType testParameterType = descriptorLanguage.getTestParamType();
         return getAllSourceFiles(containerId, tag, testParameterType, user, fileDAO, versionDAO);
+    }
+
+    private void checkNotNullParameter(Object parameter, String nullMessage) {
+        if (parameter == null) {
+            throw new CustomWebApplicationException(nullMessage, HttpStatus.SC_BAD_REQUEST);
+        }
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -816,6 +816,7 @@ public class DockerRepoResource
     public List<Tool> getPublishedContainerByPath(
         @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
         List<Tool> tools = toolDAO.findAllByPath(path, true);
+        checkNotNull(tools, "Invalid repository path");
         filterContainersForHiddenTags(tools);
         checkCanRead(null, tools);
         return tools;
@@ -832,6 +833,7 @@ public class DockerRepoResource
     public List<Tool> getContainerByPath(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth User user,
         @ApiParam(value = "repository path", required = true) @PathParam("repository") String path) {
         List<Tool> tools = toolDAO.findAllByPath(path, false);
+        checkNotNull(tools, "Invalid repository path");
         tools.forEach(tool -> checkCanExamine(user, tool));
         return tools;
     }
@@ -951,7 +953,7 @@ public class DockerRepoResource
     public List<SourceFile> secondaryDescriptors(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
         @ApiParam(value = "Descriptor language", required = true) @QueryParam("language") DescriptorLanguage language) {
-        checkNotNullParameter(language, "Language is required");
+        checkNotNull(language, "Language is required");
         final FileType fileType = language.getFileType();
         return getAllSecondaryFiles(containerId, tag, fileType, user, fileDAO, versionDAO);
     }
@@ -966,15 +968,9 @@ public class DockerRepoResource
     public List<SourceFile> getTestParameterFiles(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth Optional<User> user,
         @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
         @ApiParam(value = "Descriptor Type", required = true) @QueryParam("descriptorType") DescriptorLanguage descriptorLanguage) {
-        checkNotNullParameter(descriptorLanguage, "DescriptorLanguage is required");
+        checkNotNull(descriptorLanguage, "DescriptorLanguage is required");
         final FileType testParameterType = descriptorLanguage.getTestParamType();
         return getAllSourceFiles(containerId, tag, testParameterType, user, fileDAO, versionDAO);
-    }
-
-    private void checkNotNullParameter(Object parameter, String nullMessage) {
-        if (parameter == null) {
-            throw new CustomWebApplicationException(nullMessage, HttpStatus.SC_BAD_REQUEST);
-        }
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -950,10 +950,10 @@ public class DockerRepoResource
     @Operation(operationId = "secondaryDescriptors", description = "Get a list of secondary descriptor files.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Get a list of secondary descriptor files.", tags = {
         "containers"}, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {@Authorization(value = JWT_SECURITY_DEFINITION_NAME)})
-    public List<SourceFile> secondaryDescriptors(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth Optional<User> user,
-        @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
-        @ApiParam(value = "Descriptor language", required = true) @QueryParam("language") DescriptorLanguage language) {
-        checkNotNull(language, "Language is required");
+    public List<SourceFile> secondaryDescriptors(@Parameter(hidden = true, name = "user") @Auth Optional<User> user,
+        @Parameter(description = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
+        @Parameter(description = "Descriptor language", required = true) @QueryParam("language") DescriptorLanguage language) {
+        checkNotNull(language, "Descriptor language is required");
         final FileType fileType = language.getFileType();
         return getAllSecondaryFiles(containerId, tag, fileType, user, fileDAO, versionDAO);
     }
@@ -965,10 +965,10 @@ public class DockerRepoResource
     @Operation(operationId = "getTestParameterFiles", description = "Get the corresponding test parameter files.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(value = "Get the corresponding test parameter files.", tags = {
         "containers"}, notes = OPTIONAL_AUTH_MESSAGE, response = SourceFile.class, responseContainer = "List", authorizations = {@Authorization(value = JWT_SECURITY_DEFINITION_NAME)})
-    public List<SourceFile> getTestParameterFiles(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth Optional<User> user,
-        @ApiParam(value = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
-        @ApiParam(value = "Descriptor Type", required = true) @QueryParam("descriptorType") DescriptorLanguage descriptorLanguage) {
-        checkNotNull(descriptorLanguage, "DescriptorLanguage is required");
+    public List<SourceFile> getTestParameterFiles(@Parameter(hidden = true, name = "user") @Auth Optional<User> user,
+        @Parameter(description = "Tool id", required = true) @PathParam("containerId") Long containerId, @QueryParam("tag") String tag,
+        @Parameter(description = "Descriptor Type", required = true) @QueryParam("descriptorType") DescriptorLanguage descriptorLanguage) {
+        checkNotNull(descriptorLanguage, "Descriptor Type is required");
         final FileType testParameterType = descriptorLanguage.getTestParamType();
         return getAllSourceFiles(containerId, tag, testParameterType, user, fileDAO, versionDAO);
     }

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -2427,7 +2427,8 @@ paths:
       description: Get a list of secondary descriptor files.
       operationId: secondaryDescriptors
       parameters:
-      - in: path
+      - description: Tool id
+        in: path
         name: containerId
         required: true
         schema:
@@ -2437,8 +2438,10 @@ paths:
         name: tag
         schema:
           type: string
-      - in: query
+      - description: Descriptor language
+        in: query
         name: language
+        required: true
         schema:
           type: string
           enum:
@@ -2740,7 +2743,8 @@ paths:
       description: Get the corresponding test parameter files.
       operationId: getTestParameterFiles
       parameters:
-      - in: path
+      - description: Tool id
+        in: path
         name: containerId
         required: true
         schema:
@@ -2750,8 +2754,10 @@ paths:
         name: tag
         schema:
           type: string
-      - in: query
+      - description: Descriptor Type
+        in: query
         name: descriptorType
+        required: true
         schema:
           type: string
           enum:


### PR DESCRIPTION
**Description**
This PR fixes a few minor webservice bugs (exposed during our fuzz testing) by adding checks of some inputs (and input-derived quantities).  While I was in there, I updated the swagger/openapi annotations on the affected endpoints. 

**Review Instructions**
Submit the requests listed in the ticket, and confirm that they no longer abort with a 500 http status code.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6170

**Security and Privacy**

No concerns.

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
