### PR TITLE
SEAB-7080: Use tag creation date as DOI publication date

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
@@ -689,8 +689,8 @@ public final class ZenodoHelper {
 
         // Set the publication date to the GitHub tag creation date, which should be stored in version.lastModified.
         // version.lastModified can be null, so use version.dbUpdateDate, which cannot be null, as a backup.
-        Date modifiedDate = ObjectUtils.firstNonNull(workflowVersion.getLastModified(), workflowVersion.getDbUpdateDate());
-        depositMetadata.setPublicationDate(formatDate(modifiedDate));
+        Date lastModifiedDate = ObjectUtils.firstNonNull(workflowVersion.getLastModified(), workflowVersion.getDbUpdateDate());
+        depositMetadata.setPublicationDate(formatDate(lastModifiedDate));
 
         depositMetadata.setVersion(workflowVersion.getName());
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
@@ -690,7 +690,7 @@ public final class ZenodoHelper {
         // Set the publication date to the GitHub tag creation date, which should be stored in version.lastModified.
         // version.lastModified can be null, so use version.dbUpdateDate, which cannot be null, as a backup.
         Date modifiedDate = ObjectUtils.firstNonNull(workflowVersion.getLastModified(), workflowVersion.getDbUpdateDate());
-        depositMetadata.setPublicationDate(LocalDateTime.ofInstant(modifiedDate.toInstant(), ZoneId.systemDefault()).toString());
+        depositMetadata.setPublicationDate(formatDate(modifiedDate));
 
         depositMetadata.setVersion(workflowVersion.getName());
 
@@ -699,6 +699,14 @@ public final class ZenodoHelper {
         setMetadataCreator(depositMetadata, workflow, workflowVersion);
 
         setMetadataCommunities(depositMetadata);
+    }
+
+    /**
+     * Convert a Date into a String of the form 'YYYY-MM-DD'
+     * @param date date to convert
+     */
+    private static String formatDate(Date date) {
+        return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate().toString();
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
@@ -53,9 +53,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -66,6 +67,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.http.HttpStatus;
@@ -685,8 +687,10 @@ public final class ZenodoHelper {
 
         depositMetadata.setDescription(descriptionStr);
 
-        // We will set the Zenodo workflow version publication date to the date of the DOI issuance
-        depositMetadata.setPublicationDate(ZonedDateTime.now().toLocalDate().toString());
+        // Set the publication date to the GitHub tag creation date, which should be stored in version.lastModified.
+        // version.lastModified can be null, so use version.dbUpdateDate, which cannot be null, as a backup.
+        Date modifiedDate = ObjectUtils.firstNonNull(workflowVersion.getLastModified(), workflowVersion.getDbUpdateDate());
+        depositMetadata.setPublicationDate(LocalDateTime.ofInstant(modifiedDate.toInstant(), ZoneId.systemDefault()).toString());
 
         depositMetadata.setVersion(workflowVersion.getName());
 


### PR DESCRIPTION
**Description**
This PR changes the webservice to use `WorkflowVersion.lastModified`, which for most workflows is the time at which the corresponding tag was created on GitHub, to generate the version DOI publication date.

In general, this change will make the version DOIs appear in a sane order, but may cause ordering problems when subsequent retroactive automatic DOIs are added to workflows that had pre-existing non-automatic DOIs, or pre-existing automatic DOIs that were generated for tags found when our GitHub app was installed.   Fortunately, this is a small number of workflows.

Somewhat suboptimally, Zenodo accepts a date, but not a date+time, in the publication date field for a submission (https://help.zenodo.org/docs/deposit/describe-records/publication-date/).  So, if there's lots of tags created the same day, they may still appear "out of order".  This includes the DOIs that are produced for `DockstoreTestUser4`'s workflow [when the smoke tests are run?].

**Review Instructions**
Generate a sandbox DOI for a tag and confirm that the publication date is the tag's GitHub creation date, rather than the current time.  This may be tricky.  Alternatively, check the sandbox Zenodo Dockstore community for version DOIs wherein the upload and publication dates do not match, and confirm that the publication date matches the tag creation date.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7080

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
