### PR TITLE
unit fix for calculated load metric

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -237,7 +237,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
     private static final Logger LOG = LoggerFactory.getLogger(DockstoreWebserviceApplication.class);
     private static final int BYTES_IN_KILOBYTE = 1024;
     private static final int KILOBYTES_IN_MEGABYTE = 1024;
-    private static final int CACHE_IN_MB = PERCENT;
+    private static final int CACHE_IN_MB = 100;
     private static Cache cache = null;
 
     static {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -24,9 +24,9 @@ import static org.eclipse.jetty.servlets.CrossOriginFilter.ALLOWED_METHODS_PARAM
 import static org.eclipse.jetty.servlets.CrossOriginFilter.ALLOWED_ORIGINS_PARAM;
 
 import com.codahale.metrics.ConsoleReporter;
+import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.RatioGauge;
 import com.codahale.metrics.ScheduledReporter;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
@@ -230,13 +230,14 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
     public static final String IO_DROPWIZARD_DB_HIBERNATE_SIZE = "io.dropwizard.db.ManagedPooledDataSource.hibernate.size";
     public static final String IO_DROPWIZARD_DB_HIBERNATE_IDLE = "io.dropwizard.db.ManagedPooledDataSource.hibernate.idle";
     public static final String IO_DROPWIZARD_DB_HIBERNATE_CALCULATED_LOAD = "io.dropwizard.db.ManagedPooledDataSource.hibernate.calculatedLoad";
+    public static final int PERCENT = 100;
 
 
     private static OkHttpClient okHttpClient = null;
     private static final Logger LOG = LoggerFactory.getLogger(DockstoreWebserviceApplication.class);
     private static final int BYTES_IN_KILOBYTE = 1024;
     private static final int KILOBYTES_IN_MEGABYTE = 1024;
-    private static final int CACHE_IN_MB = 100;
+    private static final int CACHE_IN_MB = PERCENT;
     private static Cache cache = null;
 
     static {
@@ -586,11 +587,11 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
     private void configureDropwizardMetrics(DockstoreWebserviceConfiguration configuration, Environment environment) {
         this.metricRegistry = new MetricRegistry();
 
-        metricRegistry.registerGauge(IO_DROPWIZARD_DB_HIBERNATE_CALCULATED_LOAD, new RatioGauge() {
+        metricRegistry.registerGauge(IO_DROPWIZARD_DB_HIBERNATE_CALCULATED_LOAD, new Gauge() {
             @Override
-            protected Ratio getRatio() {
+            public Object getValue() {
                 final int activeConnections = (int) environment.metrics().getGauges().get(IO_DROPWIZARD_DB_HIBERNATE_ACTIVE).getValue();
-                return Ratio.of(activeConnections, configuration.getDataSourceFactory().getMaxSize());
+                return ((double) activeConnections / configuration.getDataSourceFactory().getMaxSize()) * PERCENT;
             }
         });
 


### PR DESCRIPTION
**Description**
Ah math, it looks like AWS expects percentages out of a 100 rather than as a fraction as in Dropwizard Metrics. 
https://github.com/dockstore/dockstore/pull/5876

Output ends up looking like 
```
-- Gauges ----------------------------------------------------------------------
io.dropwizard.db.ManagedPooledDataSource.hibernate.active
             value = 25
io.dropwizard.db.ManagedPooledDataSource.hibernate.calculatedLoad
             value = 78.125
io.dropwizard.db.ManagedPooledDataSource.hibernate.idle
             value = 1
io.dropwizard.db.ManagedPooledDataSource.hibernate.size
             value = 25

```

**Review Instructions**
See https://ucsc-cgl.atlassian.net/browse/SEAB-6143 apologies to https://ucsc-cgl.atlassian.net/browse/SEAB-6143
Apologies to @coverbeck 

**Issue**
Follow-up for https://github.com/dockstore/dockstore/pull/5873

**Security and Privacy**

None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
