### PR TITLE
Put back reusable deploy workflow

### DIFF
--- a/.github/snapshot-mvn-settings.xml
+++ b/.github/snapshot-mvn-settings.xml
@@ -1,9 +1,0 @@
-<settings>
-  <servers>
-    <server>
-      <id>snapshots</id>
-      <username>dockstore-snapshot-bot</username>
-      <password>${env.SNAPSHOT_DEPLOY_TOKEN}</password>
-    </server>
-  </servers>
-</settings> 

--- a/.github/workflows/deploy_artifacts.yml
+++ b/.github/workflows/deploy_artifacts.yml
@@ -1,15 +1,25 @@
-name: Deploy develop snapshot
-
+name: Deploy artifacts
 on:
   push:
-    branches:
-      - develop
-      
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+    tags:
+      - '**'
+    # Run for all branches except the following
+    branches-ignore:
+      - 'master'
+      - 'release/**'
+      - 'hotfix/**'
+      - 'dependabot/**'
   
 jobs:
-  build:
+  deploy_artifacts:
+    uses: dockstore/workflow-actions/.github/workflows/deploy_artifacts.yaml@main
+    with:
+      createDockerImage: true
+      quayRepository: dockstore-webservice
+    secrets: inherit
+
+  deploy_db_docs:
+    if: ${{ github.ref_type == 'branch' && github.ref_name == 'develop' }}
     runs-on: ubuntu-22.04
     
     permissions:
@@ -54,54 +64,8 @@ jobs:
           java-version: '21.0.2+13.0.LTS'
           distribution: 'adopt'
 
-      - name: Deploy with mvnw
-        run: ./mvnw --batch-mode deploy -ntp -s .github/snapshot-mvn-settings.xml -DskipTests
-        env: 
-          SNAPSHOT_DEPLOY_TOKEN: ${{ secrets.SNAPSHOT_DEPLOY_TOKEN }}
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: docker_checksum_upload_from_github
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      # neat, quay itself uses manual github actions https://github.com/quay/quay/blob/master/.github/workflows/build-and-publish.yaml
-      - name: Login to Quay.io
-        uses: docker/login-action@v3
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USER }}
-          password: ${{ secrets.QUAY_TOKEN }}
-
-      - name: Set folder name
-        run: |
-          S3_FOLDER=${GITHUB_REF##refs/tags/}
-          if [ $GITHUB_REF == $S3_FOLDER ]; then
-            # If this isn't a tag, it must be a branch
-            S3_FOLDER=${GITHUB_REF##refs/heads/}
-          fi
-          echo "S3_FOLDER=${S3_FOLDER//\//_}" >> $GITHUB_ENV
-
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: quay.io/dockstore/dockstore-webservice:${{env.S3_FOLDER}}
-
-      - name: Create checksums
-        run: |
-          docker inspect quay.io/dockstore/dockstore-webservice:${{env.S3_FOLDER}} | grep -A 1 RepoDigests
-          docker inspect quay.io/dockstore/dockstore-webservice:${{env.S3_FOLDER}} | grep -A 1 RepoDigests | grep -oPm1 'sha256:\K\w+' > image-digest.txt        
-          
-      - name: Get short SHA
-        id: slug
-        run: echo "::set-output name=sha7::$(echo ${GITHUB_SHA} | cut -c1-7)"
-
-      - name: Copy checksum files
-        run: aws s3 cp image-digest.txt  s3://${{ secrets.AWS_BUCKET }}/${{ env.S3_FOLDER }}-${{ steps.slug.outputs.sha7 }}/image-digest.txt
+      - name: Build
+        run: ./mvnw -B clean install -DskipTests
 
       - name: Copy checksum files (new)
         run: aws s3 cp image-digest.txt  s3://${{ secrets.AWS_BUCKET }}/${{ env.S3_FOLDER }}-${{ steps.slug.outputs.sha7 }}/dockstore-webservice/image-digest.txt        
@@ -122,4 +86,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        

--- a/.github/workflows/deploy_artifacts.yml
+++ b/.github/workflows/deploy_artifacts.yml
@@ -9,6 +9,8 @@ on:
       - 'release/**'
       - 'hotfix/**'
       - 'dependabot/**'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
   
 jobs:
   deploy_artifacts:

--- a/.github/workflows/deploy_artifacts.yml
+++ b/.github/workflows/deploy_artifacts.yml
@@ -69,9 +69,6 @@ jobs:
       - name: Build
         run: ./mvnw -B clean install -DskipTests
 
-      - name: Copy checksum files (new)
-        run: aws s3 cp image-digest.txt  s3://${{ secrets.AWS_BUCKET }}/${{ env.S3_FOLDER }}-${{ steps.slug.outputs.sha7 }}/dockstore-webservice/image-digest.txt        
-
       # deploy database documentation and also verify that non-confidential migrations seem sane
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -810,7 +810,6 @@ paths:
           - ELWAZI
           - AGC
           - TOIL
-          - TOIL
           - OTHER
           - ALL
       - description: The execution ID of the execution to retrieve
@@ -881,7 +880,6 @@ paths:
           - NEXTFLOW_TOWER
           - ELWAZI
           - AGC
-          - TOIL
           - TOIL
           - OTHER
           - ALL
@@ -955,7 +953,6 @@ paths:
           - NEXTFLOW_TOWER
           - ELWAZI
           - AGC
-          - TOIL
           - TOIL
           - OTHER
           - ALL
@@ -9176,7 +9173,6 @@ components:
           - ELWAZI
           - AGC
           - TOIL
-          - TOIL
           - OTHER
           - ALL
         supportedLanguages:
@@ -10932,7 +10928,6 @@ components:
           - ELWAZI
           - AGC
           - TOIL
-          - TOIL
           - OTHER
           - ALL
     Profile:
@@ -12043,7 +12038,6 @@ components:
           - NEXTFLOW_TOWER
           - ELWAZI
           - AGC
-          - TOIL
           - TOIL
           - OTHER
           - ALL


### PR DESCRIPTION
**Description**
When we merged 1.16.4 into develop ([commit](https://github.com/dockstore/dockstore/commit/32dd919f1f4b39793f07d16d95bb05a259fae852#diff-db523f82cbf33133dceb261c4a409978ef00011ccfea1cba57fefb978bc847bf)), it accidentally reverted https://github.com/dockstore/dockstore/pull/6054 which put back the reusable deploy workflow.

This PR puts back the reusable `deploy_artifacts` workflow that was introduced in https://github.com/dockstore/dockstore/pull/6043 and reinstated in https://github.com/dockstore/dockstore/pull/6054. This PR really just cherry picks https://github.com/dockstore/dockstore/pull/6054 with the addition of adding `workflow_dispatch` so it can be called in the GitHub Actions UI as a backup. 

The old tagged_release workflow is still there as a backup and for use in 1.16.x releases. I will create a ticket to remove it in 1.18.
- Note that the manual copying of the image digest to the `dockstore-webservice` folder is still required for 1.16.x releases. This is because the tagged_release workflow in the master branch does NOT copy it to the `dockstore-webservice` folder.
- The reusable deploy workflow in this PR will not run in 1.16.x releases because it does not exist in master.
- So for a new 1.16.x release, you would manually run the tagged_release workflow then copy the image digest to the `dockstore-webservice` folder in S3. This step will go away for 1.17 because we have the reusable deploy workflow.

**Review Instructions**
Create a branch, commit a change and push it. Go to GitHub Actions tab and verify that the Deploy Artifacts workflow runs successfully. Do the same for a tag.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6916

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
