### PR TITLE
SEAB-7089: Fix slow-loading user profile "Activity" section

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -43,7 +43,8 @@ import org.hibernate.annotations.UpdateTimestamp;
     // the clauses that look like "(e.version is null or (e.version in (select id from WorkflowVersion) or e.version in (select id from Tag)))" can be removed once the version ids are consistent
     @NamedQuery(name = "io.dockstore.webservice.core.Event.deleteByEntryId", query = "DELETE from Event e where e.tool.id = :entryId OR e.workflow.id = :entryId OR e.apptool.id = :entryId OR e.service.id = :entryId OR e.notebook.id = :entryId"),
     @NamedQuery(name = "io.dockstore.webservice.core.Event.deleteByOrganizationId", query = "DELETE from Event e WHERE e.organization.id = :organizationId"),
-    @NamedQuery(name = "io.dockstore.webservice.core.Event.countAllForOrganization", query = "SELECT COUNT(*) FROM Event eve WHERE eve.organization.id = :organizationId")
+    @NamedQuery(name = "io.dockstore.webservice.core.Event.countAllForOrganization", query = "SELECT COUNT(*) FROM Event eve WHERE eve.organization.id = :organizationId"),
+    @NamedQuery(name = "io.dockstore.webservice.core.Event.findByIds", query = "SELECT e from Event e WHERE e.id IN :ids ORDER BY e.id DESC")
 })
 public class Event {
     @Id


### PR DESCRIPTION
**Description**
This PR changes the performance profile of the event retrieval endpoints, thus fixing the very slow load times of the "Activity" sections of certain user profile pages.

To retrieve events, the webservice synthesizes a `CriteriaQuery`, which, previously, results in a massive `join`:
```
select e1_0.id,e1_0.apptoolId,e1_0.collectionId,e1_0.dbCreateDate,e1_0.dbUpdateDate,e1_0.initiatorUserId,e1_0.notebookId,e1_0.organizationId,e1_0.serviceId,e1_0.toolId,e1_0.type,e1_0.userId,e1_0.versionId,v1_0.id,v1_0.clazz_,v1_0.commitID,v1_0.dbCreateDate,v1_0.dbUpdateDate,v1_0.dirtyBit,v1_0.frozen,v1_0.name,v1_0.parentid,v1_0.readMePath,v1_0.reference,v1_0.referenceType,v1_0.userFiles,v1_0.valid,v1_0.versioneditor_id,v1_0.automated,v1_0.cwlPath,v1_0.dockerfilePath,v1_0.imageId,v1_0.lastBuilt,v1_0.size,v1_0.wdlPath,v1_0.dagJson,v1_0.isLegacyVersion,v1_0.kernelImagePath,v1_0.lastModified,v1_0.synced,v1_0.toolTableJson,v1_0.workflowPath,e1_0.workflowId from event e1_0 left join Tool t1_0 on t1_0.id=e1_0.toolId left join workflow w1_0 on w1_0.id=e1_0.workflowId left join apptool a1_0 on a1_0.id=e1_0.apptoolId left join service s1_0 on s1_0.id=e1_0.serviceId left join notebook n1_0 on n1_0.id=e1_0.notebookId left join organization o1_0 on o1_0.id=e1_0.organizationId left join ( select id, commitID, dbCreateDate, dbUpdateDate, dirtyBit, frozen, name, readMePath, reference, referenceType, userFiles, valid, parentid, versioneditor_id, automated, cwlPath, dockerfilePath, imageId, lastBuilt, size, wdlPath, null::text as dagJson, null::boolean as isLegacyVersion, null::text as kernelImagePath, null::timestamp as lastModified, null::boolean as synced, null::text as toolTableJson, null::text as workflowPath, 1 as clazz_ from tag union all select id, commitID, dbCreateDate, dbUpdateDate, dirtyBit, frozen, name, readMePath, reference, referenceType, userFiles, valid, parentid, versioneditor_id, null::boolean as automated, null::text as cwlPath, null::text as dockerfilePath, null::text as imageId, null::timestamp as lastBuilt, null::bigint as size, null::text as wdlPath, dagJson, isLegacyVersion, kernelImagePath, lastModified, synced, toolTableJson, workflowPath, 2 as clazz_ from workflowversion ) v1_0 on v1_0.id=e1_0.versionId where e1_0.initiatorUserId in(?) and (e1_0.toolId is null and e1_0.workflowId is null and e1_0.apptoolId is null and e1_0.serviceId is null and e1_0.notebookId is null or t1_0.isPublished or w1_0.isPublished or a1_0.isPublished or s1_0.isPublished or n1_0.isPublished or e1_0.type in(?,?,?,?,?,?,?)) and (not(o1_0.categorizer) or e1_0.organizationId is null) order by e1_0.id desc offset ? rows fetch first ? rows only
```
The join "pulls in" lots of seemingly-unnecessary information, like versions, because, although it isn't being used to determine which `Event`s to select, it's needed to construct fully-formed `Event`s from the results.
 
At some point between 15/Oct/2024 and 2/Nov/2024, the database changed so that, for users with lots of events, this join performs poorly and induces the observed delay.  That is, on the 15/Oct db, the query is fast, and on the 2/Nov db, it is very slow.  I confirmed this behavior by loading prod db dumps onto my local 1.17 build.

I'm not sure of the root cause.  Could be that the involved data now exceeds some sort of internal threshold/limit in the db server, causing the query planner to do a worse job, or inducing the server to use a different internal data structure that doesn't perform as well.  Or maybe something else.  IMHO, it's potentially not the best use of our time to investigate more deeply, could take a while and might not reveal anything actionable...

This PR changes the query to retrieve a list of Event IDs, simplifying the above join to:
```
select e1_0.id from event e1_0 left join Tool t1_0 on t1_0.id=e1_0.toolId left join workflow w1_0 on w1_0.id=e1_0.workflowId left join apptool a1_0 on a1_0.id=e1_0.apptoolId left join service s1_0 on s1_0.id=e1_0.serviceId left join notebook n1_0 on n1_0.id=e1_0.notebookId left join organization o1_0 on o1_0.id=e1_0.organizationId where e1_0.initiatorUserId in(?) and (e1_0.toolId is null and e1_0.workflowId is null and e1_0.apptoolId is null and e1_0.serviceId is null and e1_0.notebookId is null or t1_0.isPublished or w1_0.isPublished or a1_0.isPublished or s1_0.isPublished or n1_0.isPublished or e1_0.type in(?,?,?,?,?,?,?)) and (not(o1_0.categorizer) or e1_0.organizationId is null) order by 1 desc offset ? rows fetch first ? rows only
```
The resulting list of Event IDs is then converted to a list of Events in a subsequent query.

For users with many Events, the new scheme is much much faster.  However, it's unchanged to negligibly slower for users that have few events.  Wall clock time for http://localhost:4200/api/events/user-id?eventSearchType=PROFILE with this PR running locally, for different users:
```
denis-yuen (id 3): 0.45s
kathy-t (id 36641): 0.30s
bvizzier (id 56241): 0.21s
svonworl (id 62319): 0.30s
```
Same test, running on local develop build:
```
denis-yuen (id 3): 11.88s
kathy-t (id 36641): 9.25s
bvizzier (id 56241): 0.19s
svonworl (id 62319): 0.34s
```

**Review Instructions**
Confirm that the "Activity" section of the user profile pages is responding fast enough, and contains the correct information, sorted in the correct order.  Make sure to check when you are both logged-in and logged-out.  Suggested urls: https://qa.dockstore.org/users/denis-yuen etc

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7089

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
