### PR TITLE
SEAB-6508: Allow workflows with DOIs to be restubbed

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
@@ -34,7 +34,6 @@ import static io.dockstore.webservice.helpers.ZenodoHelper.NO_ZENODO_USER_TOKEN;
 import static io.dockstore.webservice.helpers.ZenodoHelper.PUBLISHED_ENTRY_REQUIRED;
 import static io.dockstore.webservice.helpers.ZenodoHelper.UNHIDDEN_VERSION_REQUIRED;
 import static io.dockstore.webservice.resources.WorkflowResource.A_WORKFLOW_MUST_BE_UNPUBLISHED_TO_RESTUB;
-import static io.dockstore.webservice.resources.WorkflowResource.A_WORKFLOW_MUST_HAVE_NO_DOI_TO_RESTUB;
 import static io.dockstore.webservice.resources.WorkflowResource.A_WORKFLOW_MUST_HAVE_NO_SNAPSHOT_TO_RESTUB;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
@@ -358,9 +358,9 @@ class ZenodoIT {
         // unpublish workflow
         workflowsApi.publish1(workflowBeforeFreezing.getId(), CommonTestUtilities.createOpenAPIPublishRequest(false));
 
-        // should not be able to restub workflow with DOI even if it is unpublished
-        exception = assertThrows(ApiException.class, () -> workflowsApi.restub(workflowId));
-        assertTrue(exception.getMessage().contains(A_WORKFLOW_MUST_HAVE_NO_DOI_TO_RESTUB));
+        // should be able to restub workflow with DOI
+        workflowsApi.restub(workflowId);
+        assertEquals(0, workflowsApi.getWorkflow(workflowId, null).getWorkflowVersions().size());
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
@@ -357,9 +357,8 @@ class ZenodoIT {
         // unpublish workflow
         workflowsApi.publish1(workflowBeforeFreezing.getId(), CommonTestUtilities.createOpenAPIPublishRequest(false));
 
-        // Should not be able to restub an unpublished workflow that has a frozen version
+        // Should not be able to restub an unpublished workflow that has a frozen version or a DOI, depending upon the environment
         exception = assertThrows(ApiException.class, () -> workflowsApi.restub(workflowId));
-        assertTrue(exception.getMessage().contains(A_WORKFLOW_MUST_HAVE_NO_SNAPSHOT_TO_RESTUB));
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
@@ -358,7 +358,7 @@ class ZenodoIT {
         // unpublish workflow
         workflowsApi.publish1(workflowBeforeFreezing.getId(), CommonTestUtilities.createOpenAPIPublishRequest(false));
 
-        // should be able to restub workflow with DOI
+        // should be able to restub unpublished workflow with DOI, so long as no versions are frozen
         workflowsApi.restub(workflowId);
         assertEquals(0, workflowsApi.getWorkflow(workflowId, null).getWorkflowVersions().size());
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
@@ -357,9 +357,9 @@ class ZenodoIT {
         // unpublish workflow
         workflowsApi.publish1(workflowBeforeFreezing.getId(), CommonTestUtilities.createOpenAPIPublishRequest(false));
 
-        // should be able to restub unpublished workflow with DOI, so long as no versions are frozen
-        workflowsApi.restub(workflowId);
-        assertEquals(0, workflowsApi.getWorkflow(workflowId, null).getWorkflowVersions().size());
+        // Should not be able to restub an unpublished workflow that has a frozen version
+        exception = assertThrows(ApiException.class, () -> workflowsApi.restub(workflowId));
+        assertTrue(exception.getMessage().contains(A_WORKFLOW_MUST_HAVE_NO_SNAPSHOT_TO_RESTUB));
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -188,7 +188,6 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     private static final String VERSION_INCLUDE_MESSAGE = "Comma-delimited list of fields to include: " + VERSION_INCLUDE;
     private static final String WORKFLOW_INCLUDE_MESSAGE = "Comma-delimited list of fields to include: " + WORKFLOW_INCLUDE;
     public static final String A_WORKFLOW_MUST_BE_UNPUBLISHED_TO_RESTUB = "A workflow must be unpublished to restub.";
-    public static final String A_WORKFLOW_MUST_HAVE_NO_DOI_TO_RESTUB = "A workflow must have no issued DOIs to restub";
     public static final String A_WORKFLOW_MUST_HAVE_NO_SNAPSHOT_TO_RESTUB = "A workflow must have no snapshots to restub, you may consider unpublishing";
     public static final String YOU_CANNOT_CHANGE_THE_DESCRIPTOR_TYPE_OF_A_FULL_OR_HOSTED_WORKFLOW = "You cannot change the descriptor type of a FULL or HOSTED workflow.";
     public static final String YOUR_USER_DOES_NOT_HAVE_ACCESS_TO_THIS_ORGANIZATION = "Your user does not have access to this organization.";

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -188,6 +188,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     private static final String VERSION_INCLUDE_MESSAGE = "Comma-delimited list of fields to include: " + VERSION_INCLUDE;
     private static final String WORKFLOW_INCLUDE_MESSAGE = "Comma-delimited list of fields to include: " + WORKFLOW_INCLUDE;
     public static final String A_WORKFLOW_MUST_BE_UNPUBLISHED_TO_RESTUB = "A workflow must be unpublished to restub.";
+    public static final String A_WORKFLOW_MUST_HAVE_NO_DOI_TO_RESTUB = "A workflow must have no issued DOIs to restub";
     public static final String A_WORKFLOW_MUST_HAVE_NO_SNAPSHOT_TO_RESTUB = "A workflow must have no snapshots to restub, you may consider unpublishing";
     public static final String YOU_CANNOT_CHANGE_THE_DESCRIPTOR_TYPE_OF_A_FULL_OR_HOSTED_WORKFLOW = "You cannot change the descriptor type of a FULL or HOSTED workflow.";
     public static final String YOUR_USER_DOES_NOT_HAVE_ACCESS_TO_THIS_ORGANIZATION = "Your user does not have access to this organization.";

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -201,6 +201,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
     private final PermissionsInterface permissionsInterface;
     private final String dashboardPrefix;
+    private final boolean isProduction;
 
     public WorkflowResource(HttpClient client, SessionFactory sessionFactory, PermissionsInterface permissionsInterface,
         EntryResource entryResource, DockstoreWebserviceConfiguration configuration) {
@@ -214,6 +215,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
         this.permissionsInterface = permissionsInterface;
         dashboardPrefix = configuration.getDashboard();
+        isProduction = configuration.getExternalConfig().computeIsProduction();
     }
 
     /**
@@ -240,6 +242,9 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         }
         if (workflow.isIsChecker()) {
             throw new CustomWebApplicationException("A checker workflow cannot be restubed.", HttpStatus.SC_BAD_REQUEST);
+        }
+        if (!workflow.getConceptDois().isEmpty() && isProduction) {
+            throw new CustomWebApplicationException(A_WORKFLOW_MUST_HAVE_NO_DOI_TO_RESTUB, HttpStatus.SC_BAD_REQUEST);
         }
         if (versionDAO.getVersionsFrozen(workflowId) > 0) {
             throw new CustomWebApplicationException(A_WORKFLOW_MUST_HAVE_NO_SNAPSHOT_TO_RESTUB, HttpStatus.SC_BAD_REQUEST);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -242,9 +242,6 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         if (workflow.isIsChecker()) {
             throw new CustomWebApplicationException("A checker workflow cannot be restubed.", HttpStatus.SC_BAD_REQUEST);
         }
-        if (!workflow.getConceptDois().isEmpty()) {
-            throw new CustomWebApplicationException(A_WORKFLOW_MUST_HAVE_NO_DOI_TO_RESTUB, HttpStatus.SC_BAD_REQUEST);
-        }
         if (versionDAO.getVersionsFrozen(workflowId) > 0) {
             throw new CustomWebApplicationException(A_WORKFLOW_MUST_HAVE_NO_SNAPSHOT_TO_RESTUB, HttpStatus.SC_BAD_REQUEST);
         }


### PR DESCRIPTION
**Description**
Per Slack threads https://ucsc-gi.slack.com/archives/C05EZH3RVNY/p1727218276099849 and https://ucsc-gi.slack.com/archives/C05EZH3RVNY/p1727221659689669, this PR changes the webservice to allow unpublished workflows with DOIs to be restubbed, allowing us to restub previously-published workflows that now have auto-generated DOIs, so that our smoke tests can do better testing.

**Review Instructions**
Manually register a workflow with a tag on qa, publish it, confirm the tagged version gets a DOI, unpublish it, and confirm that you can restub successfully.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6508

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
