### PR TITLE
SEAB-6978: Lock down "platform partner" users

### DIFF
--- a/.github/workflows/deploy_artifacts.yml
+++ b/.github/workflows/deploy_artifacts.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Generate database documentation  
         run: | 
           rm dockstore-webservice/target/dockstore-webservice-*sources.jar || true
-          java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate --include 1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0  dockstore-integration-testing/src/test/resources/dockstore.yml
+          java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate --include 1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0  dockstore-integration-testing/src/test/resources/dockstore.yml
           java -jar dockstore-webservice/target/dockstore-webservice-*.jar db generate-docs dockstore-integration-testing/src/test/resources/dockstore.yml generated-docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -86,7 +86,7 @@ public final class CommonTestUtilities {
     private static final Logger LOG = LoggerFactory.getLogger(CommonTestUtilities.class);
     public static final String OLD_DOCKSTORE_VERSION = "1.15.1";
     public static final List<String> COMMON_MIGRATIONS = List.of("1.3.0.generated", "1.3.1.consistency", "1.4.0", "1.5.0", "1.6.0", "1.7.0",
-            "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0", "1.14.0", "1.15.0", "1.16.0");
+            "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0", "1.14.0", "1.15.0", "1.16.0", "1.17.0");
     // Travis is slow, need to wait up to 1 min for webservice to return
     public static final int WAIT_TIME = 60000;
     public static final String PUBLIC_CONFIG_PATH = getUniversalResourceFileAbsolutePath("dockstore.yml").orElse(null);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceOpenApiIT.java
@@ -426,8 +426,8 @@ class UserResourceOpenApiIT extends BaseIT {
     void testCreateMetricsRobotToken() {
         UsersApi anonApi = new UsersApi(getAnonymousOpenAPIWebClient());
         UsersApi userApi = new UsersApi(getOpenAPIWebClient(OTHER_USERNAME, testingPostgres));
-        UsersApi adminApi = new UsersApi(getOpenAPIWebClient(USER_2_USERNAME, testingPostgres));
-        UsersApi robotApi = new UsersApi(getOpenAPIWebClient(USER_4_USERNAME, testingPostgres));
+        UsersApi adminApi = new UsersApi(getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres));
+        UsersApi robotApi = new UsersApi(getOpenAPIWebClient(USER_2_USERNAME, testingPostgres));
         PrivilegeRequest privilegeRequest = new PrivilegeRequest();
         privilegeRequest.setMetricsRobot(true);
         adminApi.setUserPrivileges(privilegeRequest, robotApi.getUser().getId());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceOpenApiIT.java
@@ -492,8 +492,11 @@ class UserResourceOpenApiIT extends BaseIT {
             }
         }
 
-        // Admin should be able to delete a robot Dockstore token.
+        // A robot user should not be able to delete their Dockstore token.
         TokenUser token = getDockstoreToken(adminApi, robotId);
+        assertThrowsCode(HttpStatus.SC_FORBIDDEN, () -> new TokensApi(getOpenAPIWebClient(robotUsername, testingPostgres)).deleteToken(token.getId()));
+
+        // Admin should be able to delete a robot Dockstore token.
         new TokensApi(getOpenAPIWebClient(adminUsername, testingPostgres)).deleteToken(token.getId());
 
         // Admin should be able to create a robot Dockstore token.
@@ -502,8 +505,8 @@ class UserResourceOpenApiIT extends BaseIT {
         assertTrue(StringUtils.containsOnly(tokenContent, "0123456789abcdef"));
 
         // Confirm that robot Dockstore token was updated and matches what was returned.
-        token = getDockstoreToken(adminApi, robotId);
-        assertEquals(100, token.getId());
+        TokenUser newToken = getDockstoreToken(adminApi, robotId);
+        assertEquals(100, newToken.getId());
         assertEquals(tokenContent, getDockstoreTokenContent(testingPostgres, robotId));
 
         // Robot user should still be able to access the metrics submission endpoints.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -87,6 +87,7 @@ import io.dockstore.webservice.core.metrics.ValidatorVersionInfo;
 import io.dockstore.webservice.doi.DOIGeneratorFactory;
 import io.dockstore.webservice.filters.AdminPrivilegesFilter;
 import io.dockstore.webservice.filters.AuthenticatedUserFilter;
+import io.dockstore.webservice.filters.DenyPlatformPartnerFilter;
 import io.dockstore.webservice.filters.UsernameRenameRequiredFilter;
 import io.dockstore.webservice.helpers.CacheConfigManager;
 import io.dockstore.webservice.helpers.DiagnosticsHelper;
@@ -655,6 +656,8 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
         environment.jersey().register(new UsernameRenameRequiredFilter());
 
         environment.jersey().register(new AuthenticatedUserFilter());
+
+        environment.jersey().register(new DenyPlatformPartnerFilter());
 
         // Swagger providers
         environment.jersey().register(SwaggerSerializers.class);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -87,7 +87,7 @@ import io.dockstore.webservice.core.metrics.ValidatorVersionInfo;
 import io.dockstore.webservice.doi.DOIGeneratorFactory;
 import io.dockstore.webservice.filters.AdminPrivilegesFilter;
 import io.dockstore.webservice.filters.AuthenticatedUserFilter;
-import io.dockstore.webservice.filters.DenyPlatformPartnerFilter;
+import io.dockstore.webservice.filters.DenyRobotFilter;
 import io.dockstore.webservice.filters.UsernameRenameRequiredFilter;
 import io.dockstore.webservice.helpers.CacheConfigManager;
 import io.dockstore.webservice.helpers.DiagnosticsHelper;
@@ -657,7 +657,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
 
         environment.jersey().register(new AuthenticatedUserFilter());
 
-        environment.jersey().register(new DenyPlatformPartnerFilter());
+        environment.jersey().register(new DenyRobotFilter());
 
         // Swagger providers
         environment.jersey().register(SwaggerSerializers.class);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/SimpleAuthorizer.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/SimpleAuthorizer.java
@@ -32,7 +32,8 @@ public class SimpleAuthorizer implements Authorizer<User> {
     public static final String ADMIN = "admin";
     public static final String CURATOR = "curator";
     public static final String PLATFORM_PARTNER = "platformPartner";
-    public static final List<String> ROLES = List.of(ADMIN, CURATOR, PLATFORM_PARTNER);
+    public static final String METRICS_ROBOT = "metricsRobot";
+    public static final List<String> ROLES = List.of(ADMIN, CURATOR, PLATFORM_PARTNER, METRICS_ROBOT);
     private static final Logger LOG = LoggerFactory.getLogger(SimpleAuthorizer.class);
 
     @Override
@@ -47,6 +48,8 @@ public class SimpleAuthorizer implements Authorizer<User> {
             return principal.isCurator();
         } else if (PLATFORM_PARTNER.equalsIgnoreCase(role)) {
             return principal.isPlatformPartner();
+        } else if (METRICS_ROBOT.equalsIgnoreCase(role)) {
+            return principal.isMetricsRobot();
         } else {
             return true;
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/api/PrivilegeRequest.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/api/PrivilegeRequest.java
@@ -49,4 +49,5 @@ public class PrivilegeRequest {
 
     public void setMetricsRobot(boolean metricsRobot) {
         this.metricsRobot = metricsRobot;
+    }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/api/PrivilegeRequest.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/api/PrivilegeRequest.java
@@ -43,7 +43,7 @@ public class PrivilegeRequest {
     }
 
     @JsonProperty
-    public boolean getMetricsRobot() {
+    public boolean isMetricsRobot() {
         return metricsRobot;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/api/PrivilegeRequest.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/api/PrivilegeRequest.java
@@ -13,6 +13,7 @@ public class PrivilegeRequest {
     private boolean admin;
     private boolean curator;
     private Partner platformPartner;
+    private boolean metricsRobot;
 
     @JsonProperty
     public boolean isAdmin() {
@@ -40,4 +41,12 @@ public class PrivilegeRequest {
     public void setPlatformPartner(Partner platformPartner) {
         this.platformPartner = platformPartner;
     }
+
+    @JsonProperty
+    public boolean getMetricsRobot() {
+        return metricsRobot;
+    }
+
+    public void setMetricsRobot(boolean metricsRobot) {
+        this.metricsRobot = metricsRobot;
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -169,7 +169,7 @@ public class User implements Principal, Comparable<User>, Serializable {
     private Partner platformPartner;
 
     @Column(columnDefinition = "boolean default 'false'")
-    @Schema(description = "Indicates whether this user is a robot that submits metrics");
+    @Schema(description = "Indicates whether this user is a robot that submits metrics")
     private boolean metricsRobot;
 
     @Column(columnDefinition = "boolean default 'false'")

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -169,6 +169,10 @@ public class User implements Principal, Comparable<User>, Serializable {
     private Partner platformPartner;
 
     @Column(columnDefinition = "boolean default 'false'")
+    @Schema(description = "Indicates whether this user is a robot that submits metrics");
+    private boolean metricsRobot;
+
+    @Column(columnDefinition = "boolean default 'false'")
     @ApiModelProperty(value = "Indicates whether this user has accepted their username", required = true, position = 12)
     private boolean setupComplete = false;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -587,6 +587,14 @@ public class User implements Principal, Comparable<User>, Serializable {
         this.platformPartner = platformPartner;
     }
 
+    public boolean isMetricsRobot() {
+        return metricsRobot;
+    }
+
+    public void setMetricsRobot(boolean metricsRobot) {
+        this.metricsRobot = metricsRobot;
+    }
+
     /**
      * The profile of a user using a token (Google profile, GitHub profile, etc)
      * The order of the properties are important, the UI lists these properties in this order.

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -168,7 +168,7 @@ public class User implements Principal, Comparable<User>, Serializable {
     @Schema(description = INDICATES_WHETHER_THIS_ACCOUNT_CORRESPONDS_TO_A_PLATFORM_PARTNER)
     private Partner platformPartner;
 
-    @Column(columnDefinition = "boolean default 'false'")
+    @Column(nullable = false, columnDefinition = "boolean default 'false'")
     @Schema(description = "Indicates whether this user is a robot that submits metrics")
     private boolean metricsRobot;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/filters/DenyPlatformPartnerFilter.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/filters/DenyPlatformPartnerFilter.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Deny all requests by a "platformPartner" user to an endpoint that does not have a @RolesAllowed annotation.
+ * Deny any request by a "platformPartner" user to an authorized endpoint (an endpoint that requires a User) that does not have a @RolesAllowed annotation.
  */
 @Provider
 public class DenyPlatformPartnerFilter implements ContainerRequestFilter {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/filters/DenyPlatformPartnerFilter.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/filters/DenyPlatformPartnerFilter.java
@@ -45,7 +45,7 @@ public class DenyPlatformPartnerFilter implements ContainerRequestFilter {
         if (requestContext != null) {
             final Principal principal = requestContext.getSecurityContext().getUserPrincipal();
             if (principal instanceof User user) {
-                if (user.isPlatformPartner()) {
+                if (user.isMetricsRobot()) {
                     final Method resourceMethod = resourceInfo.getResourceMethod();
                     if (resourceMethod != null) {
                         final RolesAllowed rolesAllowedAnnotation = resourceMethod.getAnnotation(RolesAllowed.class);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/filters/DenyPlatformPartnerFilter.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/filters/DenyPlatformPartnerFilter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.dockstore.webservice.filters;
+
+import io.dockstore.webservice.SimpleAuthorizer;
+import io.dockstore.webservice.core.User;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.ext.Provider;
+import java.lang.reflect.Method;
+import java.security.Principal;
+import java.text.MessageFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Deny all requests by a "platformPartner" user to an endpoint that does not have a @RolesAllowed annotation.
+ */
+@Provider
+public class DenyPlatformPartnerFilter implements ContainerRequestFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(DenyPlatformPartnerFilter.class);
+
+    @Context
+    private ResourceInfo resourceInfo;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        if (requestContext != null) {
+            final Principal principal = requestContext.getSecurityContext().getUserPrincipal();
+            if (principal instanceof User user) {
+                if (user.isPlatformPartner()) {
+                    final Method resourceMethod = resourceInfo.getResourceMethod();
+                    if (resourceMethod != null) {
+                        final RolesAllowed rolesAllowedAnnotation = resourceMethod.getAnnotation(RolesAllowed.class);
+                        if (rolesAllowedAnnotation == null) {
+                            throw new ForbiddenException();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/filters/DenyPlatformPartnerFilter.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/filters/DenyPlatformPartnerFilter.java
@@ -17,7 +17,6 @@
 
 package io.dockstore.webservice.filters;
 
-import io.dockstore.webservice.SimpleAuthorizer;
 import io.dockstore.webservice.core.User;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.ForbiddenException;
@@ -28,7 +27,6 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.ext.Provider;
 import java.lang.reflect.Method;
 import java.security.Principal;
-import java.text.MessageFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/filters/DenyRobotFilter.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/filters/DenyRobotFilter.java
@@ -31,11 +31,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Deny any request by a "platformPartner" user to an authorized endpoint (an endpoint that requires a User) that does not have a @RolesAllowed annotation.
+ * Deny any request by a "robot" user to an authorized endpoint (an endpoint that requires a User) that does not have a @RolesAllowed annotation.
  */
 @Provider
-public class DenyPlatformPartnerFilter implements ContainerRequestFilter {
-    private static final Logger LOG = LoggerFactory.getLogger(DenyPlatformPartnerFilter.class);
+public class DenyRobotFilter implements ContainerRequestFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(DenyRobotFilter.class);
 
     @Context
     private ResourceInfo resourceInfo;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -295,7 +295,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
         @ApiParam(value = "Token id to delete", required = true) @PathParam("tokenId") Long tokenId) {
         Token token = tokenDAO.findById(tokenId);
         checkNotNullToken(token);
-        if (!user.isCurator() && !user.getIsAdmin()) {
+        if (!user.getIsAdmin()) {
             checkUserId(user, token.getUserId());
         }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -31,9 +31,6 @@ import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson.JacksonFactory;
 import com.google.api.services.oauth2.model.Userinfoplus;
-import com.google.common.base.Charsets;
-import com.google.common.hash.Hashing;
-import com.google.common.io.BaseEncoding;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -84,7 +81,6 @@ import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.security.SecureRandom;
 import java.text.MessageFormat;
 import java.time.Instant;
 import java.util.Collections;
@@ -123,7 +119,6 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
      */
     public static final JsonFactory JSON_FACTORY = new JacksonFactory();
     public static final String ADMINS_AND_CURATORS_MAY_NOT_LOGIN_WITH_GOOGLE = "Admins and curators may not login with Google";
-    public static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private static final String QUAY_URL = "https://quay.io/api/v1/";
     private static final String BITBUCKET_URL = "https://bitbucket.org/";
@@ -300,7 +295,9 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
         @ApiParam(value = "Token id to delete", required = true) @PathParam("tokenId") Long tokenId) {
         Token token = tokenDAO.findById(tokenId);
         checkNotNullToken(token);
-        checkUserId(user, token.getUserId());
+        if (!user.isCurator() && !user.getIsAdmin()) {
+            checkUserId(user, token.getUserId());
+        }
 
         // invalidate cache now that we're deleting the token
         cachingAuthenticator.invalidate(token.getContent());
@@ -504,7 +501,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
         user = userDAO.findById(userID);
         if (dockstoreToken == null) {
             LOG.info("Could not find user's dockstore token. Making new one...");
-            dockstoreToken = createDockstoreToken(userID, user.getUsername());
+            dockstoreToken = tokenDAO.createDockstoreToken(userID, user.getUsername());
         }
 
         if (googleToken == null) {
@@ -660,7 +657,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
                 throw loginFailedException();
             }
             LOG.info("Could not find user's dockstore token. Making new one...");
-            dockstoreToken = createDockstoreToken(userID, user.getUsername());
+            dockstoreToken = tokenDAO.createDockstoreToken(userID, user.getUsername());
         }
 
         if (githubToken == null) {
@@ -693,24 +690,6 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
             username = githubLogin + count++;
         }
         return username;
-    }
-
-    private Token createDockstoreToken(long userID, String githubLogin) {
-        Token dockstoreToken;
-        final int bufferLength = 1024;
-        final byte[] buffer = new byte[bufferLength];
-        SECURE_RANDOM.nextBytes(buffer);
-        String randomString = BaseEncoding.base64Url().omitPadding().encode(buffer);
-        final String dockstoreAccessToken = Hashing.sha256().hashString(githubLogin + randomString, Charsets.UTF_8).toString();
-
-        dockstoreToken = new Token();
-        dockstoreToken.setTokenSource(TokenType.DOCKSTORE);
-        dockstoreToken.setContent(dockstoreAccessToken);
-        dockstoreToken.setUserId(userID);
-        dockstoreToken.setUsername(githubLogin);
-        long dockstoreTokenId = tokenDAO.create(dockstoreToken);
-        dockstoreToken = tokenDAO.findById(dockstoreTokenId);
-        return dockstoreToken;
     }
 
     public boolean shouldRestrictUser(String username) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -505,14 +505,14 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
     public String createPlatformPartnerToken(@Parameter(hidden = true, name = "user")@Auth User user,
         @PathParam("userId") long userId) {
-        User fetchedUser = userDAO.findById(userId);
-        checkNotNullUser(fetchedUser);
+        User targetUser = userDAO.findById(userId);
+        checkNotNullUser(targetUser);
 
-        if (!fetchedUser.isPlatformPartner()) {
-            throw new CustomWebApplicationException("User must be a platform partner.", HttpStatus.SC_BAD_REQUEST);
+        if (!targetUser.isPlatformPartner()) {
+            throw new CustomWebApplicationException("Target user must be a platform partner.", HttpStatus.SC_BAD_REQUEST);
         }
 
-        Token dockstoreToken = tokenDAO.createDockstoreToken(userId, fetchedUser.getUsername());
+        Token dockstoreToken = tokenDAO.createDockstoreToken(userId, targetUser.getUsername());
         return dockstoreToken.getContent();
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -507,7 +507,6 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
         @PathParam("userId") long userId) {
         User targetUser = userDAO.findById(userId);
         checkNotNullUser(targetUser);
-
         if (!targetUser.isPlatformPartner()) {
             throw new CustomWebApplicationException("Target user must be a platform partner.", HttpStatus.SC_BAD_REQUEST);
         }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -1209,7 +1209,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
         targetUser.setIsAdmin(privilegeRequest.isAdmin());
         targetUser.setCurator(privilegeRequest.isCurator());
         targetUser.setPlatformPartner(privilegeRequest.getPlatformPartner());
-        targetUser.setMetricsRobot(privilegeRequest.getMetricsRobot());
+        targetUser.setMetricsRobot(privilegeRequest.isMetricsRobot());
 
         // A metrics robot user cannot have any other privileges.
         if (targetUser.isMetricsRobot() && (targetUser.getIsAdmin() || targetUser.isCurator() || targetUser.isPlatformPartner())) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -495,6 +495,26 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
         return tokenDAO.findByUserId(userId);
     }
 
+    @POST
+    @Timed
+    @UnitOfWork()
+    @RolesAllowed("admin")
+    @Path("/{userId}/tokens")
+    @Operation(operationId = "createPlatformPartnerToken", description = "Create a Dockstore token for a platform partner user.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "The new token.")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
+    public String createPlatformPartnerToken(@Parameter(hidden = true, name = "user")@Auth User user,
+        @PathParam("userId") long userId) {
+        User fetchedUser = userDAO.findById(userId);
+        checkNotNullUser(fetchedUser);
+
+        if (!fetchedUser.isPlatformPartner()) {
+            throw new CustomWebApplicationException("User must be a platform partner.", HttpStatus.SC_BAD_REQUEST);
+        }
+
+        Token dockstoreToken = tokenDAO.createDockstoreToken(userId, fetchedUser.getUsername());
+        return dockstoreToken.getContent();
+    }
 
     @GET
     @Timed

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -501,7 +501,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @RolesAllowed("admin")
     @Path("/{userId}/tokens")
     @Operation(operationId = "createMetricsRobotToken", description = "Create a Dockstore token for a metrics robot user.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
-    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "The new token.")
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "The new token.", content = @Content(schema = @Schema(implementation = String.class)))
     @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
     public String createMetricsRobotToken(@Parameter(hidden = true, name = "user")@Auth User user,
         @PathParam("userId") long userId) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -500,15 +500,15 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
     @UnitOfWork()
     @RolesAllowed("admin")
     @Path("/{userId}/tokens")
-    @Operation(operationId = "createPlatformPartnerToken", description = "Create a Dockstore token for a platform partner user.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
+    @Operation(operationId = "createMetricsRobotToken", description = "Create a Dockstore token for a metrics robot user.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "The new token.")
     @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = HttpStatusMessageConstants.FORBIDDEN)
-    public String createPlatformPartnerToken(@Parameter(hidden = true, name = "user")@Auth User user,
+    public String createMetricsRobotToken(@Parameter(hidden = true, name = "user")@Auth User user,
         @PathParam("userId") long userId) {
         User targetUser = userDAO.findById(userId);
         checkNotNullUser(targetUser);
-        if (!targetUser.isPlatformPartner()) {
-            throw new CustomWebApplicationException("Target user must be a platform partner.", HttpStatus.SC_BAD_REQUEST);
+        if (!targetUser.isMetricsRobot()) {
+            throw new CustomWebApplicationException("Target user must be a metrics robot.", HttpStatus.SC_BAD_REQUEST);
         }
 
         Token dockstoreToken = tokenDAO.createDockstoreToken(userId, targetUser.getUsername());
@@ -1204,6 +1204,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
         targetUser.setIsAdmin(privilegeRequest.isAdmin());
         targetUser.setCurator(privilegeRequest.isCurator());
         targetUser.setPlatformPartner(privilegeRequest.getPlatformPartner());
+        targetUser.setMetricsRobot(privilegeRequest.getMetricsRobot());
 
         // Invalidate any tokens corresponding to the target user.
         tokenDAO.findByUserId(targetUser.getId()).forEach(token -> this.cachingAuthenticator.invalidate(token.getContent()));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
@@ -236,7 +236,7 @@ public class ToolsExtendedApi {
 
     @POST
     @UnitOfWork
-    @RolesAllowed({"curator", "admin", "platformPartner"})
+    @RolesAllowed({"curator", "admin", "platformPartner", "metricsRobot"})
     @Path("/{id}/versions/{version_id}/executions")
     @Consumes(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ExecutionMetricsPost.SUMMARY, notes = ExecutionMetricsPost.DESCRIPTION, authorizations = {
@@ -314,7 +314,7 @@ public class ToolsExtendedApi {
 
     @GET
     @UnitOfWork(readOnly = true)
-    @RolesAllowed({"curator", "admin", "platformPartner"})
+    @RolesAllowed({"curator", "admin", "platformPartner", "metricsRobot"})
     @Path("/{id}/versions/{version_id}/execution")
     @Produces({MediaType.APPLICATION_JSON})
     @Operation(operationId = "executionGet", summary = ExecutionGet.SUMMARY, description = ExecutionGet.DESCRIPTION, security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME), responses = {
@@ -336,7 +336,7 @@ public class ToolsExtendedApi {
 
     @PUT
     @UnitOfWork
-    @RolesAllowed({"curator", "admin", "platformPartner"})
+    @RolesAllowed({"curator", "admin", "platformPartner", "metricsRobot"})
     @Path("/{id}/versions/{version_id}/executions")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON})

--- a/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
@@ -1,0 +1,28 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<!--
+  ~    Copyright 2025 OICR and UCSC
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
+                   context="1.17.0">
+    <changeSet author="svonworl" id="addMetricsRobotProperty">
+        <addColumn tableName="enduser">
+            <column defaultValueBoolean="false" name="metricsRobot" type="bool">
+                 <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
@@ -20,7 +20,7 @@
                    context="1.17.0">
     <changeSet author="svonworl" id="addMetricsRobotProperty">
         <addColumn tableName="enduser">
-            <column defaultValueBoolean="false" name="metricsRobot" type="bool">
+            <column defaultValueBoolean="false" name="metricsrobot" type="bool">
                  <constraints nullable="false"/>
             </column>
         </addColumn>

--- a/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
@@ -25,4 +25,17 @@
             </column>
         </addColumn>
     </changeSet>
+    <changeSet author="svonworl" id="limitMetricsRobotPrivileges">
+        <sql dbms="postgresql">
+            CREATE OR REPLACE FUNCTION raise_metrics_robot_privileges_exception()
+            RETURNS TRIGGER AS $$
+            BEGIN
+            RAISE EXCEPTION 'a metrics robot can have no other privileges and is a metrics robot forever';
+            END
+            $$ LANGUAGE plpgsql;
+
+            CREATE TRIGGER update_metrics_robot_to_non_metrics_robot BEFORE UPDATE ON enduser FOR EACH ROW WHEN (OLD.metricsrobot AND NOT NEW.metricsrobot) EXECUTE FUNCTION raise_metrics_robot_privileges_exception();
+            CREATE TRIGGER update_metrics_robot_to_add_privileges BEFORE UPDATE ON enduser FOR EACH ROW WHEN (NEW.metricsrobot AND (NEW.isadmin OR NEW.curator OR NEW.platformpartner IS NOT NULL)) EXECUTE FUNCTION raise_metrics_robot_privileges_exception();
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.xml
+++ b/dockstore-webservice/src/main/resources/migrations.xml
@@ -48,4 +48,5 @@
     <include file="migrations.test.add_notebook_1.14.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.15.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.16.0.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.1.17.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -6781,6 +6781,25 @@ paths:
       - BEARER: []
       tags:
       - users
+    post:
+      description: Create a Dockstore token for a platform partner user.
+      operationId: createPlatformPartnerToken
+      parameters:
+      - in: path
+        name: userId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: The new token.
+        "403":
+          description: Forbidden
+      security:
+      - BEARER: []
+      tags:
+      - users
   /users/{userId}/workflows:
     get:
       description: List all workflows owned by the authenticated user.

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -6793,6 +6793,10 @@ paths:
           format: int64
       responses:
         "200":
+          content:
+            application/json:
+              schema:
+                type: string
           description: The new token.
         "403":
           description: Forbidden

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -6782,8 +6782,8 @@ paths:
       tags:
       - users
     post:
-      description: Create a Dockstore token for a platform partner user.
-      operationId: createPlatformPartnerToken
+      description: Create a Dockstore token for a metrics robot user.
+      operationId: createMetricsRobotToken
       parameters:
       - in: path
         name: userId
@@ -10994,6 +10994,8 @@ components:
           type: boolean
         curator:
           type: boolean
+        metricsRobot:
+          type: boolean
         platformPartner:
           type: string
           enum:
@@ -12100,6 +12102,9 @@ components:
           type: boolean
           description: Indicates whether the user is an admin.  The value is always
             false unless requested for oneself or by an admin
+        metricsRobot:
+          type: boolean
+          description: Indicates whether this user is a robot that submits metrics
         name:
           type: string
         orcid:

--- a/propose_migration.sh
+++ b/propose_migration.sh
@@ -27,8 +27,8 @@ rm dockstore-webservice/target/detected-migrations.xml || true
 
 ## load up the old database based on current migration
 rm dockstore-webservice/target/dockstore-webservice-*sources.jar || true
-# java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.consistency,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0 # uncomment this line if you want to diff with an already loaded db dump
-java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.generated,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0 # uncomment this line if you want to generate a DB from scratch with migrations
+# java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.consistency,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0 # uncomment this line if you want to diff with an already loaded db dump
+java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.generated,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0 # uncomment this line if you want to generate a DB from scratch with migrations
 
 ## create the new database based on JPA (ugly, should really create a proper dw command if this works)
 ## remove timeout for mac devices, will have to break manually


### PR DESCRIPTION
**Description**
This PR adds a new "metricsRobot" role to the webservice.  A metrics robot can only access authorized endpoints which have a `@RolesAllowed` annotation that allows them.  All attempts by a metrics robot to access authorized endpoints that don't have a suitable annotation are denied via the new `DenyRobotFilter` filter.

See the comments in https://ucsc-cgl.atlassian.net/browse/SEAB-6978 for more information about the metrics robot role.

After a user becomes a metrics robot, the Dockstore UI will not function properly for that user, so generating a Dockstore token via the login process and managing it via the UI will not be possible.  To compensate, this PR:
1. introduces an admin-only endpoint that generates a Dockstore token for a metrics robot.
2. adds admin access to the token DELETE endpoint, so that we can manage said tokens.

This PR updates the migrations with a new file for the 1.17 release.

To facilitate its reuse, the `createDockstoreToken` method moves to `TokenDAO`, which kinda makes sense, I think.  

For now, I propose that any platform partner or metrics robot is allowed to submit any type of metrics, including updates, and we adjust the aggregator to ignore the submissions that don't make sense.  This proposal assumes that all submissions are accumulated "log-style": that is, all submissions persist, and aren't affected by subsequent activity.
 
**Review Instructions**
Create a user on qa, make them a metrics robot via the `setUserPrivileges` endpoint, and confirm that you can use their token to submit metrics, but cannot access authorized non-metrics endpoints.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6978

**Security and Privacy**

This PR adds a new role to the webservice, and changes the required access to some of the endpoints.  Please scrutinize with extra zest.

- [ ] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
