### PR TITLE
Make ConnectionPoolHealthCheck always healthy

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ConnectionPoolHealthCheck.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/ConnectionPoolHealthCheck.java
@@ -27,9 +27,10 @@ public class ConnectionPoolHealthCheck extends HealthCheck  {
 
         if (activeConnections == maxConnections) {
             LOG.info("size: {}, active: {}, idle: {}, calculatedLoad: {}", sizeConnections, activeConnections, idleConnections, loadConnections);
-            return Result.unhealthy("No database connections available");
-        } else {
-            return Result.healthy();
         }
+        // All connections being in use doesn't necessarily mean the container is unhealthy; it's probably just processing many requests.
+        // See discussion at https://ucsc-cgl.atlassian.net/browse/SEAB-4879. Always return healthy for now; perhaps we'll improve it to
+        // detect unhealthiness in the future.
+        return Result.healthy();
     }
 }


### PR DESCRIPTION
**Description**
We were considering all active DB connections in use as meaning the container is unhealthy. But it doesn't necessarily mean that, it could be the results of a wave of requests. If that's the case, marking the container unhealthy will only exacerbate the problem, as it can push more load on the healthy containers, making them unhealthy, etc. See SEAB-4879's comments, where this is discussed in more detail.

We could just remove the health check entirely, but then it's another PR to dockstore-deploy to not invoke the check. I figured it was better/easier to keep the framework and log a message. And if we find a way to determine unhealthiness in the future, the scaffolding is there. But if others feel we should just remove the check entirely, please opine.

**Review Instructions**
Hard to review, try to slam environment to chew up DB connections, and make sure that container does not get shut down due to being unhealthy. Even without this change, I've been unable to make the container go unhealthy, so it will be hard to verify. Make sure there's no regression at least.

**Issue**
SEAB-4879

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
