### PR TITLE
DOCK-2565: Notebook name/path clash improvements

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -197,7 +197,7 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
 
         existing.ifPresent(e -> {
             String term = e.getEntryType().getTerm();
-            throw new CustomWebApplicationException("A " + term + " with the same path already exists. Add the 'name' field to the entry you are currently trying to register to give it a unique path.", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            throw new CustomWebApplicationException("A " + term + " with the same path already exists. Add the 'name' field to the entry you are currently trying to register to give it a unique path.", HttpStatus.SC_BAD_REQUEST);
         });
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -19,8 +19,7 @@ package io.dockstore.webservice.jdbi;
 import io.dockstore.common.DescriptorLanguage;
 import io.dockstore.common.SourceControl;
 import io.dockstore.webservice.CustomWebApplicationException;
-import io.dockstore.webservice.core.AppTool;
-import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.Service;
 import io.dockstore.webservice.core.SourceControlConverter;
 import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Workflow;
@@ -187,27 +186,18 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
     }
 
     /**
-     * Find if a path already exists in the BioWorkflow or Apptool table since we do not want duplicate names between them.
-     * If creating an apptool, check the workflow table and vice versa.
-     *
+     * Find if a path already exists in the BioWorkflow, Apptool, or Notebook tables, since we do not want duplicate names between them.
      * @param path
-     * @param clazz the table you want to check for a duplicate for
      * @return
      */
-    public <T extends Workflow> void checkForDuplicateAcrossTables(String path, Class<T> clazz) {
-        final List<Workflow> workflows = findByPath(path, false);
-        final List<Workflow> filteredWorkflows = workflows.stream()
-            .filter(workflow -> workflow.getClass() == BioWorkflow.class || workflow.getClass() == AppTool.class)
-            .toList();
+    public <T extends Workflow> void checkForDuplicateAcrossTables(String path) {
+        final Optional<Workflow> existing = findByPath(path, false).stream()
+            .filter(workflow -> workflow.getClass() != Service.class)
+            .findFirst();
 
-        if (filteredWorkflows.size() > 0) {
-            String workflowType;
-            if (clazz == AppTool.class) {
-                workflowType = "tool";
-            } else {
-                workflowType = "workflow";
-            }
-            throw new CustomWebApplicationException("A " + workflowType + " with the same path already exists. Add the 'name' field to the entry you are currently trying to register to give it a unique path.", HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        if (existing.isPresent()) {
+            String term = existing.get().getEntryType().getTerm();
+            throw new CustomWebApplicationException("A " + term + " with the same path already exists. Add the 'name' field to the entry you are currently trying to register to give it a unique path.", HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -190,7 +190,7 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
      * @param path
      * @return
      */
-    public <T extends Workflow> void checkForDuplicateAcrossTables(String path) {
+    public void checkForDuplicateAcrossTables(String path) {
         final Optional<Workflow> existing = findByPath(path, false).stream()
             .filter(workflow -> workflow.getClass() != Service.class)
             .findFirst();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowDAO.java
@@ -195,10 +195,10 @@ public class WorkflowDAO extends EntryDAO<Workflow> {
             .filter(workflow -> workflow.getClass() != Service.class)
             .findFirst();
 
-        if (existing.isPresent()) {
-            String term = existing.get().getEntryType().getTerm();
+        existing.ifPresent(e -> {
+            String term = e.getEntryType().getTerm();
             throw new CustomWebApplicationException("A " + term + " with the same path already exists. Add the 'name' field to the entry you are currently trying to register to give it a unique path.", HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        }
+        });
     }
 
     public List<Workflow> findByPaths(List<String> paths, boolean findPublished) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -890,16 +890,18 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
 
             StringInputValidationHelper.checkEntryName(workflowType, workflowName);
 
+            if (workflowType != Service.class) {
+                workflowDAO.checkForDuplicateAcrossTables(dockstoreWorkflowPath);
+            }
+
             if (workflowType == Notebook.class) {
                 YamlNotebook yamlNotebook = (YamlNotebook)wf;
                 workflowToUpdate = gitHubSourceCodeRepo.initializeNotebookFromGitHub(repository, yamlNotebook.getFormat(), yamlNotebook.getLanguage(), workflowName);
             } else if (workflowType == BioWorkflow.class) {
-                workflowDAO.checkForDuplicateAcrossTables(dockstoreWorkflowPath, AppTool.class);
                 workflowToUpdate = gitHubSourceCodeRepo.initializeWorkflowFromGitHub(repository, wf.getSubclass().toString(), workflowName);
             } else if (workflowType == Service.class) {
                 workflowToUpdate = gitHubSourceCodeRepo.initializeServiceFromGitHub(repository, wf.getSubclass().toString(), null);
             } else if (workflowType == AppTool.class) {
-                workflowDAO.checkForDuplicateAcrossTables(dockstoreWorkflowPath, BioWorkflow.class);
                 workflowToUpdate = gitHubSourceCodeRepo.initializeOneStepWorkflowFromGitHub(repository, wf.getSubclass().toString(), workflowName);
             } else {
                 throw new CustomWebApplicationException(workflowType.getCanonicalName()  + " is not a valid workflow type. Currently only workflows, tools, notebooks, and services are supported by GitHub Apps.", LAMBDA_FAILURE);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -845,15 +845,26 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         return workflow.getWorkflowName();
     }
 
+    /**
+     * Convert the specified workflow information into an identifying string that can be shown to the end user (in the app logs, exception messages, etc).
+     * @param workflowType type of the workflow
+     * @param workflowish description of the workflow
+     * @return string describing the workflow
+     */
     private String computeWorkflowPhrase(Class<?> workflowType, Workflowish workflow) {
-        return computeWorkflowPhrase(computeTermFromClass(workflowType), computeWorkflowName(workflow));
+        return formatTermAndName(computeTermFromClass(workflowType), computeWorkflowName(workflow));
     }
 
+    /**
+     * Convert the specified workflow into an identifying string that can be shown to the end user (in the app logs, exception messages, etc).
+     * @param workflow workflow to be converted
+     * @return string describing the workflow
+     */
     private String computeWorkflowPhrase(Workflow workflow) {
-        return computeWorkflowPhrase(workflow.getEntryType().getTerm(), computeWorkflowName(workflow));
+        return formatTermAndName(workflow.getEntryType().getTerm(), computeWorkflowName(workflow));
     }
 
-    private String computeWorkflowPhrase(String term, String name) {
+    private String formatTermAndName(String term, String name) {
         if (name != null) {
             return "%s '%s'".formatted(term, name);
         } else {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -852,7 +852,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @return string describing the workflow
      */
     private String computeWorkflowPhrase(Class<?> workflowType, Workflowish workflow) {
-        return formatTermAndName(computeTermFromClass(workflowType), computeWorkflowName(workflow));
+        return formatWorkflowTermAndName(computeTermFromClass(workflowType), computeWorkflowName(workflow));
     }
 
     /**
@@ -861,10 +861,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @return string describing the workflow
      */
     private String computeWorkflowPhrase(Workflow workflow) {
-        return formatTermAndName(workflow.getEntryType().getTerm(), computeWorkflowName(workflow));
+        return formatWorkflowTermAndName(workflow.getEntryType().getTerm(), computeWorkflowName(workflow));
     }
 
-    private String formatTermAndName(String term, String name) {
+    private String formatWorkflowTermAndName(String term, String name) {
         if (name != null) {
             return "%s '%s'".formatted(term, name);
         } else {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -723,8 +723,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                     isSuccessful = false;
                     rethrowIfFatal(ex);
                     if (!logged) {
-                        final String message = String.format("Failed to create %s '%s':%n- %s",
-                            computeTermFromClass(workflowType), computeWorkflowName(wf), generateMessageFromException(ex));
+                        final String message = "Failed to create %s:%n- %s".formatted(computeWorkflowPhrase(workflowType, wf), generateMessageFromException(ex));
                         LOG.error(message, ex);
                         transactionHelper.transaction(() -> {
                             LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, usernames.sender(), LambdaEvent.LambdaEventType.PUSH, false, deliveryId, computeWorkflowName(wf));
@@ -818,7 +817,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         List<Validation> validations = version.getValidations().stream().filter(v -> !v.isValid()).toList();
         StringBuilder stringBuilder = new StringBuilder();
         if (!validations.isEmpty()) {
-            stringBuilder.append(String.format("Successfully created %s '%s', but encountered validation errors:%n", workflow.getEntryType().getTerm(), computeWorkflowName(workflow)));
+            stringBuilder.append("Successfully created %s, but encountered validation errors:%n".formatted(computeWorkflowPhrase(workflow)));
             validations.forEach(validation -> addValidationToMessage(validation, stringBuilder));
         }
         return stringBuilder.toString();
@@ -839,6 +838,22 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
 
     private String computeWorkflowName(Workflow workflow) {
         return workflow.getWorkflowName();
+    }
+
+    private String computeWorkflowPhrase(Class<?> workflowType, Workflowish workflow) {
+        return computeWorkflowPhrase(computeTermFromClass(workflowType), computeWorkflowName(workflow));
+    }
+
+    private String computeWorkflowPhrase(Workflow workflow) {
+        return computeWorkflowPhrase(workflow.getEntryType().getTerm(), computeWorkflowName(workflow));
+    }
+
+    private String computeWorkflowPhrase(String term, String name) {
+        if (name != null) {
+            return "%s '%s'".formatted(term, name);
+        } else {
+            return term;
+        }
     }
 
     private String generateMessageFromException(Exception ex) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -692,7 +692,10 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                         final boolean latestTagAsDefault = wf.getLatestTagAsDefault();
                         final List<YamlAuthor> yamlAuthors = wf.getAuthors();
 
-                        Workflow workflow = createOrGetWorkflow(workflowType, repository, user, workflowName, wf, gitHubSourceCodeRepo);
+                        WorkflowAndExisted workflowAndExisted = createOrGetWorkflow(workflowType, repository, user, workflowName, wf, gitHubSourceCodeRepo);
+                        Workflow workflow = workflowAndExisted.workflow;
+                        boolean existed = workflowAndExisted.existed;
+
                         workflow.getUsers().addAll(otherUsers.stream().map(User::getId).map(userDAO::findById).toList()); // Because of Hibernate transactions, safest to lookup users again
                         WorkflowVersion version = addDockstoreYmlVersionToWorkflow(repository, gitReference, dockstoreYml, gitHubSourceCodeRepo, workflow, latestTagAsDefault, yamlAuthors);
 
@@ -700,7 +703,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                         eventDAO.createAddTagToEntryEvent(user, workflow, version);
 
                         LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, usernames.sender(), LambdaEvent.LambdaEventType.PUSH, true, deliveryId, computeWorkflowName(wf));
-                        setEventMessage(lambdaEvent, createValidationsMessage(workflow, version));
+                        setEventMessage(lambdaEvent, createValidationsMessage(workflow, version, existed));
                         lambdaEventDAO.create(lambdaEvent);
 
                         publishWorkflowAndLog(workflow, publish, user, repository, gitReference, deliveryId);
@@ -723,7 +726,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                     isSuccessful = false;
                     rethrowIfFatal(ex);
                     if (!logged) {
-                        final String message = "Failed to create %s:%n- %s".formatted(computeWorkflowPhrase(workflowType, wf), generateMessageFromException(ex));
+                        final String message = "Failed to process %s:%n- %s".formatted(computeWorkflowPhrase(workflowType, wf), generateMessageFromException(ex));
                         LOG.error(message, ex);
                         transactionHelper.transaction(() -> {
                             LambdaEvent lambdaEvent = createBasicEvent(repository, gitReference, usernames.sender(), LambdaEvent.LambdaEventType.PUSH, false, deliveryId, computeWorkflowName(wf));
@@ -813,11 +816,13 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
         return "entry";
     }
 
-    private String createValidationsMessage(Workflow workflow, WorkflowVersion version) {
+    private String createValidationsMessage(Workflow workflow, WorkflowVersion version, boolean existed) {
         List<Validation> validations = version.getValidations().stream().filter(v -> !v.isValid()).toList();
         StringBuilder stringBuilder = new StringBuilder();
         if (!validations.isEmpty()) {
-            stringBuilder.append("Successfully created %s, but encountered validation errors:%n".formatted(computeWorkflowPhrase(workflow)));
+            String verb = existed ? "updated" : "created";
+            String workflowPhrase = computeWorkflowPhrase(workflow);
+            stringBuilder.append("Successfully %s %s, but encountered validation errors:%n".formatted(verb, workflowPhrase));
             validations.forEach(validation -> addValidationToMessage(validation, stringBuilder));
         }
         return stringBuilder.toString();
@@ -877,16 +882,15 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @param user User that triggered action
      * @param workflowName User that triggered action
      * @param gitHubSourceCodeRepo Source Code Repo
-     * @return New or updated workflow
+     * @return New or updated workflow, and whether it existed prior to this method's invocation
      */
-    private Workflow createOrGetWorkflow(Class workflowType, String repository, User user, String workflowName, Workflowish wf, GitHubSourceCodeRepo gitHubSourceCodeRepo) {
+    private WorkflowAndExisted createOrGetWorkflow(Class workflowType, String repository, User user, String workflowName, Workflowish wf, GitHubSourceCodeRepo gitHubSourceCodeRepo) {
         // Check for existing workflow
         String dockstoreWorkflowPath = "github.com/" + repository + (workflowName != null && !workflowName.isEmpty() ? "/" + workflowName : "");
-        Optional<T> workflow = workflowDAO.findByPath(dockstoreWorkflowPath, false, workflowType);
-
-        Workflow workflowToUpdate = null;
+        Optional<T> existingWorkflow = workflowDAO.findByPath(dockstoreWorkflowPath, false, workflowType);
+        Workflow workflowToUpdate;
         // Create workflow if one does not exist
-        if (workflow.isEmpty()) {
+        if (existingWorkflow.isEmpty()) {
 
             StringInputValidationHelper.checkEntryName(workflowType, workflowName);
 
@@ -912,7 +916,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 LOG.info("Workflow {} has been created.", Utilities.cleanForLogging(dockstoreWorkflowPath));
             }
         } else {
-            workflowToUpdate = workflow.get();
+            workflowToUpdate = existingWorkflow.get();
             gitHubSourceCodeRepo.updateWorkflowInfo(workflowToUpdate, repository); // Update info that can change between GitHub releases
 
             if (Objects.equals(workflowToUpdate.getMode(), FULL) || Objects.equals(workflowToUpdate.getMode(), STUB)) {
@@ -948,7 +952,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
             }
         }
 
-        return workflowToUpdate;
+        return new WorkflowAndExisted(workflowToUpdate, existingWorkflow.isPresent());
     }
 
     private void checkCompatibleTypeAndSubclass(Workflow existing, Workflowish update) {
@@ -1375,4 +1379,6 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
      * @param otherUsers - other users, not including the sender, that can be in the delivery.
      */
     public record GitHubUsernames(String sender, Set<String> otherUsers) {}
+
+    private record WorkflowAndExisted(Workflow workflow, boolean existed) {}
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -40,7 +40,6 @@ import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.api.PublishRequest;
 import io.dockstore.webservice.api.StarRequest;
-import io.dockstore.webservice.core.AppTool;
 import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Doi.DoiInitiator;
 import io.dockstore.webservice.core.Entry;
@@ -2030,8 +2029,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             throw new CustomWebApplicationException("A workflow with the same path and name already exists.", HttpStatus.SC_BAD_REQUEST);
         }
 
-        // Check that there isn't a duplicate in the Apptool table.
-        workflowDAO.checkForDuplicateAcrossTables(workflow.getWorkflowPath(), AppTool.class);
+        // Check that there isn't another entry with the same path.
+        workflowDAO.checkForDuplicateAcrossTables(workflow.getWorkflowPath());
         final long workflowID = workflowDAO.create(workflow);
         final Workflow workflowFromDB = workflowDAO.findById(workflowID);
         workflowFromDB.getUsers().add(user);


### PR DESCRIPTION
**Description**
This PR changes the webservice to more gracefully handles a collision of a notebook with another existing entry, and reports some information more accurately.  Specifically, it:
* modifies the method `checkForDuplicateAcrossTables` to check the specified path against all non-Service entries.
* improves lambda log messages to properly reference workflows with no name, and to use the correct verb when an existing workflow is processed ("updated") versus when a non-existent workflow is processed ("created").

This PR includes the webservice portion of https://ucsc-cgl.atlassian.net/browse/DOCK-2469.

**Review Instructions**
1. Push a new "nameless" notebook that has the same path as an existing notebook, and confirm that the push fails and the corresponding lambda event message explains the name collision in a sensical manner.
2. Push a valid update to an existing entry, and confirm that the corresponding lambda event message says that the event was "updated".

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2565
https://ucsc-cgl.atlassian.net/browse/DOCK-2469

**Security and Privacy**
No concerns.

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
