### PR TITLE
Add other TRS entry types to getToolId so other entry types can be aggregated

### DIFF
--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-common</artifactId>
-  <version>1.16.0-beta.6</version>
+  <version>1.16.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/dockstore-common/src/main/java/io/dockstore/common/S3ClientHelper.java
+++ b/dockstore-common/src/main/java/io/dockstore/common/S3ClientHelper.java
@@ -134,10 +134,8 @@ public final class S3ClientHelper {
         final String decodedToolId = URLDecoder.decode(encodedToolId, StandardCharsets.UTF_8);
         if ("tool".equals(entryType)) {
             return decodedToolId;
-        } else if ("workflow".equals(entryType)) {
-            return "#workflow/" + decodedToolId;
         } else {
-            return "";
+            return "#" + entryType + "/" + decodedToolId;
         }
     }
 

--- a/dockstore-common/src/test/java/io/dockstore/common/S3ClientHelperTest.java
+++ b/dockstore-common/src/test/java/io/dockstore/common/S3ClientHelperTest.java
@@ -59,6 +59,20 @@ class S3ClientHelperTest {
         // Key of tool with tool name
         s3Key = "tool/quay.io/pancancer/pcawg-bwa-mem-workflow%2Fthing";
         assertEquals("quay.io/pancancer/pcawg-bwa-mem-workflow/thing", S3ClientHelper.getToolId(s3Key));
+
+        // Key of notebook with no notebook name
+        s3Key = "notebook/github.com/dockstore/trs-notebook/1.0/terra/foo.json";
+        assertEquals("#notebook/github.com/dockstore/trs-notebook", S3ClientHelper.getToolId(s3Key));
+        // Key of notebook with notebook name
+        s3Key = "notebook/github.com/dockstore/trs-notebook%2Ffoo/1.0/terra/foo.json";
+        assertEquals("#notebook/github.com/dockstore/trs-notebook/foo", S3ClientHelper.getToolId(s3Key));
+
+        // Key of service with no service name
+        s3Key = "service/github.com/dockstore/trs-service/1.0/terra/foo.json";
+        assertEquals("#service/github.com/dockstore/trs-service", S3ClientHelper.getToolId(s3Key));
+        // Key of service with service name
+        s3Key = "service/github.com/dockstore/trs-service%2Ffoo/1.0/terra/foo.json";
+        assertEquals("#service/github.com/dockstore/trs-service/foo", S3ClientHelper.getToolId(s3Key));
     }
 
     @Test

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-integration-testing</artifactId>
-  <version>1.16.0-beta.6</version>
+  <version>1.16.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -72,25 +72,25 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.16.0-beta.6</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.16.0-beta.6</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.16.0-beta.6</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>openapi-java-client</artifactId>
-      <version>1.16.0-beta.6</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-language-plugin-parent</artifactId>
-  <version>1.16.0-beta.6</version>
+  <version>1.16.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.16.0-beta.6</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-webservice</artifactId>
-  <version>1.16.0-beta.6</version>
+  <version>1.16.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -90,13 +90,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.16.0-beta.6</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-language-plugin-parent</artifactId>
-      <version>1.16.0-beta.6</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -13,7 +13,7 @@ info:
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
   termsOfService: https://github.com/dockstore/dockstore-ui2/raw/develop/src/assets/docs/Dockstore_Terms_of_Service.pdf
   title: Dockstore API
-  version: 1.16.0-beta.6
+  version: 1.16.0-SNAPSHOT
 servers:
 - description: Current server when hosted on AWS
   url: /api

--- a/openapi-java-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>openapi-java-client</artifactId>
-  <version>1.16.0-beta.6</version>
+  <version>1.16.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.16.0-beta.6</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/reports/generated/src/main/resources/pom.xml
+++ b/reports/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>reports</artifactId>
-  <version>1.16.0-beta.6</version>
+  <version>1.16.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,19 +30,19 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.16.0-beta.6</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.16.0-beta.6</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-integration-testing</artifactId>
-      <version>1.16.0-beta.6</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/swagger-java-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-client</artifactId>
-  <version>1.16.0-beta.6</version>
+  <version>1.16.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.16.0-beta.6</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
**Description**
Another follow-up to https://ucsc-cgl.atlassian.net/browse/SEAB-6467 and https://github.com/dockstore/dockstore/pull/6022, this time it's failing on the metrics-aggregator side when aggregating notebooks because it's calling a dockstore-common function that doesn't take into account other TRS entry types [here](https://github.com/dockstore/dockstore-support/blob/0db8b4b8ab19c281abeb14c041601dcb0b3c1197/metricsaggregator/src/main/java/io/dockstore/metricsaggregator/MetricsAggregatorS3Client.java#L261).

This PR is set to the release branch...if it's too late, I can put it to develop. It just means that aggregation of other entry types that are not tools and workflows would fail from the metrics-aggregator side. We're only ingesting metrics for workflows from Terra right now, so maybe that's okay.

**Review Instructions**
See https://github.com/dockstore/dockstore-support/pull/500

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6467 

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
