### PR TITLE
SEAB-6484: Improve "representative" version selection

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
@@ -232,10 +232,8 @@ class ExtendedTRSApiIT extends BaseIT {
         containersApi.publish(containerByToolPath.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
 
         String versionName = extendedGa4GhApi.getAITopicCandidate(trsId);
+        assertEquals("master", versionName);
         assertThrows(ApiException.class, () -> extendedGa4GhApi.getAITopicCandidate("messed up id that does not exist"));
-
-        Long latestDate = containerByToolPath.getWorkflowVersions().stream().filter(t -> t.getName().equals(versionName)).findFirst().get().getDbUpdateDate();
-        assertTrue(containerByToolPath.getWorkflowVersions().stream().allMatch(t -> t.getDbUpdateDate() <= latestDate));
 
         assertFalse(testingPostgres.runSelectStatement("select aitopicprocessed from tag where name = '" + versionName + "'", Boolean.class));
         // Non-admin user should not be able to submit AI topic

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -466,19 +466,16 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
     }
 
     static Optional<Version> determineRepresentativeVersion(Entry entry) {
-        Version defaultVersion = entry.getActualDefaultVersion();
-        if (defaultVersion != null) {
-            return Optional.of(defaultVersion);
-        }
-
-        Set<String> mainlineVersionNames = Set.of("master", "main", "develop");
-        Set<Version> versions = entry.getWorkflowVersions();
-        Stream<Version> mainlineVersions = versions.stream().filter(version -> mainlineVersionNames.contains(version.getName()));
-        Stream<Version> validVersions = versions.stream().filter(Version::isValid);
-        Stream<Version> allVersions = versions.stream();
-        return youngestVersion(mainlineVersions)
-            .or(() -> youngestVersion(validVersions))
-            .or(() -> youngestVersion(allVersions));
+        return Optional.ofNullable(entry.getActualDefaultVersion()).or(() -> {
+            Set<String> mainlineVersionNames = Set.of("master", "main", "develop");
+            Set<Version> versions = entry.getWorkflowVersions();
+            Stream<Version> mainlineVersions = versions.stream().filter(version -> mainlineVersionNames.contains(version.getName()));
+            Stream<Version> validVersions = versions.stream().filter(Version::isValid);
+            Stream<Version> allVersions = versions.stream();
+            return youngestVersion(mainlineVersions)
+                .or(() -> youngestVersion(validVersions))
+                .or(() -> youngestVersion(allVersions));
+        });
     }
 
     private static Optional<Version> youngestVersion(Stream<Version> versions) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -466,19 +466,21 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
     }
 
     static Optional<Version> determineRepresentativeVersion(Entry entry) {
-        return Optional.ofNullable(entry.getActualDefaultVersion()).or(() -> {
-            Set<String> mainlineVersionNames = Set.of("master", "main", "develop");
-            Set<Version> versions = entry.getWorkflowVersions();
-            Stream<Version> mainlineVersions = versions.stream().filter(version -> mainlineVersionNames.contains(version.getName()));
-            Stream<Version> validVersions = versions.stream().filter(Version::isValid);
-            Stream<Version> allVersions = versions.stream();
-            return youngestVersion(mainlineVersions)
-                .or(() -> youngestVersion(validVersions))
-                .or(() -> youngestVersion(allVersions));
-        });
+        return Optional.ofNullable(entry.getActualDefaultVersion())
+            .or(() -> determineRepresentativeVersion(entry.getWorkflowVersions()));
     }
 
-    private static Optional<Version> youngestVersion(Stream<Version> versions) {
+    static <V extends Version> Optional<V> determineRepresentativeVersion(Set<V> versions) {
+        Set<String> mainlineVersionNames = Set.of("master", "main", "develop");
+        Stream<V> mainlineVersions = versions.stream().filter(version -> mainlineVersionNames.contains(version.getName()));
+        Stream<V> validVersions = versions.stream().filter(Version::isValid);
+        Stream<V> allVersions = versions.stream();
+        return youngestVersion(mainlineVersions)
+            .or(() -> youngestVersion(validVersions))
+            .or(() -> youngestVersion(allVersions));
+    }
+
+    private static <V extends Version> Optional<V> youngestVersion(Stream<V> versions) {
         return versions.max(Comparator.comparing(Version::getId));
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -465,12 +465,22 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
 
     }
 
+    /**
+     * Determine which Version of the specified Entry is most representative of the Entry.
+     * The resulting Version is used to generate identifying information about the Entry
+     * (Search fields, AI topic, and perhaps other things)
+     */
     static Optional<Version> determineRepresentativeVersion(Entry entry) {
         return Optional.ofNullable(entry.getActualDefaultVersion())
             .or(() -> determineRepresentativeVersion(entry.getWorkflowVersions()));
     }
 
+    /**
+     * Determine which of the specified Versions, which should be of the same Entry,
+     * is most representative of the Entry.
+     */
     static <V extends Version> Optional<V> determineRepresentativeVersion(Set<V> versions) {
+        // Prefer "mainline" Versions over valid Versions over all Versions, with ties going to the most-recently-created Version.
         Set<String> mainlineVersionNames = Set.of("master", "main", "develop");
         Stream<V> mainlineVersions = versions.stream().filter(version -> mainlineVersionNames.contains(version.getName()));
         Stream<V> validVersions = versions.stream().filter(Version::isValid);
@@ -481,6 +491,7 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
     }
 
     private static <V extends Version> Optional<V> youngestVersion(Stream<V> versions) {
+        // Because we assign IDs sequentially, in increasing order, the Version with the highest ID was created most recently.
         return versions.max(Comparator.comparing(Version::getId));
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -465,24 +465,24 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
 
     }
 
-    default Optional<U> determineBestVersion(T entry) {
-        U defaultVersion = entry.getActualDefaultVersion();
+    static Optional<Version> determineRepresentativeVersion(Entry entry) {
+        Version defaultVersion = entry.getActualDefaultVersion();
         if (defaultVersion != null) {
             return Optional.of(defaultVersion);
         }
 
         Set<String> mainlineVersionNames = Set.of("master", "main", "develop");
-        Set<U> versions = entry.getWorkflowVersions();
-        Stream<U> mainlineVersions = versions.stream().filter(version -> mainlineVersionNames.contains(version.getName()));
-        Stream<U> validVersions = versions.stream().filter(U::isValid);
-        Stream<U> allVersions = versions.stream();
+        Set<Version> versions = entry.getWorkflowVersions();
+        Stream<Version> mainlineVersions = versions.stream().filter(version -> mainlineVersionNames.contains(version.getName()));
+        Stream<Version> validVersions = versions.stream().filter(Version::isValid);
+        Stream<Version> allVersions = versions.stream();
         return youngestVersion(mainlineVersions)
             .or(() -> youngestVersion(validVersions))
             .or(() -> youngestVersion(allVersions));
     }
 
-    default Optional<U> youngestVersion(Stream<U> versions) {
-        return versions.max(Comparator.comparing(U::getId));
+    private static Optional<Version> youngestVersion(Stream<Version> versions) {
+        return versions.max(Comparator.comparing(Version::getId));
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -34,6 +34,7 @@ import io.dockstore.webservice.core.User;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.helpers.ElasticSearchHelper;
+import io.dockstore.webservice.helpers.EntryVersionHelper;
 import io.dockstore.webservice.helpers.ORCIDHelper;
 import io.dockstore.webservice.helpers.StateManagerMode;
 import io.dropwizard.jackson.Jackson;
@@ -41,7 +42,6 @@ import io.openapi.model.DescriptorType;
 import io.swagger.api.impl.ToolsImplCommon;
 import java.io.IOException;
 import java.text.MessageFormat;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -390,28 +390,6 @@ public class ElasticListener implements StateListenerInterface {
         }
     }
 
-    /**
-     * Similar to logic in https://github.com/dockstore/dockstore-ui2/blob/2.10.0/src/app/shared/entry.ts#L171
-     * except it will return a default version even if there is no valid version.
-     * @param entry
-     * @return
-     */
-    private static Version defaultVersionWithFallback(Entry entry) {
-        if (entry.getActualDefaultVersion() != null) {
-            return entry.getActualDefaultVersion();
-        }
-        final Stream<Version> stream = versionStream(entry.getWorkflowVersions());
-        return stream.max(Comparator.comparing(Version::getId)).orElse(null);
-    }
-
-    private static Stream<Version> versionStream(Set<Version> versions) {
-        if (versions.stream().anyMatch(Version::isValid)) {
-            return versions.stream().filter(Version::isValid);
-        } else {
-            return versions.stream();
-        }
-    }
-
     private static Set<Version> detachVersions(final Set<Version> originalWorkflowVersions, final Version defaultVersion) {
         Set<Version> detachedVersions = new HashSet<>();
         originalWorkflowVersions.forEach(workflowVersion -> {
@@ -451,7 +429,7 @@ public class ElasticListener implements StateListenerInterface {
         entry.getStarredUsers().forEach(user -> detachedEntry.addStarredUser((User)user));
 
         // Add the detached versions
-        Version defaultVersion = defaultVersionWithFallback(entry);
+        Version defaultVersion = EntryVersionHelper.determineRepresentativeVersion(entry).orElse(null);
         Set<Version> detachedVersions = detachVersions(entry.getWorkflowVersions(), defaultVersion);
         detachedEntry.setWorkflowVersions(detachedVersions);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -42,6 +42,7 @@ import io.dockstore.webservice.core.WorkflowVersion;
 import io.dockstore.webservice.core.webhook.GitCommit;
 import io.dockstore.webservice.core.webhook.PushPayload;
 import io.dockstore.webservice.helpers.CheckUrlInterface;
+import io.dockstore.webservice.helpers.EntryVersionHelper;
 import io.dockstore.webservice.helpers.FileFormatHelper;
 import io.dockstore.webservice.helpers.GitHelper;
 import io.dockstore.webservice.helpers.GitHubHelper;
@@ -73,7 +74,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -379,10 +379,9 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                     // If the default version is going to be deleted, select a new default version
                     Version defaultVersion = workflow.getActualDefaultVersion();
                     if (defaultVersion != null && shouldDeleteVersion.test(defaultVersion)) {
-                        Optional<WorkflowVersion> max = workflow.getWorkflowVersions().stream()
-                            .filter(v -> !Objects.equals(v.getName(), gitReferenceName.get()))
-                            .max(Comparator.comparingLong(ver -> ver.getDate().getTime()));
-                        workflow.setActualDefaultVersion(max.orElse(null));
+                        Set<WorkflowVersion> remainingVersions = workflow.getWorkflowVersions().stream().filter(v -> !Objects.equals(v.getName(), gitReferenceName.get())).collect(Collectors.toSet());
+                        Optional<WorkflowVersion> newDefaultVersion = EntryVersionHelper.determineRepresentativeVersion(remainingVersions);
+                        workflow.setActualDefaultVersion(newDefaultVersion.orElse(null));
                     }
 
                     // Delete all matching versions

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/statelisteners/ElasticListenerTest.java
@@ -84,6 +84,7 @@ class ElasticListenerTest {
         initEntry(nextflowWorkflow);
         nextflowWorkflow.setDescriptorType(DescriptorLanguage.NEXTFLOW);
         nextflowVersion = new WorkflowVersion();
+        initVersion(nextflowVersion, FIRST_VERSION_NAME, FIRST_VERSION_ID, List.of());
         nextflowVersion.getVersionMetadata().setEngineVersions(List.of(NEXTFLOW_22_10_1));
         nextflowWorkflow.getWorkflowVersions().add(nextflowVersion);
 


### PR DESCRIPTION
**Description**
This PR changes the webservice so that the search code, the AI topic code, and the GitHub-event-based delete code all use the same method to determine the "representative"/default Version for a given Entry.  The new method, which we decided upon in this Slack thread https://ucsc-gi.slack.com/archives/C05EZH3RVNY/p1726596676751349, selects the representative version from one of the following options, best option first, most recently-created Version breaks ties:

1. Entry's default Version
2. Version with name of "master", "main", or "develop"
3. valid Version
4. any Version

The new, common implementation is in `EntryVersionHelper.determineRepresentativeVersion`.  For fun, I tried to make it as Optionally/Streamy as possible...

In https://ucsc-cgl.atlassian.net/browse/SEAB-5195, we changed the webservice to set a pushed version as the Entry's default version, when no default version is set and the pushed version name matches the GitHub default branch.    This will be deployed in 1.16.  After that, for `.dockstore.yml`-based entries, the overall default version coverage will improve over time.

**Review Instructions**
Still pondering the best way to user test this, will fill in later... 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6484

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
