### PR TITLE
DOCK-2591: Change default version sort order to descending

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/WorkflowVersionDAO.java
@@ -128,10 +128,10 @@ public class WorkflowVersionDAO extends VersionDAO<WorkflowVersion> {
                 .when(cb.equal(versionId, representativeVersionId), 1)
                 .otherwise(0);
         }
-        if ("desc".equalsIgnoreCase(sortOrder)) {
-            query.orderBy(cb.desc(sortExpression), cb.desc(lastModified), cb.desc(versionId));
-        } else {
+        if ("asc".equalsIgnoreCase(sortOrder)) {
             query.orderBy(cb.asc(sortExpression), cb.asc(lastModified), cb.asc(versionId));
+        } else {
+            query.orderBy(cb.desc(sortExpression), cb.desc(lastModified), cb.desc(versionId));
         }
         return predicates;
     }


### PR DESCRIPTION
**Description**
Previously, the default sort order of `WorkflowVersionDAO.getWorkflowVersionsByWorkflowId` was `asc` (ascending).  This caused the `getPublishedWorkflowByPath` endpoint (which calls `getWorkflowVersionsByWorkflowId`) to return a page from the list of versions ordered by ascending modification date (least recently modified versions first), with the default version always being the final entry in the list.

Since we limit the number of versions to 200 in the workflow reply, the upshot was for workflows with more than 200 versions, the default version wasn't included in the list of versions.  Also, the oldest versions were included, rather than the newest.  As a result, the UI was adding the wrong version name (rather than the default version name) to the entry page URL, and the contents of the "Recent Versions" box were incorrect.

See this Slack thread for more information:
https://ucsc-gi.slack.com/archives/C05EZH3RVNY/p1741194751144899

This PR changes the default version sort order to descending, which fixes the problem.

**Review Instructions**
View https://qa.dockstore.org/workflows/github.com/broadinstitute/gatk/mutect2 and confirm that:
* the default version name is added to the url.
* the "Recent Versions" box contains the recent versions (and default version).

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2591
#6019 

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
