### PR TITLE
Don't check OpenAPI for tag builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,8 +274,6 @@ jobs:
             # skip swagger validation because of difficult-to-fix operationId duplications
             # java -jar openapi-generator-cli.jar validate -i dockstore-webservice/src/main/resources/swagger.yaml
             java -jar openapi-generator-cli.jar validate -i dockstore-webservice/src/main/resources/openapi3/openapi.yaml
-          when:
-
       - run:
           name: Check Java imports sorted and OpenAPI
           # A dirty Java file after a build probably means it was committed without building, and its imports are out of order
@@ -287,6 +285,7 @@ jobs:
             fi
             # SEAB-6379, openapi check will fail on build of a tag
             if [[ -z "${CIRCLE_TAG}" ]]; then
+              echo "Checking openapi.yaml"
               if [[ $(git diff --name-only | grep "openapi.yaml") != '' ]]; then
                 echo "openapi.yaml is out of sync"
                 git diff --stat | grep "openapi.yaml"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,6 +274,8 @@ jobs:
             # skip swagger validation because of difficult-to-fix operationId duplications
             # java -jar openapi-generator-cli.jar validate -i dockstore-webservice/src/main/resources/swagger.yaml
             java -jar openapi-generator-cli.jar validate -i dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+          when:
+
       - run:
           name: Check Java imports sorted and OpenAPI
           # A dirty Java file after a build probably means it was committed without building, and its imports are out of order
@@ -283,10 +285,13 @@ jobs:
               git diff --stat | grep "\.java$"
               exit 1
             fi
-            if [[ $(git diff --name-only | grep "openapi.yaml") != '' ]]; then
-              echo "openapi.yaml is out of sync"
-              git diff --stat | grep "openapi.yaml"
-              exit 1
+            # SEAB-6379, openapi check will fail on build of a tag
+            if [[ -z "${CIRCLE_TAG}" ]]; then
+              if [[ $(git diff --name-only | grep "openapi.yaml") != '' ]]; then
+                echo "openapi.yaml is out of sync"
+                git diff --stat | grep "openapi.yaml"
+                exit 1
+              fi
             fi
 
       - persist_to_workspace:


### PR DESCRIPTION
**Description**
If building a tag, don't check if the openapi is correct. We do something similar already [here](https://github.com/dockstore/dockstore/blob/develop/.circleci/config.yml#L299).

This is because of the way we do releases with the Maven plug-in. See "Dockstore Releases" Confluence page (intentionally not putting in the actual link) -- tags get created in that scenario without rebuilding.

Note that the openapi.yaml will be correct when publishing to Maven, because that is done in a different code path via GitHub actions, not in the config.yml.

**Review Instructions**
1. Create a tag off develop branch: `git tag 5867review`
2. `git push --tags`
3. Wait for CircleCI build to complete
4. Verify that the "Check Java imports sorted and OpenAPI" output does not contain the message "Checking openapi.yaml".
5. Delete the test tag
    1. `git tag push origin :5867review`
    2. git tag --delete 5867review

**Issue**
SEAB-6379

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
