### PR TITLE
Allow DOI selection

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
@@ -152,6 +152,7 @@ class ZenodoIT {
         foobar2TagVersion08 = workflowsApi.getWorkflowVersionById(foobar2.getId(), foobar2TagVersion08.getId(), "");
         assertFalse(foobar2TagVersion08.isFrozen(), "Version should not be snapshotted for automatic DOI creation");
         assertNotNull(foobar2TagVersion08.getDois().get(DoiInitiator.DOCKSTORE.name()).getName());
+        foobar2 = workflowsApi.getWorkflow(foobar2Id, "");
         assertEquals(DoiSelectionEnum.DOCKSTORE, foobar2.getDoiSelection(), "DOI selection should update to DOCKSTORE since there were previously no DOIs");
 
         // Should be able to request a user-created DOI for the version even though it has a Dockstore-created DOI
@@ -208,6 +209,7 @@ class ZenodoIT {
 
         tagVersion = workflowsApi.getWorkflowVersionById(workflow.getId(), tagVersion.getId(), "");
         assertNotNull(tagVersion.getDois().get(DoiInitiator.DOCKSTORE.name()).getName(), "Should have automatic DOI because it's a valid published tag");
+        workflow = workflowsApi.getWorkflow(workflow.getId(), "");
         assertEquals(DoiSelectionEnum.DOCKSTORE, workflow.getDoiSelection(), "DOI selection should update to DOCKSTORE since there were previously no DOIs");
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
@@ -249,6 +249,7 @@ class ZenodoIT {
         workflowsApi.refresh1(workflow.getId(), false);
         workflow = workflowsApi.getWorkflow(workflow.getId(), "versions");
         assertTrue(workflow.getConceptDois().isEmpty(), "Should not have any automatic DOIs because it's unpublished");
+        assertEquals(DoiSelectionEnum.USER, workflow.getDoiSelection(), "Default should be USER");
 
         // Get a valid tag
         WorkflowVersion tagVersion = getWorkflowVersion(workflow, "1.1").orElse(null);
@@ -261,6 +262,12 @@ class ZenodoIT {
         assertNotNull(workflow.getConceptDois().get(DoiInitiator.DOCKSTORE.name()).getName(), "Should have automatic concept DOI");
         assertNotNull(tagVersion.getDois().get(DoiInitiator.DOCKSTORE.name()).getName(), "Should have automatic DOI because it's a valid published tag");
         assertEquals(DoiSelectionEnum.DOCKSTORE, workflow.getDoiSelection(), "DOI selection should update to DOCKSTORE since there were previously no DOIs");
+
+        // Change DOI selection to GITHUB. It should be ignored because there are no GitHub DOIs for the workflow
+        workflow.setDoiSelection(DoiSelectionEnum.GITHUB);
+        workflowsApi.updateWorkflow(workflow.getId(), workflow);
+        workflow = workflowsApi.getWorkflow(workflow.getId(), "");
+        assertEquals(DoiSelectionEnum.DOCKSTORE, workflow.getDoiSelection(), "The DOI selection should not change");
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
@@ -55,6 +55,7 @@ import io.dockstore.openapi.client.api.WorkflowsApi;
 import io.dockstore.openapi.client.model.AccessLink;
 import io.dockstore.openapi.client.model.PublishRequest;
 import io.dockstore.openapi.client.model.Workflow;
+import io.dockstore.openapi.client.model.Workflow.DoiSelectionEnum;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
 import io.dockstore.openapi.client.model.WorkflowVersion;
 import io.dockstore.webservice.core.Doi.DoiInitiator;
@@ -151,6 +152,7 @@ class ZenodoIT {
         foobar2TagVersion08 = workflowsApi.getWorkflowVersionById(foobar2.getId(), foobar2TagVersion08.getId(), "");
         assertFalse(foobar2TagVersion08.isFrozen(), "Version should not be snapshotted for automatic DOI creation");
         assertNotNull(foobar2TagVersion08.getDois().get(DoiInitiator.DOCKSTORE.name()).getName());
+        assertEquals(DoiSelectionEnum.DOCKSTORE, foobar2.getDoiSelection(), "DOI selection should update to DOCKSTORE since there were previously no DOIs");
 
         // Should be able to request a user-created DOI for the version even though it has a Dockstore-created DOI
         foobar2TagVersion08.setFrozen(true);
@@ -159,6 +161,7 @@ class ZenodoIT {
         foobar2 = workflowsApi.getWorkflow(foobar2Id, "versions");
         foobar2TagVersion08 = getWorkflowVersion(foobar2, "0.8").orElse(null);
         assertNotNull(foobar2TagVersion08.getDois().get(DoiInitiator.USER.name()).getName());
+        assertEquals(DoiSelectionEnum.USER, foobar2.getDoiSelection(), "DOI selection should update to USER since it takes highest precedence");
 
         // Release a different tag. Should automatically create DOI
         handleGitHubRelease(workflowsApi, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, "refs/tags/0.9", USER_2_USERNAME);
@@ -166,6 +169,7 @@ class ZenodoIT {
         WorkflowVersion foobar2TagVersion09 = getWorkflowVersion(foobar2, "0.9").orElse(null);
         assertNotNull(foobar2TagVersion09);
         assertNotNull(foobar2TagVersion09.getDois().get(DoiInitiator.DOCKSTORE.name()).getName());
+        assertEquals(DoiSelectionEnum.USER, foobar2.getDoiSelection(), "DOI selection should be USER since it takes highest precedence");
 
         // Release a branch. Should not automatically create a DOI because it's not a tag
         handleGitHubRelease(workflowsApi, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, "refs/heads/master", USER_2_USERNAME);
@@ -173,6 +177,13 @@ class ZenodoIT {
         WorkflowVersion foobar2BranchVersion = getWorkflowVersion(foobar2, "master").orElse(null);
         assertNotNull(foobar2BranchVersion);
         assertFalse(foobar2BranchVersion.getDois().containsKey(DoiInitiator.DOCKSTORE.name()));
+
+        // Test updating the DOI selection
+        assertEquals(DoiSelectionEnum.USER, foobar2.getDoiSelection());
+        foobar2.setDoiSelection(DoiSelectionEnum.DOCKSTORE);
+        workflowsApi.updateWorkflow(foobar2Id, foobar2);
+        foobar2 = workflowsApi.getWorkflow(foobar2Id, "versions");
+        assertEquals(DoiSelectionEnum.DOCKSTORE, foobar2.getDoiSelection());
     }
 
     @Test
@@ -197,6 +208,7 @@ class ZenodoIT {
 
         tagVersion = workflowsApi.getWorkflowVersionById(workflow.getId(), tagVersion.getId(), "");
         assertNotNull(tagVersion.getDois().get(DoiInitiator.DOCKSTORE.name()).getName(), "Should have automatic DOI because it's a valid published tag");
+        assertEquals(DoiSelectionEnum.DOCKSTORE, workflow.getDoiSelection(), "DOI selection should update to DOCKSTORE since there were previously no DOIs");
     }
 
     @Test
@@ -220,6 +232,7 @@ class ZenodoIT {
         tagVersion = getWorkflowVersion(workflow, "0.8").orElse(null);
         assertNotNull(workflow.getConceptDois().get(DoiInitiator.DOCKSTORE.name()).getName());
         assertNotNull(tagVersion.getDois().get(DoiInitiator.DOCKSTORE.name()).getName());
+        assertEquals(DoiSelectionEnum.DOCKSTORE, workflow.getDoiSelection(), "DOI selection should update to DOCKSTORE since there were previously no DOIs");
     }
 
     @Test
@@ -245,6 +258,7 @@ class ZenodoIT {
         tagVersion = workflowsApi.getWorkflowVersionById(workflow.getId(), tagVersion.getId(), "");
         assertNotNull(workflow.getConceptDois().get(DoiInitiator.DOCKSTORE.name()).getName(), "Should have automatic concept DOI");
         assertNotNull(tagVersion.getDois().get(DoiInitiator.DOCKSTORE.name()).getName(), "Should have automatic DOI because it's a valid published tag");
+        assertEquals(DoiSelectionEnum.DOCKSTORE, workflow.getDoiSelection(), "DOI selection should update to DOCKSTORE since there were previously no DOIs");
     }
 
     @Test
@@ -318,6 +332,7 @@ class ZenodoIT {
         assertNotNull(workflow.getConceptDois().get(DoiInitiator.USER.name()));
         master = workflowsApi.getWorkflowVersionById(workflowId, versionId, "");
         assertNotNull(master.getDois().get(DoiInitiator.USER.name()).getName());
+        assertEquals(DoiSelectionEnum.USER, workflow.getDoiSelection());
 
         // unpublish workflow
         workflowsApi.publish1(workflowBeforeFreezing.getId(), CommonTestUtilities.createOpenAPIPublishRequest(false));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -269,6 +269,11 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     @Schema(description = "The Digital Object Identifier (DOI) representing all of the versions of your workflow")
     private Map<DoiInitiator, Doi> conceptDois = new HashMap<>();
 
+    @Enumerated(EnumType.STRING)
+    @Schema(description = "The Digital Object Identifier (DOI) to display publicly")
+    @Column(nullable = false, columnDefinition = "varchar(32) default 'USER'")
+    private DoiInitiator doiSelection = DoiInitiator.USER;
+
     @JsonProperty("input_file_formats")
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "entry_input_fileformat", joinColumns = @JoinColumn(name = "entryid", referencedColumnName = "id", columnDefinition = "bigint"), inverseJoinColumns = @JoinColumn(name = "fileformatid", referencedColumnName = "id", columnDefinition = "bigint"))
@@ -420,6 +425,14 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     public void setConceptDois(Map<DoiInitiator, Doi> conceptDois) {
         this.conceptDois.clear();
         this.conceptDois.putAll(conceptDois);
+    }
+
+    public DoiInitiator getDoiSelection() {
+        return this.doiSelection;
+    }
+
+    public void setDoiSelection(DoiInitiator doiSelection) {
+        this.doiSelection = doiSelection;
     }
 
     @JsonIgnore // Don't surface this, just a helper method

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
@@ -340,6 +340,10 @@ public final class ZenodoHelper {
         String conceptDoi = publishedDeposit.getConceptdoi();
 
         ZenodoDoiResult zenodoDoiResult = new ZenodoDoiResult(doiAlias, publishedDeposit.getMetadata().getDoi(), conceptDoi);
+        // A user-requested DOI takes highest precedence
+        if (doiInitiator == DoiInitiator.USER || workflow.getConceptDois().isEmpty()) {
+            workflow.setDoiSelection(doiInitiator);
+        }
         workflowVersion.getDois().put(doiInitiator, getDoiFromDatabase(DoiType.VERSION, doiInitiator, zenodoDoiResult.doiUrl()));
         workflow.getConceptDois().put(doiInitiator, getDoiFromDatabase(DoiType.CONCEPT, doiInitiator, zenodoDoiResult.conceptDoi()));
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -498,7 +498,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @UnitOfWork
     @Path("/{workflowId}")
     @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(operationId = "updateWorkflow", description = "Update the workflow with the given workflow.", security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME))
+    @Operation(operationId = "updateWorkflow", summary = "Update some of the workflow with the given workflow.",
+            description = "Updates descriptor type, default workflow path, default test parameter file path, default version, forum URL, manual topic, topic selection, and DOI selection", security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME))
     @ApiOperation(nickname = "updateWorkflow", value = "Update the workflow with the given workflow.", authorizations = {
         @Authorization(value = JWT_SECURITY_DEFINITION_NAME)}, response = Workflow.class,
         notes = "Updates descriptor type (if stub), default workflow path, default file path, and default version")
@@ -539,7 +540,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         return (Workflow) updateDefaultVersionHelper(version, workflowId, user);
     }
 
-    // Used to update workflow manually (not refresh)
+    // Used to update some of the workflow manually (not refresh)
     private void updateInfo(Workflow oldWorkflow, Workflow newWorkflow) {
         // If workflow is FULL or HOSTED and descriptor type is being changed throw an error
         if ((Objects.equals(oldWorkflow.getMode(), WorkflowMode.FULL) || Objects.equals(oldWorkflow.getMode(), WorkflowMode.HOSTED)) && !Objects

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -569,8 +569,10 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             oldWorkflow.setTopicSelection(newWorkflow.getTopicSelection());
         }
 
-        // Update DOI selection
-        oldWorkflow.setDoiSelection(newWorkflow.getDoiSelection());
+        // Update DOI selection if the workflow has DOIs for the selection
+        if (oldWorkflow.getConceptDois().containsKey(newWorkflow.getDoiSelection())) {
+            oldWorkflow.setDoiSelection(newWorkflow.getDoiSelection());
+        }
 
         if (newWorkflow.getDefaultVersion() != null) {
             if (!oldWorkflow.checkAndSetDefaultVersion(newWorkflow.getDefaultVersion()) && newWorkflow.getMode() != WorkflowMode.STUB) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -512,7 +512,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         Workflow duplicate = workflowDAO.findByPath(workflow.getWorkflowPath(), false, BioWorkflow.class).orElse(null);
 
         if (duplicate != null && duplicate.getId() != workflowId) {
-            LOG.info(user.getUsername() + ": " + "duplicate workflow found: {}" + workflow.getWorkflowPath());
+            LOG.info("{}: " + "duplicate workflow found: {}", user.getUsername(), workflow.getWorkflowPath());
             throw new CustomWebApplicationException("Workflow " + workflow.getWorkflowPath() + " already exists.",
                 HttpStatus.SC_BAD_REQUEST);
         }
@@ -567,6 +567,9 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                 || (Objects.equals(oldWorkflow.getMode(), WorkflowMode.HOSTED) && newWorkflow.getTopicSelection() != TopicSelection.AUTOMATIC)) {
             oldWorkflow.setTopicSelection(newWorkflow.getTopicSelection());
         }
+
+        // Update DOI selection
+        oldWorkflow.setDoiSelection(newWorkflow.getDoiSelection());
 
         if (newWorkflow.getDefaultVersion() != null) {
             if (!oldWorkflow.checkAndSetDefaultVersion(newWorkflow.getDefaultVersion()) && newWorkflow.getMode() != WorkflowMode.STUB) {

--- a/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
@@ -316,4 +316,31 @@
             WHERE version_metadata.doiurl IS NOT NULL;
         </sql>
     </changeSet>
+    <changeSet author="ktran (generated)" id="addDoiSelection">
+        <addColumn tableName="apptool">
+            <column defaultValue="USER" name="doiselection" type="varchar(32 BYTE)">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <addColumn tableName="notebook">
+            <column defaultValue="USER" name="doiselection" type="varchar(32 BYTE)">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <addColumn tableName="service">
+            <column defaultValue="USER" name="doiselection" type="varchar(32 BYTE)">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <addColumn tableName="tool">
+            <column defaultValue="USER" name="doiselection" type="varchar(32 BYTE)">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <addColumn tableName="workflow">
+            <column defaultValue="USER" name="doiselection" type="varchar(32 BYTE)">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -9276,6 +9276,13 @@ components:
           type: array
           items:
             type: string
+        doiSelection:
+          type: string
+          description: The Digital Object Identifier (DOI) to display publicly
+          enum:
+          - USER
+          - DOCKSTORE
+          - GITHUB
         entryType:
           $ref: '#/components/schemas/EntryType'
         entryTypeMetadata:
@@ -9492,6 +9499,13 @@ components:
           type: boolean
         description:
           type: string
+        doiSelection:
+          type: string
+          description: The Digital Object Identifier (DOI) to display publicly
+          enum:
+          - USER
+          - DOCKSTORE
+          - GITHUB
         entryType:
           $ref: '#/components/schemas/EntryType'
         entryTypeMetadata:
@@ -12108,6 +12122,13 @@ components:
           - Julia
           - other
           - n/a
+        doiSelection:
+          type: string
+          description: The Digital Object Identifier (DOI) to display publicly
+          enum:
+          - USER
+          - DOCKSTORE
+          - GITHUB
         entryType:
           $ref: '#/components/schemas/EntryType'
         entryTypeMetadata:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -7675,7 +7675,9 @@ paths:
       tags:
       - workflows
     put:
-      description: Update the workflow with the given workflow.
+      description: "Updates descriptor type, default workflow path, default test parameter\
+        \ file path, default version, forum URL, manual topic, topic selection, and\
+        \ DOI selection"
       operationId: updateWorkflow
       parameters:
       - in: path
@@ -7698,6 +7700,7 @@ paths:
           description: default response
       security:
       - BEARER: []
+      summary: Update some of the workflow with the given workflow.
       tags:
       - workflows
   /workflows/{workflowId}/DOIEditLink:


### PR DESCRIPTION
**Description**
UI PR: https://github.com/dockstore/dockstore-ui2/pull/1994

Dockstore now allows multiple sources/initiators of DOIs: user-generated through the UI, harvested GitHub DOIs, and auto-created DOIs.

This PR adds a field that allows users to select the type of DOI they want to display. It defaults to `USER`, but if a DOI was automatically generated by Dockstore and the workflow previously had no DOIs, then the selection is automatically updated to the Dockstore DOI. If the user decides to manually generate their own DOI through the UI, then the selection is automatically set to `USER`.
 
**Review Instructions**
See https://github.com/dockstore/dockstore-ui2/pull/1994

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6495

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
