### PR TITLE
(Sonar) Fixed finding: "@Override should be used on overriding and implementing methods"

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/InstallationRepositoriesPayload.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/InstallationRepositoriesPayload.java
@@ -105,6 +105,7 @@ public class InstallationRepositoriesPayload extends Payload {
             this.value = value;
         }
 
+        @Override
         public String toString() {
             return value;
         }


### PR DESCRIPTION
## Remediation

This change fixes "`@Override` should be used on overriding and implementing methods" (id = [java:S1161](https://rules.sonarsource.com/java/RSPEC-1161/)) identified by Sonar.

## Details

This change adds missing `@Override` to known subclasses. Documenting inheritance will help readers and static analysis tools understand the code better, spot bugs easier, and in general lead to more efficient and effective review.

Our changes look something like this:

```diff
  interface AcmeParent {
     void doThing();
  } 

  class AcmeChild implements AcmeParent {

+   @Override
    void doThing() {
      thing();
    }
    
  }
```

<details>
  <summary>More reading</summary>

  * [https://rules.sonarsource.com/java/RSPEC-1161/](https://rules.sonarsource.com/java/RSPEC-1161/)
</details>

🧚🤖  Powered by Pixeebot  

[Feedback](https://ask.pixee.ai/feedback) | [Community](https://pixee-community.slack.com/signup#/domain-signup) | [Docs](https://docs.pixee.ai/) | Codemod ID: [sonar:java/add-missing-override-s1161](https://docs.pixee.ai/codemods/java/sonar_java_add-missing-override-s1161) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2Fdockstore%7C498c11e5283aa09c11936f7207d9ebdc38e82994)


<!--{"type":"DRIP","codemod":"sonar:java/add-missing-override-s1161"}-->