### PR TITLE
Change java distribution to temurin in Regular Dockstore build GitHub Action

### DIFF
--- a/.github/workflows/mvnw.yml
+++ b/.github/workflows/mvnw.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - if: "!contains(github.ref, 'dependabot')"
         name: Initialize CodeQL


### PR DESCRIPTION
**Description**
The `setup-java` step was failing with `Error: Could not find satisfied version for SemVer '21.0.2+13.0.LTS'. ` (see [run](https://github.com/dockstore/dockstore/actions/runs/11279009306/job/31368798630)). I updated the distribution from `adopt` to `temurin` and it works. We also use `temurin` in dockstore-deploy and dockstore-cli. See the passed run [here](https://github.com/dockstore/dockstore/actions/runs/11279577057).

**Review Instructions**
[Regular Dockstore build](https://github.com/dockstore/dockstore/actions/workflows/mvnw.yml) GitHub Action should pass.

**Issue**
n/a

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
