### PR TITLE
SEAB-6310: Log privileged endpoints at webservice startup

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -40,6 +40,7 @@ import io.dockstore.common.LanguagePluginManager;
 import io.dockstore.language.CompleteLanguageInterface;
 import io.dockstore.language.MinimalLanguageInterface;
 import io.dockstore.language.RecommendedLanguageInterface;
+import io.dockstore.webservice.SimpleAuthorizer;
 import io.dockstore.webservice.core.AppTool;
 import io.dockstore.webservice.core.Author;
 import io.dockstore.webservice.core.BioWorkflow;
@@ -721,8 +722,8 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         @Override
         public void onEvent(ApplicationEvent event) {
             if (event.getType() == ApplicationEvent.Type.INITIALIZATION_APP_FINISHED) {
-                List<String> roles = List.of("admin", "curator", "platformPartner");
                 StringBuilder builder = new StringBuilder();
+                List<String> roles = SimpleAuthorizer.ROLES;
                 for (Resource resource: event.getResourceModel().getResources()) {
                     formatResource(builder, "/", resource, roles);
                 }
@@ -735,7 +736,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             for (ResourceMethod resourceMethod: resource.getAllMethods()) {
                 RolesAllowed rolesAllowed = resourceMethod.getInvocable().getHandlingMethod().getAnnotation(RolesAllowed.class);
                 if (rolesAllowed != null && !Collections.disjoint(Set.of(rolesAllowed.value()), selectRoles)) {
-                    builder.append(String.format("%s %s %s\n", resourceMethod.getHttpMethod(), path, rolesAllowed));
+                    builder.append(String.format("    %s %s %s\n", resourceMethod.getHttpMethod(), path, rolesAllowed));
                 }
             }
             for (Resource child: resource.getChildResources()) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -40,7 +40,6 @@ import io.dockstore.common.LanguagePluginManager;
 import io.dockstore.language.CompleteLanguageInterface;
 import io.dockstore.language.MinimalLanguageInterface;
 import io.dockstore.language.RecommendedLanguageInterface;
-import io.dockstore.webservice.SimpleAuthorizer;
 import io.dockstore.webservice.core.AppTool;
 import io.dockstore.webservice.core.Author;
 import io.dockstore.webservice.core.BioWorkflow;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/SimpleAuthorizer.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/SimpleAuthorizer.java
@@ -19,6 +19,7 @@ package io.dockstore.webservice;
 import io.dockstore.webservice.core.User;
 import io.dropwizard.auth.Authorizer;
 import jakarta.ws.rs.container.ContainerRequestContext;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +30,9 @@ import org.slf4j.LoggerFactory;
 public class SimpleAuthorizer implements Authorizer<User> {
 
     public static final String ADMIN = "admin";
+    public static final String CURATOR = "curator";
+    public static final String PLATFORM_PARTNER = "platformPartner";
+    public static final List<String> ROLES = List.of(ADMIN, CURATOR, PLATFORM_PARTNER);
     private static final Logger LOG = LoggerFactory.getLogger(SimpleAuthorizer.class);
 
     @Override
@@ -39,9 +43,9 @@ public class SimpleAuthorizer implements Authorizer<User> {
         }
         if (ADMIN.equalsIgnoreCase(role)) {
             return principal.getIsAdmin();
-        } else if  ("curator".equalsIgnoreCase(role)) {
+        } else if (CURATOR.equalsIgnoreCase(role)) {
             return principal.isCurator();
-        } else if ("platformPartner".equalsIgnoreCase(role)) {
+        } else if (PLATFORM_PARTNER.equalsIgnoreCase(role)) {
             return principal.isPlatformPartner();
         } else {
             return true;


### PR DESCRIPTION
**Description**
This PR modifies the webservice to log a message that contains a list of "privileged" endpoints, which are endpoints with a `@RolesAllowed` annotation which allows one or more of the `admin`, `curator`, or  `platformPartner` roles.  The list is logged once, at startup time.

Example log excerpt:

```
INFO  [2024-05-09 00:28:37,868] io.dockstore.webservice.DockstoreWebserviceApplication: Endpoints that allow a role in [admin, curator, platformPartner]:
GET /organizations/all @jakarta.annotation.security.RolesAllowed({"curator", "admin"})
POST /organizations/{organizationId}/reject @jakarta.annotation.security.RolesAllowed({"curator", "admin"})
POST /organizations/{organizationId}/approve @jakarta.annotation.security.RolesAllowed({"curator", "admin"})
POST /cloudInstances @jakarta.annotation.security.RolesAllowed({"admin"})
DELETE /cloudInstances/{cloudInstanceId} @jakarta.annotation.security.RolesAllowed({"admin"})
GET /lambdaEvents/user/{userid} @jakarta.annotation.security.RolesAllowed({"admin", "curator"})
POST /curation/notifications @jakarta.annotation.security.RolesAllowed({"curator", "admin"})
[...]
```

The ticket (and ticket writer) preferred that the role information was added to our swagger UI page.  This would have required us to first propagate the "admin" info from our code into `openapi.yaml`, and then to modify our Swagger UI page (which reads a public copy of `openapi.yaml`) to render the new OpenAPI information.  There doesn't appear to be direct support for roles in OpenAPI, so we would have had to map the `@RolesAllowed` annotations to the closest security-related OpenAPI analog.  Certainly, all of this would have been possible, but there didn't appear to be a quick and simple way...

The goal was to get the auditor a list of "admin" endpoints, and although this implementation might not be 100% optimal, they should be able to work with this format.  

Originally, I'd anticipated logging at `DEBUG` level, but to ensure the information makes it to CloudWatch, should we need it, I promoted the message to `INFO` level.  It's logged one time per run, so no big deal.

The semantics which we use to combine endpoint path fragments are a bit different than typical file path semantics, thus the custom `joinPaths` method (rather than using a canned method).

**Review Instructions**
Check the webservice logs, and confirm that the new message appears, and has the correct number of endpoints listed.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6310

**Security and Privacy**
No concerns. 

- [x] Security and Privacy assessed

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
