### PR TITLE
Handle expired GitHub token

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
@@ -453,7 +453,7 @@ class GitHubWorkflowIT extends BaseIT {
         trsVersion = ga4Ghv20Api.toolsIdVersionsVersionIdGet("#workflow/github.com/" + DockstoreTesting.HELLO_WDL_WORKFLOW, quayDigestVersionName);
         assertEquals(1, trsVersion.getImages().size(), "Should be one image in this TRS version");
         trsVersion.getImages().forEach(image -> assertEquals(
-            "quay.io/ga4gh-dream/dockstore-tool-helloworld@sha256:3a854fd1ebd970011fa57c8c099347314eda36cc746fd831f4deff9a1d433718", image.getImageName()));
+            "quay.io/ga4gh-dream/dockstore-tool-helloworld@sha256:71c0f43d9081cb14411adae56773762b1e829f7175645484571dcb1c6e120d23", image.getImageName()));
 
         // Workflow with Docker Hub image specified using a tag (6 images actually retrieved, one per architecture type)
         String dockerHubTagVersionName = "dockerHubTagImage";

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1102,6 +1102,8 @@ class WebhookIT extends BaseIT {
         final ApiClient webClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi client = new WorkflowsApi(webClient);
 
+        final Long initialWorkflowCount = testingPostgres.runSelectStatement("select count(*) from workflow", long.class);
+        assertEquals(0, initialWorkflowCount, "There should be no workflows to start");
         // Make USER_2_USERNAME's token invalid, which behaves similar to an expired token
         testingPostgres.runUpdateStatement("update token set content='expiredtoken' where username = '%s' and tokensource='github.com'".formatted(USER_2_USERNAME));
         handleGitHubRelease(client, DockstoreTestUser2.WORKFLOW_DOCKSTORE_YML, "refs/tags/0.1", "thisisafakeuser", null, List.of(USER_2_USERNAME));

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1109,12 +1109,14 @@ class WebhookIT extends BaseIT {
                 "select count(*) from workflow w where w.id not in (select entryid from user_entry)", long.class);
         assertEquals(1, userlessWorkflows);
         final Long wvCount1 = testingPostgres.runSelectStatement("select count(*) from workflowversion", long.class);
-        assertEquals(1, wvCount1, "The userless workflow should now have 1 version1");
+        assertEquals(1, wvCount1, "The userless workflow should now have 1 version");
 
 
         // Ensure update also doesn't fail
         handleGitHubRelease(client, DockstoreTestUser2.WORKFLOW_DOCKSTORE_YML, "refs/tags/0.2", "thisisafakeuser", null, List.of(USER_2_USERNAME));
-        final Long wvCount2 = testingPostgres.runSelectStatement("select count(*) from workflowversion where workflowpath = '/Dockstore.wdl'", long.class); // 0.2 also has CWL version
+
+        // 0.2 also creates a CWL version, so only look for WDL versions
+        final Long wvCount2 = testingPostgres.runSelectStatement("select count(*) from workflowversion where workflowpath = '/Dockstore.wdl'", long.class);
         assertEquals(2, wvCount2, "The userless workflow should now have 2 WDL versions");
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -768,8 +768,15 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                         final GitHubSourceCodeRepo userSourceCodeRepo = new GitHubSourceCodeRepo(profile.username,
                                 gitHubToken.getContent());
                         // Get a map of all repos the user has permissions to
-                        final Map<String, String> map = userSourceCodeRepo.getWorkflowGitUrl2RepositoryId();
-                        return map.values().contains(repository);
+                        try {
+                            final Map<String, String> map = userSourceCodeRepo.getWorkflowGitUrl2RepositoryId();
+                            return map.values().contains(repository);
+                        } catch (CustomWebApplicationException ex) {
+                            // https://ucsc-cgl.atlassian.net/browse/SEAB-6850 - User had an expired token, exception wrapped here:
+                            // io.dockstore.webservice.helpers.SourceCodeRepoInterface.handleGetWorkflowGitUrl2RepositoryIdError
+                            LOG.error("Error listing user's repositories ", ex);
+                            return false;
+                        }
                     }
                     return false;
                 }).toList();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -774,7 +774,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                         } catch (CustomWebApplicationException ex) {
                             // https://ucsc-cgl.atlassian.net/browse/SEAB-6850 - User had an expired token, exception wrapped here:
                             // io.dockstore.webservice.helpers.SourceCodeRepoInterface.handleGetWorkflowGitUrl2RepositoryIdError
-                            LOG.error("Error listing user's repositories ", ex);
+                            LOG.info("Error listing user's repositories for determining permissions", ex);
                             return false;
                         }
                     }


### PR DESCRIPTION
**Description**
Handles the case where a Dockstore user with an expired GitHub token is involved in a GItHub push notification.

Steve described the bug in the ticket, here's my step-by-step view:

1. There's a push for a repo with an existing workflow(s)
2. Who did the push (the sender) doesn't matter (bot, a Dockstore user)
3. The push can have multiple users associated with it -- authors and committers from all the commits being pushed.
4. We attempt to list each of those user's GitHub repos so we can automatically add them to the workflow if the repo is one of theirs.
5. One of those users has an expired GitHub token, which throws an exception and rolls back everything.

Alternative and/or temporary fix: we could delete expired GitHub tokens, which may not be a bad idea anyway. The problem is we don't have an easy way to figure that out, and it would sort of risky updating the DB directly with SQL.

**Review Instructions**
This will be tricky to verify in staging.

Find an event that failed and redeliver it in prod.

Verify there are no errors in CloudWatch if you search for `"Bad credentials" "Error handling push event"`

**Issue**
SEAB-6850

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
