### PR TITLE
Serialize webhook's release payload published_at property as a string

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
@@ -104,7 +104,7 @@ public final class GitHubAppHelper {
      */
     public static void handleGitHubTaggedRelease(WorkflowsApi workflowsApi, String repository, String tagName, Date date, String username) {
         final ReleasePayload releasePayload = new ReleasePayload();
-        releasePayload.setRelease(new WebhookRelease().tagName(tagName).publishedAt(date.getTime()));
+        releasePayload.setRelease(new WebhookRelease().tagName(tagName).publishedAt(date));
         releasePayload.setAction(Action.PUBLISHED.toString());
         releasePayload.setRepository(new WebhookRepository().fullName(repository));
         releasePayload.setSender(new Sender().login(username));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/TimestampDeserializer.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/TimestampDeserializer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.dockstore.webservice.helpers;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.time.OffsetDateTime;
+
+/**
+ * Handles deserializing dates in string formats. In particular, can handle both strings with milliseconds and without milliseconds. See
+ * @{see io.dockstore.core.webhook.WebhookRelease}
+ */
+public class TimestampDeserializer extends StdDeserializer<Timestamp> {
+
+    public TimestampDeserializer() {
+        this(null);
+    }
+
+    public TimestampDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public Timestamp deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+        final String dateStr = p.getText();
+        if (dateStr == null) {
+            return null;
+        }
+        final OffsetDateTime offsetDateTime = OffsetDateTime.parse(dateStr);
+        return new Timestamp((offsetDateTime.toInstant().toEpochMilli()));
+    }
+}

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -12112,8 +12112,8 @@ components:
       description: Details about the release
       properties:
         published_at:
-          type: integer
-          format: int64
+          type: string
+          format: date-time
         tag_name:
           type: string
           description: Name of the tag associated with the release


### PR DESCRIPTION
**Description**
Ran into this when trying to redeliver events in dockstore-support.

1. The GitHub JSON payload has a `published_at` field with a date in string form, e.g., `2024-07-23T21:30:12Z`
2. But for the OpenAPI, copying code where we handle Timestamps elsewhere, I specified the type as a long (`int64`).

In dockstore-support, when trying to read in a raw GitHub event we'd stored in s3 into an OpenAPI generated Java class, it would fail, because the OpenAPI generated code expected a long, but got a string.

So serialize `published_at` as a string, so the type of the field is the same both when coming from GitHub and when being invoked with the OpenAPI.

Next problem I ran into was into is that the OpenAPI client code serializes the date with milliseconds, e.g., `2024-07-23T21:30:12.123Z`, whereas the GitHub payload does not have milliseconds. The default Jackson deserializer cannot handle both cases, so I had to write a custom deserializer.

**Review Instructions**
Verify that in https://qa.dockstore.org/api/static/swagger-ui/index.html#/workflows/handleGitHubTaggedRelease, the schema for ReleasePayload|WebHookRelease|published_at is a string.

**Issue**
SEAB-6466

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
