### PR TITLE
Support Userless workflows

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/OpenAPIServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/OpenAPIServiceIT.java
@@ -155,7 +155,7 @@ public class OpenAPIServiceIT extends BaseIT {
     }
 
     /**
-     * Ensures that you cannot create a service if the given user is not on Dockstore
+     * Ensures that you can create a service if the given user is not on Dockstore
      */
     @Test
     void createServiceNoUser() {
@@ -163,13 +163,12 @@ public class OpenAPIServiceIT extends BaseIT {
         WorkflowsApi client = new WorkflowsApi(webClient);
 
         // Add service
-        ApiException ex = assertThrows(ApiException.class, () -> handleGitHubRelease(client, DockstoreTestUser2.TEST_SERVICE, "refs/tags/1.0", "iamnotarealuser"));
-        assertEquals(LAMBDA_FAILURE, ex.getCode(), "Should have error code 418");
+        handleGitHubRelease(client, DockstoreTestUser2.TEST_SERVICE, "refs/tags/1.0", "iamnotarealuser");
 
         final long count = testingPostgres.runSelectStatement(
             "select count(*) from service where sourcecontrol = 'github.com' and organization = 'DockstoreTestUser2' and repository = 'test-service'",
             long.class);
-        assertEquals(0, count, "there should be no matching service");
+        assertEquals(1, count, "there should be no matching service");
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/OpenAPIServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/OpenAPIServiceIT.java
@@ -168,7 +168,7 @@ public class OpenAPIServiceIT extends BaseIT {
         final long count = testingPostgres.runSelectStatement(
             "select count(*) from service where sourcecontrol = 'github.com' and organization = 'DockstoreTestUser2' and repository = 'test-service'",
             long.class);
-        assertEquals(1, count, "there should be no matching service");
+        assertEquals(1, count, "there should be one matching service");
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1068,8 +1068,9 @@ class WebhookIT extends BaseIT {
         WorkflowsApi client = new WorkflowsApi(webClient);
 
         handleGitHubRelease(client, DockstoreTestUser2.WORKFLOW_DOCKSTORE_YML, "refs/tags/0.1", "thisisafakeuser");
+        // Test starts from scratch
         final Long userlessWorkflows = testingPostgres.runSelectStatement(
-                "select count(*) from workflow w where w.id not in (select userid from user_entry)", long.class);
+                "select count(*) from workflow w where w.id not in (select entryid from user_entry)", long.class);
         assertEquals(1, userlessWorkflows);
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1060,19 +1060,34 @@ class WebhookIT extends BaseIT {
     }
 
     /**
-     * This tests the GitHub release process does not work for users that do not exist on Dockstore
+     * This tests the GitHub release process works for users that do not exist on Dockstore
      */
     @Test
     void testGitHubReleaseNoWorkflowOnDockstoreNoUser() {
         final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi client = new WorkflowsApi(webClient);
 
-        try {
-            handleGitHubRelease(client, DockstoreTestUser2.WORKFLOW_DOCKSTORE_YML, "refs/tags/0.1", "thisisafakeuser");
-            fail("Should not reach this statement.");
-        } catch (ApiException ex) {
-            assertEquals(LAMBDA_ERROR, ex.getCode(), "Should not be able to add a workflow when user does not exist on Dockstore.");
-        }
+        handleGitHubRelease(client, DockstoreTestUser2.WORKFLOW_DOCKSTORE_YML, "refs/tags/0.1", "thisisafakeuser");
+        final Long userlessWorkflows = testingPostgres.runSelectStatement(
+                "select count(*) from workflow w where w.id not in (select userid from user_entry)", long.class);
+        assertEquals(1, userlessWorkflows);
+    }
+
+    /**
+     * Test that if a webhook committer, but not the sender, is a Dockstore user, the workflow gets added to the commiter
+     */
+    @Test
+    void testGitHubReleaseNoWorkflowSenderNotADockstoreUser() {
+        final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi client = new WorkflowsApi(webClient);
+
+        handleGitHubRelease(client, DockstoreTestUser2.WORKFLOW_DOCKSTORE_YML, "refs/tags/0.1", "thisisafakeuser", null, List.of(USER_2_USERNAME));
+        // Only the 1 workflow is in the DB, verify that it has USER_2_USERNAME as a user, even though they were not the sender of the event
+        final String workflowUser = testingPostgres.runSelectStatement(
+                "select username from enduser e where e.id in (select ue.userid from user_entry ue where ue.entryid = (select w.id from workflow w where w.repository = 'workflow-dockstore-yml'))",
+                String.class);
+        assertEquals(USER_2_USERNAME, workflowUser);
+
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
@@ -6,6 +6,8 @@ import static io.dockstore.webservice.core.webhook.ReleasePayload.Action;
 import io.dockstore.common.RepositoryConstants.DockstoreTestUser2;
 import io.dockstore.openapi.client.ApiClient;
 import io.dockstore.openapi.client.api.WorkflowsApi;
+import io.dockstore.openapi.client.model.GitCommit;
+import io.dockstore.openapi.client.model.GitHubUser;
 import io.dockstore.openapi.client.model.Installation;
 import io.dockstore.openapi.client.model.InstallationRepositoriesPayload;
 import io.dockstore.openapi.client.model.PushPayload;
@@ -34,6 +36,34 @@ public final class GitHubAppHelper {
     }
 
     /**
+     *
+     * @param workflowsApi
+     * @param repository Repository path (ex. dockstore/dockstore-ui2)
+     * @param gitRef Full git reference for a GitHub branch/tag. Ex. refs/heads/master or refs/tags/v1.0
+     * @param gitHubUsername Username of user on GitHub who triggered action
+     * @param after commit SHA of head commit on reference, or null to force the release
+     * @param commiters a list of commiter GitHub usernames, can be empty
+     */
+    public static void handleGitHubRelease(WorkflowsApi workflowsApi, String repository, String gitRef, String gitHubUsername, String after, List<String> commiters) {
+        PushPayload pushPayload = new PushPayload().ref(gitRef);
+        pushPayload.setRepository(new WebhookRepository().fullName(repository));
+        pushPayload.setSender(new Sender().login(gitHubUsername));
+        pushPayload.setInstallation(new Installation().id(INSTALLATION_ID));
+        pushPayload.setAfter(after);
+        final List<GitCommit> gitCommits = commiters.stream().map(username -> {
+            final GitHubUser gitHubUser = new GitHubUser();
+            gitHubUser.setUsername(username);
+            gitHubUser.setEmail("email@doesntmatter.com");
+            gitHubUser.setName("Name does not matter");
+            final GitCommit gitCommit = new GitCommit();
+            gitCommit.setAuthor(gitHubUser);
+            gitCommit.setCommiter(gitHubUser);
+            return gitCommit;
+        }).toList();
+        pushPayload.setCommits(gitCommits);
+        workflowsApi.handleGitHubRelease(pushPayload, generateXGitHubDelivery());
+    }
+    /**
      * Performs a GitHub release, using a generated X-GitHub-Delivery header
      * @param workflowsApi
      * @param repository Repository path (ex. dockstore/dockstore-ui2)
@@ -42,12 +72,7 @@ public final class GitHubAppHelper {
      * @param after commit SHA of head commit on reference, or null to force the release
      */
     public static void handleGitHubRelease(WorkflowsApi workflowsApi, String repository, String gitRef, String gitHubUsername, String after) {
-        PushPayload pushPayload = new PushPayload().ref(gitRef);
-        pushPayload.setRepository(new WebhookRepository().fullName(repository));
-        pushPayload.setSender(new Sender().login(gitHubUsername));
-        pushPayload.setInstallation(new Installation().id(INSTALLATION_ID));
-        pushPayload.setAfter(after);
-        workflowsApi.handleGitHubRelease(pushPayload, generateXGitHubDelivery());
+        handleGitHubRelease(workflowsApi, repository, gitRef, gitHubUsername, after, List.of());
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
@@ -57,7 +57,7 @@ public final class GitHubAppHelper {
             gitHubUser.setName("Name does not matter");
             final GitCommit gitCommit = new GitCommit();
             gitCommit.setAuthor(gitHubUser);
-            gitCommit.setCommiter(gitHubUser);
+            gitCommit.setCommitter(gitHubUser);
             return gitCommit;
         }).toList();
         pushPayload.setCommits(gitCommits);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/GitCommit.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/GitCommit.java
@@ -19,7 +19,7 @@ package io.dockstore.webservice.core.webhook;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "Information about the head commit on a GitHub push event")
+@Schema(description = "Information about a commit on a GitHub push event. See https://docs.github.com/en/webhooks/webhook-events-and-payloads#push, under commits and head_commit")
 public class GitCommit {
 
     private GitHubUser author;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/GitCommit.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/GitCommit.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.dockstore.webservice.core.webhook;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Information about the head commit on a GitHub push event")
+public class GitCommit {
+
+    private GitHubUser author;
+    private GitHubUser commiter;
+
+    public GitHubUser getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(GitHubUser author) {
+        this.author = author;
+    }
+
+    public GitHubUser getCommiter() {
+        return commiter;
+    }
+
+    public void setCommiter(GitHubUser commiter) {
+        this.commiter = commiter;
+    }
+
+    public record GitHubUser(String username, String name, String email) {}
+}
+

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/GitCommit.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/GitCommit.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class GitCommit {
 
     private GitHubUser author;
-    private GitHubUser commiter;
+    private GitHubUser committer;
 
     public GitHubUser getAuthor() {
         return author;
@@ -33,12 +33,12 @@ public class GitCommit {
         this.author = author;
     }
 
-    public GitHubUser getCommiter() {
-        return commiter;
+    public GitHubUser getCommitter() {
+        return committer;
     }
 
-    public void setCommiter(GitHubUser commiter) {
-        this.commiter = commiter;
+    public void setCommitter(GitHubUser committer) {
+        this.committer = committer;
     }
 
     public record GitHubUser(String username, String name, String email) {}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/PushPayload.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/PushPayload.java
@@ -17,8 +17,10 @@
 
 package io.dockstore.webservice.core.webhook;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import java.util.List;
 
 /**
  * A subset of fields available in a GitHub webhook push payload. The fields in this class are fields that the webservice uses.
@@ -32,6 +34,15 @@ public class PushPayload extends Payload {
     // The following description is directly quoted from the above github doc
     @Schema(description = "The SHA of the most recent commit on ref after the push", requiredMode = RequiredMode.NOT_REQUIRED, example = "6d96270004515a0486bb7f76196a72b40c55a47f")
     private String after;
+
+    // The GitHub doc says "object or null", sigh
+    @Schema(description = "The head commit")
+    @JsonProperty("head_commit")
+    private GitCommit headCommit;
+
+    // The following description is the first sentence directly quoted from the above GitHub doc
+    @Schema(description = "An array of commit objects describing the pushed commits")
+    private List<GitCommit> commits;
 
     public PushPayload() {
     }
@@ -50,6 +61,22 @@ public class PushPayload extends Payload {
 
     public void setAfter(String after) {
         this.after = after;
+    }
+
+    public GitCommit getHeadCommit() {
+        return headCommit;
+    }
+
+    public void setHeadCommit(GitCommit gitCommit) {
+        this.headCommit = gitCommit;
+    }
+
+    public List<GitCommit> getCommits() {
+        return commits;
+    }
+
+    public void setCommits(List<GitCommit> commits) {
+        this.commits = commits;
     }
 
     @Override

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/PushPayload.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/PushPayload.java
@@ -35,7 +35,7 @@ public class PushPayload extends Payload {
     @Schema(description = "The SHA of the most recent commit on ref after the push", requiredMode = RequiredMode.NOT_REQUIRED, example = "6d96270004515a0486bb7f76196a72b40c55a47f")
     private String after;
 
-    // The GitHub doc says "object or null", sigh
+    // The following description is directly quoted from the above github doc
     @Schema(description = "The head commit")
     @JsonProperty("head_commit")
     private GitCommit headCommit;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -100,7 +100,6 @@ import org.kohsuke.github.GHException;
 import org.kohsuke.github.GHFileNotFoundException;
 import org.kohsuke.github.GHMyself;
 import org.kohsuke.github.GHMyself.RepositoryListFilter;
-import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHRateLimit;
 import org.kohsuke.github.GHRef;
 import org.kohsuke.github.GHRepository;
@@ -1479,16 +1478,6 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         reportOnRateLimit("syncTopics", startRateLimit, endRateLimit);
 
         return numOfEntriesNotUpdatedWithTopic;
-    }
-
-    public void listUsers(String reposistory) throws IOException {
-        final String org = reposistory.split("/")[0];
-        final GHRepository repository = github.getRepository(reposistory);
-        final List<GHUser> repositoryCollaborators = repository.listCollaborators(GHRepository.CollaboratorAffiliation.DIRECT).toList();
-        System.out.println("repositoryCollaborators = " + repositoryCollaborators);
-        final GHOrganization organization = github.getOrganization(org);
-        final List<GHUser> orgMembers = organization.listMembers().toList();
-        System.out.println("orgMembers = " + orgMembers);
     }
 
     public User.Profile getProfile(final User user, final GHUser ghUser) throws IOException {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/GitHubSourceCodeRepo.java
@@ -100,6 +100,7 @@ import org.kohsuke.github.GHException;
 import org.kohsuke.github.GHFileNotFoundException;
 import org.kohsuke.github.GHMyself;
 import org.kohsuke.github.GHMyself.RepositoryListFilter;
+import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHRateLimit;
 import org.kohsuke.github.GHRef;
 import org.kohsuke.github.GHRepository;
@@ -1478,6 +1479,16 @@ public class GitHubSourceCodeRepo extends SourceCodeRepoInterface {
         reportOnRateLimit("syncTopics", startRateLimit, endRateLimit);
 
         return numOfEntriesNotUpdatedWithTopic;
+    }
+
+    public void listUsers(String reposistory) throws IOException {
+        final String org = reposistory.split("/")[0];
+        final GHRepository repository = github.getRepository(reposistory);
+        final List<GHUser> repositoryCollaborators = repository.listCollaborators(GHRepository.CollaboratorAffiliation.DIRECT).toList();
+        System.out.println("repositoryCollaborators = " + repositoryCollaborators);
+        final GHOrganization organization = github.getOrganization(org);
+        final List<GHUser> orgMembers = organization.listMembers().toList();
+        System.out.println("orgMembers = " + orgMembers);
     }
 
     public User.Profile getProfile(final User user, final GHUser ghUser) throws IOException {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -872,11 +872,6 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         Workflow workflowToUpdate = null;
         // Create workflow if one does not exist
         if (workflow.isEmpty()) {
-            // Commented this out as part of SEAB-5994
-            // Ensure that a Dockstore user exists to add to the workflow
-            // if (user == null) {
-            //    throw new CustomWebApplicationException("User does not have an account on Dockstore.", LAMBDA_FAILURE);
-            // }
 
             StringInputValidationHelper.checkEntryName(workflowType, workflowName);
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -1318,8 +1318,8 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             gitCommits.add(payload.getHeadCommit());
         }
         gitCommits.stream().forEach(commit -> {
-            if (commit.getCommiter() != null && commit.getCommiter().username() != null) {
-                commitUsernames.add(commit.getCommiter().username());
+            if (commit.getCommitter() != null && commit.getCommitter().username() != null) {
+                commitUsernames.add(commit.getCommitter().username());
             }
             if (commit.getAuthor() != null && commit.getAuthor().username() != null) {
                 commitUsernames.add(commit.getAuthor().username());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -447,6 +447,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         boolean isSuccessful = true;
 
         try {
+            gitHubSourceCodeRepo.listUsers(repository);
             // Ignore the push event if the "after" hash exists and does not match the current ref head hash.
             if (!shouldProcessPush(gitHubSourceCodeRepo, repository, gitReference, afterCommit)) {
                 LOG.info("ignoring push event, repository={}, reference={}, deliveryId={}, afterCommit={}", repository, gitReference, deliveryId, afterCommit);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -38,6 +38,8 @@ import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowMode;
 import io.dockstore.webservice.core.WorkflowVersion;
+import io.dockstore.webservice.core.webhook.GitCommit;
+import io.dockstore.webservice.core.webhook.PushPayload;
 import io.dockstore.webservice.helpers.CheckUrlInterface;
 import io.dockstore.webservice.helpers.FileFormatHelper;
 import io.dockstore.webservice.helpers.GitHelper;
@@ -68,6 +70,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -431,7 +434,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * - Create services and workflows when necessary
      * - Add or update version for corresponding service and workflow
      * @param repository Repository path (ex. dockstore/dockstore-ui2)
-     * @param username Username of GitHub user that triggered action
+     * @param gitHubUsernames Usernames of GitHub user that triggered action, as well as other users that may have committed
      * @param gitReference Git reference from GitHub (ex. refs/tags/1.0)
      * @param installationId GitHub App installation ID
      * @param deliveryId The GitHub delivery ID, used to group all lambda events that were created during this GitHub webhook release
@@ -439,19 +442,19 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @param throwIfNotSuccessful throw if the release was not entirely successful
      * @return List of new and updated workflows
      */
-    protected void githubWebhookRelease(String repository, String username, String gitReference, long installationId, String deliveryId, String afterCommit, boolean throwIfNotSuccessful) {
+    protected void githubWebhookRelease(String repository, GitHubUsernames gitHubUsernames, String gitReference, long installationId, String deliveryId, String afterCommit, boolean throwIfNotSuccessful) {
         // Grab Dockstore YML from GitHub
         GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createGitHubAppRepo(installationId);
         GHRateLimit startRateLimit = gitHubSourceCodeRepo.getGhRateLimitQuietly();
 
         boolean isSuccessful = true;
 
+        final String sender = gitHubUsernames.sender();
         try {
-            gitHubSourceCodeRepo.listUsers(repository);
             // Ignore the push event if the "after" hash exists and does not match the current ref head hash.
             if (!shouldProcessPush(gitHubSourceCodeRepo, repository, gitReference, afterCommit)) {
                 LOG.info("ignoring push event, repository={}, reference={}, deliveryId={}, afterCommit={}", repository, gitReference, deliveryId, afterCommit);
-                lambdaEventDAO.create(createIgnoredEvent(repository, gitReference, username, LambdaEvent.LambdaEventType.PUSH, deliveryId));
+                lambdaEventDAO.create(createIgnoredEvent(repository, gitReference, sender, LambdaEvent.LambdaEventType.PUSH, deliveryId));
                 return;
             }
 
@@ -464,21 +467,21 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             // '&=' does not short-circuit, ensuring that all of the lists are processed.
             // 'isSuccessful &= x()' is equivalent to 'isSuccessful = isSuccessful & x()'.
             List<Service12> services = dockstoreYaml12.getService() != null ? List.of(dockstoreYaml12.getService()) : List.of();
-            isSuccessful &= createWorkflowsAndVersionsFromDockstoreYml(services, repository, gitReference, installationId, username, dockstoreYml, Service.class, deliveryId);
-            isSuccessful &= createWorkflowsAndVersionsFromDockstoreYml(dockstoreYaml12.getWorkflows(), repository, gitReference, installationId, username, dockstoreYml, BioWorkflow.class, deliveryId);
-            isSuccessful &= createWorkflowsAndVersionsFromDockstoreYml(dockstoreYaml12.getTools(), repository, gitReference, installationId, username, dockstoreYml, AppTool.class, deliveryId);
-            isSuccessful &= createWorkflowsAndVersionsFromDockstoreYml(dockstoreYaml12.getNotebooks(), repository, gitReference, installationId, username, dockstoreYml, Notebook.class, deliveryId);
+            isSuccessful &= createWorkflowsAndVersionsFromDockstoreYml(services, repository, gitReference, installationId, gitHubUsernames, dockstoreYml, Service.class, deliveryId);
+            isSuccessful &= createWorkflowsAndVersionsFromDockstoreYml(dockstoreYaml12.getWorkflows(), repository, gitReference, installationId, gitHubUsernames, dockstoreYml, BioWorkflow.class, deliveryId);
+            isSuccessful &= createWorkflowsAndVersionsFromDockstoreYml(dockstoreYaml12.getTools(), repository, gitReference, installationId, gitHubUsernames, dockstoreYml, AppTool.class, deliveryId);
+            isSuccessful &= createWorkflowsAndVersionsFromDockstoreYml(dockstoreYaml12.getNotebooks(), repository, gitReference, installationId, gitHubUsernames, dockstoreYml, Notebook.class, deliveryId);
 
         } catch (Exception ex) {
 
             // If an exception propagates to here, log something helpful and abort .dockstore.yml processing.
             isSuccessful = false;
             String msg = "Error handling push event for repository " + repository + " and reference " + gitReference + ":\n- " + generateMessageFromException(ex) + "\nTerminated processing of .dockstore.yml";
-            LOG.info("User " + username + ": " + msg, ex);
+            LOG.info("User " + sender + ": " + msg, ex);
 
             // Make an entry in the github apps logs.
             new TransactionHelper(sessionFactory).transaction(() -> {
-                LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, username, LambdaEvent.LambdaEventType.PUSH, false, deliveryId);
+                LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, sender, LambdaEvent.LambdaEventType.PUSH, false, deliveryId);
                 setEventMessage(lambdaEvent, msg);
                 lambdaEventDAO.create(lambdaEvent);
             });
@@ -488,7 +491,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             }
         } finally {
             GHRateLimit endRateLimit = gitHubSourceCodeRepo.getGhRateLimitQuietly();
-            gitHubSourceCodeRepo.reportOnGitHubRelease(startRateLimit, endRateLimit, repository, username, gitReference, isSuccessful);
+            gitHubSourceCodeRepo.reportOnGitHubRelease(startRateLimit, endRateLimit, repository, sender, gitReference, isSuccessful);
         }
 
         if (!isSuccessful && throwIfNotSuccessful) {
@@ -653,12 +656,12 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @param repository Repository path (ex. dockstore/dockstore-ui2)
      * @param gitReference Git reference from GitHub (ex. refs/tags/1.0)
      * @param installationId Installation id needed to setup GitHub apps
-     * @param username       Name of user that triggered action
+     * @param usernames       User that triggered action and other users in the payload
      * @param dockstoreYml
      * @param deliveryId The GitHub delivery ID, used to identify events that belong to the same GitHub webhook invocation
      */
     @SuppressWarnings({"lgtm[java/path-injection]", "checkstyle:ParameterNumber"})
-    private boolean createWorkflowsAndVersionsFromDockstoreYml(List<? extends Workflowish> yamlWorkflows, String repository, String gitReference, long installationId, String username,
+    private boolean createWorkflowsAndVersionsFromDockstoreYml(List<? extends Workflowish> yamlWorkflows, String repository, String gitReference, long installationId, GitHubUsernames usernames,
             final SourceFile dockstoreYml, Class<?> workflowType, String deliveryId) {
 
         GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createGitHubAppRepo(installationId);
@@ -674,7 +677,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                     DockstoreYamlHelper.validate(wf, true, "a " + computeTermFromClass(workflowType));
 
                     // Retrieve the user who triggered the call (must exist on Dockstore if workflow is not already present)
-                    User user = GitHubHelper.findUserByGitHubUsername(this.tokenDAO, this.userDAO, username, false);
+                    User user = GitHubHelper.findUserByGitHubUsername(this.tokenDAO, this.userDAO, usernames.sender(), false);
+                    final List<User> otherUsers = usernames.otherUsers().stream()
+                            .map(u -> GitHubHelper.findUserByGitHubUsername(this.tokenDAO, this.userDAO, u, false)).filter(Objects::nonNull)
+                            .toList();
 
                     // Update the workflow version in its own database transaction.
                     Pair<Workflow, WorkflowVersion> result = transactionHelper.transaction(() -> {
@@ -684,12 +690,13 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                         final List<YamlAuthor> yamlAuthors = wf.getAuthors();
 
                         Workflow workflow = createOrGetWorkflow(workflowType, repository, user, workflowName, wf, gitHubSourceCodeRepo);
+                        workflow.getUsers().addAll(otherUsers);
                         WorkflowVersion version = addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, latestTagAsDefault, yamlAuthors);
 
                         // Create some events.
                         eventDAO.createAddTagToEntryEvent(user, workflow, version);
 
-                        LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, username, LambdaEvent.LambdaEventType.PUSH, true, deliveryId, computeWorkflowName(wf));
+                        LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, usernames.sender(), LambdaEvent.LambdaEventType.PUSH, true, deliveryId, computeWorkflowName(wf));
                         setEventMessage(lambdaEvent, createValidationsMessage(workflow, version));
                         lambdaEventDAO.create(lambdaEvent);
 
@@ -717,7 +724,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                             computeTermFromClass(workflowType), computeWorkflowName(wf), generateMessageFromException(ex));
                         LOG.error(message, ex);
                         transactionHelper.transaction(() -> {
-                            LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, username, LambdaEvent.LambdaEventType.PUSH, false, deliveryId, computeWorkflowName(wf));
+                            LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, usernames.sender(), LambdaEvent.LambdaEventType.PUSH, false, deliveryId, computeWorkflowName(wf));
                             setEventMessage(lambdaEvent, message);
                             lambdaEventDAO.create(lambdaEvent);
                         });
@@ -827,10 +834,11 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         Workflow workflowToUpdate = null;
         // Create workflow if one does not exist
         if (workflow.isEmpty()) {
+            // Commented this out as part of SEAB-5994
             // Ensure that a Dockstore user exists to add to the workflow
-            if (user == null) {
-                throw new CustomWebApplicationException("User does not have an account on Dockstore.", LAMBDA_FAILURE);
-            }
+            // if (user == null) {
+            //    throw new CustomWebApplicationException("User does not have an account on Dockstore.", LAMBDA_FAILURE);
+            // }
 
             StringInputValidationHelper.checkEntryName(workflowType, workflowName);
 
@@ -1245,6 +1253,39 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         return workflow;
     }
 
+    /**
+     * Returns all the GitHub usernames from a push payload. There are several usernames in the payload, which may all be the same, or
+     * might be different. See https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
+     *
+     * <ol>
+     *     <li>sender.login - the user who triggered the event, e.g., I think, they created a new branch and pushed it</li>
+     *     <li>There is a headCommit field and a commits field, the first may have a single GitCommit, the second has an array of GitCommits. A GitCommit
+     *     contains:</li>
+     *     <ul>
+     *     <li>commit.author - the user who wrote the code</li>
+     *     <li>commit.commiter - the user who committed the code, e.g., they cherry-picked a commit to another branch,
+     *     or the author committed via the GitHub UI (web-flow is the user in the second case)</li>
+     *     </ul>
+     * </ol>
+     * @param payload
+     * @return
+     */
+    protected GitHubUsernames gitHubUsernamesFromPushPayload(PushPayload payload) {
+        final Set<String> userNames = new HashSet<>();
+        final ArrayList<GitCommit> gitCommits = new ArrayList<>(payload.getCommits()); // Per GitHub doc, getCommits() is never null
+        if (payload.getHeadCommit() != null) { // But this one can be null
+            gitCommits.add(payload.getHeadCommit());
+        }
+        gitCommits.stream().forEach(commit -> {
+            userNames.add(commit.getCommiter().username());
+            userNames.add(commit.getAuthor().username());
+        });
+        final String senderUsername = payload.getSender().getLogin();
+        userNames.remove(senderUsername);
+        return new GitHubUsernames(senderUsername, userNames);
+    }
+
+
     private void createAndSetDiscourseTopic(Workflow workflow) {
         if (workflow.getTopicId() == null) {
             try {
@@ -1269,4 +1310,12 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
         }
     }
+
+    /**
+     * The GitHub usernames from a GitHub Webhook delivery payload. The payload can have several references to a GitHub usernames, and those
+     * usernames may all be the same or different.
+     * @param sender - the sender of the GitHub webhook delivery
+     * @param otherUsers - other users, not including the sender, that can be in the delivery.
+     */
+    public record GitHubUsernames(String sender, Set<String> otherUsers) {}
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -443,7 +443,8 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @param throwIfNotSuccessful throw if the release was not entirely successful
      * @return List of new and updated workflows
      */
-    protected void githubWebhookRelease(String repository, GitHubUsernames gitHubUsernames, String gitReference, long installationId, String deliveryId, String afterCommit, boolean throwIfNotSuccessful) {
+    protected void githubWebhookRelease(String repository, GitHubUsernames gitHubUsernames, String gitReference, long installationId, String deliveryId, String afterCommit,
+            boolean throwIfNotSuccessful) {
         // Grab Dockstore YML from GitHub
         GitHubSourceCodeRepo gitHubSourceCodeRepo = (GitHubSourceCodeRepo)SourceCodeRepoFactory.createGitHubAppRepo(installationId);
         GHRateLimit startRateLimit = gitHubSourceCodeRepo.getGhRateLimitQuietly();
@@ -469,9 +470,11 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             // 'isSuccessful &= x()' is equivalent to 'isSuccessful = isSuccessful & x()'.
             List<Service12> services = dockstoreYaml12.getService() != null ? List.of(dockstoreYaml12.getService()) : List.of();
             isSuccessful &= createWorkflowsAndVersionsFromDockstoreYml(services, repository, gitReference, installationId, gitHubUsernames, dockstoreYml, Service.class, deliveryId);
-            isSuccessful &= createWorkflowsAndVersionsFromDockstoreYml(dockstoreYaml12.getWorkflows(), repository, gitReference, installationId, gitHubUsernames, dockstoreYml, BioWorkflow.class, deliveryId);
+            isSuccessful &= createWorkflowsAndVersionsFromDockstoreYml(dockstoreYaml12.getWorkflows(), repository, gitReference, installationId, gitHubUsernames, dockstoreYml, BioWorkflow.class,
+                    deliveryId);
             isSuccessful &= createWorkflowsAndVersionsFromDockstoreYml(dockstoreYaml12.getTools(), repository, gitReference, installationId, gitHubUsernames, dockstoreYml, AppTool.class, deliveryId);
-            isSuccessful &= createWorkflowsAndVersionsFromDockstoreYml(dockstoreYaml12.getNotebooks(), repository, gitReference, installationId, gitHubUsernames, dockstoreYml, Notebook.class, deliveryId);
+            isSuccessful &= createWorkflowsAndVersionsFromDockstoreYml(dockstoreYaml12.getNotebooks(), repository, gitReference, installationId, gitHubUsernames, dockstoreYml, Notebook.class,
+                    deliveryId);
 
         } catch (Exception ex) {
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -1272,13 +1272,20 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      */
     protected GitHubUsernames gitHubUsernamesFromPushPayload(PushPayload payload) {
         final Set<String> userNames = new HashSet<>();
-        final ArrayList<GitCommit> gitCommits = new ArrayList<>(payload.getCommits()); // Per GitHub doc, getCommits() is never null
+        final ArrayList<GitCommit> gitCommits = new ArrayList<>();
+        if (payload.getCommits() != null) { // It should never be null per GitHub doc, but we have some test data with it; easiest to just check
+            gitCommits.addAll(payload.getCommits());
+        }
         if (payload.getHeadCommit() != null) { // But this one can be null
             gitCommits.add(payload.getHeadCommit());
         }
         gitCommits.stream().forEach(commit -> {
-            userNames.add(commit.getCommiter().username());
-            userNames.add(commit.getAuthor().username());
+            if (commit.getCommiter() != null && commit.getCommiter().username() != null) {
+                userNames.add(commit.getCommiter().username());
+            }
+            if (commit.getAuthor() != null && commit.getAuthor().username() != null) {
+                userNames.add(commit.getAuthor().username());
+            }
         });
         final String senderUsername = payload.getSender().getLogin();
         userNames.remove(senderUsername);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -2128,8 +2128,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         if (LOG.isInfoEnabled()) {
             LOG.info(String.format("Branch/tag %s pushed to %s(%s)", Utilities.cleanForLogging(gitReference), Utilities.cleanForLogging(repository), Utilities.cleanForLogging(username)));
         }
-
-        githubWebhookRelease(repository, username, gitReference, installationId, deliveryId, afterCommit, true);
+        githubWebhookRelease(repository, gitHubUsernamesFromPushPayload(payload), gitReference, installationId, deliveryId, afterCommit, true);
     }
 
     @POST
@@ -2192,7 +2191,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                         LOG.info(String.format("Retrospectively processing branch/tag %s in %s(%s)", Utilities.cleanForLogging(gitReference), Utilities.cleanForLogging(repository),
                             Utilities.cleanForLogging(username)));
                     }
-                    githubWebhookRelease(repository, username, gitReference, installationId, deliveryId, null, false);
+                    githubWebhookRelease(repository, new GitHubUsernames(username, Set.of()), gitReference, installationId, deliveryId, null, false);
                 }
             }
         }

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -9968,7 +9968,7 @@ components:
       properties:
         author:
           $ref: '#/components/schemas/GitHubUser'
-        commiter:
+        committer:
           $ref: '#/components/schemas/GitHubUser'
     GitHubUser:
       type: object

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -9964,7 +9964,8 @@ components:
           type: string
     GitCommit:
       type: object
-      description: Information about the head commit on a GitHub push event
+      description: "Information about a commit on a GitHub push event. See https://docs.github.com/en/webhooks/webhook-events-and-payloads#push,\
+        \ under commits and head_commit"
       properties:
         author:
           $ref: '#/components/schemas/GitHubUser'

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -9962,6 +9962,23 @@ components:
           type: string
         url:
           type: string
+    GitCommit:
+      type: object
+      description: Information about the head commit on a GitHub push event
+      properties:
+        author:
+          $ref: '#/components/schemas/GitHubUser'
+        commiter:
+          $ref: '#/components/schemas/GitHubUser'
+    GitHubUser:
+      type: object
+      properties:
+        email:
+          type: string
+        name:
+          type: string
+        username:
+          type: string
     HealthCheckResult:
       type: object
       properties:
@@ -10639,6 +10656,13 @@ components:
             type: string
             description: The SHA of the most recent commit on ref after the push
             example: 6d96270004515a0486bb7f76196a72b40c55a47f
+          commits:
+            type: array
+            description: An array of commit objects describing the pushed commits
+            items:
+              $ref: '#/components/schemas/GitCommit'
+          head_commit:
+            $ref: '#/components/schemas/GitCommit'
           ref:
             type: string
             description: The full git ref that was pushed


### PR DESCRIPTION
**Description**
1. Allows workflows to be created from a .dockstore.yml if there is no corresponding user on Dockstore.
2. Also look for more users to make owners of the workflow upon creation.

***Why***
Some workflows are new via a .dockstore.yml, but the push is done by a bot not registered in Dockstore, so the workflow doesn't appear. 

Why did we not support userless workflows? This was explicitly disallowed, with a test, when services were added in #2574, and the code was carried over to workflows. I could find no other reasons for it, although I can see how it makes sense. There are no implications as far as I can tell by allowing workflows without a user.

***Users in a GitHub webhook push event***
Following is extracted from [here](https://docs.github.com/en/webhooks/webhook-events-and-payloads#push):
There are potentially many unique GitHub users in a GitHub event:
1. The sender - the only user we've been looking at so far. It's the user that triggered the event. In our team's typical usage it's the same as the person who committed and pushed, but I think it could be, for example, a bot that created and pushed a branch.
2. For a commit, there is an author and a committer.
    1. The author is the user who wrote the code.
    2. The committer is the user who commited the code, who is not necessarily the same as the author.
        1. Example 1, I edit a file in the GitHub web UI. I will be the author, the user `web-flow` will be the committer.
        2. Example 2, I commit file to a branch. I am the author and the committer. Denis cherry-picks my commit to another branch. I am the author of the cherry-picked commit, but Denis is the committer.

The payload has a `head_commit`, which could be null, and a `commits` array, which could be empty. I'm not clear how far back in time the commits array can go, and when `head_commit` is set.

***Looking for additional users***
Note: we could drop this part if we think it's risky/slow.

Even though the idea is to support userless workflows, it would be nice it we could auto-discover some users if the sender is not in Dockstore. We look through the committers and authors to see if we can add any of them as owners.

I'm concerned that an author/committer may not have current permissions (for example a PR from a fork might get merged, but it doesn't mean the author has permissions), so we do a check to be safe. This check can be slow.

Why don't we just query the repo for its owners? Because the GitHub app doesn't have permissions.

**Review Instructions**
This will be tricky, I think you can simulate it by unlinking your GitHub account:
1. Ensure you have a repo configured with the GitHub App
2. Unlink GitHub from your Dockstore account
3. Add a new workflow, with publish set to true, in the .dockstore.yml
4. Push it
5. After a couple of minutes the workflow should appear in search
6. Relink your GitHub account in Dockstore.
7. You should not see the new workflow in My Workflows
8. Click Discover Workflows.
9. You should now see the new workflow in Dockstore.

**Issue**
SEAB-5994

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
