### PR TITLE
SEAB-6342: Ignore frozen cwltool dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,11 +28,3 @@ updates:
     open-pull-requests-limit: 0
     reviewers:
       - "dockstore/dockstore"   
-
-  # Maintain dependencies for cwltool
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    reviewers:
-      - "dockstore/dockstore"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,11 +29,10 @@ updates:
     reviewers:
       - "dockstore/dockstore"   
 
-  # Maintain dependencies for swagger-ui and cwltool
+  # Maintain dependencies for cwltool
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
-    # start with security updates only https://stackoverflow.com/a/68254421
     reviewers:
-      - "dockstore/dockstore"        
+      - "dockstore/dockstore"


### PR DESCRIPTION
**Description**
We want cwltool dependencies to be ignored when Dependabot makes dependency updates.

After taking a look with @denis-yuen, it appeared that `package-ecosystem: "pip"` was only opening PRs for cwltool dependencies and wasn't actually maintaining Swagger UI dependencies, contrary to what this [comment](https://github.com/dockstore/dockstore/blob/7347da6a1ecb1c7f8d1385c4d17b273bf1244b21/.github/dependabot.yml#L32) suggests. If this is the case, then removing the pip package manager altogether should get rid of unwanted PRs associated with cwltool dependencies.

**Review Instructions**
Confirm (or deny) that Dependabot's pip updates are solely for cwltool dependencies (which we want to freeze), and that pip can be removed from dependabot.yml.

If we do need to keep the pip package manager: this [workaround](https://github.com/dependabot/dependabot-core/issues/4364#issuecomment-2002406602) (suggested in the ticket) involves specifying a directory for Dependabot to ignore (via `directory: "/directory-to-exclude"`). What would be our "`directory-to-exclude`", in order to ignore cwltool dependencies?

**Issue**
SEAB-6342

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
