### PR TITLE
DOCK-2608: Incorporate other signals into version sorting

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
@@ -22,20 +22,17 @@ import com.google.common.base.Strings;
 import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.Version.ReferenceType;
 import io.dockstore.webservice.core.WorkflowVersion;
-import io.dockstore.webservice.core.metrics.Metrics;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Expression;
-import jakarta.persistence.criteria.Join;
-import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.metamodel.Attribute;
 import java.sql.Timestamp;
-import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import org.apache.http.HttpStatus;
 import org.hibernate.SessionFactory;
@@ -102,14 +99,13 @@ public class WorkflowVersionDAO extends VersionDAO<WorkflowVersion> {
         return query.getResultList();
     }
 
+    @SuppressWarnings("checkstyle:MagicNumber")
     private List<Predicate> processQuery(String sortCol, String sortOrder, CriteriaBuilder cb, CriteriaQuery query, Root<WorkflowVersion> version, long representativeVersionId) {
         List<Predicate> predicates = new ArrayList<>();
 
         Path<?> versionId = version.get("id");
         Path<Timestamp> lastModified = version.get("lastModified");
-        Path<?> name = version.get("name");
-        Path<?> referenceType = version.get("referenceType");
-        Path<Boolean> valid = version.get("valid");
+
         Expression<?> sortExpression;
         if (!Strings.isNullOrEmpty(sortCol)) {
             Path<?> versionMetadata = version.get("versionMetadata");
@@ -133,13 +129,15 @@ public class WorkflowVersionDAO extends VersionDAO<WorkflowVersion> {
                 sortExpression = version.get(sortCol);
             }
         } else {
-            Expression<Double> typeExpression = cb.<Double>selectCase()
-                .when(cb.equal(name, "master"), 20.)
-                .when(cb.equal(name, "main"), 20.)
-                .when(cb.equal(name, "develop"), 19.)
-                .when(cb.equal(referenceType, ReferenceType.TAG), 3.)
-                .otherwise(1.);
+            // Create a sort expression that "scores" each version.
+            // To ensure that "relevant" versions appear first, we rank "mainstem" branches, tags, more recently-modified versions, valid versions, and versions with metrics higher.
+            Path<?> name = version.get("name");
+            Path<?> referenceType = version.get("referenceType");
+            Path<Boolean> valid = version.get("valid");
+            Path<? extends Collection> metricsByPlatform = version.get("metricsByPlatform");
 
+            // Compute the "age" of the version, which is the date since it was last modified, in days.
+            // To prevent the sort order from constantly changing, calculate the age relative to the beginning of tomorrow.
             Expression<Double> secondsPerDay = cb.literal(24 * 3600.);
             Expression<Timestamp> now = cb.currentTimestamp();
             Expression<Timestamp> modified = cb.coalesce(lastModified, version.get("dbCreateDate"));
@@ -147,29 +145,39 @@ public class WorkflowVersionDAO extends VersionDAO<WorkflowVersion> {
             Expression<Double> modifiedDays = cb.toDouble(cb.quot(cb.function("date_part", Double.class, cb.literal("epoch"), modified), secondsPerDay));
             Expression<Double> tomorrowDays = cb.sum(cb.function("floor", Double.class, nowDays), 1.);
             Expression<Double> ageDays = cb.diff(tomorrowDays, modifiedDays);
-            Expression<Double> ageWeight = cb.toDouble(cb.quot(1., cb.function("greatest", Double.class, ageDays, cb.literal(1e-5))));
 
+            // Calculate some weights based on the "age", validity, and presence of metrics.
+            Expression<Double> ageWeight = cb.toDouble(cb.quot(1., cb.function("greatest", Double.class, ageDays, cb.literal(0.5))));
             Expression<Double> validWeight = cb.<Double>selectCase()
                 .when(cb.isTrue(valid), 3.)
                 .otherwise(1.);
-
-            Join<WorkflowVersion, Metrics> metrics = version.join("metricsByPlatform", JoinType.LEFT);
             Expression<Double> metricsWeight = cb.<Double>selectCase()
-                .when(cb.isNotNull(metrics), 2.)
+                .when(cb.isNotEmpty(metricsByPlatform), 2.)
                 .otherwise(1.);
 
-            Expression<Double> scaledTypeExpression = cb.prod(cb.prod(cb.prod(typeExpression, ageWeight), validWeight), metricsWeight);
-            // scaledTypeExpression = typeExpression;
+            // Calculate a base "score", which ranks "mainstem" branches highest and tags higher.
+            Expression<Double> baseScore = cb.<Double>selectCase()
+                .when(cb.equal(name, "master"), 20.)
+                .when(cb.equal(name, "main"), 20.)
+                .when(cb.equal(name, "develop"), 19.)
+                .when(cb.equal(referenceType, ReferenceType.TAG), 2.)
+                .otherwise(1.);
 
+            // Combine the weights with our base score to get a weighted score.
+            Expression<Double> weightedScore = cb.prod(cb.prod(cb.prod(baseScore, ageWeight), validWeight), metricsWeight);
+
+            // The final "sort expression" uses our weighted score, except for the representative version, which always ranks highest.
             sortExpression = cb.selectCase()
                 .when(cb.equal(versionId, representativeVersionId), 1e9)
-                .otherwise(scaledTypeExpression);
+                .otherwise(weightedScore);
         }
+
         if ("desc".equalsIgnoreCase(sortOrder)) {
             query.orderBy(cb.desc(sortExpression), cb.desc(lastModified), cb.desc(versionId));
         } else {
             query.orderBy(cb.asc(sortExpression), cb.asc(lastModified), cb.asc(versionId));
         }
+
         return predicates;
     }
 }


### PR DESCRIPTION
**Description**
This PR enhances the default version table sorting so that it takes into account the following additional factors:

* name of version (one of "master", "main", "develop")
* reference type (tag or not)
* presence of metrics
* validity

with the goal of ranking the more relevant versions higher.

While not directly described by the ticket, this PR sprang from some experiments with UI mods that would feature metrics more prominently.

The underlying mechanism scores each version, per an equation that:
1. calculates a base score based on the version name and whether or not it is a tag.
2. multiplies the base score by some weights that adjust the version's score by the inverse of age (based on last modification date), double the score if the version has metrics, and triple the score if it is valid.

We calculate the age relative to the beginning of tomorrow (the upcoming midnight), so that the version ordering does not constantly change.

Generally, this PR seems to improve the ordering.  The mainstem branch(es) always appear near the top, and tags and versions with metrics tend to predominate in the first page of results.  Recently-modified branches can appear at the top, but will fall in rank more quickly at they age, relative to tags.  Most invalid branches without metrics are clustered at the end.

See the screenshots below.

gatk/mutect2
Before:
<img width="983" alt="dump 2025-03-04 at 2 24 58 PM" src="https://github.com/user-attachments/assets/f015bbec-8dd7-4872-9732-d5ec40348938" />

After:
<img width="974" alt="dump 2025-03-04 at 2 25 14 PM" src="https://github.com/user-attachments/assets/b52c50be-2e61-48fe-965c-e4d3dbe13d4e" />

**Review Instructions**
View the versions table and make sure that it:
* looks sane
* the default version appears at top
* the most relevant versions tend towards the top.
* that the ordering is consistent with what is described above.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2608
https://github.com/dockstore/dockstore/issues/6059

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
