### PR TITLE
DOCK-2573: Fix 500 related to AI topic + frozen version

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
@@ -176,7 +176,7 @@ class ExtendedTRSApiIT extends BaseIT {
             WorkflowVersion::getLastModified).collect(
             Collectors.toSet()));
 
-        assertFalse(testingPostgres.runSelectStatement("select aitopicprocessed from workflowversion where name = '" + versionName + "' and parentid = " + workflow.getId(), Boolean.class));
+        assertFalse(testingPostgres.runSelectStatement("select aitopicprocessed from version_metadata join workflowversion on workflowversion.name = '" + versionName + "' and workflowversion.parentid = " + workflow.getId() + " and workflowversion.id = version_metadata.id", Boolean.class));
         // Non-admin user should not be able to submit AI topic
         exception = assertThrows(ApiException.class, () -> otherExtendedGa4GhApi.updateAITopic(updateAITopicRequest, versionName, trsId));
         assertEquals(HttpStatus.SC_FORBIDDEN, exception.getCode());
@@ -246,6 +246,6 @@ class ExtendedTRSApiIT extends BaseIT {
         containerByToolPath = containersApi.getContainerByToolPath(trsId, null);
         assertEquals(DockstoreTool.TopicSelectionEnum.AI, containerByToolPath.getTopicSelection());
         assertEquals(aiTopic, containerByToolPath.getTopicAI());
-        assertTrue(testingPostgres.runSelectStatement("select aitopicprocessed from tag where name = '" + versionName + "' and parentid = " + containerByToolPath.getId(), Boolean.class));
+        assertTrue(testingPostgres.runSelectStatement("select aitopicprocessed from version_metadata join tag on where tag.name = '" + versionName + "' and tag.parentid = " + containerByToolPath.getId() + " and tag.id = version_metadata.id", Boolean.class));
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
@@ -246,6 +246,6 @@ class ExtendedTRSApiIT extends BaseIT {
         containerByToolPath = containersApi.getContainerByToolPath(trsId, null);
         assertEquals(DockstoreTool.TopicSelectionEnum.AI, containerByToolPath.getTopicSelection());
         assertEquals(aiTopic, containerByToolPath.getTopicAI());
-        assertTrue(testingPostgres.runSelectStatement("select aitopicprocessed from version_metadata join tag on where tag.name = '" + versionName + "' and tag.parentid = " + containerByToolPath.getId() + " and tag.id = version_metadata.id", Boolean.class));
+        assertTrue(testingPostgres.runSelectStatement("select aitopicprocessed from version_metadata join tag on tag.name = '" + versionName + "' and tag.parentid = " + containerByToolPath.getId() + " and tag.id = version_metadata.id", Boolean.class));
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
@@ -184,7 +184,7 @@ class ExtendedTRSApiIT extends BaseIT {
         // Admin should be able to submit AI topic for published workflow
         assertThrows(ApiException.class, () -> extendedGa4GhApi.updateAITopic(updateAITopicRequest, "messed up version that does not exist", trsId));
         extendedGa4GhApi.updateAITopic(updateAITopicRequest, versionName, trsId);
-        assertTrue(testingPostgres.runSelectStatement("select aitopicprocessed from workflowversion where name = '" + versionName + "' and parentid = " + workflow.getId(), Boolean.class));
+        assertTrue(testingPostgres.runSelectStatement("select aitopicprocessed from version_metadata join workflowversion on workflowversion.name = '" + versionName + "' and workflowversion.parentid = " + workflow.getId() + " and workflowversion.id = version_metadata.id", Boolean.class));
         workflow = workflowsApi.getWorkflow(workflow.getId(), null);
         assertEquals(aiTopic, workflow.getTopicAI());
         assertEquals(TopicSelectionEnum.AUTOMATIC, workflow.getTopicSelection()); // Topic selection is unchanged because an automatic topic exists
@@ -235,7 +235,7 @@ class ExtendedTRSApiIT extends BaseIT {
         assertEquals("master", versionName);
         assertThrows(ApiException.class, () -> extendedGa4GhApi.getAITopicCandidate("messed up id that does not exist"));
 
-        assertFalse(testingPostgres.runSelectStatement("select aitopicprocessed from tag where name = '" + versionName + "'", Boolean.class));
+        assertFalse(testingPostgres.runSelectStatement("select aitopicprocessed from version_metadata join tag on tag.name = '" + versionName + "' and tag.id = version_metadata.id", Boolean.class));
         // Non-admin user should not be able to submit AI topic
         ApiException apiException = assertThrows(ApiException.class, () -> otherExtendedGa4GhApi.updateAITopic(updateAITopicRequest, versionName, trsId));
         assertEquals(HttpStatus.SC_FORBIDDEN, apiException.getCode());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Version.java
@@ -168,10 +168,6 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     @ApiModelProperty(value = "True if user has altered the tag", position = 8)
     private boolean dirtyBit = false;
 
-    @Column(columnDefinition = "boolean default false")
-    @Schema(description = "True if Dockstore has processed this version for an AI topic")
-    private boolean aiTopicProcessed = false;
-
     // Warning: this is eagerly loaded because of two reasons:
     // the 4 @ApiModelProperty that uses version metadata
     // This OneToOne
@@ -690,11 +686,11 @@ public abstract class Version<T extends Version> implements Comparable<T> {
     }
 
     public boolean isAiTopicProcessed() {
-        return aiTopicProcessed;
+        return getVersionMetadata().isAiTopicProcessed();
     }
 
     public void setAiTopicProcessed(boolean aiTopicProcessed) {
-        this.aiTopicProcessed = aiTopicProcessed;
+        getVersionMetadata().setAiTopicProcessed(aiTopicProcessed);
     }
 
     public enum DOIStatus { NOT_REQUESTED, REQUESTED, CREATED

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
@@ -165,6 +165,10 @@ public class VersionMetadata {
     @Schema(description = "The timestamp of the last metrics aggregation", type = "integer", format = "int64")
     private Timestamp latestMetricsAggregationDate;
 
+    @Column(columnDefinition = "boolean default false")
+    @Schema(description = "True if Dockstore has processed this version for an AI topic")
+    private boolean aiTopicProcessed = false;
+
     public long getId() {
         return id;
     }
@@ -245,5 +249,13 @@ public class VersionMetadata {
 
     public void setLatestMetricsAggregationDate(Timestamp latestMetricsAggregationDate) {
         this.latestMetricsAggregationDate = latestMetricsAggregationDate;
+    }
+
+    public boolean isAiTopicProcessed() {
+        return aiTopicProcessed;
+    }
+
+    public void setAiTopicProcessed(boolean aiTopicProcessed) {
+        this.aiTopicProcessed = aiTopicProcessed;
     }
 }

--- a/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
@@ -424,7 +424,7 @@
         </addColumn>
     </changeSet>
     <changeSet author="dyuen (generated)" id="move_aitopicprocessed_to_versionmetadata">
-        <addColumn tableName="versionmetadata">
+        <addColumn tableName="version_metadata">
             <column defaultValueBoolean="false" name="aitopicprocessed" type="bool"/>
         </addColumn>
         <dropColumn tableName="tag" columnName="aitopicprocessed">

--- a/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.16.0.xml
@@ -423,4 +423,13 @@
             </column>
         </addColumn>
     </changeSet>
+    <changeSet author="dyuen (generated)" id="move_aitopicprocessed_to_versionmetadata">
+        <addColumn tableName="versionmetadata">
+            <column defaultValueBoolean="false" name="aitopicprocessed" type="bool"/>
+        </addColumn>
+        <dropColumn tableName="tag" columnName="aitopicprocessed">
+        </dropColumn>
+        <dropColumn tableName="workflowversion" columnName="aitopicprocessed">
+        </dropColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -11129,7 +11129,6 @@ components:
       properties:
         aiTopicProcessed:
           type: boolean
-          description: True if Dockstore has processed this version for an AI topic
         author:
           type: string
         authors:
@@ -12056,7 +12055,6 @@ components:
       properties:
         aiTopicProcessed:
           type: boolean
-          description: True if Dockstore has processed this version for an AI topic
         author:
           type: string
         authors:
@@ -12185,6 +12183,9 @@ components:
     VersionMetadata:
       type: object
       properties:
+        aiTopicProcessed:
+          type: boolean
+          description: True if Dockstore has processed this version for an AI topic
         descriptorTypeVersions:
           type: array
           items:
@@ -12512,7 +12513,6 @@ components:
       properties:
         aiTopicProcessed:
           type: boolean
-          description: True if Dockstore has processed this version for an AI topic
         aliases:
           type: object
           additionalProperties:


### PR DESCRIPTION
**Description**
As described in the ticket, currently, when an AI topic is generated, the webservice attempts to set the `aitopicprocessed` field in the corresponding version.  If the version is frozen, the version's db row cannot be updated, and the webservice responds with a 500.

This PR moves the `aitopicprocessed` field from `Version` to `VersionMetadata`, so it can always be set, even if the corresponding version is frozen.
   
**Review Instructions**
Freeze the default version of a workflow, then issue a similar API request to that detailed in the ticket (which uses the version to generate the AI topic).  Confirm that the webservice responds correctly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2573
#5986

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
