### PR TITLE
fix unit for metric unload for calculated db load

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/CloudWatchMetricsReporter.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/CloudWatchMetricsReporter.java
@@ -72,12 +72,8 @@ public class CloudWatchMetricsReporter extends ScheduledReporter {
             String time = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
             Instant instant = Instant.parse(time);
             if (gauge.getValue() instanceof Number number) {
-                MetricDatum metricDatum;
-                if (gauge instanceof RatioGauge) {
-                    metricDatum = getMetricDatum(name, number.doubleValue(), instant, StandardUnit.PERCENT);
-                } else {
-                    metricDatum = getMetricDatum(name, number.doubleValue(), instant, StandardUnit.NONE);
-                }
+                StandardUnit unit = gauge instanceof RatioGauge ? StandardUnit.PERCENT : StandardUnit.NONE;
+                MetricDatum metricDatum = getMetricDatum(name, number.doubleValue(), instant, unit);
                 metricDataList.add(metricDatum);
             }
         });


### PR DESCRIPTION
**Description**
Adds a unit for calculated database load (and other future ratio gauges)

**Review Instructions**
If you chart the metric after deployment in qa, it may show up as a percentage (upper left)
https://stackoverflow.com/questions/46711700/can-i-change-metric-units-on-cloudwatch

**Issue**
Follow-up for https://github.com/dockstore/dockstore/pull/5873

**Security and Privacy**

None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
