### PR TITLE
GitHub pr experiment

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -136,7 +136,7 @@ Lists of 329 third-party dependencies.
      (MIT) ficus (com.iheart:ficus_2.13:1.5.2 - http://iheartradio.github.io/ficus)
      (The Apache Software License, Version 2.0) GeantyRef (io.leangen.geantyref:geantyref:1.3.14 - https://github.com/leangen/geantyref)
      (Apache 2.0) genericExtras (io.circe:circe-generic-extras_2.13:0.14.1 - https://github.com/circe/circe-generic-extras)
-     (The MIT license) GitHub API for Java (org.kohsuke:github-api:1.313 - https://github-api.kohsuke.org/)
+     (The MIT license) GitHub API for Java (org.kohsuke:github-api:1.322 - https://github-api.kohsuke.org/)
      (The Apache Software License, Version 2.0) Gitlab Java API Wrapper (org.gitlab:java-gitlab-api:4.0.0 - http://nexus.sonatype.org/oss-repository-hosting.html/java-gitlab-api)
      (The Apache Software License, Version 2.0) Google APIs Client Library for Java (com.google.api-client:google-api-client:1.35.0 - https://github.com/googleapis/google-api-java-client/google-api-client)
      (BSD New license) Google Auth Library for Java - Credentials (com.google.auth:google-auth-library-credentials:1.5.3 - https://github.com/googleapis/google-auth-library-java/google-auth-library-credentials)

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -1315,7 +1315,7 @@ POM as their parent.
             <dependency>
                 <groupId>org.kohsuke</groupId>
                 <artifactId>github-api</artifactId>
-                <version>1.313</version>
+                <version>1.322</version>
             </dependency>
             <!-- used for github-api build-in handing of JWTtokens -->
             <dependency>

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
-      <version>1.313</version>
+      <version>1.322</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -83,6 +83,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.context.internal.ManagedSessionContext;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kohsuke.github.AbuseLimitHandler;
@@ -136,6 +137,15 @@ class GeneralIT extends GeneralWorkflowBaseIT {
     @Override
     public void resetDBBetweenTests() throws Exception {
         CommonTestUtilities.addAdditionalToolsWithPrivate2(SUPPORT, false, testingPostgres);
+    }
+
+    @Test
+    @Disabled("cannot repeat easily ... yet")
+    void testForkAndCreatePR() throws IOException {
+        String githubToken = "< insert a token with repo, user scope >";
+        GitHub gitHub = new GitHubBuilder().withOAuthToken(githubToken).withRateLimitHandler(RateLimitHandler.FAIL).withAbuseLimitHandler(
+            AbuseLimitHandler.FAIL).build();
+        GitHubHelper.createForkPlusPR("groovy pr content", gitHub, "dockstore-testing/hello-wdl-workflow");
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -142,7 +142,7 @@ class GeneralIT extends GeneralWorkflowBaseIT {
 
     @Test
     @Disabled("cannot repeat easily ... yet")
-    void testForkAndCreatePR() throws IOException, io.openapi.api.ApiException {
+    void testForkAndCreatePR() throws IOException {
         // get a PR from https://github.com/settings/tokens
         String githubToken = "< insert a token with repo, user scope >";
         GitHub gitHub = new GitHubBuilder().withOAuthToken(githubToken).withRateLimitHandler(RateLimitHandler.FAIL).withAbuseLimitHandler(

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -70,6 +70,7 @@ import io.swagger.client.model.Tag.DoiStatusEnum;
 import io.swagger.client.model.Workflow;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -141,12 +142,13 @@ class GeneralIT extends GeneralWorkflowBaseIT {
 
     @Test
     @Disabled("cannot repeat easily ... yet")
-    void testForkAndCreatePR() throws IOException {
+    void testForkAndCreatePR() throws IOException, io.openapi.api.ApiException {
         // get a PR from https://github.com/settings/tokens
         String githubToken = "< insert a token with repo, user scope >";
         GitHub gitHub = new GitHubBuilder().withOAuthToken(githubToken).withRateLimitHandler(RateLimitHandler.FAIL).withAbuseLimitHandler(
             AbuseLimitHandler.FAIL).build();
-        GitHubHelper.createForkPlusPR("groovy pr content", gitHub, "dockstore-testing/hello-wdl-workflow", "master");
+        URL forkPlusPR = GitHubHelper.createForkPlusPR("groovy pr content", gitHub, "dockstore-testing/hello-wdl-workflow", "master");
+        assertNotNull(forkPlusPR);
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -142,10 +142,11 @@ class GeneralIT extends GeneralWorkflowBaseIT {
     @Test
     @Disabled("cannot repeat easily ... yet")
     void testForkAndCreatePR() throws IOException {
+        // get a PR from https://github.com/settings/tokens
         String githubToken = "< insert a token with repo, user scope >";
         GitHub gitHub = new GitHubBuilder().withOAuthToken(githubToken).withRateLimitHandler(RateLimitHandler.FAIL).withAbuseLimitHandler(
             AbuseLimitHandler.FAIL).build();
-        GitHubHelper.createForkPlusPR("groovy pr content", gitHub, "dockstore-testing/hello-wdl-workflow");
+        GitHubHelper.createForkPlusPR("groovy pr content", gitHub, "dockstore-testing/hello-wdl-workflow", "master");
     }
 
     @Test

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -860,7 +860,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
-      <version>1.313</version>
+      <version>1.322</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
@@ -50,9 +50,9 @@ public final class GitHubHelper {
     public static final String BRANCHNAME_FOR_BOT = "feature/add_dockstore_yml";
 
     public static final String DOCKSTORE_BOT_PR_TEXT = """
-           Dockstore's bot has guessed at a .dockstore.yml for your repository.
+           The dockstore-bot has guessed at a .dockstore.yml for your repository.
            
-           Please review, make appropriate changes, add any [additional keys](https://docs.dockstore.org/en/stable/assets/templates/template.html) and merge in order to complete integration with Dockstore, allowing Dockstore to keep informed of new changes to your workkflow, notebook, or tools.
+           Please review, make appropriate changes, add any [additional keys](https://docs.dockstore.org/en/stable/assets/templates/template.html) and merge in order to complete integration with Dockstore, allowing Dockstore to keep informed of new changes to your workflow(s), notebook(s), or tool(s).
            """;
 
     private GitHubHelper() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
@@ -49,12 +49,12 @@ public final class GitHubHelper {
     public static final String BRANCHNAME_FOR_BOT = "feature/add_dockstore_yml";
 
     public static final String DOCKSTORE_BOT_PR_TEXT = """
-           The dockstore-bot has guessed at a .dockstore.yml for your repository.
+           The dockstore-bot has guessed at a .dockstore.yml for your repository to enable Dockstore's [GitHub app](https://docs.dockstore.org/en/stable/getting-started/github-apps/github-apps-landing-page.html).
            
            Please review, make appropriate changes, add any [additional keys](https://docs.dockstore.org/en/stable/assets/templates/template.html) and merge in order to complete integration with Dockstore, allowing Dockstore to keep informed of new changes to your workflow(s), notebook(s), or tool(s).
            """;
 
-    public static final String DOCKSTORE_BOT_PR_TITLE =  "dockstore-bot inferred .dockstore.yml";
+    public static final String DOCKSTORE_BOT_PR_TITLE =  "Add dockstore-bot inferred .dockstore.yml";
 
     private GitHubHelper() {
     }
@@ -85,7 +85,7 @@ public final class GitHubHelper {
             String masterSha = fork.getRef("heads/" + targetBranch).getObject().getSha();
             GHRef ref = fork.createRef("refs/heads/" + BRANCHNAME_FOR_BOT, masterSha);
             fork.createContent().content(inferredDockstoreYml).branch(ref.getRef()).message(DOCKSTORE_BOT_PR_TITLE).commit();
-            GHPullRequest pullRequest = targetRepository.createPullRequest(prTitle, username + ":" + branchForBot, targetBranch, prDescription, true, true);
+            GHPullRequest pullRequest = targetRepository.createPullRequest(prTitle, username + ":" + branchForBot, targetBranch, prDescription, true, false);
             return pullRequest.getUrl();
         } catch (IOException e) {
             String msg = "Something messed up creating a PR on: " + repositoryName;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
@@ -59,7 +59,7 @@ public final class GitHubHelper {
     }
 
     /**
-     * Experimental building block, given a repository, create a fork of it and a PR to it
+     * Experimental building block, given a repository, create a fork of it (to the personal organization for the robot user) and a PR to it
      * @param inferredDockstoreYml should be the only real change in the PR
      * @param gitHub    The GitHub API
      * @param repositoryName    Name of the GitHub repository (e.g. dockstore/lambda)

--- a/keysmap.list
+++ b/keysmap.list
@@ -68,7 +68,7 @@ org.jboss.logging:jboss-logging:jar:3.4.3.Final = badSig
 org.broadinstitute:cromwell-wdl-transforms-draft2_2.13:jar:84 = badSig
 
 
-
+org.kohsuke:github-api:pom:1.322                                    = badSig
 org.kohsuke:github-api:pom:1.313                                    = badSig
 org.kohsuke:github-api:pom:1.123                                    = badSig
 com.spotify:docker-client:pom:8.16.0                                = badSig


### PR DESCRIPTION
**Description**
Demonstrate how to create a PR programmatically. Turned out fairly simple, added a test but requires a live write token and wouldn't be safe to run in parallel. Doesn't seem to be worth it to mock since it's almost all interacting with GitHub. 

**Review Instructions**
Follow the comment, add a token for a user with rights to the `dockstore-testing` org (or this particular repo)/ 
Run the test to create a fork and PR. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6463

**Security and Privacy**

None

- [ ] Security and Privacy assessed

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
