### PR TITLE
Cherry pick "DOCK-2600: Fix backlinks from Zenodo DOI records" to hotfix

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AliasHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/AliasHelper.java
@@ -96,4 +96,8 @@ public final class AliasHelper {
         newAliases.forEach(alias -> workflowVersion.getAliases().put(alias, new Alias()));
         return workflowVersion;
     }
+
+    public static String createWorkflowVersionAliasUrl(String dockstoreUrl, Workflow workflow, String alias) {
+        return "%s/aliases/%s-versions/%s".formatted(dockstoreUrl, workflow.getEntryTypeMetadata().getTerm(), alias);
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
@@ -1,7 +1,5 @@
 package io.dockstore.webservice.helpers;
 
-import static io.swagger.api.impl.ToolsImplCommon.WORKFLOW_PREFIX;
-
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.DockstoreWebserviceConfiguration;
 import io.dockstore.webservice.core.Doi;
@@ -504,12 +502,10 @@ public final class ZenodoHelper {
      *     %2Ftopmed-workflows%2FUM_variant_caller_wdl/versions/1.32.0/PLAIN-WDL/descriptor/topmed_freeze3_calling.wdl)
      */
     protected static String createWorkflowTrsUrl(Workflow workflow, WorkflowVersion workflowVersion) {
-        final String sourceControlPath = workflow.getWorkflowPath();
-        final String workflowVersionPrimaryDescriptorPath = WORKFLOW_PREFIX + "/" + sourceControlPath;
-        final String workflowVersionPrimaryDescriptorPathPlainText;
+        final String trsId = workflow.getTrsId();
+        final String baseTrsUrl;
         try {
-            workflowVersionPrimaryDescriptorPathPlainText =
-                    ToolsImplCommon.getUrl(workflowVersionPrimaryDescriptorPath, dockstoreGA4GHBaseUrl);
+            baseTrsUrl = ToolsImplCommon.getUrl(trsId, dockstoreGA4GHBaseUrl);
         } catch (UnsupportedEncodingException e) {
             LOG.error("Could not create Zenodo related identifier. Error is {}", e.getMessage(), e);
             throw new CustomWebApplicationException("Could not create Zenodo related identifier",
@@ -519,9 +515,8 @@ public final class ZenodoHelper {
         final String workflowDescriptorName = workflowVersion.getWorkflowPath();
         Path p = Paths.get(workflowDescriptorName);
         final String descriptorFile = p.getFileName().toString();
-        final String versionOfWorkflow = workflowVersion.getName();
-        return workflowVersionPrimaryDescriptorPathPlainText + "/versions/" + versionOfWorkflow
-                + "/PLAIN-" + workflowVersionType + "/descriptor/" + descriptorFile;
+        final String versionName = workflowVersion.getName();
+        return baseTrsUrl + "/versions/" + versionName + "/PLAIN-" + workflowVersionType + "/descriptor/" + descriptorFile;
     }
 
     /**
@@ -539,7 +534,7 @@ public final class ZenodoHelper {
 
         // Add the workflow version alias as a related identifier on Zenodo
         // E.g https://dockstore.org/aliases/workflow-versions/10.5281-zenodo.2630727
-        final String aliasUrl = dockstoreUrl + "/aliases/workflow-versions/" + doiAlias;
+        final String aliasUrl = AliasHelper.createWorkflowVersionAliasUrl(dockstoreUrl, workflow, doiAlias);
         addUriToRelatedIdentifierList(relatedIdentifierList, aliasUrl);
 
         // Add the UI2 link to the workflow to Zenodo as a related identifier

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/AliasHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/AliasHelperTest.java
@@ -1,0 +1,18 @@
+package io.dockstore.webservice.helpers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.dockstore.webservice.core.BioWorkflow;
+import io.dockstore.webservice.core.Notebook;
+import org.junit.jupiter.api.Test;
+
+class AliasHelperTest {
+
+    @Test
+    void testCreateWorkflowVersionAliasUrl() {
+        assertEquals("https://dockstore.url/aliases/workflow-versions/abc123",
+            AliasHelper.createWorkflowVersionAliasUrl("https://dockstore.url", new BioWorkflow(), "abc123"));
+        assertEquals("https://dockstore.url/aliases/notebook-versions/foobar",
+            AliasHelper.createWorkflowVersionAliasUrl("https://dockstore.url", new Notebook(), "foobar"));
+    }
+}

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
@@ -18,6 +18,7 @@ import io.dockstore.webservice.core.BioWorkflow;
 import io.dockstore.webservice.core.Doi;
 import io.dockstore.webservice.core.Doi.DoiInitiator;
 import io.dockstore.webservice.core.Doi.DoiType;
+import io.dockstore.webservice.core.Notebook;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.WorkflowVersion;
 import io.dockstore.webservice.helpers.ZenodoHelper.TagAndDoi;
@@ -81,7 +82,7 @@ class ZenodoHelperTest {
     }
 
     @Test
-    void testcreateWorkflowTrsUrl() {
+    void testCreateWorkflowTrsUrl() {
         final Workflow workflow = new BioWorkflow();
 
         final WorkflowVersion workflowVersion = new WorkflowVersion();
@@ -99,6 +100,26 @@ class ZenodoHelperTest {
         String trsUrl = ZenodoHelper.createWorkflowTrsUrl(workflow, workflowVersion);
         assertEquals("https://dockstore.org/api/ga4gh/trs/v2/tools/%23workflow%2Fgithub.com%2FDataBiosphere"
                 + "%2Ftopmed-workflows%2FUM_variant_caller_wdl/versions/1.32.0/PLAIN-WDL/descriptor/topmed_freeze3_calling.wdl", trsUrl);
+    }
+
+    @Test
+    void testCreateNotebookTrsUrl() {
+        final Notebook notebook = new Notebook();
+        notebook.setSourceControl(SourceControl.GITHUB);
+        notebook.setOrganization("SomeOrganization");
+        notebook.setRepository("a-repository");
+        notebook.setWorkflowName("cool-notebook");
+        notebook.setDescriptorType(DescriptorLanguage.JUPYTER);
+
+        final WorkflowVersion version = new WorkflowVersion();
+        version.setWorkflowPath("a-file.ipynb");
+        version.setName("1.2.34");
+
+        DockstoreWebserviceConfiguration config = createDockstoreConfiguration();
+        ZenodoHelper.initConfig(config);
+        String trsUrl = ZenodoHelper.createWorkflowTrsUrl(notebook, version);
+        assertEquals("https://dockstore.org/api/ga4gh/trs/v2/tools/%23notebook%2Fgithub.com%2FSomeOrganization%2Fa-repository"
+                + "%2Fcool-notebook/versions/1.2.34/PLAIN-jupyter/descriptor/a-file.ipynb", trsUrl);
     }
 
     @Test


### PR DESCRIPTION
This PR cherry-picks https://github.com/dockstore/dockstore/pull/6053 to the current hotfix branch.

**Description**
See original PR.

**Review Instructions**
See original PR.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2600
#6033

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
