### PR TITLE
DOCK-2534: Fully support CWLs that contain .nan or .inf values

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java
@@ -552,7 +552,7 @@ public class CWLHandler extends AbstractLanguageHandler implements LanguageHandl
      */
     private <T> T parseWithClass(Object obj, Class<T> klass, String description) {
         if (obj instanceof Map) {
-            Gson gson = CWL.getTypeSafeCWLToolDocument();
+            Gson gson = CWL.getTypeSafeCWLToolDocument().newBuilder().serializeSpecialFloatingPointValues().create();
             Map<Object, Object> map = convertRequirementsAndHintsToLists((Map<Object, Object>)obj, "in the requirements/hints of " + description);
             return gson.fromJson(gson.toJson(map), klass);
         } else {

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/languages/CWLHandlerTest.java
@@ -528,4 +528,21 @@ class CWLHandlerTest {
         final List<String> possibleUrls = cwlHandler.possibleUrlsFromTestParameterFile(jsonObject.get());
         assertEquals(8, possibleUrls.size());
     }
+
+    @Test
+    void testCanHandleNanAndInf() throws IOException {
+        final String cwl = """
+        cwlVersion: v1.0
+        class: Workflow
+        inputs:
+          nan_input: {default: .nan, id: nan_input, type: float}
+          inf_input: {default: .inf, id: inf_input, type: float}
+        outputs:
+        steps:
+            """;
+        final CWLHandler cwlHandler = new CWLHandler();
+        final Set<SourceFile> emptySet = Collections.emptySet();
+        final ToolDAO toolDAO = Mockito.mock(ToolDAO.class);
+        cwlHandler.getContent("/main.cwl", cwl, emptySet, LanguageHandlerInterface.Type.TOOLS, toolDAO);
+    }
 }


### PR DESCRIPTION
**Description**
This PR changes the `CWLHandler.getContent` method so that it can successfully process CWLs that contain `.nan` or `.inf` [yaml] number values.  Previously, the method threw when it encountered those values, causing the webservice to 500.

The problem was in the `parseWithClass` method:
https://github.com/dockstore/dockstore/blob/ee8503a70285afdc8fcfdb70580c59cdf8130889/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/CWLHandler.java#L557

This method creates a class instance from a `Map` by first converting it to JSON, then converting the JSON back to an instance of the desired class.  If the `Map` contained NaN or Infinity values, the conversion to JSON would fail, because JSON doesn't support NaN or Infinity values.

The fix was to tweak the `Gson` instance so that it will disregard the JSON spec and output JSON containing special float values (Nan, Infinity).  By default, `Gson` _reads_ the non-standard-conformant values without problems, but will not write them.

There are other calls to `Gson.toJson` thoughout our code, but none of them looked like they would ever need to output NaN or Infinity, so I did not modify them.

**Review Instructions**
Fork the repo described in the ticket, register it, then view its Tools tab, and make sure that tools are displayed and that the associated request to the webservice did not 500.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2534
#5911

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
