### PR TITLE
SEAB-6489: Version-level sourcefile size limits

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -1118,9 +1118,9 @@ class GeneralWorkflowIT extends BaseIT {
     void testVersionSourceFileSizeLimit() {
         ApiClient client = getWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(client);
-        Workflow workflow = manualRegisterAndPublish(workflowsApi, "dockstore-testing/large-sourcefiles", "main", "cwl", SourceControl.GITHUB, "/main.cwl", true);
+        Workflow workflow = manualRegisterAndPublish(workflowsApi, "dockstore-testing/large-sourcefiles", "v1_11MB", "cwl", SourceControl.GITHUB, "/main.cwl", true);
         List<String> testFiles = IntStream.range(0, 12).mapToObj(i -> "/test%d.json".formatted(i)).toList();
-        workflowsApi.addTestParameterFiles(workflow.getId(), testFiles, "", "main");
+        workflowsApi.addTestParameterFiles(workflow.getId(), testFiles, "", "v1_11MB");
         try {
             workflowsApi.refresh(workflow.getId(), false);
             fail("refresh should have failed");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -2157,7 +2157,7 @@ class WebhookIT extends BaseIT {
         final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         final WorkflowsApi workflowsApi = new WorkflowsApi(webClient);
         try {
-            handleGitHubRelease(workflowsApi, "dockstore-testing/large-sourcefiles", "refs/heads/main", USER_2_USERNAME);
+            handleGitHubRelease(workflowsApi, "dockstore-testing/large-sourcefiles", "refs/tags/v1_11MB", USER_2_USERNAME);
             fail("registration should have failed");
         } catch (ApiException e) {
             // Expected execution path.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/LimitHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/LimitHelper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.dockstore.webservice.helpers;
+
+import io.dockstore.webservice.CustomWebApplicationException;
+import io.dockstore.webservice.core.Version;
+import org.apache.http.HttpStatus;
+
+public final class LimitHelper {
+
+    public static final long BYTES_PER_MEGABYTE = 1_000_000L;
+    public static final long MAXIMUM_VERSION_FILE_SIZE = 10 * BYTES_PER_MEGABYTE;
+
+    private LimitHelper() {
+        // This space intentionally left blank.
+    }
+
+    public static void checkVersion(Version<?> version) {
+        if (totalFileSize(version) > MAXIMUM_VERSION_FILE_SIZE) {
+            String message = "A version must contain less than %.1dMB of files".formatted(MAXIMUM_VERSION_FILE_SIZE / BYTES_PER_MEGABYTE);
+            throw new CustomWebApplicationException(message, HttpStatus.SC_BAD_REQUEST);
+        }
+    }
+
+    private static long totalFileSize(Version<?> version) {
+        return version.getSourceFiles().stream().mapToLong(file -> file.getContent().length()).sum();
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/LimitHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/LimitHelper.java
@@ -32,7 +32,7 @@ public final class LimitHelper {
 
     public static void checkVersion(Version<?> version) {
         if (totalFileSize(version) > MAXIMUM_VERSION_FILE_SIZE) {
-            String message = "A version must contain less than %.1dMB of files".formatted(MAXIMUM_VERSION_FILE_SIZE / BYTES_PER_MEGABYTE);
+            String message = "A version must contain less than %.1fMB of files".formatted(MAXIMUM_VERSION_FILE_SIZE / (double)BYTES_PER_MEGABYTE);
             throw new CustomWebApplicationException(message, HttpStatus.SC_BAD_REQUEST);
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractHostedEntryResource.java
@@ -36,6 +36,7 @@ import io.dockstore.webservice.core.WorkflowVersion;
 import io.dockstore.webservice.helpers.EntryVersionHelper;
 import io.dockstore.webservice.helpers.FileFormatHelper;
 import io.dockstore.webservice.helpers.LambdaUrlChecker;
+import io.dockstore.webservice.helpers.LimitHelper;
 import io.dockstore.webservice.helpers.PublicStateManager;
 import io.dockstore.webservice.helpers.StateManagerMode;
 import io.dockstore.webservice.jdbi.EntryDAO;
@@ -249,6 +250,9 @@ public abstract class AbstractHostedEntryResource<T extends Entry<T, U>, U exten
                 + invalidFileNames;
             throw new CustomWebApplicationException(message, HttpStatus.SC_BAD_REQUEST);
         }
+
+        // Check the version to see if it exceeds any limits.
+        LimitHelper.checkVersion(validatedVersion);
 
         validatedVersion.setValid(true); // Hosted entry versions must be valid to save
         validatedVersion.setVersionEditor(user);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -44,6 +44,7 @@ import io.dockstore.webservice.helpers.GitHelper;
 import io.dockstore.webservice.helpers.GitHubHelper;
 import io.dockstore.webservice.helpers.GitHubSourceCodeRepo;
 import io.dockstore.webservice.helpers.LambdaUrlChecker;
+import io.dockstore.webservice.helpers.LimitHelper;
 import io.dockstore.webservice.helpers.ORCIDHelper;
 import io.dockstore.webservice.helpers.PublicStateManager;
 import io.dockstore.webservice.helpers.SourceCodeRepoFactory;
@@ -1016,6 +1017,9 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             if (workflow.getLastModified() == null || (updatedWorkflowVersion.getLastModified() != null && workflow.getLastModifiedDate().before(updatedWorkflowVersion.getLastModified()))) {
                 workflow.setLastModified(updatedWorkflowVersion.getLastModified());
             }
+
+            // Check the version to see if it exceeds any limits.
+            LimitHelper.checkVersion(updatedWorkflowVersion);
 
             // Update verification information.
             updatedWorkflowVersion.updateVerified();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -65,6 +65,7 @@ import io.dockstore.webservice.core.webhook.PushPayload;
 import io.dockstore.webservice.core.webhook.WebhookRepository;
 import io.dockstore.webservice.helpers.EntryVersionHelper;
 import io.dockstore.webservice.helpers.FileFormatHelper;
+import io.dockstore.webservice.helpers.LimitHelper;
 import io.dockstore.webservice.helpers.ORCIDHelper;
 import io.dockstore.webservice.helpers.PublicStateManager;
 import io.dockstore.webservice.helpers.SourceCodeRepoFactory;
@@ -374,6 +375,10 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
         // Use new workflow to update existing workflow
         updateDBWorkflowWithSourceControlWorkflow(existingWorkflow, newWorkflow, user, version);
+
+        // Check each version to see if it exceeds any limits.
+        existingWorkflow.getWorkflowVersions().forEach(LimitHelper::checkVersion);
+
         // Update file formats in each version and then the entry
         FileFormatHelper.updateFileFormats(existingWorkflow, newWorkflow.getWorkflowVersions(), fileFormatDAO, true);
 


### PR DESCRIPTION
**Description**
This PR limits the SourceFiles in a newly-registered Version to a total size of no more than 10MB.  The new code is on the manual, .dockstore.yml-based, and hosted Workflow (bioworkflows, apptools, services, notebooks) registration paths.

**Review Instructions**
Register an entry with a number of sourcefiles that total more than 10MB.  Make sure that each sourcefile is less than 1MB to avoid the individual sourcefile size limit, and prefer test files, which won't be subject to limits that might be coded into the language handler (for example, the cwl handler must be expanded.

**Issue**


**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
