### PR TITLE
Upload metrics for other entry types to the correct S3 directory

### DIFF
--- a/dockstore-common/src/main/java/io/dockstore/common/S3ClientHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/S3ClientHelper.java
@@ -101,7 +101,7 @@ public final class S3ClientHelper {
 
     /**
      * Converts the toolId into a key for s3 storage.  Used by both webservice and tooltester
-     * Workflows will be in a "workflow" directory whereas tools will be in a "tool" directory
+     * Tools will be in a "tool" directory and other entry types will be in a directory named after the entry type (ex: workflows are in a "workflow" directory)
      * repository and optional toolname or workflowname must be encoded or else looking for logs of a specific tool without toolname (quay.io/dockstore/hello_world)
      * will return logs for the other ones with toolnames (quay.io/dockstore/hello_world/thing)
      * TODO: Somehow reuse this between repos
@@ -111,8 +111,8 @@ public final class S3ClientHelper {
      */
     public static String convertToolIdToPartialKey(String toolId) {
         String partialKey = toolId;
-        if (partialKey.startsWith("#workflow")) {
-            partialKey = partialKey.replaceFirst("#workflow", "workflow");
+        if (partialKey.startsWith("#")) {
+            partialKey = partialKey.replaceFirst("^#", "");
         } else {
             partialKey = "tool/" + partialKey;
         }

--- a/dockstore-common/src/test/java/io/dockstore/common/S3ClientHelperTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/S3ClientHelperTest.java
@@ -38,6 +38,10 @@ class S3ClientHelperTest {
         assertEquals("tool/quay.io/pancancer/pcawg-bwa-mem-workflow", S3ClientHelper.convertToolIdToPartialKey(toolId));
         toolId = "quay.io/pancancer/pcawg-bwa-mem-workflow/thing";
         assertEquals("tool/quay.io/pancancer/pcawg-bwa-mem-workflow%2Fthing", S3ClientHelper.convertToolIdToPartialKey(toolId));
+        toolId = "#notebook/github.com/dockstore/trs-notebook";
+        assertEquals("notebook/github.com/dockstore/trs-notebook", S3ClientHelper.convertToolIdToPartialKey(toolId));
+        toolId = "#service/github.com/dockstore/simple-service";
+        assertEquals("service/github.com/dockstore/simple-service", S3ClientHelper.convertToolIdToPartialKey(toolId));
     }
 
     @Test


### PR DESCRIPTION
**Description**
This is a fix for the bug that was found during review: https://ucsc-cgl.atlassian.net/browse/SEAB-6467?focusedCommentId=48295.

We weren't uploading metrics for other entry types to the correct directory so the directory structure in S3 was wrong for these entry types which meant that the metrics aggregator couldn't find the metrics files. For example, the bug was for a notebook, which got uploaded to the `tool` directory like so: `tool/#notebook/github.com/hyunnaye/simple-notebook/simple/2.0/GALAXY/` when it should instead be `notebook/github.com/hyunnaye/simple-notebook/simple/2.0/GALAXY/`.

**Review Instructions**
See https://github.com/dockstore/dockstore-support/pull/500

**Issue**
[SEAB-6467](https://ucsc-cgl.atlassian.net/browse/SEAB-6467)

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 


[SEAB-6467]: https://ucsc-cgl.atlassian.net/browse/SEAB-6467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ