### PR TITLE
SEAB-6995: Reenable "authorless" DOIs 

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
@@ -77,7 +77,6 @@ public final class ZenodoHelper {
     // The max number of versions to process when automatically creating DOIs for a workflow
     public static final int AUTOMATIC_DOI_CREATION_VERSIONS_LIMIT = 10;
     public static final String NO_ZENODO_USER_TOKEN = "Could not get Zenodo token for user";
-    public static final String AT_LEAST_ONE_AUTHOR_IS_REQUIRED_TO_PUBLISH_TO_ZENODO = "At least one author is required to publish to Zenodo";
     public static final String FROZEN_VERSION_REQUIRED = "Frozen version required to generate DOI";
     public static final String UNHIDDEN_VERSION_REQUIRED = "Unhidden version required to generate DOI";
     public static final String PUBLISHED_ENTRY_REQUIRED = "Published entry required to generate DOI";
@@ -591,7 +590,9 @@ public final class ZenodoHelper {
         }
 
         if (setOfAuthors.isEmpty()) {
-            throw new CustomWebApplicationException(AT_LEAST_ONE_AUTHOR_IS_REQUIRED_TO_PUBLISH_TO_ZENODO, HttpStatus.SC_BAD_REQUEST);
+            Author fillerAuthor = new Author();
+            fillerAuthor.setName("Author not specified");
+            setOfAuthors.add(fillerAuthor);
         }
 
         return setOfAuthors;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
@@ -591,7 +591,7 @@ public final class ZenodoHelper {
 
         if (setOfAuthors.isEmpty()) {
             Author fillerAuthor = new Author();
-            fillerAuthor.setName("Author not specified");
+            fillerAuthor.setName(workflow.getOrganization());
             setOfAuthors.add(fillerAuthor);
         }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
@@ -144,9 +144,11 @@ class ZenodoHelperTest {
         final DepositMetadata depositMetadata = new DepositMetadata();
         final BioWorkflow bioWorkflow = new BioWorkflow();
         final WorkflowVersion workflowVersion = new WorkflowVersion();
+        final String organizationName = "some-organization";
         bioWorkflow.getWorkflowVersions().add(workflowVersion);
+        bioWorkflow.setOrganization(organizationName);
         ZenodoHelper.setMetadataCreator(depositMetadata, bioWorkflow, workflowVersion);
-        assertEquals("Author not specified", depositMetadata.getCreators().get(0).getName());
+        assertEquals(organizationName, depositMetadata.getCreators().get(0).getName());
         assertEquals(1, depositMetadata.getCreators().size());
     }
 

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/ZenodoHelperTest.java
@@ -145,12 +145,9 @@ class ZenodoHelperTest {
         final BioWorkflow bioWorkflow = new BioWorkflow();
         final WorkflowVersion workflowVersion = new WorkflowVersion();
         bioWorkflow.getWorkflowVersions().add(workflowVersion);
-        try {
-            ZenodoHelper.setMetadataCreator(depositMetadata, bioWorkflow, workflowVersion);
-            fail("Should have failed");
-        } catch (CustomWebApplicationException ex) {
-            assertEquals(ZenodoHelper.AT_LEAST_ONE_AUTHOR_IS_REQUIRED_TO_PUBLISH_TO_ZENODO, ex.getMessage());
-        }
+        ZenodoHelper.setMetadataCreator(depositMetadata, bioWorkflow, workflowVersion);
+        assertEquals("Author not specified", depositMetadata.getCreators().get(0).getName());
+        assertEquals(1, depositMetadata.getCreators().size());
     }
 
     @Test
@@ -166,6 +163,7 @@ class ZenodoHelperTest {
         bioWorkflow.setActualDefaultVersion(workflowVersion);
         ZenodoHelper.setMetadataCreator(depositMetadata, bioWorkflow, workflowVersion);
         assertEquals(joeBlow, depositMetadata.getCreators().get(0).getName());
+        assertEquals(1, depositMetadata.getCreators().size());
     }
 
     @Test


### PR DESCRIPTION
**Description**
This PR changes the webservice's DOI generation logic so that it will generate a DOI for a Workflow with no author in the metadata.  Essentially, we revert to the pre-1.14 behavior, wherein a filler author is used when no author exists, except that now, we use the Workflow's organization as the filler author's name.

**Review Instructions**
Create a valid tagged version without an author on a published workflow, and confirm that an automatic DOI is generated, and that the DOI author name matches the workflow's organization.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6995

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
