### PR TITLE
Fix http imports from a local secondary file

### DIFF
--- a/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
+++ b/dockstore-common/src/main/scala/io/dockstore/common/WdlBridge.scala
@@ -483,7 +483,7 @@ case class MapResolver(filePath: String) extends ImportResolver {
     val content = secondaryWdlFiles.get(absolutePath)
     val mapResolver = MapResolver(absolutePath)
     mapResolver.setSecondaryFiles(this.secondaryWdlFiles)
-    if (content == null) InvalidCheck(s"Not found $path for resolver with path $this.filePath").invalidNelCheck else ResolvedImportBundle(content, List(mapResolver), ResolvedImportRecord(absolutePath.toString)).validNelCheck
+    if (content == null) InvalidCheck(s"Not found $path for resolver with path $this.filePath").invalidNelCheck else ResolvedImportBundle(content, currentResolvers :+ mapResolver, ResolvedImportRecord(absolutePath.toString)).validNelCheck
   }
 
   override def cleanupIfNecessary(): ErrorOr[Unit] = ().validNel

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SubmoduleIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SubmoduleIT.java
@@ -135,6 +135,6 @@ class SubmoduleIT extends BaseIT {
         assertFalse(sourcefiles.stream().anyMatch(f -> f.getPath().contains("../wdl-common/wdl/tasks/zip_index_vcf.wdl")));
         LambdaEventsApi lambdaEventsApi = new LambdaEventsApi(webClient);
         final List<LambdaEvent> lambdaEventsByOrganization = lambdaEventsApi.getLambdaEventsByOrganization("dockstore-testing", 0, 10, null, null, null);
-        assertTrue(lambdaEventsByOrganization.stream().anyMatch(e -> e.getMessage().contains("Failed to import") && e.getMessage().contains("Not found wdl-common/wdl")));
+        assertTrue(lambdaEventsByOrganization.stream().anyMatch(e -> e.getMessage().contains("Failed to import") && e.getMessage().contains("File not found: wdl-common/wdl")));
     }
 }


### PR DESCRIPTION
**Description**
We were creating a ResolvedImportBundle that didn't include existing resolvers.

The second parameter name in `ResolvedImportBundle` is `newResolvers`, which I had previously interpreted to mean any resolvers not already in the list of the resolvers. But Scala Lists are by default immutable, so I came to realize that
they wanted a new complete list of resolvers.

The `:+` operand creates a new list from an existing list and an item.

Having all resolvers present makes it work; I don't exactly understand how Cromwell knows which of the resolvers to use, but it makes sense given the list is being passed around.

Tested manually using instructions in the GitHub issue. ~~There should ideally still be a test for this.~~ Denis added a test.

**Review Instructions**
Follow the instructions in #6061.

**Issue**
#6061 
DOCK-2609

**Security and Privacy**

None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
