### PR TITLE
Feature/fix swagger validation

### DIFF
--- a/.github/workflows/validate_openapi.yaml
+++ b/.github/workflows/validate_openapi.yaml
@@ -5,7 +5,7 @@ on: [push]
 
 jobs:
   test_swagger_editor_validator_remote:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Swagger Editor Validator Remote
 
 

--- a/.github/workflows/validate_openapi.yaml
+++ b/.github/workflows/validate_openapi.yaml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Validate OpenAPI definition
-        uses: char0n/swagger-editor-validate@v1.4.0
+        uses: swaggerexpert/apidom-validate@v1.4.0
         with:
           definition-file: dockstore-webservice/src/main/resources/openapi3/openapi.yaml


### PR DESCRIPTION
**Description**
swagger validation broke due to automatic github upgrade to ubuntu 24.04
https://github.com/actions/runner-images/issues/10636

Turns out github action has switched their repo and newer versions just work, so switched and pinned ubuntu version

**Review Instructions**
swagger/openapi validation job should just work in develop

**Issue**
n/a

**Security and Privacy**

None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
