### PR TITLE
Add id-token write permisson for deploying db docs

### DIFF
--- a/.github/workflows/deploy_artifacts.yml
+++ b/.github/workflows/deploy_artifacts.yml
@@ -19,7 +19,7 @@ jobs:
     secrets: inherit
 
   deploy_db_docs:
-    if: ${{ github.ref_type == 'branch' }}
+    if: ${{ github.ref_type == 'branch' && github.ref_name == 'develop' }}
     runs-on: ubuntu-22.04
     
     permissions:

--- a/.github/workflows/deploy_artifacts.yml
+++ b/.github/workflows/deploy_artifacts.yml
@@ -19,7 +19,7 @@ jobs:
     secrets: inherit
 
   deploy_db_docs:
-    if: ${{ github.ref_type == 'branch' && github.ref_name == 'develop' }}
+    if: ${{ github.ref_type == 'branch' }}
     runs-on: ubuntu-22.04
     
     permissions:

--- a/.github/workflows/deploy_artifacts.yml
+++ b/.github/workflows/deploy_artifacts.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: read
       pages: write
+      id-token: write
       
     # Service containers to run with `container-job`
     services:


### PR DESCRIPTION
**Description**
Follow-up to https://github.com/dockstore/dockstore/pull/6043, where I removed the `id-token: write` permissions because I thought it was only used for deploying the image. Turns out it's needed for deploying the DB docs (see the error in the Annotations section [here](https://github.com/dockstore/dockstore/actions/runs/12181477003)). The error didn't pop up until I merged the PR to the develop branch because the job only runs for the develop branch.


**Review Instructions**
DB docs should be deployed for the develop branch

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6771

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
