### PR TITLE
DOCK-2591: Sort "representative" version first by default

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIGeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIGeneralIT.java
@@ -290,6 +290,23 @@ class OpenAPIGeneralIT extends BaseIT {
         assertEquals("testCWL", workflowVersions.get(0).getName(), "The first version should be testCWL");
     }
 
+    @Test
+    void testWorkflowVersionsDefaultSorting() {
+        ApiClient client = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowsOpenApi = new WorkflowsApi(client);
+
+        Workflow workflow = registerWorkflowWithTwoVersions();
+        List<String> versionNames = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, null, null).stream().map(WorkflowVersion::getName).toList();
+        assertTrue(versionNames.size() >= 2);
+
+        // set each version as the default and confirm that when we don't specify a sortCol to `getWorkflowVersion`, the default version is first in the returned list
+        for (String versionName: versionNames) {
+            workflowsOpenApi.updateDefaultVersion1(workflow.getId(), versionName);
+            List<WorkflowVersion> workflowVersions = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, null, null);
+            assertEquals(versionName, workflowVersions.get(0).getName(), "the default version should be sorted first");
+        }
+    }
+
     private Workflow registerWorkflowWithTwoVersions() {
         ApiClient client = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowsOpenApi = new WorkflowsApi(client);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -466,6 +466,14 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
     }
 
     /**
+     * Return the ID of the version that is most representative of the Entry,
+     * or -1 if no such version exists.
+     */
+    static long determineRepresentativeVersionId(Entry entry) {
+        return determineRepresentativeVersion(entry).map(Version::getId).orElse(-1L);
+    }
+
+    /**
      * Determine which Version of the specified Entry is most representative of the Entry.
      * The resulting Version is used to generate identifying information about the Entry
      * (Search fields, AI topic, and perhaps other things)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
@@ -100,6 +100,7 @@ public class WorkflowVersionDAO extends VersionDAO<WorkflowVersion> {
         List<Predicate> predicates = new ArrayList<>();
 
         Path<?> versionId = version.get("id");
+        Path<?> lastModified = version.get("lastModified");
         Expression<?> sortExpression;
         if (!Strings.isNullOrEmpty(sortCol)) {
             Path<?> versionMetadata = version.get("versionMetadata");
@@ -128,9 +129,9 @@ public class WorkflowVersionDAO extends VersionDAO<WorkflowVersion> {
                 .otherwise(0);
         }
         if ("desc".equalsIgnoreCase(sortOrder)) {
-            query.orderBy(cb.desc(sortExpression), cb.desc(versionId));
+            query.orderBy(cb.desc(sortExpression), cb.desc(lastModified), cb.desc(versionId));
         } else {
-            query.orderBy(cb.asc(sortExpression), cb.asc(versionId));
+            query.orderBy(cb.asc(sortExpression), cb.asc(lastModified), cb.asc(versionId));
         }
         return predicates;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
@@ -65,12 +65,12 @@ public class WorkflowVersionDAO extends VersionDAO<WorkflowVersion> {
      * @param excludeHidden boolean value to exclude hidden versions (used for public page)
      *
      */
-    public List<WorkflowVersion> getWorkflowVersionsByWorkflowId(long workflowId, int limit, int offset, String sortOrder, String sortCol, boolean excludeHidden, long featuredVersionId) {
+    public List<WorkflowVersion> getWorkflowVersionsByWorkflowId(long workflowId, int limit, int offset, String sortOrder, String sortCol, boolean excludeHidden, long representativeVersionId) {
         CriteriaBuilder cb = currentSession().getCriteriaBuilder();
         CriteriaQuery<WorkflowVersion> query = criteriaQuery();
         Root<WorkflowVersion> version = query.from(WorkflowVersion.class);
 
-        List<Predicate> predicates = processQuery(sortCol, sortOrder, cb, query, version, featuredVersionId);
+        List<Predicate> predicates = processQuery(sortCol, sortOrder, cb, query, version, representativeVersionId);
         predicates.add(cb.equal(version.get("parent").get("id"), workflowId));
         if (excludeHidden) {
             predicates.add(cb.isFalse(version.get("versionMetadata").get("hidden")));
@@ -96,7 +96,7 @@ public class WorkflowVersionDAO extends VersionDAO<WorkflowVersion> {
         return query.getResultList();
     }
 
-    private List<Predicate> processQuery(String sortCol, String sortOrder, CriteriaBuilder cb, CriteriaQuery query, Root<WorkflowVersion> version, long featuredVersionId) {
+    private List<Predicate> processQuery(String sortCol, String sortOrder, CriteriaBuilder cb, CriteriaQuery query, Root<WorkflowVersion> version, long representativeVersionId) {
         List<Predicate> predicates = new ArrayList<>();
 
         Path<Object> versionId = version.get("id");
@@ -129,7 +129,7 @@ public class WorkflowVersionDAO extends VersionDAO<WorkflowVersion> {
             }
         } else {
             Expression<Object> defaultHighest = cb.selectCase()
-                .when(cb.equal(versionId, featuredVersionId), 1)
+                .when(cb.equal(versionId, representativeVersionId), 1)
                 .otherwise(0);
             if ("desc".equalsIgnoreCase(sortOrder)) {
                 query.orderBy(cb.desc(defaultHighest), cb.desc(versionId));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -453,7 +453,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                 name = "workflowId", description = "id of the worflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
         @QueryParam("limit") @Min(1) @Max(MAX_PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) Integer limit,
         @QueryParam("offset") @Min(0) @DefaultValue("0") Integer offset,
-        @DefaultValue("lastModified") @QueryParam("sortCol") String sortCol,
+        @QueryParam("sortCol") String sortCol,
         @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
         @Context HttpServletResponse response) {
         Workflow workflow = workflowDAO.findById(workflowId);
@@ -480,7 +480,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                 name = "workflowId", description = "id of the worflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
         @QueryParam("limit") @Min(1) @Max(MAX_PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) Integer limit,
         @QueryParam("offset") @Min(0) @DefaultValue("0") Integer offset,
-        @DefaultValue("lastModified") @QueryParam("sortCol") String sortCol,
+        @QueryParam("sortCol") String sortCol,
         @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
         @Context HttpServletResponse response) {
         Workflow workflow = workflowDAO.findPublishedById(workflowId);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -450,7 +450,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad Request")
     public Set<WorkflowVersion> getWorkflowVersions(@Parameter(hidden = true, name = "user") @Auth User user,
         @Parameter(
-                name = "workflowId", description = "id of the worflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
+                name = "workflowId", description = "id of the workflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
         @QueryParam("limit") @Min(1) @Max(MAX_PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) Integer limit,
         @QueryParam("offset") @Min(0) @DefaultValue("0") Integer offset,
         @QueryParam("sortCol") String sortCol,
@@ -477,7 +477,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad Request")
     public Set<WorkflowVersion> getPublicWorkflowVersions(
             @Parameter(
-                name = "workflowId", description = "id of the worflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
+                name = "workflowId", description = "id of the workflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
         @QueryParam("limit") @Min(1) @Max(MAX_PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) Integer limit,
         @QueryParam("offset") @Min(0) @DefaultValue("0") Integer offset,
         @QueryParam("sortCol") String sortCol,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -453,7 +453,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                 name = "workflowId", description = "id of the workflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
         @QueryParam("limit") @Min(1) @Max(MAX_PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) Integer limit,
         @QueryParam("offset") @Min(0) @DefaultValue("0") Integer offset,
-        @QueryParam("sortCol") String sortCol,
+        @Parameter(name = "sortCol", description = "column used to sort versions. if omitted, the webservice determines the sort order, currently default version first", required = false, in = ParameterIn.QUERY) @QueryParam("sortCol") String sortCol,
         @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
         @Context HttpServletResponse response) {
         Workflow workflow = workflowDAO.findById(workflowId);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -462,7 +462,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         response.addHeader(X_TOTAL_COUNT, String.valueOf(versionDAO.getVersionsCount(workflowId)));
         response.addHeader(ACCESS_CONTROL_EXPOSE_HEADERS, X_TOTAL_COUNT);
 
-        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, false);
+        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, false, EntryVersionHelper.determineRepresentativeVersionId(workflow));
         return new LinkedHashSet<>(versions);
     }
 
@@ -488,7 +488,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         response.addHeader(X_TOTAL_COUNT, String.valueOf(versionDAO.getPublicVersionsCount(workflowId)));
         response.addHeader(ACCESS_CONTROL_EXPOSE_HEADERS, X_TOTAL_COUNT);
 
-        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, true);
+        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, true, EntryVersionHelper.determineRepresentativeVersionId(workflow));
         return new LinkedHashSet<>(versions);
     }
 
@@ -909,7 +909,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         sessionFactory.getCurrentSession().detach(workflow);
 
         // Almost all observed workflows have under 200 version, this number should be lowered once the frontend actually supports pagination
-        List<WorkflowVersion> ids = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), VERSION_PAGINATION_LIMIT, 0, null, null, false);
+        List<WorkflowVersion> ids = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), VERSION_PAGINATION_LIMIT, 0, null, null, false, EntryVersionHelper.determineRepresentativeVersionId(workflow));
         SortedSet<WorkflowVersion> workflowVersions = new TreeSet<>(ids);
         if (versionName != null && workflowVersions.stream().noneMatch(version -> version.getName().equals(versionName))) {
             WorkflowVersion workflowVersionByWorkflowIdAndVersionName = this.workflowVersionDAO

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -906,10 +906,11 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
     @SuppressWarnings("checkstyle:MagicNumber")
     private void setWorkflowVersionSubset(Workflow workflow, String include, String versionName) {
+        long representativeVersionId = EntryVersionHelper.determineRepresentativeVersionId(workflow);
         sessionFactory.getCurrentSession().detach(workflow);
 
         // Almost all observed workflows have under 200 version, this number should be lowered once the frontend actually supports pagination
-        List<WorkflowVersion> ids = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), VERSION_PAGINATION_LIMIT, 0, null, null, false, EntryVersionHelper.determineRepresentativeVersionId(workflow));
+        List<WorkflowVersion> ids = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), VERSION_PAGINATION_LIMIT, 0, null, null, false, representativeVersionId);
         SortedSet<WorkflowVersion> workflowVersions = new TreeSet<>(ids);
         if (versionName != null && workflowVersions.stream().noneMatch(version -> version.getName().equals(versionName))) {
             WorkflowVersion workflowVersionByWorkflowIdAndVersionName = this.workflowVersionDAO

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -8641,8 +8641,8 @@ paths:
           format: int32
           default: 0
           minimum: 0
-      - description: "column used to sort versions. if omitted, the webservice will\
-          \ determine the sort order, currently default version first"
+      - description: "column used to sort versions. if omitted, the webservice determines\
+          \ the sort order, currently default version first"
         in: query
         name: sortCol
         schema:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -7581,7 +7581,7 @@ paths:
       description: Return paginated versions in an public entry
       operationId: getPublicWorkflowVersions
       parameters:
-      - description: id of the worflow
+      - description: id of the workflow
         in: path
         name: workflowId
         required: true
@@ -8619,7 +8619,7 @@ paths:
       description: Return paginated versions in an entry. Max pagination is 100 versions.
       operationId: getWorkflowVersions
       parameters:
-      - description: id of the worflow
+      - description: id of the workflow
         in: path
         name: workflowId
         required: true

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -7607,7 +7607,6 @@ paths:
         name: sortCol
         schema:
           type: string
-          default: lastModified
       - in: query
         name: sortOrder
         schema:
@@ -8646,7 +8645,6 @@ paths:
         name: sortCol
         schema:
           type: string
-          default: lastModified
       - in: query
         name: sortOrder
         schema:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -8641,7 +8641,9 @@ paths:
           format: int32
           default: 0
           minimum: 0
-      - in: query
+      - description: "column used to sort versions. if omitted, the webservice will\
+          \ determine the sort order, currently default version first"
+        in: query
         name: sortCol
         schema:
           type: string


### PR DESCRIPTION
**Description**
This PR changes the webservice's version retrieval endpoints to allow no sort column to be specified, in which case, the "representative" version (typically the default version) appears first in the results, and other results are sorted in recently-modified order.  The rationale here is that now that pagination happens on the database side, the database (rather than the UI) has the necessary information to decide the default sort behavior, and should do so.  This is analogous to how our ES search results work.

If  a sort column is specified, the results are sorted as they are now, the representative version appears wherever it should, per the specified ordering.

Also, we change the secondary sort criteria to be the last modified date (and the tertiary sort criteria becomes the created date), to be consistent with our current "default" table sort order.

Right now, in the UI, the version table sorts by "lastModified" when the table loads.  So, to use this PR, we'll need to modify the UI, probably by changing the column "sort direction" controls to have three possible states: asc, desc, and none.  When the version table first appears, the controls will be set to "none", signaling the webservice to return the results in default order.  Again, this is similar to how the search result table works.

The UI PR will happen after https://github.com/dockstore/dockstore-ui2/pull/2023 merges.

~~I didn't add a test, because it was relatively labor/code intensive.   Probably easier to do it in the UI, and possibly more appropriate.  In the interim, if this change breaks, it'll be very visible.~~

**Review Instructions**
Query the `getWorkflowVersions` endpoint without a sort column and confirm that the default/representative version appears first in the results.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2591
#6019 

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
