### PR TITLE
SEAB-6958: Make notebook registration error message more explanatory

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/JupyterHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/JupyterHandler.java
@@ -234,7 +234,7 @@ public class JupyterHandler implements LanguageHandlerInterface {
             String entryLanguage = workflow.getDescriptorTypeSubclass().toString();
             String notebookLanguage = extractProgrammingLanguage(notebook);
             if (!entryLanguage.equalsIgnoreCase(notebookLanguage)) {
-                return negativeValidation(notebookPath, String.format("The notebook programming language must be '%s'", entryLanguage));
+                return negativeValidation(notebookPath, String.format("The notebook's programming language must match the 'language' field specified in .dockstore.yml ('%s')", entryLanguage));
             }
         } catch (JsonParseException ex) {
             return negativeValidation(notebookPath, "Error reading the notebook programming language", ex);


### PR DESCRIPTION
**Description**
When registering a Jupyter notebook, Dockstore enforces that the language specified in the `.dockstore.yml` (default: 'Python') matches the language that is specified in the notebook file itself.  If it does not, validation fails.  This PR improves the associated error message so that what has happened is more apparent, allowing the user to correct the problem.

**Review Instructions**
Register a Python jupyter notebook, but specify `language: r` in the `.dockstore.yml`.  Confirm that an explanatory error message appears in the App logs.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6958

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
