### PR TITLE
new linux machine executor with Java 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ executors:
     resource_class: medium+
   machine_integration_test_exec:
     machine: # run the steps with Ubuntu VM, warning this VM does not have a Java 17 equivalent (yet)
-      image: ubuntu-2204:2023.10.1
+      image: ubuntu-2204:2024.04.4
     environment:
       PGHOST: 127.0.0.1
     resource_class: medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ executors:
           - discovery.type: single-node
     resource_class: medium+
   machine_integration_test_exec:
-    machine: # run the steps with Ubuntu VM, warning this VM does not have a Java 17 equivalent (yet)
+    machine: # run the steps with Ubuntu VM
       image: ubuntu-2204:2024.04.4
     environment:
       PGHOST: 127.0.0.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
       - run:
           name: build sam-cli
           command: |
-            pip3 install aws-sam-cli
+            pip3 install aws-sam-cli==1.121.0
             sudo apt install unzip
             wget -O wdl-parsing.zip https://github.com/dockstore/lambda/releases/download/0.2.2-SNAPSHOT/wdl-parsing.zip
             unzip wdl-parsing.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,11 +207,7 @@ jobs:
       - run:
           name: build sam-cli
           command: |
-            # workaround https://github.com/aws/aws-sam-cli/issues/3791#issuecomment-1096604840
-            pip3 install Jinja2==2.11.3
-            pip3 install wheel \
-            && pip3 install --no-build-isolation "Cython<3" "pyyaml==5.4.1"
-            pip3 install aws-sam-cli==1.52.0 
+            pip3 install aws-sam-cli
             sudo apt install unzip
             wget -O wdl-parsing.zip https://github.com/dockstore/lambda/releases/download/0.2.2-SNAPSHOT/wdl-parsing.zip
             unzip wdl-parsing.zip

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <postgresql.version>42.2.23</postgresql.version>
         <maven-surefire.version>3.0.0-M5</maven-surefire.version>
         <maven-failsafe.version>2.22.2</maven-failsafe.version>
-        <maven-java.version>17</maven-java.version>
+        <maven-java.version>21</maven-java.version>
 
         <skipTests>false</skipTests>
         <skipITs>true</skipITs>
@@ -523,7 +523,7 @@
 				    -->
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>[17.0.3,22.0)</version>
+                                    <version>[21.0.0,22.0)</version>
                                 </requireJavaVersion>
                                 <banDuplicatePomDependencyVersions />
                                 <bannedDependencies>
@@ -684,7 +684,7 @@
             <plugin>
                 <groupId>net.revelc.code</groupId>
                 <artifactId>impsort-maven-plugin</artifactId>
-                <version>1.8.0</version>
+                <version>1.11.0</version>
                 <executions>
                     <execution>
                         <id>sort-imports</id>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <postgresql.version>42.2.23</postgresql.version>
         <maven-surefire.version>3.0.0-M5</maven-surefire.version>
         <maven-failsafe.version>2.22.2</maven-failsafe.version>
-        <maven-java.version>21</maven-java.version>
+        <maven-java.version>17</maven-java.version>
 
         <skipTests>false</skipTests>
         <skipITs>true</skipITs>

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -13,10 +13,10 @@ fi
 if [ "${TESTING_PROFILE}" = "regression-integration-tests" ]; then
     pip3 install -r dockstore-webservice/src/main/resources/requirements/1.13.0/requirements3.txt
 elif [ "${TESTING_PROFILE}" == "language-parsing-tests" ]; then
-    #pip3 install -r dockstore-webservice/src/main/resources/requirements/1.14.0/requirements3.txt
+    # depending on https://github.com/dockstore/dockstore/pull/5958 we may want to match where we go with the cwltool install, for now apt seems to work well
     sudo apt-get update
     # https://stackoverflow.com/questions/44331836/apt-get-install-tzdata-noninteractive needed by cwltool
-    DEBIAN_FRONTEND=noninteractive sudo apt-get install -y tzdata
+    DEBIAN_FRONTEND=noninteractive sudo apt-get -qq --yes --force-yes install tzdata
     sudo apt-get -qq --yes --force-yes install cwltool=3.1.20220224085855-1
 else
     pip3 install --user -r dockstore-webservice/src/main/resources/requirements/1.14.0/requirements3.txt

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -13,7 +13,11 @@ fi
 if [ "${TESTING_PROFILE}" = "regression-integration-tests" ]; then
     pip3 install -r dockstore-webservice/src/main/resources/requirements/1.13.0/requirements3.txt
 elif [ "${TESTING_PROFILE}" == "language-parsing-tests" ]; then
-    pip3 install -r dockstore-webservice/src/main/resources/requirements/1.14.0/requirements3.txt
+    #pip3 install -r dockstore-webservice/src/main/resources/requirements/1.14.0/requirements3.txt
+    apt-get update
+    # https://stackoverflow.com/questions/44331836/apt-get-install-tzdata-noninteractive needed by cwltool
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
+    apt-get -qq --yes --force-yes install cwltool
 else
     pip3 install --user -r dockstore-webservice/src/main/resources/requirements/1.14.0/requirements3.txt
 fi

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -17,7 +17,7 @@ elif [ "${TESTING_PROFILE}" == "language-parsing-tests" ]; then
     sudo apt-get update
     # https://stackoverflow.com/questions/44331836/apt-get-install-tzdata-noninteractive needed by cwltool
     DEBIAN_FRONTEND=noninteractive sudo apt-get install -y tzdata
-    sudo apt-get -qq --yes --force-yes install cwltool
+    sudo apt-get -qq --yes --force-yes install cwltool=3.1.20220224085855-1
 else
     pip3 install --user -r dockstore-webservice/src/main/resources/requirements/1.14.0/requirements3.txt
 fi

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -14,10 +14,10 @@ if [ "${TESTING_PROFILE}" = "regression-integration-tests" ]; then
     pip3 install -r dockstore-webservice/src/main/resources/requirements/1.13.0/requirements3.txt
 elif [ "${TESTING_PROFILE}" == "language-parsing-tests" ]; then
     #pip3 install -r dockstore-webservice/src/main/resources/requirements/1.14.0/requirements3.txt
-    apt-get update
+    sudo apt-get update
     # https://stackoverflow.com/questions/44331836/apt-get-install-tzdata-noninteractive needed by cwltool
-    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
-    apt-get -qq --yes --force-yes install cwltool
+    DEBIAN_FRONTEND=noninteractive sudo apt-get install -y tzdata
+    sudo apt-get -qq --yes --force-yes install cwltool
 else
     pip3 install --user -r dockstore-webservice/src/main/resources/requirements/1.14.0/requirements3.txt
 fi


### PR DESCRIPTION
**Description**
Try a new CircleCI machine with Java 21, this means our build environment for language parsing tests uses a VM that matches the jdk we expect to run at. Still, we're compiling to Java 17 

~Trade-offs:~
~We'll finally be able to use Java 21 features, though we've been running in a Java 21 VM for quite a while, this will mean that our webservice jar is actually Java 21. Developers will need to use Java 21 locally, We gain a couple more years of support. see https://endoflife.date/oracle-jdk~

Split out 
* https://ucsc-cgl.atlassian.net/browse/SEAB-6612
* https://ucsc-cgl.atlassian.net/browse/SEAB-6611
* https://ucsc-cgl.atlassian.net/browse/SEAB-6610

Will probably be easier upgrading the dependent projects to Java 21 and then coming back than vice versa

**Review Instructions**
Builds should pass, qa should run. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6269
https://discuss.circleci.com/t/linux-machine-executor-2024-q2-update-including-cuda/50844

**Security and Privacy**

None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
