### PR TITLE
Add conceptdoi to mocked Zenodo responses

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/Hoverfly.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/Hoverfly.java
@@ -193,7 +193,7 @@ public final class Hoverfly {
 
     public static final String ZENODO_SIMULATION_URL = "https://sandbox.zenodo.org";
     public static final SimulationSource ZENODO_SIMULATION_SOURCE = dsl(service(ZENODO_SIMULATION_URL)
-            .andDelay(200, TimeUnit.MILLISECONDS).forAll() // I don't know why, but need a short delay for random integers to be generated and not be repeated
+            .andDelay(500, TimeUnit.MILLISECONDS).forAll() // I don't know why, but need a short delay for random integers to be generated and not be repeated
             .post("/oauth/token").anyBody().willReturn(success(GSON.toJson(getFakeTokenResponse("")), MediaType.APPLICATION_JSON))
             // createDeposit
             .post("/api/deposit/depositions").anyBody().anyQueryParams().willReturn(success(fixture("fixtures/createDepositResponse.json"), MediaType.APPLICATION_JSON))

--- a/dockstore-integration-testing/src/test/resources/fixtures/getDepositResponse.json
+++ b/dockstore-integration-testing/src/test/resources/fixtures/getDepositResponse.json
@@ -1,5 +1,6 @@
 {
   "conceptrecid": 51309,
+  "conceptdoi": "10.5072/zenodo.{{ randomIntegerRange 10000 99999 }}",
   "created": "2024-05-02T15:13:00.593467+00:00",
   "files": [
     {

--- a/dockstore-integration-testing/src/test/resources/fixtures/newDepositVersionResponse.json
+++ b/dockstore-integration-testing/src/test/resources/fixtures/newDepositVersionResponse.json
@@ -1,5 +1,6 @@
 {
   "conceptrecid": 51309,
+  "conceptdoi": "10.5072/zenodo.{{ randomIntegerRange 10000 99999 }}",
   "created": "2024-05-02T15:13:00.593467+00:00",
   "files": [
     {

--- a/dockstore-integration-testing/src/test/resources/fixtures/publishDepositResponse.json
+++ b/dockstore-integration-testing/src/test/resources/fixtures/publishDepositResponse.json
@@ -1,5 +1,6 @@
 {
   "conceptrecid": {{ randomIntegerRange 10000 99999 }},
+  "conceptdoi": "10.5072/zenodo.{{ randomIntegerRange 10000 99999 }}",
   "created": "2024-05-02T15:13:00.593467+00:00",
   "files": [
     {


### PR DESCRIPTION
**Description**
Noticed some Zenodo hoverfly test failures in the develop branch. This PR fixes the tests by adding the `conceptdoi` property used in https://github.com/dockstore/dockstore/pull/5894 to the mocked Hoverfly responses. Also added a longer delay because I noticed one of the tests seemed flaky

**Review Instructions**
hoverfly-tests job should pass on CircleCI

**Issue**
n/a

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
