### PR TITLE
Adjust quay image sha

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
@@ -453,7 +453,7 @@ class GitHubWorkflowIT extends BaseIT {
         trsVersion = ga4Ghv20Api.toolsIdVersionsVersionIdGet("#workflow/github.com/" + DockstoreTesting.HELLO_WDL_WORKFLOW, quayDigestVersionName);
         assertEquals(1, trsVersion.getImages().size(), "Should be one image in this TRS version");
         trsVersion.getImages().forEach(image -> assertEquals(
-            "quay.io/ga4gh-dream/dockstore-tool-helloworld@sha256:3a854fd1ebd970011fa57c8c099347314eda36cc746fd831f4deff9a1d433718", image.getImageName()));
+            "quay.io/ga4gh-dream/dockstore-tool-helloworld@sha256:71c0f43d9081cb14411adae56773762b1e829f7175645484571dcb1c6e120d23", image.getImageName()));
 
         // Workflow with Docker Hub image specified using a tag (6 images actually retrieved, one per architecture type)
         String dockerHubTagVersionName = "dockerHubTagImage";


### PR DESCRIPTION
**Description**
Recently, a Quay image sha changed, breaking an integration test.  We adjusted the tag/branch in `dockstore-testing/hello-wdl-workflow` for the new sha.  This PR adjusts the referencing test similarly.  For more information, see this Slack thread: https://ucsc-gi.slack.com/archives/C05EZH3RVNY/p1733851040745499

**Review Instructions**
Confirm integration tests pass.

**Issue**
None.

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
