### PR TITLE
Set successful in lambda release event

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -597,7 +597,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @param deliveryId The GitHub delivery ID, used to group lambda events that belong to the same GitHub webook invocation
      * @return New lambda event
      */
-    private LambdaEvent createBasicEvent(String repository, String gitReference, String username, LambdaEvent.LambdaEventType type, boolean isSuccessful, String deliveryId) {
+    LambdaEvent createBasicEvent(String repository, String gitReference, String username, LambdaEvent.LambdaEventType type, boolean isSuccessful, String deliveryId) {
         LambdaEvent lambdaEvent = new LambdaEvent();
         String[] repo = repository.split("/");
         lambdaEvent.setOrganization(repo[0]);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -2244,7 +2244,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         final String actionString = payload.getAction();
         final Optional<ReleasePayload.Action> optionalAction = ReleasePayload.Action.findAction(actionString);
         if (optionalAction.isPresent() && optionalAction.get() == PUBLISHED) { // Zenodo will only create DOIs for published relesaes
-            createReleaseLambdaEvent(deliveryId, payload);
+            createBasicEvent(payload.getRepository().getFullName(), "refs/tags/" + payload.getRelease().getTagName(),
+                    payload.getSender().getLogin(), LambdaEvent.LambdaEventType.RELEASE, true, deliveryId);
             final List<Workflow> workflows = workflowDAO.findAllByPath("github.com/" + payload.getRepository().getFullName(), false);
             final Timestamp publishedAt = payload.getRelease().getPublishedAt();
             workflows.stream().filter(w -> Objects.isNull(w.getLatestReleaseDate()) || w.getLatestReleaseDate().before(publishedAt))
@@ -2256,24 +2257,6 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             LOG.info("Ignoring action in release event: {}", actionString);
         }
         return Response.status(HttpStatus.SC_NO_CONTENT).build();
-    }
-
-    private LambdaEvent createReleaseLambdaEvent(String deliveryId, ReleasePayload payload) {
-        final String username = payload.getSender().getLogin();
-        final Optional<User> triggerUser = Optional.ofNullable(userDAO.findByGitHubUsername(username));
-        final LambdaEvent lambdaEvent = new LambdaEvent();
-        final String orgRepo = payload.getRepository().getFullName();
-        final String[] splitRepo = orgRepo.split("/");
-        final String org = splitRepo[0];
-        final String repo = splitRepo[1];
-        lambdaEvent.setType(LambdaEvent.LambdaEventType.RELEASE);
-        lambdaEvent.setDeliveryId(deliveryId);
-        lambdaEvent.setOrganization(org);
-        lambdaEvent.setRepository(repo);
-        lambdaEvent.setReference("refs/tags/" + payload.getRelease().getTagName());
-        triggerUser.ifPresent(lambdaEvent::setUser);
-        lambdaEventDAO.create(lambdaEvent);
-        return lambdaEvent;
     }
 
     @GET

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -2244,8 +2244,10 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         final String actionString = payload.getAction();
         final Optional<ReleasePayload.Action> optionalAction = ReleasePayload.Action.findAction(actionString);
         if (optionalAction.isPresent() && optionalAction.get() == PUBLISHED) { // Zenodo will only create DOIs for published relesaes
-            createBasicEvent(payload.getRepository().getFullName(), "refs/tags/" + payload.getRelease().getTagName(),
-                    payload.getSender().getLogin(), LambdaEvent.LambdaEventType.RELEASE, true, deliveryId);
+            final LambdaEvent lambdaEvent = createBasicEvent(payload.getRepository().getFullName(),
+                    "refs/tags/" + payload.getRelease().getTagName(), payload.getSender().getLogin(), LambdaEvent.LambdaEventType.RELEASE,
+                    true, deliveryId);
+            lambdaEventDAO.create(lambdaEvent);
             final List<Workflow> workflows = workflowDAO.findAllByPath("github.com/" + payload.getRepository().getFullName(), false);
             final Timestamp publishedAt = payload.getRelease().getPublishedAt();
             workflows.stream().filter(w -> Objects.isNull(w.getLatestReleaseDate()) || w.getLatestReleaseDate().before(publishedAt))


### PR DESCRIPTION
**Description**
Noticed it wasn't set when writing an integration test in dockstore-deploy. Then, in looking at it, I'd essentially duplicated an existing method, so I got rid of it.

**Review Instructions**
1. Do a GitHub release for a repo that is configured in Dockstore QA
2. Look at the app logs in a couple of minutes for the repo's org, and ensure that there is a release event, and that it is successful.

**Issue**
SEAB-6466

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
