### PR TITLE
SEAB-6488: Modify SourceFile to flag errors

### DIFF
--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -860,7 +860,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
-      <version>1.313</version>
+      <version>1.322</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -860,7 +860,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
-      <version>1.322</version>
+      <version>1.313</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LimitedSourceFileBuilder.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LimitedSourceFileBuilder.java
@@ -121,7 +121,7 @@ public class LimitedSourceFileBuilder {
         }
 
         private static long computeMaximumSize(String path) {
-            // Jupyter notebooks can contain embedded images, making them larger, on average.
+            // Jupyter notebook files can contain embedded images, making them tend to be larger.
             if (StringUtils.endsWith(path, ".ipynb")) {
                 return NOTEBOOK_MAXIMUM_FILE_SIZE;
             }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LimitedSourceFileBuilder.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LimitedSourceFileBuilder.java
@@ -95,6 +95,7 @@ public class LimitedSourceFileBuilder {
         private static void setContentWithLimits(SourceFile file, String content, String path) {
             String limitedContent = content;
             SourceFile.FormEnum limitedForm = SourceFile.FormEnum.COMPLETE;
+            // Limit certain types of content.
             if (content == null) {
                 limitedContent = "Dockstore could not retrieve this file";
                 limitedForm = SourceFile.FormEnum.ERROR;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LimitedSourceFileBuilder.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LimitedSourceFileBuilder.java
@@ -105,12 +105,12 @@ public class LimitedSourceFileBuilder {
             } else {
                 byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
                 if (Bytes.indexOf(bytes, Byte.decode("0x00")) != -1) {
-                    // Postgres cannot store strings that contain "NUL" characters.
+                    // Postgres cannot store strings that contain "NUL" (value 0) characters.
                     // Thus, Dockstore cannot currently store binary files.
                     // https://www.postgresql.org/docs/current/datatype-character.html#DATATYPE-CHARACTER
                     // https://www.ascii-code.com/character/%E2%90%80
                     file.setContent("Dockstore does not store binary files");
-                    file.setState(SourceFile.State.MESSAGE);
+                    file.setState(SourceFile.State.NOT_STORED);
                     logContentAction(path, "binary file");
                     return;
                 }
@@ -119,7 +119,7 @@ public class LimitedSourceFileBuilder {
                     // A large file is probably up to no good.
                     double megabytes = maximumSize / (double) BYTES_PER_MEGABYTE;
                     file.setContent("Dockstore does not store files of this type over %.1fMB in size".formatted(megabytes));
-                    file.setState(SourceFile.State.MESSAGE);
+                    file.setState(SourceFile.State.NOT_STORED);
                     logContentAction(path, "large file (%n bytes)".formatted(bytes.length));
                     return;
                 }
@@ -127,8 +127,7 @@ public class LimitedSourceFileBuilder {
         }
 
         private static void logContentAction(String path, String why) {
-            String message = "incomplete content for file %s: %s".formatted(path, why);
-            LOG.info(message);
+            LOG.info("incomplete content for file %s: %s".formatted(path, why));
         }
 
         private static long computeMaximumSize(String path) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LimitedSourceFileBuilder.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/LimitedSourceFileBuilder.java
@@ -99,9 +99,7 @@ public class LimitedSourceFileBuilder {
             SourceFile.Reason limitedReason = null;
             // Limit certain types of content.
             if (content == null) {
-                limitedContent = "Dockstore could not retrieve this file";
-                limitedState = SourceFile.State.MESSAGE;
-                limitedReason = SourceFile.Reason.READ_ERROR;
+                limitedState = SourceFile.State.STUB;
             } else {
                 byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
                 if (Bytes.indexOf(bytes, Byte.decode("0x00")) != -1) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -166,7 +166,7 @@ public class SourceFile implements Comparable<SourceFile> {
 
     @Enumerated(EnumType.STRING)
     @Schema(description = "Enumerates the form of file", requiredMode = RequiredMode.REQUIRED)
-    private FormEnum form;
+    private FormEnum form = FormEnum.COMPLETE;
 
     @OneToOne(cascade = CascadeType.ALL, mappedBy = "parent", orphanRemoval = true)
     @Cascade(org.hibernate.annotations.CascadeType.ALL)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -164,6 +164,10 @@ public class SourceFile implements Comparable<SourceFile> {
     @BatchSize(size = 25)
     private Map<String, VerificationInformation> verifiedBySource = new HashMap<>();
 
+    @Enumerated(EnumType.STRING)
+    @Schema(description = "Enumerates the form of file", requiredMode = RequiredMode.REQUIRED)
+    private FormEnum form;
+
     @OneToOne(cascade = CascadeType.ALL, mappedBy = "parent", orphanRemoval = true)
     @Cascade(org.hibernate.annotations.CascadeType.ALL)
     @PrimaryKeyJoinColumn
@@ -295,7 +299,7 @@ public class SourceFile implements Comparable<SourceFile> {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("id", id).add("type", type).add("path", path).add("absolutePath", absolutePath).toString();
+        return MoreObjects.toStringHelper(this).add("id", id).add("type", type).add("path", path).add("absolutePath", absolutePath).add("form", form).toString();
     }
 
     public boolean isFrozen() {
@@ -304,6 +308,14 @@ public class SourceFile implements Comparable<SourceFile> {
 
     public void setFrozen(boolean frozen) {
         this.frozen = frozen;
+    }
+
+    public FormEnum getForm() {
+        return form;
+    }
+
+    public void setForm(FormEnum form) {
+        this.form = form;
     }
 
     public SourceFileMetadata getMetadata() {
@@ -315,14 +327,15 @@ public class SourceFile implements Comparable<SourceFile> {
     }
 
     /**
-     * Make this SourceFile appear to have the equivalent content/attributes as the specified SourceFile.
-     * Do not include "Hibernate-managed" fields such as the ID and creation/update dates.
+     * Copy content/attributes from the specified SourceFile to this SourceFile,
+     * except for "Hibernate-managed" fields such as the ID and creation/update dates.
      */
     public void updateFrom(SourceFile src) {
         setType(src.getType());
         setContent(src.getContent());
         setPath(src.getPath());
         setAbsolutePath(src.getAbsolutePath());
+        setForm(src.getForm());
         getMetadata().setTypeVersion(src.getMetadata().getTypeVersion());
     }
 
@@ -370,5 +383,10 @@ public class SourceFile implements Comparable<SourceFile> {
         private Timestamp dbCreateDate;
 
         // There is no dbupdatedate because it doesn't work with @Embeddable nor @ElementCollection
+    }
+
+    public enum FormEnum {
+        COMPLETE,
+        ERROR
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -402,7 +402,8 @@ public class SourceFile implements Comparable<SourceFile> {
 
     public enum State {
         COMPLETE,
-        MESSAGE
+        MESSAGE,
+        STUB
     }
 
     public enum Reason {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -387,8 +387,18 @@ public class SourceFile implements Comparable<SourceFile> {
     }
 
     public enum State {
+        /**
+         * The full file body is stored in the SourceFile's content field.
+         */
         COMPLETE,
+        /**
+         * The file body is not stored.
+         * The content field contains a message describing why the file's body is not stored.
+         */
         NOT_STORED,
+        /**
+         * The file represents a stub.  The content field is null.
+         */
         STUB
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -169,11 +169,6 @@ public class SourceFile implements Comparable<SourceFile> {
     @Schema(description = "Enumerates the file state", requiredMode = RequiredMode.REQUIRED)
     private State state = State.COMPLETE;
 
-    @Column()
-    @Enumerated(EnumType.STRING)
-    @Schema(description = "Enumerates the reason for the file state")
-    private Reason reason;
-
     @OneToOne(cascade = CascadeType.ALL, mappedBy = "parent", orphanRemoval = true)
     @Cascade(org.hibernate.annotations.CascadeType.ALL)
     @PrimaryKeyJoinColumn
@@ -305,7 +300,7 @@ public class SourceFile implements Comparable<SourceFile> {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("id", id).add("type", type).add("path", path).add("absolutePath", absolutePath).add("state", state).add("reason", reason).toString();
+        return MoreObjects.toStringHelper(this).add("id", id).add("type", type).add("path", path).add("absolutePath", absolutePath).add("state", state).toString();
     }
 
     public boolean isFrozen() {
@@ -322,14 +317,6 @@ public class SourceFile implements Comparable<SourceFile> {
 
     public void setState(State state) {
         this.state = state;
-    }
-
-    public Reason getReason() {
-        return reason;
-    }
-
-    public void setReason(Reason reason) {
-        this.reason = reason;
     }
 
     public SourceFileMetadata getMetadata() {
@@ -350,7 +337,6 @@ public class SourceFile implements Comparable<SourceFile> {
         setPath(src.getPath());
         setAbsolutePath(src.getAbsolutePath());
         setState(src.getState());
-        setReason(src.getReason());
         getMetadata().setTypeVersion(src.getMetadata().getTypeVersion());
     }
 
@@ -404,11 +390,5 @@ public class SourceFile implements Comparable<SourceFile> {
         COMPLETE,
         MESSAGE,
         STUB
-    }
-
-    public enum Reason {
-        TOO_LARGE,
-        BINARY,
-        READ_ERROR
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -166,8 +166,13 @@ public class SourceFile implements Comparable<SourceFile> {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    @Schema(description = "Enumerates the form of file", requiredMode = RequiredMode.REQUIRED)
-    private FormEnum form = FormEnum.COMPLETE;
+    @Schema(description = "Enumerates the file state", requiredMode = RequiredMode.REQUIRED)
+    private State state = State.COMPLETE;
+
+    @Column()
+    @Enumerated(EnumType.STRING)
+    @Schema(description = "Enumerates the reason for the file state")
+    private Reason reason;
 
     @OneToOne(cascade = CascadeType.ALL, mappedBy = "parent", orphanRemoval = true)
     @Cascade(org.hibernate.annotations.CascadeType.ALL)
@@ -300,7 +305,7 @@ public class SourceFile implements Comparable<SourceFile> {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("id", id).add("type", type).add("path", path).add("absolutePath", absolutePath).add("form", form).toString();
+        return MoreObjects.toStringHelper(this).add("id", id).add("type", type).add("path", path).add("absolutePath", absolutePath).add("state", state).add("reason", reason).toString();
     }
 
     public boolean isFrozen() {
@@ -311,12 +316,20 @@ public class SourceFile implements Comparable<SourceFile> {
         this.frozen = frozen;
     }
 
-    public FormEnum getForm() {
-        return form;
+    public State getState() {
+        return state;
     }
 
-    public void setForm(FormEnum form) {
-        this.form = form;
+    public void setState(State state) {
+        this.state = state;
+    }
+
+    public Reason getReason() {
+        return reason;
+    }
+
+    public void setReason(Reason reason) {
+        this.reason = reason;
     }
 
     public SourceFileMetadata getMetadata() {
@@ -336,7 +349,8 @@ public class SourceFile implements Comparable<SourceFile> {
         setContent(src.getContent());
         setPath(src.getPath());
         setAbsolutePath(src.getAbsolutePath());
-        setForm(src.getForm());
+        setState(src.getState());
+        setReason(src.getReason());
         getMetadata().setTypeVersion(src.getMetadata().getTypeVersion());
     }
 
@@ -386,8 +400,14 @@ public class SourceFile implements Comparable<SourceFile> {
         // There is no dbupdatedate because it doesn't work with @Embeddable nor @ElementCollection
     }
 
-    public enum FormEnum {
+    public enum State {
         COMPLETE,
-        ERROR
+        MESSAGE
+    }
+
+    public enum Reason {
+        TOO_LARGE,
+        BINARY,
+        READ_ERROR
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -388,7 +388,7 @@ public class SourceFile implements Comparable<SourceFile> {
 
     public enum State {
         COMPLETE,
-        MESSAGE,
+        NOT_STORED,
         STUB
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -164,6 +164,7 @@ public class SourceFile implements Comparable<SourceFile> {
     @BatchSize(size = 25)
     private Map<String, VerificationInformation> verifiedBySource = new HashMap<>();
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     @Schema(description = "Enumerates the form of file", requiredMode = RequiredMode.REQUIRED)
     private FormEnum form = FormEnum.COMPLETE;

--- a/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
@@ -327,8 +327,8 @@
             </column>
         </addColumn>
         <sql dbms="postgresql">
-            <comment>Set state and content for sourcefiles with null content</comment>
-            UPDATE sourcefile SET state = 'MESSAGE', content = 'Dockstore could not retrieve this file' WHERE content IS NULL;
+            <comment>Set state and for sourcefiles with null content</comment>
+            UPDATE sourcefile SET state = 'STUB' WHERE content IS NULL;
         </sql>
         <sql dbms="postgresql">
             <comment>Set state and reason for binary sourcefiles</comment>

--- a/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
@@ -316,7 +316,7 @@
             WHERE version_metadata.doiurl IS NOT NULL;
         </sql>
     </changeSet>
-    <changeSet author="svonworl" id="addFormFieldToSourceFile">
+    <changeSet author="svonworl" id="addFieldsToSourceFile">
         <addColumn tableName="sourcefile">
             <column name="state" type="VARCHAR(255)" value="COMPLETE">
                 <constraints nullable="false"/>

--- a/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
@@ -322,5 +322,13 @@
                 <constraints nullable="false"/>
             </column>
         </addColumn>
+        <sql dbms="postgresql">
+            <comment>Set appropriate content and form for sourcefiles with null content</comment>
+            UPDATE sourcefile SET form = 'ERROR', content = 'Dockstore could not retrieve this file' WHERE content IS NULL;
+        </sql>
+        <sql dbms="postgresql">
+            <comment>Set form = ERROR for binary sourcefiles</comment>
+            UPDATE sourcefile SET form = 'ERROR' WHERE content = 'Dockstore does not store binary files';
+        </sql>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
@@ -316,23 +316,19 @@
             WHERE version_metadata.doiurl IS NOT NULL;
         </sql>
     </changeSet>
-    <changeSet author="svonworl" id="addFieldsToSourceFile">
+    <changeSet author="svonworl" id="addStateFieldToSourceFile">
         <addColumn tableName="sourcefile">
             <column name="state" type="VARCHAR(255)" value="COMPLETE">
                 <constraints nullable="false"/>
             </column>
         </addColumn>
-        <addColumn tableName="sourcefile">
-            <column name="reason" type="VARCHAR(255)">
-            </column>
-        </addColumn>
         <sql dbms="postgresql">
-            <comment>Set state and for sourcefiles with null content</comment>
+            <comment>Set state for sourcefiles with null content</comment>
             UPDATE sourcefile SET state = 'STUB' WHERE content IS NULL;
         </sql>
         <sql dbms="postgresql">
-            <comment>Set state and reason for binary sourcefiles</comment>
-            UPDATE sourcefile SET state = 'MESSAGE', reason = 'BINARY' WHERE content = 'Dockstore does not store binary files';
+            <comment>Set state for binary sourcefiles</comment>
+            UPDATE sourcefile SET state = 'NOT_STORED' WHERE content = 'Dockstore does not store binary files';
         </sql>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
@@ -316,4 +316,11 @@
             WHERE version_metadata.doiurl IS NOT NULL;
         </sql>
     </changeSet>
+    <changeSet author="svonworl" id="addFormToSourceFile">
+        <addColumn tableName="sourcefile">
+            <column name="form" type="varchar(32 BYTE)" value="COMPLETE">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
@@ -316,9 +316,9 @@
             WHERE version_metadata.doiurl IS NOT NULL;
         </sql>
     </changeSet>
-    <changeSet author="svonworl" id="addFormToSourceFile">
+    <changeSet author="svonworl" id="addFormFieldToSourceFile">
         <addColumn tableName="sourcefile">
-            <column name="form" type="varchar(32 BYTE)" value="COMPLETE">
+            <column name="form" type="VARCHAR(255)" value="COMPLETE">
                 <constraints nullable="false"/>
             </column>
         </addColumn>

--- a/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
@@ -318,17 +318,21 @@
     </changeSet>
     <changeSet author="svonworl" id="addFormFieldToSourceFile">
         <addColumn tableName="sourcefile">
-            <column name="form" type="VARCHAR(255)" value="COMPLETE">
+            <column name="state" type="VARCHAR(255)" value="COMPLETE">
                 <constraints nullable="false"/>
             </column>
         </addColumn>
+        <addColumn tableName="sourcefile">
+            <column name="reason" type="VARCHAR(255)">
+            </column>
+        </addColumn>
         <sql dbms="postgresql">
-            <comment>Set appropriate content and form for sourcefiles with null content</comment>
-            UPDATE sourcefile SET form = 'ERROR', content = 'Dockstore could not retrieve this file' WHERE content IS NULL;
+            <comment>Set state and content for sourcefiles with null content</comment>
+            UPDATE sourcefile SET state = 'MESSAGE', content = 'Dockstore could not retrieve this file' WHERE content IS NULL;
         </sql>
         <sql dbms="postgresql">
-            <comment>Set form = ERROR for binary sourcefiles</comment>
-            UPDATE sourcefile SET form = 'ERROR' WHERE content = 'Dockstore does not store binary files';
+            <comment>Set state and reason for binary sourcefiles</comment>
+            UPDATE sourcefile SET state = 'MESSAGE', reason = 'BINARY' WHERE content = 'Dockstore does not store binary files';
         </sql>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -10757,12 +10757,6 @@ components:
             $ref: '#/components/schemas/Checksum'
         content:
           type: string
-        form:
-          type: string
-          description: Enumerates the form of file
-          enum:
-          - COMPLETE
-          - ERROR
         frozen:
           type: boolean
         id:
@@ -10773,6 +10767,19 @@ components:
         path:
           type: string
           description: Path to sourcefile relative to its parent
+        reason:
+          type: string
+          description: Enumerates the reason for the file state
+          enum:
+          - TOO_LARGE
+          - BINARY
+          - READ_ERROR
+        state:
+          type: string
+          description: Enumerates the file state
+          enum:
+          - COMPLETE
+          - MESSAGE
         type:
           type: string
           description: Enumerates the type of file
@@ -10806,8 +10813,8 @@ components:
             $ref: '#/components/schemas/VerificationInformation'
       required:
       - absolutePath
-      - form
       - path
+      - state
       - type
     SourceFileMetadata:
       type: object

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -10767,13 +10767,6 @@ components:
         path:
           type: string
           description: Path to sourcefile relative to its parent
-        reason:
-          type: string
-          description: Enumerates the reason for the file state
-          enum:
-          - TOO_LARGE
-          - BINARY
-          - READ_ERROR
         state:
           type: string
           description: Enumerates the file state

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -10780,6 +10780,7 @@ components:
           enum:
           - COMPLETE
           - MESSAGE
+          - STUB
         type:
           type: string
           description: Enumerates the type of file

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -10772,7 +10772,7 @@ components:
           description: Enumerates the file state
           enum:
           - COMPLETE
-          - MESSAGE
+          - NOT_STORED
           - STUB
         type:
           type: string

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -10757,6 +10757,12 @@ components:
             $ref: '#/components/schemas/Checksum'
         content:
           type: string
+        form:
+          type: string
+          description: Enumerates the form of file
+          enum:
+          - COMPLETE
+          - ERROR
         frozen:
           type: boolean
         id:
@@ -10800,6 +10806,7 @@ components:
             $ref: '#/components/schemas/VerificationInformation'
       required:
       - absolutePath
+      - form
       - path
       - type
     SourceFileMetadata:

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/core/LimitedSourceFileBuilderTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/core/LimitedSourceFileBuilderTest.java
@@ -21,7 +21,6 @@ class LimitedSourceFileBuilderTest {
         assertEquals(TYPE, file.getType());
         assertEquals(SMALL_CONTENT, file.getContent());
         assertEquals(SourceFile.State.COMPLETE, file.getState());
-        assertEquals(null, file.getReason());
         assertEquals(PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }
@@ -32,7 +31,6 @@ class LimitedSourceFileBuilderTest {
         assertEquals(TYPE, file.getType());
         assertTrue(file.getContent().startsWith("Dockstore does not store files of this type over"));
         assertEquals(SourceFile.State.MESSAGE, file.getState());
-        assertEquals(SourceFile.Reason.TOO_LARGE, file.getReason());
         assertEquals(PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }
@@ -43,7 +41,6 @@ class LimitedSourceFileBuilderTest {
         assertEquals(TYPE, file.getType());
         assertEquals("Dockstore does not store binary files", file.getContent());
         assertEquals(SourceFile.State.MESSAGE, file.getState());
-        assertEquals(SourceFile.Reason.BINARY, file.getReason());
         assertEquals(PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }
@@ -54,7 +51,6 @@ class LimitedSourceFileBuilderTest {
         assertEquals(TYPE, file.getType());
         assertEquals(null, file.getContent());
         assertEquals(SourceFile.State.STUB, file.getState());
-        assertEquals(null, file.getReason());
         assertEquals(PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }
@@ -65,7 +61,6 @@ class LimitedSourceFileBuilderTest {
         assertEquals(TYPE, file.getType());
         assertEquals(SMALL_CONTENT, file.getContent());
         assertEquals(SourceFile.State.COMPLETE, file.getState());
-        assertEquals(null, file.getReason());
         assertEquals(ABSOLUTE_PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/core/LimitedSourceFileBuilderTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/core/LimitedSourceFileBuilderTest.java
@@ -52,9 +52,9 @@ class LimitedSourceFileBuilderTest {
     void testNullContent() {
         SourceFile file = SourceFile.limitedBuilder().type(TYPE).content(null).path(PATH).absolutePath(ABSOLUTE_PATH).build();
         assertEquals(TYPE, file.getType());
-        assertEquals("Dockstore could not retrieve this file", file.getContent());
-        assertEquals(SourceFile.State.MESSAGE, file.getState());
-        assertEquals(SourceFile.Reason.READ_ERROR, file.getReason());
+        assertEquals(null, file.getContent());
+        assertEquals(SourceFile.State.STUB, file.getState());
+        assertEquals(null, file.getReason());
         assertEquals(PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/core/LimitedSourceFileBuilderTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/core/LimitedSourceFileBuilderTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 class LimitedSourceFileBuilderTest {
 
     private static final DescriptorLanguage.FileType TYPE = DescriptorLanguage.FileType.DOCKSTORE_WDL;
-    private static final String SMALL_CONTENT = "This is some content.";
+    private static final String SMALL_CONTENT = "A small bit of content.";
     private static final String HUGE_CONTENT = ".".repeat(100_000_000);
     private static final String BINARY_CONTENT = "Content that contains a nul character \u0000";
     private static final String PATH = "abc.wdl";

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/core/LimitedSourceFileBuilderTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/core/LimitedSourceFileBuilderTest.java
@@ -30,7 +30,7 @@ class LimitedSourceFileBuilderTest {
         SourceFile file = SourceFile.limitedBuilder().type(TYPE).content(HUGE_CONTENT).path(PATH).absolutePath(ABSOLUTE_PATH).build();
         assertEquals(TYPE, file.getType());
         assertTrue(file.getContent().startsWith("Dockstore does not store files of this type over"));
-        assertEquals(SourceFile.State.MESSAGE, file.getState());
+        assertEquals(SourceFile.State.NOT_STORED, file.getState());
         assertEquals(PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }
@@ -40,7 +40,7 @@ class LimitedSourceFileBuilderTest {
         SourceFile file = SourceFile.limitedBuilder().type(TYPE).content(BINARY_CONTENT).path(PATH).absolutePath(ABSOLUTE_PATH).build();
         assertEquals(TYPE, file.getType());
         assertEquals("Dockstore does not store binary files", file.getContent());
-        assertEquals(SourceFile.State.MESSAGE, file.getState());
+        assertEquals(SourceFile.State.NOT_STORED, file.getState());
         assertEquals(PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/core/LimitedSourceFileBuilderTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/core/LimitedSourceFileBuilderTest.java
@@ -20,6 +20,7 @@ class LimitedSourceFileBuilderTest {
         SourceFile file = SourceFile.limitedBuilder().type(TYPE).content(SMALL_CONTENT).path(PATH).absolutePath(ABSOLUTE_PATH).build();
         assertEquals(TYPE, file.getType());
         assertEquals(SMALL_CONTENT, file.getContent());
+        assertEquals(SourceFile.FormEnum.COMPLETE, file.getForm());
         assertEquals(PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }
@@ -29,6 +30,7 @@ class LimitedSourceFileBuilderTest {
         SourceFile file = SourceFile.limitedBuilder().type(TYPE).content(HUGE_CONTENT).path(PATH).absolutePath(ABSOLUTE_PATH).build();
         assertEquals(TYPE, file.getType());
         assertTrue(file.getContent().startsWith("Dockstore does not store files of this type over"));
+        assertEquals(SourceFile.FormEnum.ERROR, file.getForm());
         assertEquals(PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }
@@ -37,7 +39,8 @@ class LimitedSourceFileBuilderTest {
     void testBinaryContent() {
         SourceFile file = SourceFile.limitedBuilder().type(TYPE).content(BINARY_CONTENT).path(PATH).absolutePath(ABSOLUTE_PATH).build();
         assertEquals(TYPE, file.getType());
-        assertTrue(file.getContent().startsWith("Dockstore does not store binary files"));
+        assertEquals("Dockstore does not store binary files", file.getContent());
+        assertEquals(SourceFile.FormEnum.ERROR, file.getForm());
         assertEquals(PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }
@@ -46,7 +49,8 @@ class LimitedSourceFileBuilderTest {
     void testNullContent() {
         SourceFile file = SourceFile.limitedBuilder().type(TYPE).content(null).path(PATH).absolutePath(ABSOLUTE_PATH).build();
         assertEquals(TYPE, file.getType());
-        assertEquals(null, file.getContent());
+        assertEquals("Dockstore could not retrieve this file", file.getContent());
+        assertEquals(SourceFile.FormEnum.ERROR, file.getForm());
         assertEquals(PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }
@@ -56,6 +60,7 @@ class LimitedSourceFileBuilderTest {
         SourceFile file = SourceFile.limitedBuilder().type(TYPE).content(SMALL_CONTENT).paths(ABSOLUTE_PATH).build();
         assertEquals(TYPE, file.getType());
         assertEquals(SMALL_CONTENT, file.getContent());
+        assertEquals(SourceFile.FormEnum.COMPLETE, file.getForm());
         assertEquals(ABSOLUTE_PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/core/LimitedSourceFileBuilderTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/core/LimitedSourceFileBuilderTest.java
@@ -20,7 +20,8 @@ class LimitedSourceFileBuilderTest {
         SourceFile file = SourceFile.limitedBuilder().type(TYPE).content(SMALL_CONTENT).path(PATH).absolutePath(ABSOLUTE_PATH).build();
         assertEquals(TYPE, file.getType());
         assertEquals(SMALL_CONTENT, file.getContent());
-        assertEquals(SourceFile.FormEnum.COMPLETE, file.getForm());
+        assertEquals(SourceFile.State.COMPLETE, file.getState());
+        assertEquals(null, file.getReason());
         assertEquals(PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }
@@ -30,7 +31,8 @@ class LimitedSourceFileBuilderTest {
         SourceFile file = SourceFile.limitedBuilder().type(TYPE).content(HUGE_CONTENT).path(PATH).absolutePath(ABSOLUTE_PATH).build();
         assertEquals(TYPE, file.getType());
         assertTrue(file.getContent().startsWith("Dockstore does not store files of this type over"));
-        assertEquals(SourceFile.FormEnum.ERROR, file.getForm());
+        assertEquals(SourceFile.State.MESSAGE, file.getState());
+        assertEquals(SourceFile.Reason.TOO_LARGE, file.getReason());
         assertEquals(PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }
@@ -40,7 +42,8 @@ class LimitedSourceFileBuilderTest {
         SourceFile file = SourceFile.limitedBuilder().type(TYPE).content(BINARY_CONTENT).path(PATH).absolutePath(ABSOLUTE_PATH).build();
         assertEquals(TYPE, file.getType());
         assertEquals("Dockstore does not store binary files", file.getContent());
-        assertEquals(SourceFile.FormEnum.ERROR, file.getForm());
+        assertEquals(SourceFile.State.MESSAGE, file.getState());
+        assertEquals(SourceFile.Reason.BINARY, file.getReason());
         assertEquals(PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }
@@ -50,7 +53,8 @@ class LimitedSourceFileBuilderTest {
         SourceFile file = SourceFile.limitedBuilder().type(TYPE).content(null).path(PATH).absolutePath(ABSOLUTE_PATH).build();
         assertEquals(TYPE, file.getType());
         assertEquals("Dockstore could not retrieve this file", file.getContent());
-        assertEquals(SourceFile.FormEnum.ERROR, file.getForm());
+        assertEquals(SourceFile.State.MESSAGE, file.getState());
+        assertEquals(SourceFile.Reason.READ_ERROR, file.getReason());
         assertEquals(PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }
@@ -60,7 +64,8 @@ class LimitedSourceFileBuilderTest {
         SourceFile file = SourceFile.limitedBuilder().type(TYPE).content(SMALL_CONTENT).paths(ABSOLUTE_PATH).build();
         assertEquals(TYPE, file.getType());
         assertEquals(SMALL_CONTENT, file.getContent());
-        assertEquals(SourceFile.FormEnum.COMPLETE, file.getForm());
+        assertEquals(SourceFile.State.COMPLETE, file.getState());
+        assertEquals(null, file.getReason());
         assertEquals(ABSOLUTE_PATH, file.getPath());
         assertEquals(ABSOLUTE_PATH, file.getAbsolutePath());
     }


### PR DESCRIPTION
This PR modifies SourceFile so that we can conclusively differentiate a successfully downloaded file from one which failed to meet our requirements (for example, a file that could not be stored because it was binary.)  See this PR for some motivation, search for "in a followup PR": https://github.com/dockstore/dockstore/pull/5893

Specifically, this PR:

* adds a `state` property to SourceFile, which describes the representation of the SourceFile, and currently has two values:

1. `COMPLETE`: the file was successfully downloaded and the SourceFile's `content` represents the file body.
2. `NOT_STORED`: the SourceFile's `content` contains a message, rather than the actual file body, that explains why the body isn't stored.  For example, "Dockstore does not store binary files".
3. `STUB`: the SourceFile is a stub and has null content.
* changes the "limited" SourceFile builder to set the new properties appropriately.
* changes the SourceFile copy/duplicate helper methods to copy the new properties.

Later, we could add other values to the new enum.  For example, if we wanted to try to handle big files by storing a smaller alternate representation of the content (instead of totally jettisoning it), we could have new `state` values like:
* `SUMMARY`: the content represents a summarized version of the file content.
* `HEAD`: the content represents the leading portion of the file content.

The above might be useful to support the registration of AI models, for example, which have files containing gigabytes of weights. 

The PR also contains some db migration fixups for the existing sourcefile values.

There will be a companion UI PR, which, at a minimum, will tweak the UI so it builds and change the notebook preview code to not attempt to render not-`COMPLETE` content as a notebook.

**Review Instructions**

Register an entry that contains files that are binary and/or too large, and confirm that the resulting sourcefiles have the correct "state" values, both in the db and in the API responses.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6488

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
