### PR TITLE
DOCK-2589: Fix content type of TRS zip response

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
@@ -163,7 +163,7 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
             "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + refresh.getFullWorkflowPath(), StandardCharsets.UTF_8) + "/versions/" + URLEncoder.encode(GATK_SV_TAG, StandardCharsets.UTF_8)
                 + "/" + DescriptorTypeWithPlain.WDL
                 + "/files?format=zip", new GenericType<>() {
-                }, ownerWebClient);
+                }, ownerWebClient, "application/zip");
         checkOnZipFile(arbitraryURL, DescriptorLanguage.WDL);
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
@@ -162,8 +162,8 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
         byte[] arbitraryURL = CommonTestUtilities.invokeAPI(
             "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + refresh.getFullWorkflowPath(), StandardCharsets.UTF_8) + "/versions/" + URLEncoder.encode(GATK_SV_TAG, StandardCharsets.UTF_8)
                 + "/" + DescriptorTypeWithPlain.WDL
-                + "/files?format=zip", new GenericType<>() {
-                }, ownerWebClient, "application/zip");
+                + "/files?format=zip", new GenericType<byte[]>() {
+                }, ownerWebClient, "application/zip").getData();
         checkOnZipFile(arbitraryURL, DescriptorLanguage.WDL);
     }
 
@@ -514,24 +514,24 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
         byte[] arbitraryURL = CommonTestUtilities.invokeAPI(
             "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
                 + "/" + DescriptorTypeWithPlain.CWL
-                + "/files?format=zip", new GenericType<>() {
-                }, webClient, MediaType.MEDIA_TYPE_WILDCARD);
+                + "/files?format=zip", new GenericType<byte[]>() {
+                }, webClient, MediaType.MEDIA_TYPE_WILDCARD).getData();
         checkOnZipFile(arbitraryURL, DescriptorLanguage.CWL);
 
         // even more wildcard, should get zip
         arbitraryURL = CommonTestUtilities.invokeAPI(
             "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
                 + "/" + DescriptorTypeWithPlain.CWL
-                + "/files?format=zip", new GenericType<>() {
-                }, webClient, MediaType.WILDCARD);
+                + "/files?format=zip", new GenericType<byte[]>() {
+                }, webClient, MediaType.WILDCARD).getData();
         checkOnZipFile(arbitraryURL, DescriptorLanguage.CWL);
 
         // json header with zip format, should get error
         arbitraryURL = CommonTestUtilities.invokeAPI(
             "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
                 + "/" + DescriptorTypeWithPlain.CWL
-                + "/files?format=zip", new GenericType<>() {
-                }, webClient, MediaType.WILDCARD);
+                + "/files?format=zip", new GenericType<byte[]>() {
+                }, webClient, MediaType.WILDCARD).getData();
         checkOnZipFile(arbitraryURL, DescriptorLanguage.CWL);
 
 
@@ -539,16 +539,16 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
         arbitraryURL = CommonTestUtilities.invokeAPI(
             "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
                 + "/" + DescriptorTypeWithPlain.CWL
-                + "/files", new GenericType<>() {
-                }, webClient, MediaType.MEDIA_TYPE_WILDCARD);
+                + "/files", new GenericType<byte[]>() {
+                }, webClient, MediaType.MEDIA_TYPE_WILDCARD).getData();
         checkOnJsonFile(arbitraryURL);
 
         // no parameter with even more wildcard, should get json
         arbitraryURL = CommonTestUtilities.invokeAPI(
             "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
                 + "/" + DescriptorTypeWithPlain.CWL
-                + "/files", new GenericType<>() {
-                }, webClient, MediaType.WILDCARD);
+                + "/files", new GenericType<byte[]>() {
+                }, webClient, MediaType.WILDCARD).getData();
         checkOnJsonFile(arbitraryURL);
 
         // test combination of zip only with json return (should fail)
@@ -556,8 +556,8 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
             CommonTestUtilities.invokeAPI(
                 "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
                     + "/" + DescriptorTypeWithPlain.CWL
-                    + "/files?format=zip", new GenericType<>() {
-                    }, webClient, MediaType.APPLICATION_JSON);
+                    + "/files?format=zip", new GenericType<byte[]>() {
+                    }, webClient, MediaType.APPLICATION_JSON).getData();
             fail("should have died with bad request");
         } catch (ApiException e) {
             assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
@@ -41,6 +41,7 @@ import io.openapi.api.impl.ToolsApiServiceImpl;
 import io.openapi.model.DescriptorTypeWithPlain;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
+import io.swagger.client.ApiResponse;
 import io.swagger.client.api.ContainersApi;
 import io.swagger.client.api.EntriesApi;
 import io.swagger.client.api.Ga4GhApi;
@@ -514,24 +515,24 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
         GenericType<byte[]> byteArrayType = new GenericType<>() {};
 
         // zip parameter with wildcard media type, should get zip
-        byte[] arbitraryURL = CommonTestUtilities.invokeAPI(trsPath + "?format=zip", byteArrayType, webClient, MediaType.MEDIA_TYPE_WILDCARD).getData();
-        checkOnZipFile(arbitraryURL, DescriptorLanguage.CWL);
+        ApiResponse<byte[]> response = CommonTestUtilities.invokeAPI(trsPath + "?format=zip", byteArrayType, webClient, MediaType.MEDIA_TYPE_WILDCARD);
+        checkOnZipFile(response.getData(), DescriptorLanguage.CWL);
 
         // zip parameter with even more wildcard media type, should get zip
-        arbitraryURL = CommonTestUtilities.invokeAPI(trsPath + "?format=zip", byteArrayType, webClient, MediaType.WILDCARD).getData();
-        checkOnZipFile(arbitraryURL, DescriptorLanguage.CWL);
+        response = CommonTestUtilities.invokeAPI(trsPath + "?format=zip", byteArrayType, webClient, MediaType.WILDCARD);
+        checkOnZipFile(response.getData(), DescriptorLanguage.CWL);
 
         // no parameter with wildcard media type, should get json
-        arbitraryURL = CommonTestUtilities.invokeAPI(trsPath, byteArrayType, webClient, MediaType.MEDIA_TYPE_WILDCARD).getData();
-        checkOnJsonFile(arbitraryURL);
+        response = CommonTestUtilities.invokeAPI(trsPath, byteArrayType, webClient, MediaType.MEDIA_TYPE_WILDCARD);
+        checkOnJsonFile(response.getData());
 
         // no parameter with even more wildcard media type, should get json
-        arbitraryURL = CommonTestUtilities.invokeAPI(trsPath, byteArrayType, webClient, MediaType.WILDCARD).getData();
-        checkOnJsonFile(arbitraryURL);
+        response = CommonTestUtilities.invokeAPI(trsPath, byteArrayType, webClient, MediaType.WILDCARD);
+        checkOnJsonFile(response.getData());
 
         // zip parameter with json media type (should fail)
         try {
-            CommonTestUtilities.invokeAPI(trsPath + "?format=zip", byteArrayType, webClient, MediaType.APPLICATION_JSON).getData();
+            CommonTestUtilities.invokeAPI(trsPath + "?format=zip", byteArrayType, webClient, MediaType.APPLICATION_JSON);
             fail("should have died with bad request");
         } catch (ApiException e) {
             assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
@@ -169,7 +169,7 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
     }
 
     private static void checkOnJsonFile(ApiResponse<byte[]> response) {
-        assertEquals("application/json", CommonTestUtilities.getContentType(response));
+        assertTrue(CommonTestUtilities.getContentType(response).startsWith("application/json"));
         String json = new String(response.getData());
         try {
             new JSONObject(json);
@@ -183,7 +183,7 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
     }
 
     private static void checkOnZipFile(ApiResponse<byte[]> response, DescriptorLanguage language) throws IOException {
-        assertEquals("application/zip", CommonTestUtilities.getContentType(response));
+        assertTrue(CommonTestUtilities.getContentType(response).startsWith("application/zip"));
         File tempZip = File.createTempFile("temp", "zip");
         Path write = Files.write(tempZip.toPath(), response.getData());
         try (ZipFile zipFile = new ZipFile(write.toFile())) {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
@@ -169,6 +169,7 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
     }
 
     private static void checkOnJsonFile(ApiResponse<byte[]> response) {
+        assertEquals("application/json", CommonTestUtilities.getContentType(response));
         String json = new String(response.getData());
         try {
             new JSONObject(json);
@@ -182,6 +183,7 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
     }
 
     private static void checkOnZipFile(ApiResponse<byte[]> response, DescriptorLanguage language) throws IOException {
+        assertEquals("application/zip", CommonTestUtilities.getContentType(response));
         File tempZip = File.createTempFile("temp", "zip");
         Path write = Files.write(tempZip.toPath(), response.getData());
         try (ZipFile zipFile = new ZipFile(write.toFile())) {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
@@ -159,7 +159,7 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
         Ga4Ghv20Api ga4Ghv20Api = new Ga4Ghv20Api(getOpenAPIWebClient(USER_2_USERNAME, testingPostgres));
         final List<io.dockstore.openapi.client.model.ToolFile> toolFiles = ga4Ghv20Api.toolsIdVersionsVersionIdTypeFilesGet("#workflow/" + refresh.getFullWorkflowPath(),
             DescriptorTypeWithPlain.WDL.toString(), GATK_SV_TAG, null);
-        byte[] arbitraryURL = CommonTestUtilities.getArbitraryURL(
+        byte[] arbitraryURL = CommonTestUtilities.invokeAPI(
             "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + refresh.getFullWorkflowPath(), StandardCharsets.UTF_8) + "/versions/" + URLEncoder.encode(GATK_SV_TAG, StandardCharsets.UTF_8)
                 + "/" + DescriptorTypeWithPlain.WDL
                 + "/files?format=zip", new GenericType<>() {
@@ -511,7 +511,7 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
         workflowApi.refresh(workflowByPathGithub.getId(), false);
 
         // test parameter with wildcard header, should get zip
-        byte[] arbitraryURL = CommonTestUtilities.getArbitraryURL(
+        byte[] arbitraryURL = CommonTestUtilities.invokeAPI(
             "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
                 + "/" + DescriptorTypeWithPlain.CWL
                 + "/files?format=zip", new GenericType<>() {
@@ -519,7 +519,7 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
         checkOnZipFile(arbitraryURL, DescriptorLanguage.CWL);
 
         // even more wildcard, should get zip
-        arbitraryURL = CommonTestUtilities.getArbitraryURL(
+        arbitraryURL = CommonTestUtilities.invokeAPI(
             "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
                 + "/" + DescriptorTypeWithPlain.CWL
                 + "/files?format=zip", new GenericType<>() {
@@ -527,7 +527,7 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
         checkOnZipFile(arbitraryURL, DescriptorLanguage.CWL);
 
         // json header with zip format, should get error
-        arbitraryURL = CommonTestUtilities.getArbitraryURL(
+        arbitraryURL = CommonTestUtilities.invokeAPI(
             "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
                 + "/" + DescriptorTypeWithPlain.CWL
                 + "/files?format=zip", new GenericType<>() {
@@ -536,7 +536,7 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
 
 
         // test no parameter with wildcard header, should get json
-        arbitraryURL = CommonTestUtilities.getArbitraryURL(
+        arbitraryURL = CommonTestUtilities.invokeAPI(
             "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
                 + "/" + DescriptorTypeWithPlain.CWL
                 + "/files", new GenericType<>() {
@@ -544,7 +544,7 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
         checkOnJsonFile(arbitraryURL);
 
         // no parameter with even more wildcard, should get json
-        arbitraryURL = CommonTestUtilities.getArbitraryURL(
+        arbitraryURL = CommonTestUtilities.invokeAPI(
             "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
                 + "/" + DescriptorTypeWithPlain.CWL
                 + "/files", new GenericType<>() {
@@ -553,7 +553,7 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
 
         // test combination of zip only with json return (should fail)
         try {
-            CommonTestUtilities.getArbitraryURL(
+            CommonTestUtilities.invokeAPI(
                 "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
                     + "/" + DescriptorTypeWithPlain.CWL
                     + "/files?format=zip", new GenericType<>() {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
@@ -510,54 +510,28 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
 
         workflowApi.refresh(workflowByPathGithub.getId(), false);
 
-        // test parameter with wildcard header, should get zip
-        byte[] arbitraryURL = CommonTestUtilities.invokeAPI(
-            "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
-                + "/" + DescriptorTypeWithPlain.CWL
-                + "/files?format=zip", new GenericType<byte[]>() {
-                }, webClient, MediaType.MEDIA_TYPE_WILDCARD).getData();
+        String trsPath = "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master" + "/" + DescriptorTypeWithPlain.CWL + "/files";
+        GenericType<byte[]> byteArrayType = new GenericType<>() {};
+
+        // zip parameter with wildcard media type, should get zip
+        byte[] arbitraryURL = CommonTestUtilities.invokeAPI(trsPath + "?format=zip", byteArrayType, webClient, MediaType.MEDIA_TYPE_WILDCARD).getData();
         checkOnZipFile(arbitraryURL, DescriptorLanguage.CWL);
 
-        // even more wildcard, should get zip
-        arbitraryURL = CommonTestUtilities.invokeAPI(
-            "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
-                + "/" + DescriptorTypeWithPlain.CWL
-                + "/files?format=zip", new GenericType<byte[]>() {
-                }, webClient, MediaType.WILDCARD).getData();
+        // zip parameter with even more wildcard media type, should get zip
+        arbitraryURL = CommonTestUtilities.invokeAPI(trsPath + "?format=zip", byteArrayType, webClient, MediaType.WILDCARD).getData();
         checkOnZipFile(arbitraryURL, DescriptorLanguage.CWL);
 
-        // json header with zip format, should get error
-        arbitraryURL = CommonTestUtilities.invokeAPI(
-            "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
-                + "/" + DescriptorTypeWithPlain.CWL
-                + "/files?format=zip", new GenericType<byte[]>() {
-                }, webClient, MediaType.WILDCARD).getData();
-        checkOnZipFile(arbitraryURL, DescriptorLanguage.CWL);
-
-
-        // test no parameter with wildcard header, should get json
-        arbitraryURL = CommonTestUtilities.invokeAPI(
-            "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
-                + "/" + DescriptorTypeWithPlain.CWL
-                + "/files", new GenericType<byte[]>() {
-                }, webClient, MediaType.MEDIA_TYPE_WILDCARD).getData();
+        // no parameter with wildcard media type, should get json
+        arbitraryURL = CommonTestUtilities.invokeAPI(trsPath, byteArrayType, webClient, MediaType.MEDIA_TYPE_WILDCARD).getData();
         checkOnJsonFile(arbitraryURL);
 
-        // no parameter with even more wildcard, should get json
-        arbitraryURL = CommonTestUtilities.invokeAPI(
-            "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
-                + "/" + DescriptorTypeWithPlain.CWL
-                + "/files", new GenericType<byte[]>() {
-                }, webClient, MediaType.WILDCARD).getData();
+        // no parameter with even more wildcard media type, should get json
+        arbitraryURL = CommonTestUtilities.invokeAPI(trsPath, byteArrayType, webClient, MediaType.WILDCARD).getData();
         checkOnJsonFile(arbitraryURL);
 
-        // test combination of zip only with json return (should fail)
+        // zip parameter with json media type (should fail)
         try {
-            CommonTestUtilities.invokeAPI(
-                "/ga4gh/trs/v2/tools/" + URLEncoder.encode("#workflow/" + DOCKSTORE_TEST_USER2_RELATIVE_IMPORTS_WORKFLOW, StandardCharsets.UTF_8) + "/versions/master"
-                    + "/" + DescriptorTypeWithPlain.CWL
-                    + "/files?format=zip", new GenericType<byte[]>() {
-                    }, webClient, MediaType.APPLICATION_JSON).getData();
+            CommonTestUtilities.invokeAPI(trsPath + "?format=zip", byteArrayType, webClient, MediaType.APPLICATION_JSON).getData();
             fail("should have died with bad request");
         } catch (ApiException e) {
             assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -429,7 +429,7 @@ public class WorkflowIT extends BaseIT {
 
         // Download unpublished workflow version
         workflowApi.getWorkflowZip(workflowId, versionId);
-        byte[] arbitraryURL = CommonTestUtilities.getArbitraryURL("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
+        byte[] arbitraryURL = CommonTestUtilities.invokeAPI("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
         }, webClient, "application/zip");
         File tempZip = File.createTempFile("temp", "zip");
         Path write = Files.write(tempZip.toPath(), arbitraryURL);
@@ -439,7 +439,7 @@ public class WorkflowIT extends BaseIT {
         // should not be able to get zip anonymously before publication
         boolean thrownException = false;
         try {
-            CommonTestUtilities.getArbitraryURL("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
+            CommonTestUtilities.invokeAPI("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
             }, CommonTestUtilities.getWebClient(false, null, testingPostgres), "application/zip");
         } catch (Exception e) {
             thrownException = true;
@@ -449,7 +449,7 @@ public class WorkflowIT extends BaseIT {
 
         // Download published workflow version
         workflowApi.publish(workflowId, CommonTestUtilities.createPublishRequest(true));
-        arbitraryURL = CommonTestUtilities.getArbitraryURL("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
+        arbitraryURL = CommonTestUtilities.invokeAPI("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
         }, CommonTestUtilities.getWebClient(false, null, testingPostgres), "application/zip");
         File tempZip2 = File.createTempFile("temp", "zip");
         write = Files.write(tempZip2.toPath(), arbitraryURL);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -430,7 +430,7 @@ public class WorkflowIT extends BaseIT {
         // Download unpublished workflow version
         workflowApi.getWorkflowZip(workflowId, versionId);
         byte[] arbitraryURL = CommonTestUtilities.invokeAPI("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
-        }, webClient, "application/zip");
+        }, webClient, "application/zip").getData();
         File tempZip = File.createTempFile("temp", "zip");
         Path write = Files.write(tempZip.toPath(), arbitraryURL);
         ZipFile zipFile = new ZipFile(write.toFile());
@@ -450,7 +450,7 @@ public class WorkflowIT extends BaseIT {
         // Download published workflow version
         workflowApi.publish(workflowId, CommonTestUtilities.createPublishRequest(true));
         arbitraryURL = CommonTestUtilities.invokeAPI("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
-        }, CommonTestUtilities.getWebClient(false, null, testingPostgres), "application/zip");
+        }, CommonTestUtilities.getWebClient(false, null, testingPostgres), "application/zip").getData();
         File tempZip2 = File.createTempFile("temp", "zip");
         write = Files.write(tempZip2.toPath(), arbitraryURL);
         zipFile = new ZipFile(write.toFile());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -430,7 +430,7 @@ public class WorkflowIT extends BaseIT {
         // Download unpublished workflow version
         workflowApi.getWorkflowZip(workflowId, versionId);
         byte[] arbitraryURL = CommonTestUtilities.getArbitraryURL("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
-        }, webClient);
+        }, webClient, "application/zip");
         File tempZip = File.createTempFile("temp", "zip");
         Path write = Files.write(tempZip.toPath(), arbitraryURL);
         ZipFile zipFile = new ZipFile(write.toFile());
@@ -440,7 +440,7 @@ public class WorkflowIT extends BaseIT {
         boolean thrownException = false;
         try {
             CommonTestUtilities.getArbitraryURL("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
-            }, CommonTestUtilities.getWebClient(false, null, testingPostgres));
+            }, CommonTestUtilities.getWebClient(false, null, testingPostgres), "application/zip");
         } catch (Exception e) {
             thrownException = true;
         }
@@ -450,7 +450,7 @@ public class WorkflowIT extends BaseIT {
         // Download published workflow version
         workflowApi.publish(workflowId, CommonTestUtilities.createPublishRequest(true));
         arbitraryURL = CommonTestUtilities.getArbitraryURL("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
-        }, CommonTestUtilities.getWebClient(false, null, testingPostgres));
+        }, CommonTestUtilities.getWebClient(false, null, testingPostgres), "application/zip");
         File tempZip2 = File.createTempFile("temp", "zip");
         write = Files.write(tempZip2.toPath(), arbitraryURL);
         zipFile = new ZipFile(write.toFile());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/WorkflowIT.java
@@ -429,10 +429,10 @@ public class WorkflowIT extends BaseIT {
 
         // Download unpublished workflow version
         workflowApi.getWorkflowZip(workflowId, versionId);
-        byte[] arbitraryURL = CommonTestUtilities.invokeAPI("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
+        byte[] responseBody = CommonTestUtilities.invokeAPI("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
         }, webClient, "application/zip").getData();
         File tempZip = File.createTempFile("temp", "zip");
-        Path write = Files.write(tempZip.toPath(), arbitraryURL);
+        Path write = Files.write(tempZip.toPath(), responseBody);
         ZipFile zipFile = new ZipFile(write.toFile());
         assertTrue(zipFile.stream().map(ZipEntry::getName).toList().contains("md5sum/md5sum-workflow.cwl"), "zip file seems incorrect");
 
@@ -449,10 +449,10 @@ public class WorkflowIT extends BaseIT {
 
         // Download published workflow version
         workflowApi.publish(workflowId, CommonTestUtilities.createPublishRequest(true));
-        arbitraryURL = CommonTestUtilities.invokeAPI("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
+        responseBody = CommonTestUtilities.invokeAPI("/workflows/" + workflowId + "/zip/" + versionId, new GenericType<byte[]>() {
         }, CommonTestUtilities.getWebClient(false, null, testingPostgres), "application/zip").getData();
         File tempZip2 = File.createTempFile("temp", "zip");
-        write = Files.write(tempZip2.toPath(), arbitraryURL);
+        write = Files.write(tempZip2.toPath(), responseBody);
         zipFile = new ZipFile(write.toFile());
         assertTrue(zipFile.stream().map(ZipEntry::getName).toList().contains("md5sum/md5sum-workflow.cwl"), "zip file seems incorrect");
         tempZip2.deleteOnExit();

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -670,7 +670,7 @@ public final class CommonTestUtilities {
         return publishRequest;
     }
 
-    public static <T> T getArbitraryURL(String url, GenericType<T> type, ApiClient client, String acceptType) {
+    public static <T> T invokeAPI(String url, GenericType<T> type, ApiClient client, String acceptType) {
         return client
             .invokeAPI(url, "GET", new ArrayList<>(), null, new HashMap<>(), new HashMap<>(), acceptType, "text/plain",
                 new String[] { "BEARER" }, type).getData();

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -671,9 +671,9 @@ public final class CommonTestUtilities {
         return publishRequest;
     }
 
-    public static <T> ApiResponse<T> invokeAPI(String url, GenericType<T> type, ApiClient client, String acceptType) {
+    public static <T> ApiResponse<T> invokeAPI(String path, GenericType<T> type, ApiClient client, String acceptType) {
         return client
-            .invokeAPI(url, "GET", new ArrayList<>(), null, new HashMap<>(), new HashMap<>(), acceptType, "text/plain",
+            .invokeAPI(path, "GET", new ArrayList<>(), null, new HashMap<>(), new HashMap<>(), acceptType, "text/plain",
                 new String[] { "BEARER" }, type);
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -672,15 +672,8 @@ public final class CommonTestUtilities {
 
     public static <T> T getArbitraryURL(String url, GenericType<T> type, ApiClient client, String acceptType) {
         return client
-            .invokeAPI(url, "GET", new ArrayList<>(), null, new HashMap<>(), new HashMap<>(), acceptType, "application/zip",
+            .invokeAPI(url, "GET", new ArrayList<>(), null, new HashMap<>(), new HashMap<>(), acceptType, "text/plain",
                 new String[] { "BEARER" }, type).getData();
-    }
-
-    /**
-     * Get an arbitrary URL with the accept type defaulting to "application/zip".
-     */
-    public static <T> T getArbitraryURL(String url, GenericType<T> type, ApiClient client) {
-        return getArbitraryURL(url, type, client, "application/zip");
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -45,6 +45,7 @@ import io.dockstore.webservice.resources.LambdaEventResource;
 import io.dropwizard.core.Application;
 import io.dropwizard.testing.DropwizardTestSupport;
 import io.swagger.client.ApiClient;
+import io.swagger.client.ApiResponse;
 import io.swagger.client.model.PublishRequest;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Invocation;
@@ -670,10 +671,10 @@ public final class CommonTestUtilities {
         return publishRequest;
     }
 
-    public static <T> T invokeAPI(String url, GenericType<T> type, ApiClient client, String acceptType) {
+    public static <T> ApiResponse<T> invokeAPI(String url, GenericType<T> type, ApiClient client, String acceptType) {
         return client
             .invokeAPI(url, "GET", new ArrayList<>(), null, new HashMap<>(), new HashMap<>(), acceptType, "text/plain",
-                new String[] { "BEARER" }, type).getData();
+                new String[] { "BEARER" }, type);
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -677,6 +677,14 @@ public final class CommonTestUtilities {
                 new String[] { "BEARER" }, type);
     }
 
+    public static String getContentType(ApiResponse<?> response) {
+        return response.getHeaders().entrySet().stream()
+            .filter(entry -> "Content-Type".equalsIgnoreCase(entry.getKey()))
+            .map(entry -> entry.getValue().get(0))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("response contained no Content-Type header"));
+    }
+
     /**
      * This retrieves a resource file using getResourceAsStream, which works for retrieving resource files packaged in a jar.
      * This allows other repos, like dockstore-support, to use utility methods that require resource files from this package.

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -925,6 +925,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         String fileName = EntryVersionHelper.generateZipFileName(dockstoreID, name);
 
         return Response.ok().entity((StreamingOutput) output -> EntryVersionHelper.writeStreamAsZipStatic(sourceFiles, output, path))
+            .header("Content-Type", "application/zip")
             .header("Content-Disposition", "attachment; filename=\"" + fileName + "\"").build();
     }
 


### PR DESCRIPTION
**Description**
This PR corrects the TRS `toolsIdVersionsVersionIdTypeFilesGet` endpoint to set the `Content-Type` to `application/zip` when the response is a Zip file.

The fix itself is a one liner.  The rest of this PR is modifications/refactors of the related integration tests that allow the `Content-Type` header to be checked, reduce duplicate code, and improve the naming.

**Review Instructions**
Hit the endpoint as described in the ticket, and confirm that the response contains a `Content-Type` HTTP header set to `application/zip`. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2589
#6010

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
