### PR TITLE
Fix sourcefile state field migration by using defaultValue insetad of value

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/SourceFile.java
@@ -164,7 +164,7 @@ public class SourceFile implements Comparable<SourceFile> {
     @BatchSize(size = 25)
     private Map<String, VerificationInformation> verifiedBySource = new HashMap<>();
 
-    @Column(nullable = false)
+    @Column(columnDefinition = "VARCHAR(255) default 'COMPLETE'", nullable = false)
     @Enumerated(EnumType.STRING)
     @Schema(description = "Enumerates the file state", requiredMode = RequiredMode.REQUIRED)
     private State state = State.COMPLETE;

--- a/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
@@ -318,7 +318,7 @@
     </changeSet>
     <changeSet author="svonworl" id="addStateFieldToSourceFile">
         <addColumn tableName="sourcefile">
-            <column name="state" type="VARCHAR(255)" value="COMPLETE">
+            <column name="state" type="VARCHAR(255)" defaultValue="COMPLETE">
                 <constraints nullable="false"/>
             </column>
         </addColumn>


### PR DESCRIPTION
**Description**
The QA deploy was failing because the migrations failed for the new SourceFile `state` field.

The error:
```
2024-07-22T02:37:31.971-04:00	Reason: liquibase.exception.DatabaseException: ERROR: column "state" of relation "sourcefile" contains null values [Failed SQL: (0) ALTER TABLE public.sourcefile ALTER COLUMN state SET NOT NULL]
```

TIL that you can't use `value` when adding a new column with a not null constraint because it's ignored ([more info here](https://stackoverflow.com/questions/8904316/adding-a-non-nullable-column-to-existing-table-fails-is-the-value-attribute-b/8906534#8906534), but I didn't find any liquibase documentation on it).

This PR fixes the migration by using `defaultValue` instead of `value`.

**Review Instructions**
QA should deploy

**Issue**
n/a

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
