### PR TITLE
Fix bad openapi.yaml merge

### DIFF
--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -810,7 +810,6 @@ paths:
           - ELWAZI
           - AGC
           - TOIL
-          - TOIL
           - OTHER
           - ALL
       - description: The execution ID of the execution to retrieve
@@ -881,7 +880,6 @@ paths:
           - NEXTFLOW_TOWER
           - ELWAZI
           - AGC
-          - TOIL
           - TOIL
           - OTHER
           - ALL
@@ -955,7 +953,6 @@ paths:
           - NEXTFLOW_TOWER
           - ELWAZI
           - AGC
-          - TOIL
           - TOIL
           - OTHER
           - ALL
@@ -9176,7 +9173,6 @@ components:
           - ELWAZI
           - AGC
           - TOIL
-          - TOIL
           - OTHER
           - ALL
         supportedLanguages:
@@ -10932,7 +10928,6 @@ components:
           - ELWAZI
           - AGC
           - TOIL
-          - TOIL
           - OTHER
           - ALL
     Profile:
@@ -12043,7 +12038,6 @@ components:
           - NEXTFLOW_TOWER
           - ELWAZI
           - AGC
-          - TOIL
           - TOIL
           - OTHER
           - ALL


### PR DESCRIPTION
**Description**
This PR fixes the build that was broken from merging the 1.16.6 hotfix into develop. The openapi.yaml had duplicate TOIL enums.

**Review Instructions**
develop builds should pass

**Issue**
n/a

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
