### PR TITLE
DOCK-2585: remove restub functionality

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGeneralWorkflowIT.java
@@ -191,9 +191,6 @@ class BitBucketGeneralWorkflowIT extends GeneralWorkflowBaseIT {
         // Unpublish workflow
         workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(false));
 
-        // Restub
-        workflow = workflowsApi.restub(workflow.getId());
-
         // Refresh a single version
         workflow = workflowsApi.refreshVersion(workflow.getId(), "master", false);
         assertEquals(1, workflow.getWorkflowVersions().size(), "Should only have one version");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGeneralWorkflowIT.java
@@ -190,6 +190,13 @@ class BitBucketGeneralWorkflowIT extends GeneralWorkflowBaseIT {
         // Unpublish workflow
         workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(false));
 
+        // Refresh a single version
+        workflow = workflowsApi.refreshVersion(workflow.getId(), "master", false);
+        assertTrue(workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "master")), "Should have master version");
+
+        // Refresh another version
+        workflow = workflowsApi.refreshVersion(workflow.getId(), "cwl_import", false);
+        assertTrue(workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "cwl_import")), "Should have cwl_import version");
 
         try {
             workflowsApi.refreshVersion(workflow.getId(), "fakeVersion", false);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGeneralWorkflowIT.java
@@ -191,16 +191,6 @@ class BitBucketGeneralWorkflowIT extends GeneralWorkflowBaseIT {
         // Unpublish workflow
         workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(false));
 
-        // Refresh a single version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "master", false);
-        assertEquals(1, workflow.getWorkflowVersions().size(), "Should only have one version");
-        assertTrue(workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "master")), "Should have master version");
-        assertEquals(ModeEnum.FULL, workflow.getMode(), "Should no longer be a stub workflow");
-
-        // Refresh another version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "cwl_import", false);
-        assertEquals(2, workflow.getWorkflowVersions().size(), "Should now have two versions");
-        assertTrue(workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "cwl_import")), "Should have cwl_import version");
 
         try {
             workflowsApi.refreshVersion(workflow.getId(), "fakeVersion", false);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/BitBucketGeneralWorkflowIT.java
@@ -39,7 +39,6 @@ import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.DockstoreTool;
 import io.swagger.client.model.Tag;
 import io.swagger.client.model.Workflow;
-import io.swagger.client.model.Workflow.ModeEnum;
 import io.swagger.client.model.WorkflowVersion;
 import java.util.ArrayList;
 import java.util.List;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CRUDClientIT.java
@@ -611,18 +611,6 @@ class CRUDClientIT extends BaseIT {
         assertThrows(ApiException.class,  () -> workflowApi.refresh(hostedWorkflow.getId(), false));
     }
 
-    /**
-     * Ensures that hosted workflows cannot be restubed
-     */
-    @Test
-    void testRestubHostedWorkflow() {
-        ApiClient webClient = getWebClient(ADMIN_USERNAME, testingPostgres);
-        WorkflowsApi workflowApi = new WorkflowsApi(webClient);
-        HostedApi hostedApi = new HostedApi(webClient);
-        Workflow hostedWorkflow = hostedApi
-            .createHostedWorkflow("awesomeTool", null, DescriptorLanguage.CWL.toString().toLowerCase(), null, null);
-        assertThrows(ApiException.class,  () -> workflowApi.restub(hostedWorkflow.getId()));
-    }
 
     /**
      * Ensures that hosted workflows cannot be updated

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/CheckerWorkflowIT.java
@@ -182,12 +182,6 @@ class CheckerWorkflowIT extends BaseIT {
             assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
         }
 
-        try {
-            workflowApi.restub(refreshedEntry.getCheckerId());
-            fail("Should not be able to restub the checker");
-        } catch (ApiException e) {
-            assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
-        }
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -162,7 +162,7 @@ class GeneralWorkflowIT extends BaseIT {
 
         final long count6 = testingPostgres.runSelectStatement("select count(*) from workflow where ispublished='t'", long.class);
         assertEquals(0, count6, "there should be 0 published entries, there are " + count6);
-        
+
         try {
             workflowsApi.refreshVersion(workflow.getId(), "fakeVersion", false);
             fail("Should not be able to refresh a version that does not exist");
@@ -703,7 +703,6 @@ class GeneralWorkflowIT extends BaseIT {
         // Change path for each version so that it is invalid
         workflow.setWorkflowPath("thisisnotarealpath.cwl");
         workflowsApi.updateWorkflow(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId(), false);
 
         // Workflow has no valid versions so you cannot publish
 
@@ -711,34 +710,6 @@ class GeneralWorkflowIT extends BaseIT {
         final long count4 = testingPostgres.runSelectStatement("select count(*) from workflowversion where valid='f'", long.class);
         assertTrue(4 <= count4, "there should be at least 4 invalid versions, there are " + count4);
 
-
-        // Update workflow to WDL
-        workflow.setWorkflowPath("/Dockstore.wdl");
-        workflow.setDescriptorType(Workflow.DescriptorTypeEnum.WDL);
-        workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId(), false);
-
-        // Can now publish workflow
-        workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
-
-        // unpublish
-        workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(false));
-
-        // Set paths to invalid
-        workflow.setWorkflowPath("thisisnotarealpath.wdl");
-        workflowsApi.updateWorkflow(workflow.getId(), workflow);
-        workflow = workflowsApi.refresh(workflow.getId(), false);
-
-        // Check that versions are invalid
-        final long count5 = testingPostgres.runSelectStatement("select count(*) from workflowversion where valid='f'", long.class);
-        assertTrue(4 <= count5, "there should be at least 4 invalid versions, there are " + count5);
-
-        // should now not be able to publish
-        try {
-            workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
-        } catch (ApiException e) {
-            assertTrue(e.getMessage().contains("Repository does not meet requirements to publish"));
-        }
     }
 
     /**
@@ -851,15 +822,7 @@ class GeneralWorkflowIT extends BaseIT {
                 "select count(*) from workflow where actualdefaultversion = 952 and actualdefaultversion not in (select versionid from author) and actualdefaultversion not in (select versionid from version_orcidauthor) and description is null",
                 long.class);
         assertEquals(0, count7, "The given workflow should now have contact info and description");
-
-
-        // Convert to WDL workflow
-        workflow.setDescriptorType(Workflow.DescriptorTypeEnum.WDL);
-        workflow = workflowsApi.updateWorkflow(workflow.getId(), workflow);
-
-        // Should now be a WDL workflow
-        final long count9 = testingPostgres.runSelectStatement("select count(*) from workflow where descriptortype='wdl'", long.class);
-        assertEquals(1, count9, "there should be 1 wdl workflow" + count9);
+        
 
 
         // Refresh a single version
@@ -1005,11 +968,6 @@ class GeneralWorkflowIT extends BaseIT {
         final long count4 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type='CWL_TEST_JSON'", long.class);
         assertEquals(2, count4, "there should be two sourcefiles that are cwl test parameter files, there are " + count4);
 
-        // Change to WDL
-        workflow.setDescriptorType(Workflow.DescriptorTypeEnum.WDL);
-        workflow.setWorkflowPath("Dockstore.wdl");
-        workflowsApi.updateWorkflow(workflow.getId(), workflow);
-        workflowsApi.refresh(workflow.getId(), false);
 
         // Should be no sourcefiles
         final long count5 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type like '%_TEST_JSON'", long.class);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -163,9 +163,6 @@ class GeneralWorkflowIT extends BaseIT {
         final long count6 = testingPostgres.runSelectStatement("select count(*) from workflow where ispublished='t'", long.class);
         assertEquals(0, count6, "there should be 0 published entries, there are " + count6);
 
-        // Restub
-        workflow = workflowsApi.restub(workflow.getId());
-
         // Refresh a single version
         workflow = workflowsApi.refreshVersion(workflow.getId(), "master", false);
         assertEquals(1, workflow.getWorkflowVersions().size(), "Should only have one version");
@@ -317,47 +314,6 @@ class GeneralWorkflowIT extends BaseIT {
         assertEquals(1, count, "there should be 1 matching workflow version, there is " + count);
     }
 
-    /**
-     * This tests that a restub will work on an unpublished, full workflow
-     */
-    @Test
-    void testRestub() {
-        ApiClient client = getWebClient(USER_2_USERNAME, testingPostgres);
-        WorkflowsApi workflowsApi = new WorkflowsApi(client);
-
-        // refresh all and individual
-        Workflow workflow = manualRegisterAndPublish(workflowsApi, "DockstoreTestUser2/hello-dockstore-workflow", "testname", "cwl",
-            SourceControl.GITHUB, "/Dockstore.cwl", false);
-
-        // Restub workflow
-        workflowsApi.restub(workflow.getId());
-
-        final long count = testingPostgres.runSelectStatement("select count(*) from workflowversion", long.class);
-        assertEquals(0, count, "there should be 0 workflow versions, there are " + count);
-    }
-
-    /**
-     * This tests that a restub will not work on an published, full workflow
-     */
-    @Test
-    void testRestubError() {
-        ApiClient client = getWebClient(USER_2_USERNAME, testingPostgres);
-        WorkflowsApi workflowsApi = new WorkflowsApi(client);
-
-        // refresh all and individual
-        Workflow workflow = manualRegisterAndPublish(workflowsApi, "DockstoreTestUser2/hello-dockstore-workflow", "testname", "cwl",
-            SourceControl.GITHUB, "/Dockstore.cwl", false);
-
-        // Publish workflow
-        workflow = workflowsApi.publish(workflow.getId(), CommonTestUtilities.createPublishRequest(true));
-
-        // Restub
-        try {
-            workflow = workflowsApi.restub(workflow.getId());
-        } catch (ApiException e) {
-            assertTrue(e.getMessage().contains("A workflow must be unpublished to restub"));
-        }
-    }
 
     /**
      * Tests updating workflow descriptor type when a workflow is FULL and when it is a STUB
@@ -766,8 +722,6 @@ class GeneralWorkflowIT extends BaseIT {
         final long count4 = testingPostgres.runSelectStatement("select count(*) from workflowversion where valid='f'", long.class);
         assertTrue(4 <= count4, "there should be at least 4 invalid versions, there are " + count4);
 
-        // Restub
-        workflow = workflowsApi.restub(workflow.getId());
 
         // Update workflow to WDL
         workflow.setWorkflowPath("/Dockstore.wdl");
@@ -909,12 +863,6 @@ class GeneralWorkflowIT extends BaseIT {
                 long.class);
         assertEquals(0, count7, "The given workflow should now have contact info and description");
 
-        // restub
-        workflow = workflowsApi.restub(workflow.getId());
-        final long count8 = testingPostgres.runSelectStatement(
-            "select count(*) from workflow where mode='STUB' and sourcecontrol = '" + SourceControl.GITLAB
-                + "' and organization = 'dockstore.test.user2' and repository = 'dockstore-workflow-example'", long.class);
-        assertEquals(1, count8, "The workflow should now be a stub");
 
         // Convert to WDL workflow
         workflow.setDescriptorType(Workflow.DescriptorTypeEnum.WDL);
@@ -924,8 +872,6 @@ class GeneralWorkflowIT extends BaseIT {
         final long count9 = testingPostgres.runSelectStatement("select count(*) from workflow where descriptortype='wdl'", long.class);
         assertEquals(1, count9, "there should be 1 wdl workflow" + count9);
 
-        // Restub
-        workflow = workflowsApi.restub(workflow.getId());
 
         // Refresh a single version
         workflow = workflowsApi.refreshVersion(workflow.getId(), "master", false);
@@ -1069,9 +1015,6 @@ class GeneralWorkflowIT extends BaseIT {
         workflow = workflowsApi.refresh(workflow.getId(), false);
         final long count4 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type='CWL_TEST_JSON'", long.class);
         assertEquals(2, count4, "there should be two sourcefiles that are cwl test parameter files, there are " + count4);
-
-        // Restub
-        workflow = workflowsApi.restub(workflow.getId());
 
         // Change to WDL
         workflow.setDescriptorType(Workflow.DescriptorTypeEnum.WDL);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -162,18 +162,7 @@ class GeneralWorkflowIT extends BaseIT {
 
         final long count6 = testingPostgres.runSelectStatement("select count(*) from workflow where ispublished='t'", long.class);
         assertEquals(0, count6, "there should be 0 published entries, there are " + count6);
-
-        // Refresh a single version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "master", false);
-        assertEquals(1, workflow.getWorkflowVersions().size(), "Should only have one version");
-        assertTrue(workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "master")), "Should have master version");
-        assertEquals(ModeEnum.FULL, workflow.getMode(), "Should no longer be a stub workflow");
-
-        // Refresh another version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "testCWL", false);
-        assertEquals(2, workflow.getWorkflowVersions().size(), "Should now have two versions");
-        assertTrue(workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "testCWL")), "Should have testCWL version");
-
+        
         try {
             workflowsApi.refreshVersion(workflow.getId(), "fakeVersion", false);
             fail("Should not be able to refresh a version that does not exist");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -44,7 +44,6 @@ import io.swagger.client.api.UsersApi;
 import io.swagger.client.api.WorkflowsApi;
 import io.swagger.client.model.SourceFile;
 import io.swagger.client.model.Workflow;
-import io.swagger.client.model.Workflow.ModeEnum;
 import io.swagger.client.model.Workflow.TopicSelectionEnum;
 import io.swagger.client.model.WorkflowVersion;
 import io.swagger.client.model.WorkflowVersion.DoiStatusEnum;

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -704,12 +704,6 @@ class GeneralWorkflowIT extends BaseIT {
         workflow.setWorkflowPath("thisisnotarealpath.cwl");
         workflowsApi.updateWorkflow(workflow.getId(), workflow);
 
-        // Workflow has no valid versions so you cannot publish
-
-        // check that invalid
-        final long count4 = testingPostgres.runSelectStatement("select count(*) from workflowversion where valid='f'", long.class);
-        assertTrue(4 <= count4, "there should be at least 4 invalid versions, there are " + count4);
-
     }
 
     /**
@@ -822,19 +816,6 @@ class GeneralWorkflowIT extends BaseIT {
                 "select count(*) from workflow where actualdefaultversion = 952 and actualdefaultversion not in (select versionid from author) and actualdefaultversion not in (select versionid from version_orcidauthor) and description is null",
                 long.class);
         assertEquals(0, count7, "The given workflow should now have contact info and description");
-        
-
-
-        // Refresh a single version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "master", false);
-        assertEquals(1, workflow.getWorkflowVersions().size(), "Should only have one version");
-        assertTrue(workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "master")), "Should have master version");
-        assertEquals(ModeEnum.FULL, workflow.getMode(), "Should no longer be a stub workflow");
-
-        // Refresh another version
-        workflow = workflowsApi.refreshVersion(workflow.getId(), "test", false);
-        assertEquals(2, workflow.getWorkflowVersions().size(), "Should now have two versions");
-        assertTrue(workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "test")), "Should have test version");
 
         try {
             workflowsApi.refreshVersion(workflow.getId(), "fakeVersion", false);
@@ -968,18 +949,6 @@ class GeneralWorkflowIT extends BaseIT {
         final long count4 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type='CWL_TEST_JSON'", long.class);
         assertEquals(2, count4, "there should be two sourcefiles that are cwl test parameter files, there are " + count4);
 
-
-        // Should be no sourcefiles
-        final long count5 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type like '%_TEST_JSON'", long.class);
-        assertEquals(0, count5, "there should be no source files that are test parameter files, there are " + count5);
-
-        // Update version wdltest with test parameters
-        toAdd.clear();
-        toAdd.add("test.wdl.json");
-        workflowsApi.addTestParameterFiles(workflow.getId(), toAdd, "", "wdltest");
-        workflow = workflowsApi.refresh(workflow.getId(), false);
-        final long count6 = testingPostgres.runSelectStatement("select count(*) from sourcefile where type='WDL_TEST_JSON'", long.class);
-        assertEquals(1, count6, "there should be one sourcefile that is a wdl test parameter file, there are " + count6);
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -706,6 +706,8 @@ class GeneralWorkflowIT extends BaseIT {
         // Change path for each version so that it is invalid
         workflow.setWorkflowPath("thisisnotarealpath.cwl");
         workflowsApi.updateWorkflow(workflow.getId(), workflow);
+        workflowsApi.refresh(workflow.getId(), false);
+
 
         // check that invalid
         final long count4 = testingPostgres.runSelectStatement("select count(*) from workflowversion where valid='f'", long.class);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowIT.java
@@ -162,6 +162,10 @@ class GeneralWorkflowIT extends BaseIT {
         final long count6 = testingPostgres.runSelectStatement("select count(*) from workflow where ispublished='t'", long.class);
         assertEquals(0, count6, "there should be 0 published entries, there are " + count6);
 
+        // Refresh a single version
+        workflow = workflowsApi.refreshVersion(workflow.getId(), "master", false);
+        assertTrue(workflow.getWorkflowVersions().stream().anyMatch(workflowVersion -> Objects.equals(workflowVersion.getName(), "master")), "Should have master version");
+
         try {
             workflowsApi.refreshVersion(workflow.getId(), "fakeVersion", false);
             fail("Should not be able to refresh a version that does not exist");
@@ -703,6 +707,9 @@ class GeneralWorkflowIT extends BaseIT {
         workflow.setWorkflowPath("thisisnotarealpath.cwl");
         workflowsApi.updateWorkflow(workflow.getId(), workflow);
 
+        // check that invalid
+        final long count4 = testingPostgres.runSelectStatement("select count(*) from workflowversion where valid='f'", long.class);
+        assertTrue(4 <= count4, "there should be at least 4 invalid versions, there are " + count4);
     }
 
     /**

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowRegressionIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GeneralWorkflowRegressionIT.java
@@ -218,28 +218,6 @@ class GeneralWorkflowRegressionIT extends BaseIT {
     }
 
     /**
-     * This tests that a restub will work on an unpublished, full workflow
-     */
-    @Test
-    @Disabled(KNOWN_BREAKAGE_MOVING_TO_1_9_0)
-    void testRestubOld() {
-        // Set up DB
-
-        // Refresh and then restub
-        runOldDockstoreClient(dockstore,
-            new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "refresh", "--script" });
-        runOldDockstoreClient(dockstore,
-            new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "refresh", "--entry",
-                SourceControl.GITHUB.toString() + "/DockstoreTestUser2/hello-dockstore-workflow", "--script" });
-        runOldDockstoreClient(dockstore,
-            new String[] { "--config", ResourceHelpers.resourceFilePath("config_file2.txt"), "workflow", "restub", "--entry",
-                SourceControl.GITHUB.toString() + "/DockstoreTestUser2/hello-dockstore-workflow", "--script" });
-
-        final long count = testingPostgres.runSelectStatement("select count(*) from workflowversion", long.class);
-        assertEquals(0, count, "there should be 0 workflow versions, there are " + count);
-    }
-
-    /**
      * Tests that convert with valid imports will work (for WDL)
      */
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -2181,8 +2181,6 @@ class WebhookIT extends BaseIT {
         handleGitHubRelease(workflowsApi, DockstoreTesting.WORKFLOW_DOCKSTORE_YML, "refs/tags/0.9", USER_2_USERNAME);
         final Workflow workflow = workflowsApi.getWorkflowByPath("github.com/" + DockstoreTesting.WORKFLOW_DOCKSTORE_YML + "/foobar", WorkflowSubClass.BIOWORKFLOW, "versions");
 
-        // Should not be able to restub a .dockstore.yml-based workflow
-        assertThrowsApiException(() -> workflowsApi.restub(workflow.getId()), HttpStatus.SC_BAD_REQUEST);
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
@@ -418,13 +418,6 @@ class ZenodoIT {
         assertTrue(exception.getMessage().contains(UNHIDDEN_VERSION_REQUIRED));
         testingPostgres.runUpdateStatement("update version_metadata set hidden = false");
 
-        // Unpublish workflow
-        workflowsApi.publish1(workflowId, CommonTestUtilities.createOpenAPIPublishRequest(false));
-
-
-        // Publish workflow
-        workflowsApi.publish1(workflowId, CommonTestUtilities.createOpenAPIPublishRequest(true));
-
         // Should not be able to register DOI without Zenodo token
         exception = assertThrows(ApiException.class, () -> workflowsApi.requestDOIForWorkflowVersion(workflowId, versionId, ""));
         assertTrue(exception.getMessage().contains(NO_ZENODO_USER_TOKEN));

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/ZenodoIT.java
@@ -35,8 +35,6 @@ import static io.dockstore.webservice.helpers.ZenodoHelper.NO_DOCKSTORE_DOI;
 import static io.dockstore.webservice.helpers.ZenodoHelper.NO_ZENODO_USER_TOKEN;
 import static io.dockstore.webservice.helpers.ZenodoHelper.PUBLISHED_ENTRY_REQUIRED;
 import static io.dockstore.webservice.helpers.ZenodoHelper.UNHIDDEN_VERSION_REQUIRED;
-import static io.dockstore.webservice.resources.WorkflowResource.A_WORKFLOW_MUST_BE_UNPUBLISHED_TO_RESTUB;
-import static io.dockstore.webservice.resources.WorkflowResource.A_WORKFLOW_MUST_HAVE_NO_SNAPSHOT_TO_RESTUB;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -412,10 +410,6 @@ class ZenodoIT {
         // Should be able to refresh a workflow with a frozen version without throwing an error
         workflowsApi.refresh1(githubWorkflow.getId(), false);
 
-        // should not be able to restub whether published or not since there is a snapshot/frozen
-        exception = assertThrows(ApiException.class, () -> workflowsApi.restub(workflowId));
-        assertTrue(exception.getMessage().contains(A_WORKFLOW_MUST_BE_UNPUBLISHED_TO_RESTUB));
-
         // should not be able to request a DOI for a hidden version
         testingPostgres.runUpdateStatement("update version_metadata set hidden = true");
         master = workflowsApi.getWorkflowVersionById(workflowId, versionId, "");
@@ -427,9 +421,6 @@ class ZenodoIT {
         // Unpublish workflow
         workflowsApi.publish1(workflowId, CommonTestUtilities.createOpenAPIPublishRequest(false));
 
-        // don't die horribly when stubbing something with snapshots, explain the error
-        exception = assertThrows(ApiException.class, () -> workflowsApi.restub(workflowId));
-        assertTrue(exception.getMessage().contains(A_WORKFLOW_MUST_HAVE_NO_SNAPSHOT_TO_RESTUB));
 
         // Publish workflow
         workflowsApi.publish1(workflowId, CommonTestUtilities.createOpenAPIPublishRequest(true));
@@ -452,9 +443,6 @@ class ZenodoIT {
 
         // unpublish workflow
         workflowsApi.publish1(workflowBeforeFreezing.getId(), CommonTestUtilities.createOpenAPIPublishRequest(false));
-
-        // Should not be able to restub an unpublished workflow that has a frozen version or a DOI, depending upon the environment
-        exception = assertThrows(ApiException.class, () -> workflowsApi.restub(workflowId));
     }
 
     @Test

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -8453,29 +8453,6 @@ paths:
       - BEARER: []
       tags:
       - workflows
-  /workflows/{workflowId}/restub:
-    get:
-      description: Restub a workflow
-      operationId: restub
-      parameters:
-      - in: path
-        name: workflowId
-        required: true
-        schema:
-          type: integer
-          format: int64
-      responses:
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Workflow'
-          description: default response
-      security:
-      - BEARER: []
-      summary: Restub a workflow
-      tags:
-      - workflows
   /workflows/{workflowId}/secondaryDescriptors:
     get:
       description: Get the corresponding descriptor documents from source control.


### PR DESCRIPTION
**Description**
This PR removes restub functionality in the webservice

**Review Instructions**
Verify tests pass

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2585

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
