### PR TITLE
lambda pagination limit

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -74,6 +74,7 @@ public class LambdaEventResource {
             @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
             @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
             @Context HttpServletResponse response) {
+        limit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);
         final User authUser = userDAO.findById(user.getId());
         final List<Token> githubTokens = tokenDAO.findGithubByUserId(authUser.getId());
         if (githubTokens.isEmpty()) {
@@ -102,6 +103,7 @@ public class LambdaEventResource {
            @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
            @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
            @Context HttpServletResponse response) {
+        limit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);
         final User user = userDAO.findById(userid);
         if (user == null) {
             throw new CustomWebApplicationException("User not found.", HttpStatus.SC_NOT_FOUND);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -74,7 +74,7 @@ public class LambdaEventResource {
             @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
             @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
             @Context HttpServletResponse response) {
-        limit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);
+        limit = (int) Math.min(MAX_PAGINATION_LIMIT, limit);
         final User authUser = userDAO.findById(user.getId());
         final List<Token> githubTokens = tokenDAO.findGithubByUserId(authUser.getId());
         if (githubTokens.isEmpty()) {
@@ -103,7 +103,7 @@ public class LambdaEventResource {
            @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
            @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
            @Context HttpServletResponse response) {
-        limit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);
+        limit = (int) Math.min(MAX_PAGINATION_LIMIT, limit);
         final User user = userDAO.findById(userid);
         if (user == null) {
             throw new CustomWebApplicationException("User not found.", HttpStatus.SC_NOT_FOUND);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -74,7 +74,7 @@ public class LambdaEventResource {
             @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
             @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
             @Context HttpServletResponse response) {
-        limit = (int) Math.min(MAX_PAGINATION_LIMIT, limit);
+        int adjustedLimit = (int) Math.min(MAX_PAGINATION_LIMIT, limit);
         final User authUser = userDAO.findById(user.getId());
         final List<Token> githubTokens = tokenDAO.findGithubByUserId(authUser.getId());
         if (githubTokens.isEmpty()) {
@@ -84,7 +84,7 @@ public class LambdaEventResource {
         final Optional<List<String>> authorizedRepos = authorizedRepos(organization, githubToken);
         response.addHeader(X_TOTAL_COUNT, String.valueOf(lambdaEventDAO.countByOrganization(organization, authorizedRepos, filter)));
         response.addHeader(ACCESS_CONTROL_EXPOSE_HEADERS, X_TOTAL_COUNT);
-        return lambdaEventDAO.findByOrganization(organization, offset, limit, filter, sortCol, sortOrder, authorizedRepos);
+        return lambdaEventDAO.findByOrganization(organization, offset, adjustedLimit, filter, sortCol, sortOrder, authorizedRepos);
     }
 
     @GET
@@ -103,14 +103,14 @@ public class LambdaEventResource {
            @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
            @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
            @Context HttpServletResponse response) {
-        limit = (int) Math.min(MAX_PAGINATION_LIMIT, limit);
+        int adjustedLimit = (int) Math.min(MAX_PAGINATION_LIMIT, limit);
         final User user = userDAO.findById(userid);
         if (user == null) {
             throw new CustomWebApplicationException("User not found.", HttpStatus.SC_NOT_FOUND);
         }
         response.addHeader(LambdaEventResource.X_TOTAL_COUNT, String.valueOf(lambdaEventDAO.countByUser(user, filter)));
         response.addHeader(LambdaEventResource.ACCESS_CONTROL_EXPOSE_HEADERS, LambdaEventResource.X_TOTAL_COUNT);
-        return lambdaEventDAO.findByUser(user, offset, limit, filter, sortCol, sortOrder);
+        return lambdaEventDAO.findByUser(user, offset, adjustedLimit, filter, sortCol, sortOrder);
     }
 
     /**


### PR DESCRIPTION
**Description**
Add in a limit for how many lambda events to retrieve, match what we declared in openap.yaml already

**Review Instructions**
Could retrieve more than 100 events, should get 100

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5993

**Security and Privacy**

None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
