### PR TITLE
Update Surefire to non-milestone version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,7 +380,8 @@ jobs:
               ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Punit-tests,coverage -ntp \
               -Dtest=`cat /tmp/tests-to-run.txt | tr ' ' ','` -DfailIfNoTests=false | grep  -v "^Running Changeset:"
             else 
-              ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Punit-tests,coverage -ntp | grep  -v "^Running Changeset:"
+              # dockstore-language-plugin-parent has no tests, add -DfailIfNoTests=false to not have tests fail
+              ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -DfailIfNoTests=false -Punit-tests,coverage -ntp | grep  -v "^Running Changeset:"
             fi
             # The piping grep command is a temporary fix to this issue https://github.com/liquibase/liquibase/issues/2396
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,10 +378,9 @@ jobs:
             if [ $CIRCLE_NODE_TOTAL != 1 ] 
             then
               ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Punit-tests,coverage -ntp \
-              -Dtest=`cat /tmp/tests-to-run.txt | tr ' ' ','` -DfailIfNoTests=false | grep  -v "^Running Changeset:"
+              -Dtest=`cat /tmp/tests-to-run.txt | tr ' ' ','` -Dsurefire.failIfNoSpecifiedTests=false | grep  -v "^Running Changeset:"
             else 
-              # dockstore-language-plugin-parent has no tests, add -DfailIfNoTests=false to not have tests fail
-              ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -DfailIfNoTests=false -Punit-tests,coverage -ntp | grep  -v "^Running Changeset:"
+              ./mvnw -B org.jacoco:jacoco-maven-plugin:report org.jacoco:jacoco-maven-plugin:report-aggregate clean install -Dsurefire.failIfNoSpecifiedTests=false -Punit-tests,coverage -ntp | grep  -v "^Running Changeset:"
             fi
             # The piping grep command is a temporary fix to this issue https://github.com/liquibase/liquibase/issues/2396
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <openapi-annotations-version>2.2.9</openapi-annotations-version>
         <!-- Used for liquibase maven plugin. Somehow use version from bom-internal instead -->
         <postgresql.version>42.4.4</postgresql.version>
-        <maven-surefire.version>3.0.0-M5</maven-surefire.version>
+        <maven-surefire.version>3.4.0</maven-surefire.version>
         <maven-failsafe.version>2.22.2</maven-failsafe.version>
         <maven-java.version>17</maven-java.version>
 


### PR DESCRIPTION
**Description**
Discovered in https://github.com/dockstore/swagger-java-zenodo-client/pull/24#discussion_r1727146058

**Review Instructions**
None. If it works, CI tests will pass, and if they work, the PR will be merged.

**Issue**
None

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
