### PR TITLE
fix engine version metadata update and add test

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedNextflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedNextflowIT.java
@@ -26,7 +26,6 @@ import io.dockstore.common.CommonTestUtilities;
 import io.dockstore.common.ConfidentialTest;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.MuteForSuccessfulTests;
-import io.dockstore.common.RepositoryConstants.DockstoreTesting;
 import io.dockstore.common.SourceControl;
 import io.dockstore.common.WorkflowTest;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
@@ -148,7 +147,7 @@ class ExtendedNextflowIT extends BaseIT {
         final io.dockstore.openapi.client.ApiClient openApiClient = getOpenAPIWebClient(USER_1_USERNAME, testingPostgres);
         io.dockstore.openapi.client.api.WorkflowsApi openWorkflowApi = new io.dockstore.openapi.client.api.WorkflowsApi(openApiClient);
 
-        handleGitHubRelease(openWorkflowApi, DockstoreTesting.WORKFLOW_NEXTFLOW_DOCKSTORE_YML, "refs/heads/nfcore", USER_1_USERNAME);
+        handleGitHubRelease(openWorkflowApi, WORKFLOW_NEXTFLOW_DOCKSTORE_YML, "refs/heads/nfcore", USER_1_USERNAME);
 
 
         // see what state the metadata is in, before the fix (#5919) this will remain as foobar

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/RepositoryConstants.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/RepositoryConstants.java
@@ -46,6 +46,7 @@ public final class RepositoryConstants {
         public static final String TEST_WORKFLOWS_AND_TOOLS = "dockstore-testing/test-workflows-and-tools";
         public static final String WDL_HUMANWGS = "dockstore-testing/wdl-humanwgs";
         public static final String WORKFLOW_DOCKSTORE_YML = "dockstore-testing/workflow-dockstore-yml";
+        public static final String WORKFLOW_NEXTFLOW_DOCKSTORE_YML = "dockstore-testing/ampa-nf";
         public static final String TEST_SERVICE = "dockstore-testing/test-service";
         public static final String SOURCEFILE_TESTING = "dockstore-testing/sourcefile-testing";
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
@@ -94,8 +94,9 @@ public final class GitHubHelper {
         } catch (InterruptedException e) {
             String msg = "Something interrupted creating a fork on: " + repositoryName;
             LOG.error(msg, e);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            Thread.currentThread().interrupt();
         }
+        return null;
     }
 
     public static String getGitHubAccessToken(String code, String githubClientID, String githubClientSecret) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubHelper.java
@@ -94,9 +94,8 @@ public final class GitHubHelper {
         } catch (InterruptedException e) {
             String msg = "Something interrupted creating a fork on: " + repositoryName;
             LOG.error(msg, e);
-            Thread.currentThread().interrupt();
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
-        return null;
     }
 
     public static String getGitHubAccessToken(String code, String githubClientID, String githubClientSecret) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -1008,9 +1008,6 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                     existingWorkflowVersion.getVersionMetadata().setParsedInformationSet(remoteWorkflowVersion.getVersionMetadata().getParsedInformationSet());
                     existingWorkflowVersion.getVersionMetadata().setPublicAccessibleTestParameterFile(remoteWorkflowVersion.getVersionMetadata().getPublicAccessibleTestParameterFile());
 
-
-
-
                     updateDBVersionSourceFilesWithRemoteVersionSourceFiles(existingWorkflowVersion, remoteWorkflowVersion,
                             workflow.getDescriptorType());
                 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -1002,6 +1002,15 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                     existingWorkflowVersion.setKernelImagePath(remoteWorkflowVersion.getKernelImagePath());
                     existingWorkflowVersion.setReadMePath(remoteWorkflowVersion.getReadMePath());
                     existingWorkflowVersion.setDescriptionAndDescriptionSource(remoteWorkflowVersion.getDescription(), remoteWorkflowVersion.getDescriptionSource());
+                    // this kinda sucks but needs to be updated with workflow metadata too
+                    existingWorkflowVersion.getVersionMetadata().setEngineVersions(remoteWorkflowVersion.getVersionMetadata().getEngineVersions());
+                    existingWorkflowVersion.getVersionMetadata().setDescriptorTypeVersions(remoteWorkflowVersion.getVersionMetadata().getDescriptorTypeVersions());
+                    existingWorkflowVersion.getVersionMetadata().setParsedInformationSet(remoteWorkflowVersion.getVersionMetadata().getParsedInformationSet());
+                    existingWorkflowVersion.getVersionMetadata().setPublicAccessibleTestParameterFile(remoteWorkflowVersion.getVersionMetadata().getPublicAccessibleTestParameterFile());
+
+
+
+
                     updateDBVersionSourceFilesWithRemoteVersionSourceFiles(existingWorkflowVersion, remoteWorkflowVersion,
                             workflow.getDescriptorType());
                 }


### PR DESCRIPTION
**Description**
Add version metadata updates to .dockstore.yml release handling. 
Affects mainly nextflow engine version, biut could have had other side-effects. 
Added a test to reveal and then lock down the fix afterwards

**Review Instructions**
Before this fix, you could create a branch with a nextflow version claiming a need for a specific engine version. Then subsequent updates would not change this (note that tags are independent and so tags created from a branch were not affected 
Afterwards, you should be able to change it at will. 

**Issue**
https://github.com/dockstore/dockstore/issues/5919

**Security and Privacy**

None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
