### PR TITLE
SEAB-6448: Make various WorkflowResource endpoints refuse to update .dockstore.yml-based workflows

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -2109,22 +2109,15 @@ class WebhookIT extends BaseIT {
     }
 
     @Test
-    void testShouldNotBeAbleToRestubOrRefreshDockstoreYmlWorkflow() {
+    void testShouldNotBeAbleToRestubDockstoreYmlWorkflow() {
         final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         final WorkflowsApi workflowsApi = new WorkflowsApi(webClient);
 
         // Register entry and retrieve one of its versions
         handleGitHubRelease(workflowsApi, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, "refs/tags/0.9", USER_2_USERNAME);
         final Workflow workflow = workflowsApi.getWorkflowByPath("github.com/" + DockstoreTesting.WORKFLOW_DOCKSTORE_YML + "/foobar", WorkflowSubClass.BIOWORKFLOW, "versions");
-        final WorkflowVersion version = workflow.getWorkflowVersions().get(0);
 
         // Should not be able to restub a .dockstore.yml-based workflow
         assertThrowsApiException(() -> workflowsApi.restub(workflow.getId()), HttpStatus.SC_BAD_REQUEST);
-
-        // Shoold not be able to refresh a .dockstore.yml-based workflow
-        assertThrowsApiException(() -> workflowsApi.refresh1(workflow.getId(), false), HttpStatus.SC_BAD_REQUEST);
-
-        // Shoold not be able to refresh a .dockstore.yml-based workflow version
-        assertThrowsApiException(() -> workflowsApi.refreshVersion(workflow.getId(), version.getName(), false), HttpStatus.SC_BAD_REQUEST);
     }
 }


### PR DESCRIPTION
**Description**
As part of the investigation of https://ucsc-cgl.atlassian.net/browse/SEAB-6448 and https://ucsc-cgl.atlassian.net/browse/SEAB-6449 (see Slack thread https://ucsc-gi.slack.com/archives/C05EZH3RVNY/p1717540768164039), we found via testing that a workflow owner can restub .dockstore.yml-based workflows via the API, and probably update them via various other `WorkflowResource` endpoints intended only for use on STUB/FULL workflows.  This PR changes these endpoints to gracefully refuse to update .dockstore.yml-based workflows.

**Review Instructions**
Create a .dockstore.yml-based workflow on qa, then attempt to restub it via the API.  The attempt should fail with a BAD_REQUEST response code and a useful error message.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6448
https://ucsc-cgl.atlassian.net/browse/SEAB-6449

**Security and Privacy**

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
