### PR TITLE
SEAB-6831: Fix aborted DOI alias creation during bot push 

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AliasHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AliasHelper.java
@@ -78,9 +78,9 @@ public final class AliasHelper {
      * @param blockFormat if true don't allow specific formats
      * @return the Workflow Version
      */
-    public static WorkflowVersion addWorkflowVersionAliasesAndCheck(AuthenticatedResourceInterface authenticatedResourceInterface, WorkflowDAO workflowDAO,
+    public static WorkflowVersion addWorkflowVersionAliases(AuthenticatedResourceInterface authenticatedResourceInterface, WorkflowDAO workflowDAO,
             WorkflowVersionDAO workflowVersionDAO, Optional<User> user, Long id, String aliases, boolean blockFormat) {
-        WorkflowVersion workflowVersion = getAndCheckWorkflowVersionResource(authenticatedResourceInterface, workflowDAO, workflowVersionDAO, user, id);
+        WorkflowVersion workflowVersion = workflowVersionDAO.findById(id);
         Set<String> oldAliases = workflowVersion.getAliases().keySet();
         Set<String> newAliases = Sets.newHashSet(Arrays.stream(aliases.split(",")).map(String::trim).toArray(String[]::new));
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AliasHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AliasHelper.java
@@ -66,13 +66,12 @@ public final class AliasHelper {
 
     /**
      * Add aliases to a Workflow Version
-     * and check that they are valid before adding them:
-     * Only works for owner of the entry
+     * and check that the aliases are valid before adding them:
      * If blockFormat false, then no limit on format
      * @param authenticatedResourceInterface interface to check users and entries
      * @param workflowDAO Workflow data access object
      * @param workflowVersionDAO Workflow Version data access object
-     * @param user user authenticated to issue a DOI for the workflow
+     * @param user user that's adding aliases for the version
      * @param id the id of the Entry
      * @param aliases a comma separated string of aliases
      * @param blockFormat if true don't allow specific formats

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
@@ -358,7 +358,7 @@ public final class ZenodoHelper {
         // This code also checks that the alias does not start with an invalid prefix
         // If it does, this will generate an exception, the alias will not be added
         // to the workflow version, but there may be an invalid Related Identifier URL on the Zenodo entry
-        AliasHelper.addWorkflowVersionAliasesAndCheck(authenticatedResourceInterface, workflowDAO, workflowVersionDAO, workflowOwner,
+        AliasHelper.addWorkflowVersionAliases(authenticatedResourceInterface, workflowDAO, workflowVersionDAO, workflowOwner,
                 workflowVersion.getId(), zenodoDoiResult.doiAlias(), false);
 
         return zenodoDoiResult;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AliasResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AliasResource.java
@@ -111,7 +111,8 @@ public class AliasResource implements AliasableResourceInterface<WorkflowVersion
 
     @Override
     public WorkflowVersion addAliasesAndCheck(User user, Long id, String aliases, boolean blockFormat) {
-        return AliasHelper.addWorkflowVersionAliasesAndCheck(workflowResource, workflowDAO, workflowVersionDAO, Optional.ofNullable(user), id, aliases, blockFormat);
+        AliasHelper.getAndCheckWorkflowVersionResource(workflowResource, workflowDAO, workflowVersionDAO, Optional.ofNullable(user), id);
+        return AliasHelper.addWorkflowVersionAliases(workflowResource, workflowDAO, workflowVersionDAO, Optional.ofNullable(user), id, aliases, blockFormat);
 
     }
 }


### PR DESCRIPTION
**Description**
This PR removes the auth check from `AliasHelper.addWorkflowVersionAliasesAndCheck` that was causing the problem described in https://ucsc-cgl.atlassian.net/browse/SEAB-6831

Basically, the auto DOI generation code was calling `addWorkflowVersionAliasesAndCheck`, which was throwing when a bot pushed, because no Dockstore user was present, so the "can the user write to the workflow" check failed.  This exception was caught, meaning that the DOI was created, but since the alias generation code failed, no alias was saved to the db.  So, the Dockstore alias link in the DOI didn't work when clicked upon.

When removing an auth check, the big danger is that you accidentally open a security hole.  So, I tried to analyze the execution paths, and, on the "manual DOI generation" path, I've added a necessary equivalent check, further "upstream" (earlier).  Everywhere else, I think, either the user has already been confirmed to be able to write to the workflow, or the webservice is initiating an automatic generation.  Please do your own analysis to make sure.

Given the hotfix target and the sensitivity of the code, this is a minimal bug fix, and as such, I didn't clean up now-unused parameters, try to restructure for clarity, or anything like that.

Given our current testing infra, user testing might be best, ala:

1. deploy to staging
2. enable auto DOI generation on some workflows
3. do a bot push of a tag, confirm that the generated DOI contains a valid alias link that resolves to the version's page on Dockstore
4. do a regular push on a different tag, and check the DOI and link similarly

**Review Instructions**
See steps above.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6831

**Security and Privacy**

We are mucking with auth checks, please scrutinize to make sure we're still checking everywhere we should.

- [ ] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
