### PR TITLE
SEAB-6420: Add new health check names to endpoint `allowableValues`

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/MetadataResource.java
@@ -478,9 +478,8 @@ public class MetadataResource {
     @ApiResponse(responseCode = HttpStatus.SC_INTERNAL_SERVER_ERROR + "", description = "Health checks failed")
     public Set<HealthCheckResult> checkHealth(
             @Parameter(name = "include", description = "List of health checks to run. If unspecified, run all health checks", in = ParameterIn.QUERY,
-                    array = @ArraySchema(schema = @Schema(implementation = String.class, allowableValues = {"hibernate", "deadlocks", "connectionPool"})))
-            @ApiParam(name = "include", value = "List of health checks to run. If unspecified, run all health checks", allowableValues = "hibernate,deadlocks,connectionPool",
-                    type = "array") @QueryParam(value = "include") List<String> include) {
+                    array = @ArraySchema(schema = @Schema(implementation = String.class, allowableValues = {"hibernate", "deadlocks", "connectionPool", "liquibaseLock", "elasticsearchConsistency"})))
+            @QueryParam(value = "include") List<String> include) {
         Map<String, HealthCheck.Result> results;
         boolean allHealthy;
         if (include.isEmpty()) { // Run all health checks

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -4318,6 +4318,8 @@ paths:
             - hibernate
             - deadlocks
             - connectionPool
+            - liquibaseLock
+            - elasticsearchConsistency
       responses:
         "200":
           content:


### PR DESCRIPTION
**Description**
This PR adds `liquibaseLock` and `elasticSearchConsistency` to the list of allowed values for the `include` parameter of the health check endpoint.  It also removes the obsolete `@ApiParam` annotation.

**Review Instructions**
Confirm that the new values appear in `openapi.yaml`.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6420

**Security and Privacy**

No concerns.

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
