### PR TITLE
DOCK-2589: Cherry pick "Only add utf-8 charset parameter to text and json mime types" pr to release branch

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/Ga4GhTRSAPIWorkflowIT.java
@@ -183,7 +183,7 @@ class Ga4GhTRSAPIWorkflowIT extends BaseIT {
     }
 
     private static void checkOnZipFile(ApiResponse<byte[]> response, DescriptorLanguage language) throws IOException {
-        assertTrue(CommonTestUtilities.getContentType(response).startsWith("application/zip"));
+        assertEquals("application/zip", CommonTestUtilities.getContentType(response));
         File tempZip = File.createTempFile("temp", "zip");
         Path write = Files.write(tempZip.toPath(), response.getData());
         try (ZipFile zipFile = new ZipFile(write.toFile())) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/CharsetResponseFilter.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/CharsetResponseFilter.java
@@ -39,8 +39,12 @@ public class CharsetResponseFilter implements ContainerResponseFilter {
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
         MediaType contentType = responseContext.getMediaType();
         if (contentType != null) {
-            if (!contentType.toString().toLowerCase().contains("charset=utf-8")) {
-                responseContext.getHeaders().putSingle("Content-Type", contentType.toString() + ";charset=UTF-8");
+            boolean isText = "text".equalsIgnoreCase(contentType.getType());
+            boolean isJson = MediaType.APPLICATION_JSON_TYPE.equals(contentType);
+            if (isText || isJson) {
+                if (!contentType.toString().toLowerCase().contains("charset=utf-8")) {
+                    responseContext.getHeaders().putSingle("Content-Type", contentType.toString() + ";charset=UTF-8");
+                }
             }
         }
     }


### PR DESCRIPTION
**Description**
Cherry pick https://github.com/dockstore/dockstore/pull/6014 to release branch.

**Review Instructions**
See https://github.com/dockstore/dockstore/pull/6014

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2589
#6010

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
