### PR TITLE
SEAB-6535: Improve logging of mapped Exceptions

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ConstraintExceptionMapper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ConstraintExceptionMapper.java
@@ -19,7 +19,7 @@ public class ConstraintExceptionMapper implements ExceptionMapper<ConstraintViol
 
     @Override
     public Response toResponse(ConstraintViolationException exception) {
-        LOGGER.debug("failure caught by ConstraintExceptionMapper", exception);
+        LOGGER.warn("failure caught by ConstraintExceptionMapper", exception);
         return getResponse(exception);
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/PersistenceExceptionMapper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/PersistenceExceptionMapper.java
@@ -31,7 +31,7 @@ public class PersistenceExceptionMapper implements ExceptionMapper<PersistenceEx
 
     @Override
     public Response toResponse(PersistenceException e) {
-        LOGGER.debug("failure caught by PersistenceExceptionMapper", e);
+        LOGGER.warn("failure caught by PersistenceExceptionMapper", e);
         if (e.getCause() instanceof ConstraintViolationException) {
             return ConstraintExceptionMapper.getResponse((ConstraintViolationException) e.getCause());
         } else {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/TransactionExceptionMapper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/TransactionExceptionMapper.java
@@ -20,13 +20,17 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.hibernate.TransactionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Provider
 public class TransactionExceptionMapper implements ExceptionMapper<TransactionException> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(TransactionExceptionMapper.class);
+
     @Override
     public Response toResponse(TransactionException e) {
-
+        LOGGER.warn("failure caught by TransactionExceptionMapper", e);
         return processResponse(e);
     }
 


### PR DESCRIPTION
**Description**
This PR tweaks the webservice so that it logs, at `WARN` level, all exceptions handled by our custom `ExceptionMappers`.  Previously, such information either was not logged, or logged at `DEBUG` level, meaning it didn't show up in the production webservice logs.

Background: we have been seeing an occasional webservice 500 relating to the `refresh` endpoint, which shows up intermittently during smoke testing.  Inspection of the logs revealed an informational message logged by a helper function, and then the 500 server response line, with no intervening exception/stack dump.  And so, there was very little information we could use to figure out what went wrong...

Typically, the webservice logs uncaught exceptions that emerge from the handlers.  So, where did the exception message go?  My best theory is it simply didn't make it to CloudWatch, per the problem fixed by this PR.

Eventually, we'll deploy this to production, and hopefully, the exception that's causing the 500 will be logged, giving us more evidence as to the type of problem and how to solve it.

**Review Instructions**
No review necessary.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6535

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
