### PR TITLE
add skipped limit check

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/DockerRepoResource.java
@@ -791,8 +791,7 @@ public class DockerRepoResource
         @ApiParam(value = "Sort column") @DefaultValue("stars") @QueryParam("sortCol") String sortCol,
         @ApiParam(value = "Sort order", allowableValues = "asc,desc") @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
         @Context HttpServletResponse response) {
-        int maxLimit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);
-        List<Tool> tools = toolDAO.findAllPublished(offset, maxLimit, filter, sortCol, sortOrder);
+        List<Tool> tools = toolDAO.findAllPublished(offset, limit, filter, sortCol, sortOrder);
         filterContainersForHiddenTags(tools);
         stripContent(tools);
         response.addHeader(LambdaEventResource.X_TOTAL_COUNT, String.valueOf(toolDAO.countAllPublished(Optional.of(filter))));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/LambdaEventResource.java
@@ -74,7 +74,6 @@ public class LambdaEventResource {
             @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
             @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
             @Context HttpServletResponse response) {
-        int adjustedLimit = (int) Math.min(MAX_PAGINATION_LIMIT, limit);
         final User authUser = userDAO.findById(user.getId());
         final List<Token> githubTokens = tokenDAO.findGithubByUserId(authUser.getId());
         if (githubTokens.isEmpty()) {
@@ -84,7 +83,7 @@ public class LambdaEventResource {
         final Optional<List<String>> authorizedRepos = authorizedRepos(organization, githubToken);
         response.addHeader(X_TOTAL_COUNT, String.valueOf(lambdaEventDAO.countByOrganization(organization, authorizedRepos, filter)));
         response.addHeader(ACCESS_CONTROL_EXPOSE_HEADERS, X_TOTAL_COUNT);
-        return lambdaEventDAO.findByOrganization(organization, offset, adjustedLimit, filter, sortCol, sortOrder, authorizedRepos);
+        return lambdaEventDAO.findByOrganization(organization, offset, limit, filter, sortCol, sortOrder, authorizedRepos);
     }
 
     @GET
@@ -103,14 +102,13 @@ public class LambdaEventResource {
            @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
            @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
            @Context HttpServletResponse response) {
-        int adjustedLimit = (int) Math.min(MAX_PAGINATION_LIMIT, limit);
         final User user = userDAO.findById(userid);
         if (user == null) {
             throw new CustomWebApplicationException("User not found.", HttpStatus.SC_NOT_FOUND);
         }
         response.addHeader(LambdaEventResource.X_TOTAL_COUNT, String.valueOf(lambdaEventDAO.countByUser(user, filter)));
         response.addHeader(LambdaEventResource.ACCESS_CONTROL_EXPOSE_HEADERS, LambdaEventResource.X_TOTAL_COUNT);
-        return lambdaEventDAO.findByUser(user, offset, adjustedLimit, filter, sortCol, sortOrder);
+        return lambdaEventDAO.findByUser(user, offset, limit, filter, sortCol, sortOrder);
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -19,7 +19,10 @@ package io.dockstore.webservice.resources;
 import static io.dockstore.webservice.Constants.USERNAME_CONTAINS_KEYWORD_PATTERN;
 import static io.dockstore.webservice.resources.ResourceConstants.APPEASE_SWAGGER_PATCH;
 import static io.dockstore.webservice.resources.ResourceConstants.JWT_SECURITY_DEFINITION_NAME;
+import static io.dockstore.webservice.resources.ResourceConstants.MAX_PAGINATION_LIMIT;
 import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_LIMIT;
+import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_LIMIT_TEXT;
+import static io.dockstore.webservice.resources.ResourceConstants.PAGINATION_OFFSET_TEXT;
 
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.annotation.JsonView;
@@ -96,6 +99,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -110,6 +115,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.sql.Timestamp;
@@ -1195,14 +1201,19 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
             + "", description = "A list of GitHub Events for the logged in user", content = @Content(array = @ArraySchema(schema = @Schema(implementation = LambdaEvent.class))))
     @ApiOperation(value = "See OpenApi for details")
     public List<LambdaEvent> getUserGitHubEvents(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user")@Auth User authUser,
-            @Min(0) @QueryParam("offset") Integer offset,
-            @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
+            @Parameter(description = PAGINATION_OFFSET_TEXT) @Min(0) @QueryParam("offset") Integer offset,
+            @Parameter(description = PAGINATION_LIMIT_TEXT) @Max(MAX_PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) @QueryParam("limit") Integer limit,
             @DefaultValue("") @QueryParam("filter") String filter,
             @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
-            @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder) {
+            @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
+            @Context HttpServletResponse response) {
+        int adjustedLimit = (int) Math.min(MAX_PAGINATION_LIMIT, limit);
         final User user = userDAO.findById(authUser.getId());
         checkNotNullUser(user);
-        return lambdaEventDAO.findByUser(user, offset, limit, filter, sortCol, sortOrder);
+        List<LambdaEvent> byUser = lambdaEventDAO.findByUser(user, offset, adjustedLimit, filter, sortCol, sortOrder);
+        response.addHeader(LambdaEventResource.X_TOTAL_COUNT, String.valueOf(byUser.size()));
+        response.addHeader(LambdaEventResource.ACCESS_CONTROL_EXPOSE_HEADERS, LambdaEventResource.X_TOTAL_COUNT);
+        return byUser;
     }
 
     @GET

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -1207,10 +1207,9 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
             @DefaultValue("dbCreateDate") @QueryParam("sortCol") String sortCol,
             @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
             @Context HttpServletResponse response) {
-        int adjustedLimit = (int) Math.min(MAX_PAGINATION_LIMIT, limit);
         final User user = userDAO.findById(authUser.getId());
         checkNotNullUser(user);
-        List<LambdaEvent> byUser = lambdaEventDAO.findByUser(user, offset, adjustedLimit, filter, sortCol, sortOrder);
+        List<LambdaEvent> byUser = lambdaEventDAO.findByUser(user, offset, limit, filter, sortCol, sortOrder);
         response.addHeader(LambdaEventResource.X_TOTAL_COUNT, String.valueOf(byUser.size()));
         response.addHeader(LambdaEventResource.ACCESS_CONTROL_EXPOSE_HEADERS, LambdaEventResource.X_TOTAL_COUNT);
         return byUser;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -783,9 +783,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         @ApiParam(value = "Should only be used by Dockstore versions < 1.14.0. Indicates whether to get a service or workflow") @DefaultValue("false") @QueryParam("services") boolean services,
         @ApiParam(value = "Which workflow subclass to retrieve. If present takes precedence over services parameter") @QueryParam("subclass") WorkflowSubClass subclass,
         @Context HttpServletResponse response) {
-        int maxLimit = Math.min(Integer.parseInt(PAGINATION_LIMIT), limit);
         final Class<Workflow> workflowClass = (Class<Workflow>) workflowSubClass(services, subclass);
-        List<Workflow> workflows = workflowDAO.findAllPublished(offset, maxLimit, filter, sortCol, sortOrder,
+        List<Workflow> workflows = workflowDAO.findAllPublished(offset, limit, filter, sortCol, sortOrder,
                 workflowClass);
         filterContainersForHiddenTags(workflows);
         stripContent(workflows);

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -5741,18 +5741,24 @@ paths:
       description: Get all of the GitHub Events for the logged in user.
       operationId: getUserGitHubEvents
       parameters:
-      - in: query
+      - description: "Start index of paging. Pagination results can be based on numbers\
+          \ or other values chosen by the registry implementor (for example, SHA values).\
+          \ If this exceeds the current result set return an empty set.  If not specified\
+          \ in the request, this will start at the beginning of the results."
+        in: query
         name: offset
         schema:
           type: integer
           format: int32
           minimum: 0
-      - in: query
+      - description: "Amount of records to return in a given page, limited to 100"
+        in: query
         name: limit
         schema:
           type: integer
           format: int32
           default: 100
+          maximum: 100
       - in: query
         name: filter
         schema:


### PR DESCRIPTION

**Description**
Add lambda events limit, see https://github.com/dockstore/dockstore/pull/5889 for more details 
Looks like two limits were already enforced after ticket was written 

**Review Instructions**
Could try to retrieve more  than 100 events 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5993

**Security and Privacy**

None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
