### PR TITLE
SEAB-6341: add include query param to version endpoints

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
@@ -244,7 +244,7 @@ class CRUDClientIT extends BaseIT {
         file.setPath("/Dockstore.cwl");
         file.setAbsolutePath("/Dockstore.cwl");
         Workflow dockstoreWorkflow = api.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file));
-        Optional<io.dockstore.openapi.client.model.WorkflowVersion> first = openApiWorkflowsApi.getWorkflowVersions(dockstoreWorkflow.getId(), null, null, null, null).stream()
+        Optional<io.dockstore.openapi.client.model.WorkflowVersion> first = openApiWorkflowsApi.getWorkflowVersions(dockstoreWorkflow.getId(), null, null, null, null, null).stream()
                 .max(Comparator.comparingInt((io.dockstore.openapi.client.model.WorkflowVersion t) -> Integer.parseInt(t.getName())));
         List<io.dockstore.webservice.core.SourceFile> sourceFiles = fileDAO.findSourceFilesByVersion(first.get().getId());
         assertEquals(1, sourceFiles.size(), "correct number of source files");
@@ -257,7 +257,7 @@ class CRUDClientIT extends BaseIT {
         file2.setAbsolutePath("/arguments.cwl");
         // add one file and include the old one implicitly
         dockstoreWorkflow = api.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file2));
-        first = openApiWorkflowsApi.getWorkflowVersions(dockstoreWorkflow.getId(), null, null, null, null).stream()
+        first = openApiWorkflowsApi.getWorkflowVersions(dockstoreWorkflow.getId(), null, null, null, null, null).stream()
             .max(Comparator.comparingInt((io.dockstore.openapi.client.model.WorkflowVersion t) -> Integer.parseInt(t.getName())));
         sourceFiles = fileDAO.findSourceFilesByVersion(first.get().getId());
         assertEquals(2, sourceFiles.size(), "correct number of source files");
@@ -269,7 +269,7 @@ class CRUDClientIT extends BaseIT {
         file3.setAbsolutePath("/tar-param.cwl");
         // add one file and include the old one implicitly
         dockstoreWorkflow = api.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file3));
-        first = openApiWorkflowsApi.getWorkflowVersions(dockstoreWorkflow.getId(), null, null, null, null).stream()
+        first = openApiWorkflowsApi.getWorkflowVersions(dockstoreWorkflow.getId(), null, null, null, null, null).stream()
             .max(Comparator.comparingInt((io.dockstore.openapi.client.model.WorkflowVersion t) -> Integer.parseInt(t.getName())));
         sourceFiles = fileDAO.findSourceFilesByVersion(first.get().getId());
         assertEquals(3, sourceFiles.size(), "correct number of source files");
@@ -277,7 +277,7 @@ class CRUDClientIT extends BaseIT {
         // Delete the workflow version and recreate it
         api.deleteHostedWorkflowVersion(hostedWorkflow.getId(), "3");
         dockstoreWorkflow = api.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file3));
-        first = openApiWorkflowsApi.getWorkflowVersions(dockstoreWorkflow.getId(), null, null, null, null).stream()
+        first = openApiWorkflowsApi.getWorkflowVersions(dockstoreWorkflow.getId(), null, null, null, null, null).stream()
             .max(Comparator.comparingInt((io.dockstore.openapi.client.model.WorkflowVersion t) -> Integer.parseInt(t.getName())));
         assertEquals("4", first.get().getName(), "Version name should've skipped 3 because it was previously deleted");
 
@@ -285,7 +285,7 @@ class CRUDClientIT extends BaseIT {
         file2.setContent(null);
 
         dockstoreWorkflow = api.editHostedWorkflow(dockstoreWorkflow.getId(), Lists.newArrayList(file, file2));
-        first = openApiWorkflowsApi.getWorkflowVersions(dockstoreWorkflow.getId(), null, null, null, null).stream()
+        first = openApiWorkflowsApi.getWorkflowVersions(dockstoreWorkflow.getId(), null, null, null, null, null).stream()
             .max(Comparator.comparingInt((io.dockstore.openapi.client.model.WorkflowVersion t) -> Integer.parseInt(t.getName())));
         sourceFiles = fileDAO.findSourceFilesByVersion(first.get().getId());
         assertEquals(2, sourceFiles.size(), "correct number of source files");
@@ -550,7 +550,7 @@ class CRUDClientIT extends BaseIT {
         file.setPath("/Dockstore.cwl");
         file.setAbsolutePath("/Dockstore.cwl");
         Workflow dockstoreWorkflow = hostedApi.editHostedWorkflow(hostedWorkflow.getId(), Lists.newArrayList(file));
-        Optional<io.dockstore.openapi.client.model.WorkflowVersion> first = openApiWorkflowsApi.getWorkflowVersions(hostedWorkflow.getId(), null, null, null, null).stream()
+        Optional<io.dockstore.openapi.client.model.WorkflowVersion> first = openApiWorkflowsApi.getWorkflowVersions(hostedWorkflow.getId(), null, null, null, null, null).stream()
             .max(Comparator.comparingInt((io.dockstore.openapi.client.model.WorkflowVersion t) -> Integer.parseInt(t.getName())));
         assertTrue(first.isPresent());
         long numSourcefiles = testingPostgres.runSelectStatement("SELECT COUNT(*) FROM sourcefile, workflow, workflowversion, version_sourcefile WHERE workflow.id = " + hostedWorkflow.getId() + " AND workflowversion.parentid = workflow.id AND version_sourcefile.versionid = workflowversion.id AND sourcefile.id = version_sourcefile.sourcefileid", long.class);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckUrlHelperFullIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckUrlHelperFullIT.java
@@ -111,7 +111,7 @@ public class CheckUrlHelperFullIT {
         final HostedApi hostedApi = new HostedApi(webClient);
         final WorkflowsApi workflowsApi = new WorkflowsApi(webClient);
         final Workflow hostedWorkflow = CommonTestUtilities.createHostedWorkflowWithVersion(hostedApi);
-        final WorkflowVersion workflowVersion = workflowsApi.getWorkflowVersions(hostedWorkflow.getId(), null, null, null, null).get(0);
+        final WorkflowVersion workflowVersion = workflowsApi.getWorkflowVersions(hostedWorkflow.getId(), null, null, null, null, null).get(0);
         assertTrue(workflowVersion.getVersionMetadata().isPublicAccessibleTestParameterFile(), "Should be public because the descriptor has no parameters at all");
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
@@ -654,7 +654,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         platformToMetrics.put(allPlatforms, metrics);
         extendedGa4GhApi.aggregatedMetricsPut(platformToMetrics, workflowId, workflowVersionId);
         workflow = workflowsApi.getPublishedWorkflow(workflow.getId(), "metrics");
-        workflowVersion = workflowsApi.getPublicWorkflowVersions(workflow.getId(),null,null, null, null, "metrics").stream().filter(v -> workflowVersionId.equals(v.getName())).findFirst().orElse(null);
+        workflowVersion = workflowsApi.getPublicWorkflowVersions(workflow.getId(), null, null, null, null, "metrics").stream().filter(v -> workflowVersionId.equals(v.getName())).findFirst().orElse(null);
         assertNotNull(workflowVersion);
         Metrics allPlatformsMetrics = workflowVersion.getMetricsByPlatform().get(allPlatforms);
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedMetricsTRSOpenApiIT.java
@@ -654,7 +654,7 @@ class ExtendedMetricsTRSOpenApiIT extends BaseIT {
         platformToMetrics.put(allPlatforms, metrics);
         extendedGa4GhApi.aggregatedMetricsPut(platformToMetrics, workflowId, workflowVersionId);
         workflow = workflowsApi.getPublishedWorkflow(workflow.getId(), "metrics");
-        workflowVersion = workflow.getWorkflowVersions().stream().filter(v -> workflowVersionId.equals(v.getName())).findFirst().orElse(null);
+        workflowVersion = workflowsApi.getPublicWorkflowVersions(workflow.getId(),null,null, null, null, "metrics").stream().filter(v -> workflowVersionId.equals(v.getName())).findFirst().orElse(null);
         assertNotNull(workflowVersion);
         Metrics allPlatformsMetrics = workflowVersion.getMetricsByPlatform().get(allPlatforms);
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralIT.java
@@ -533,7 +533,7 @@ class GeneralIT extends GeneralWorkflowBaseIT {
         sourceFile.setAbsolutePath("/Dockstore.wdl");
 
         workflow = hostedApi.editHostedWorkflow(workflow.getId(), Lists.newArrayList(sourceFile));
-        WorkflowVersion workflowVersion = openApiWorkflowApi.getWorkflowVersions(workflow.getId(), null, null, null, null).stream().filter(wv -> wv.getName().equals("1")).findFirst().get();
+        WorkflowVersion workflowVersion = openApiWorkflowApi.getWorkflowVersions(workflow.getId(), null, null, null, null, null).stream().filter(wv -> wv.getName().equals("1")).findFirst().get();
         List<String> fileTypes = entriesApi.getVersionsFileTypes(workflow.getId(), workflowVersion.getId());
         assertEquals(1, fileTypes.size());
         assertEquals(TypeEnum.DOCKSTORE_WDL.toString(), fileTypes.get(0));
@@ -545,7 +545,7 @@ class GeneralIT extends GeneralWorkflowBaseIT {
         testFile.setAbsolutePath("/test.wdl.json");
 
         workflow = hostedApi.editHostedWorkflow(workflow.getId(), Lists.newArrayList(sourceFile, testFile));
-        workflowVersion = openApiWorkflowApi.getWorkflowVersions(workflow.getId(), null, null, null, null).stream().filter(wv -> wv.getName().equals("2")).findFirst().get();
+        workflowVersion = openApiWorkflowApi.getWorkflowVersions(workflow.getId(),  null, null, null, null, null).stream().filter(wv -> wv.getName().equals("2")).findFirst().get();
         fileTypes = entriesApi.getVersionsFileTypes(workflow.getId(), workflowVersion.getId());
         assertEquals(2, fileTypes.size());
         assertNotSame(fileTypes.get(0), fileTypes.get(1));

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/HostedWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/HostedWorkflowIT.java
@@ -86,7 +86,7 @@ class HostedWorkflowIT extends BaseIT {
 
         // Test same for hosted workflows
         Workflow hostedWorkflow = CommonTestUtilities.createHostedWorkflowWithVersion(hostedApi);
-        WorkflowVersion hostedVersion = workflowsApi.getWorkflowVersions(hostedWorkflow.getId(), null, null, null, null).get(0);
+        WorkflowVersion hostedVersion = workflowsApi.getWorkflowVersions(hostedWorkflow.getId(), null, null, null, null, null).get(0);
 
         // delete default version via DB
         testingPostgres.runUpdateStatement("update workflow set actualDefaultVersion = null");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIGeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIGeneralIT.java
@@ -282,11 +282,11 @@ class OpenAPIGeneralIT extends BaseIT {
 
         Workflow workflow = registerWorkflowWithTwoVersions();
         // Test sorting by name in ascending order
-        List<WorkflowVersion> workflowVersions = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, null, "name", "asc");
+        List<WorkflowVersion> workflowVersions = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, "name", "asc", null);
         assertEquals("master", workflowVersions.get(0).getName(), "The first version should be master");
 
         // Test sorting by name in descending order
-        workflowVersions = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, null, "name", "desc");
+        workflowVersions = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, "name", "desc", null);
         assertEquals("testCWL", workflowVersions.get(0).getName(), "The first version should be testCWL");
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIGeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIGeneralIT.java
@@ -266,12 +266,12 @@ class OpenAPIGeneralIT extends BaseIT {
         //publish workflow
         workflow = workflowsOpenApi.publish1(workflow.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
 
-        List<WorkflowVersion> workflowVersions = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, null, null);
+        List<WorkflowVersion> workflowVersions = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, null, null, null);
         //Hide version
         workflowVersions.get(1).setHidden(true);
         workflowsOpenApi.updateWorkflowVersion(workflow.getId(), workflowVersions);
 
-        List<WorkflowVersion> publicWorkflowVersions = workflowsOpenApi.getPublicWorkflowVersions(workflow.getId(), null, null, null, null);
+        List<WorkflowVersion> publicWorkflowVersions = workflowsOpenApi.getPublicWorkflowVersions(workflow.getId(), null, null, null, null, null);
         assertEquals(1, publicWorkflowVersions.size(), "Should exclude hidden version thus only have 1 version");
     }
 
@@ -282,11 +282,11 @@ class OpenAPIGeneralIT extends BaseIT {
 
         Workflow workflow = registerWorkflowWithTwoVersions();
         // Test sorting by name in ascending order
-        List<WorkflowVersion> workflowVersions = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, "name", "asc");
+        List<WorkflowVersion> workflowVersions = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, null, "name", "asc");
         assertEquals("master", workflowVersions.get(0).getName(), "The first version should be master");
 
         // Test sorting by name in descending order
-        workflowVersions = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, "name", "desc");
+        workflowVersions = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, null, "name", "desc");
         assertEquals("testCWL", workflowVersions.get(0).getName(), "The first version should be testCWL");
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIGeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIGeneralIT.java
@@ -296,13 +296,13 @@ class OpenAPIGeneralIT extends BaseIT {
         WorkflowsApi workflowsOpenApi = new WorkflowsApi(client);
 
         Workflow workflow = registerWorkflowWithTwoVersions();
-        List<String> versionNames = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null,null, null, null, null).stream().map(WorkflowVersion::getName).toList();
+        List<String> versionNames = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, null, null, null).stream().map(WorkflowVersion::getName).toList();
         assertTrue(versionNames.size() >= 2);
 
         // set each version as the default and confirm that when we don't specify a sortCol to `getWorkflowVersion`, the default version is first in the returned list
         for (String versionName: versionNames) {
             workflowsOpenApi.updateDefaultVersion1(workflow.getId(), versionName);
-            List<WorkflowVersion> workflowVersions = workflowsOpenApi.getWorkflowVersions(workflow.getId(),null, null, null, null, null);
+            List<WorkflowVersion> workflowVersions = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, null, null, null);
             assertEquals(versionName, workflowVersions.get(0).getName(), "the default version should be sorted first");
         }
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIGeneralIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIGeneralIT.java
@@ -296,13 +296,13 @@ class OpenAPIGeneralIT extends BaseIT {
         WorkflowsApi workflowsOpenApi = new WorkflowsApi(client);
 
         Workflow workflow = registerWorkflowWithTwoVersions();
-        List<String> versionNames = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, null, null).stream().map(WorkflowVersion::getName).toList();
+        List<String> versionNames = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null,null, null, null, null).stream().map(WorkflowVersion::getName).toList();
         assertTrue(versionNames.size() >= 2);
 
         // set each version as the default and confirm that when we don't specify a sortCol to `getWorkflowVersion`, the default version is first in the returned list
         for (String versionName: versionNames) {
             workflowsOpenApi.updateDefaultVersion1(workflow.getId(), versionName);
-            List<WorkflowVersion> workflowVersions = workflowsOpenApi.getWorkflowVersions(workflow.getId(), null, null, null, null);
+            List<WorkflowVersion> workflowVersions = workflowsOpenApi.getWorkflowVersions(workflow.getId(),null, null, null, null, null);
             assertEquals(versionName, workflowVersions.get(0).getName(), "the default version should be sorted first");
         }
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -1899,7 +1899,7 @@ public class OrganizationIT extends BaseIT {
         io.dockstore.openapi.client.model.Workflow workflow = hostedApi.editHostedWorkflow(sourcefiles, hostedWorkflow.getId());
         io.dockstore.openapi.client.api.WorkflowsApi workflowsApi = new io.dockstore.openapi.client.api.WorkflowsApi(openAPIWebClient);
         workflowsApi.publish1(hostedWorkflow.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
-        List<WorkflowVersion> workflowVersions = workflowsApi.getWorkflowVersions(workflow.getId(), null, null, null, null);
+        List<WorkflowVersion> workflowVersions = workflowsApi.getWorkflowVersions(workflow.getId(), null, null, null, null, null);
 
         Long idToAddAndDelete = workflowVersions.get(0).getId();
         String idToAddAndDeleteString = workflowVersions.get(0).getName();

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
@@ -529,7 +529,7 @@ class ZenodoIT {
         workflows.forEach(workflow -> {
             assertEquals(CONCEPT_DOI, workflow.getConceptDois().get(DoiInitiator.GITHUB.toString()).getName());
             assertEquals(DoiSelectionEnum.GITHUB, workflow.getDoiSelection());
-            final List<WorkflowVersion> workflowVersions = workflowsApi.getWorkflowVersions(workflow.getId(), null, null, null, null);
+            final List<WorkflowVersion> workflowVersions = workflowsApi.getWorkflowVersions(workflow.getId(), null, null, null, null, null);
             workflowVersions.stream().filter(w -> "0.8".equals(w.getName())).forEach(wv -> {
                 final Doi doi = wv.getDois().get(DoiInitiator.GITHUB.toString());
                 assertEquals(VERSION_DOI, doi.getName());
@@ -595,7 +595,7 @@ class ZenodoIT {
         testingPostgres.runUpdateStatement("update doi set name ='" + FAKE_VERSION_DOI + "', initiator = 'DOCKSTORE' where type = 'VERSION'");
         workflows = workflowsApi.updateDois(null, null);
         assertEquals(2, workflows.size(), "Concept DOI exists, but version DOIs are new");
-        workflowsApi.getWorkflowVersions(workflows.get(0).getId(), null, null, null, null).forEach(wv -> assertEquals(VERSION_DOI, wv.getDois().get(DoiSelectionEnum.GITHUB.toString()).getName(),
+        workflowsApi.getWorkflowVersions(workflows.get(0).getId(), null, null, null, null, null).forEach(wv -> assertEquals(VERSION_DOI, wv.getDois().get(DoiSelectionEnum.GITHUB.toString()).getName(),
                 "Version DOI for GitHub initiator should be set"));
 
         testingPostgres.runUpdateStatement("update doi set name = '" + conceptDoiName.replace('7', '8') + "' where type = 'CONCEPT'");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -470,12 +470,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         response.addHeader(X_TOTAL_COUNT, String.valueOf(versionDAO.getVersionsCount(workflowId)));
         response.addHeader(ACCESS_CONTROL_EXPOSE_HEADERS, X_TOTAL_COUNT);
 
-<<<<<<< Updated upstream
-        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, false, EntryVersionHelper.determineRepresentativeVersionId(workflow));
-=======
-        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, false);
+        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, true, EntryVersionHelper.determineRepresentativeVersionId(workflow));
         versions.forEach(version -> initializeAdditionalFields(include, version));
->>>>>>> Stashed changes
         return new LinkedHashSet<>(versions);
     }
 
@@ -489,13 +485,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             array = @ArraySchema(schema = @Schema(implementation = WorkflowVersion.class))))
     @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad Request")
     public Set<WorkflowVersion> getPublicWorkflowVersions(
-<<<<<<< Updated upstream
             @Parameter(
-                name = "workflowId", description = "id of the workflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
-=======
-        @Parameter(
                 name = "workflowId", description = "id of the worflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
->>>>>>> Stashed changes
         @QueryParam("limit") @Min(1) @Max(MAX_PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) Integer limit,
         @QueryParam("offset") @Min(0) @DefaultValue("0") Integer offset,
         @QueryParam("sortCol") String sortCol,
@@ -507,12 +498,8 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         response.addHeader(X_TOTAL_COUNT, String.valueOf(versionDAO.getPublicVersionsCount(workflowId)));
         response.addHeader(ACCESS_CONTROL_EXPOSE_HEADERS, X_TOTAL_COUNT);
 
-<<<<<<< Updated upstream
         List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, true, EntryVersionHelper.determineRepresentativeVersionId(workflow));
-=======
-        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, true);
         versions.forEach(version -> initializeAdditionalFields(include, version));
->>>>>>> Stashed changes
         return new LinkedHashSet<>(versions);
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -470,7 +470,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         response.addHeader(X_TOTAL_COUNT, String.valueOf(versionDAO.getVersionsCount(workflowId)));
         response.addHeader(ACCESS_CONTROL_EXPOSE_HEADERS, X_TOTAL_COUNT);
 
-        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, true, EntryVersionHelper.determineRepresentativeVersionId(workflow));
+        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, false, EntryVersionHelper.determineRepresentativeVersionId(workflow));
         versions.forEach(version -> initializeAdditionalFields(include, version));
         return new LinkedHashSet<>(versions);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -486,7 +486,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad Request")
     public Set<WorkflowVersion> getPublicWorkflowVersions(
             @Parameter(
-                name = "workflowId", description = "id of the worflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
+                name = "workflowId", description = "id of the workflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
         @QueryParam("limit") @Min(1) @Max(MAX_PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) Integer limit,
         @QueryParam("offset") @Min(0) @DefaultValue("0") Integer offset,
         @QueryParam("sortCol") String sortCol,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -454,6 +454,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         mediaType = "application/json",
         array = @ArraySchema(schema = @Schema(implementation = WorkflowVersion.class))))
     @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad Request")
+    @SuppressWarnings("checkstyle:parameternumber")
     public Set<WorkflowVersion> getWorkflowVersions(@Parameter(hidden = true, name = "user") @Auth User user,
         @Parameter(
                 name = "workflowId", description = "id of the workflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
@@ -461,6 +462,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         @QueryParam("offset") @Min(0) @DefaultValue("0") Integer offset,
         @Parameter(name = "sortCol", description = "column used to sort versions. if omitted, the webservice determines the sort order, currently default version first", required = false, in = ParameterIn.QUERY) @QueryParam("sortCol") String sortCol,
         @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
+        @Parameter(name = "include", description = VERSION_INCLUDE_MESSAGE, in = ParameterIn.QUERY) @QueryParam("include") String include,
         @Context HttpServletResponse response) {
         Workflow workflow = workflowDAO.findById(workflowId);
         checkNotNullEntry(workflow);
@@ -468,7 +470,12 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         response.addHeader(X_TOTAL_COUNT, String.valueOf(versionDAO.getVersionsCount(workflowId)));
         response.addHeader(ACCESS_CONTROL_EXPOSE_HEADERS, X_TOTAL_COUNT);
 
+<<<<<<< Updated upstream
         List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, false, EntryVersionHelper.determineRepresentativeVersionId(workflow));
+=======
+        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, false);
+        versions.forEach(version -> initializeAdditionalFields(include, version));
+>>>>>>> Stashed changes
         return new LinkedHashSet<>(versions);
     }
 
@@ -482,19 +489,30 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             array = @ArraySchema(schema = @Schema(implementation = WorkflowVersion.class))))
     @ApiResponse(responseCode = HttpStatus.SC_BAD_REQUEST + "", description = "Bad Request")
     public Set<WorkflowVersion> getPublicWorkflowVersions(
+<<<<<<< Updated upstream
             @Parameter(
                 name = "workflowId", description = "id of the workflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
+=======
+        @Parameter(
+                name = "workflowId", description = "id of the worflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") Long workflowId,
+>>>>>>> Stashed changes
         @QueryParam("limit") @Min(1) @Max(MAX_PAGINATION_LIMIT) @DefaultValue(PAGINATION_LIMIT) Integer limit,
         @QueryParam("offset") @Min(0) @DefaultValue("0") Integer offset,
         @QueryParam("sortCol") String sortCol,
         @DefaultValue("desc") @QueryParam("sortOrder") String sortOrder,
+        @Parameter(name = "include", description = VERSION_INCLUDE_MESSAGE, in = ParameterIn.QUERY) @QueryParam("include") String include,
         @Context HttpServletResponse response) {
         Workflow workflow = workflowDAO.findPublishedById(workflowId);
         checkNotNullEntry(workflow);
         response.addHeader(X_TOTAL_COUNT, String.valueOf(versionDAO.getPublicVersionsCount(workflowId)));
         response.addHeader(ACCESS_CONTROL_EXPOSE_HEADERS, X_TOTAL_COUNT);
 
+<<<<<<< Updated upstream
         List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, true, EntryVersionHelper.determineRepresentativeVersionId(workflow));
+=======
+        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, true);
+        versions.forEach(version -> initializeAdditionalFields(include, version));
+>>>>>>> Stashed changes
         return new LinkedHashSet<>(versions);
     }
 

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -7647,6 +7647,12 @@ paths:
         schema:
           type: string
           default: desc
+      - description: "Comma-delimited list of fields to include: validations, aliases,\
+          \ images, authors, metrics"
+        in: query
+        name: include
+        schema:
+          type: string
       responses:
         "200":
           content:
@@ -8687,6 +8693,12 @@ paths:
         schema:
           type: string
           default: desc
+      - description: "Comma-delimited list of fields to include: validations, aliases,\
+          \ images, authors, metrics"
+        in: query
+        name: include
+        schema:
+          type: string
       responses:
         "200":
           content:


### PR DESCRIPTION
**Description**
This PR adds the "include" parameter in `getWorkflowVersions` and `getPublicWorkflowVersions` endpoints. This allows the UI to get data like metrics for each version.

**Review Instructions**
Test getting metrics for a workflow version using the include queryparam.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6341

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
