### PR TITLE
SEAB-6978: Correct "metrics robot" design

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceOpenApiIT.java
@@ -47,6 +47,7 @@ import io.dockstore.openapi.client.model.EntryType;
 import io.dockstore.openapi.client.model.EntryUpdateTime;
 import io.dockstore.openapi.client.model.ExecutionsRequestBody;
 import io.dockstore.openapi.client.model.PrivilegeRequest;
+import io.dockstore.openapi.client.model.PrivilegeRequest.MetricsRobotPartnerEnum;
 import io.dockstore.openapi.client.model.Profile;
 import io.dockstore.openapi.client.model.StarRequest;
 import io.dockstore.openapi.client.model.TokenUser;
@@ -442,13 +443,13 @@ class UserResourceOpenApiIT extends BaseIT {
 
         // NOT able to create a metrics robot that has other privileges.
         PrivilegeRequest robotPlusAdminPrivileges = new PrivilegeRequest();
-        robotPlusAdminPrivileges.setMetricsRobot(true);
+        robotPlusAdminPrivileges.setMetricsRobotPartner(MetricsRobotPartnerEnum.TOIL);
         robotPlusAdminPrivileges.setAdmin(true);
         assertThrowsCode(HttpStatus.SC_BAD_REQUEST, () -> adminApi.setUserPrivileges(robotPlusAdminPrivileges, robotId));
 
         // Able to create a metrics robot with no other privileges.
         PrivilegeRequest robotPrivileges = new PrivilegeRequest();
-        robotPrivileges.setMetricsRobot(true);
+        robotPrivileges.setMetricsRobotPartner(MetricsRobotPartnerEnum.TOIL);
         adminApi.setUserPrivileges(robotPrivileges, robotId);
 
         // NOT able to add more privileges to an existing metrics robot.

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceOpenApiIT.java
@@ -56,7 +56,6 @@ import io.dockstore.openapi.client.model.UserInfo;
 import io.dockstore.openapi.client.model.Workflow;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
 import io.dockstore.webservice.helpers.GitHubAppHelper;
-import io.dockstore.webservice.resources.proposedGA4GH.ToolsApiExtendedServiceImpl;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -473,7 +472,8 @@ class UserResourceOpenApiIT extends BaseIT {
         assertThrowsCode(HttpStatus.SC_FORBIDDEN, () -> robotApi.changeUsername("newname"));
 
         // The robot user should NOT be able to access metrics for a different platform.
-        assertThrowsCodeAndMessage(HttpStatus.SC_BAD_REQUEST, ToolsApiExtendedServiceImpl.FORBIDDEN_PLATFORM, () -> new ExtendedGa4GhApi(getOpenAPIWebClient(robotUsername, testingPostgres)).executionGet("malformedId", "malformedVersionId", Partner.TERRA.name(), "malformedExecutionId"));
+        assertThrowsCode(HttpStatus.SC_BAD_REQUEST, () -> new ExtendedGa4GhApi(getOpenAPIWebClient(robotUsername, testingPostgres)).executionGet("malformedId", "malformedVersionId", Partner.TOIL.name(), "malformedExecutionId"));
+        assertThrowsCode(HttpStatus.SC_FORBIDDEN, () -> new ExtendedGa4GhApi(getOpenAPIWebClient(robotUsername, testingPostgres)).executionGet("malformedId", "malformedVersionId", Partner.TERRA.name(), "malformedExecutionId"));
 
         // Update token ID sequence number so that it doesn't collide with existing tokens.
         testingPostgres.runUpdateStatement("alter sequence token_id_seq increment by 50 restart with 100");
@@ -538,11 +538,5 @@ class UserResourceOpenApiIT extends BaseIT {
     private void assertThrowsCode(int statusCode, Executable executable) {
         ApiException exception = assertThrows(ApiException.class, executable);
         assertEquals(statusCode, exception.getCode());
-    }
-
-    private void assertThrowsCodeAndMessage(int statusCode, String message, Executable executable) {
-        ApiException exception = assertThrows(ApiException.class, executable);
-        assertEquals(statusCode, exception.getCode());
-        assertEquals(message, exception.getMessage());
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceOpenApiIT.java
@@ -468,8 +468,11 @@ class UserResourceOpenApiIT extends BaseIT {
 
         // The robot user should be able to access the metrics submission endpoints, and should NOT be able to access other authenticated endpoints.
         // We don't synthesize a valid metrics request here, but instead check the status code to determine "how far" the request got.
-        assertThrowsCode(HttpStatus.SC_UNPROCESSABLE_ENTITY, () -> new ExtendedGa4GhApi(getOpenAPIWebClient(robotUsername, testingPostgres)).executionMetricsPost(new ExecutionsRequestBody(), Partner.TERRA.name(), "malformedId", "malformedVersionId", null));
+        assertThrowsCode(HttpStatus.SC_UNPROCESSABLE_ENTITY, () -> new ExtendedGa4GhApi(getOpenAPIWebClient(robotUsername, testingPostgres)).executionMetricsPost(new ExecutionsRequestBody(), Partner.TOIL.name(), "malformedId", "malformedVersionId", null));
         assertThrowsCode(HttpStatus.SC_FORBIDDEN, () -> robotApi.changeUsername("newname"));
+
+        // The robot user should NOT be able to submit metrics for a different platform.
+        assertThrowsCode(HttpStatus.SC_BAD_REQUEST, () -> new ExtendedGa4GhApi(getOpenAPIWebClient(robotUsername, testingPostgres)).executionMetricsPost(new ExecutionsRequestBody(), Partner.TERRA.name(), "malformedId", "malformedVersionId", null));
 
         // Update token ID sequence number so that it doesn't collide with existing tokens.
         testingPostgres.runUpdateStatement("alter sequence token_id_seq increment by 50 restart with 100");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceOpenApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/UserResourceOpenApiIT.java
@@ -56,6 +56,7 @@ import io.dockstore.openapi.client.model.UserInfo;
 import io.dockstore.openapi.client.model.Workflow;
 import io.dockstore.openapi.client.model.WorkflowSubClass;
 import io.dockstore.webservice.helpers.GitHubAppHelper;
+import io.dockstore.webservice.resources.proposedGA4GH.ToolsApiExtendedServiceImpl;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -471,8 +472,8 @@ class UserResourceOpenApiIT extends BaseIT {
         assertThrowsCode(HttpStatus.SC_UNPROCESSABLE_ENTITY, () -> new ExtendedGa4GhApi(getOpenAPIWebClient(robotUsername, testingPostgres)).executionMetricsPost(new ExecutionsRequestBody(), Partner.TOIL.name(), "malformedId", "malformedVersionId", null));
         assertThrowsCode(HttpStatus.SC_FORBIDDEN, () -> robotApi.changeUsername("newname"));
 
-        // The robot user should NOT be able to submit metrics for a different platform.
-        assertThrowsCode(HttpStatus.SC_BAD_REQUEST, () -> new ExtendedGa4GhApi(getOpenAPIWebClient(robotUsername, testingPostgres)).executionMetricsPost(new ExecutionsRequestBody(), Partner.TERRA.name(), "malformedId", "malformedVersionId", null));
+        // The robot user should NOT be able to access metrics for a different platform.
+        assertThrowsCodeAndMessage(HttpStatus.SC_BAD_REQUEST, ToolsApiExtendedServiceImpl.FORBIDDEN_PLATFORM, () -> new ExtendedGa4GhApi(getOpenAPIWebClient(robotUsername, testingPostgres)).executionGet("malformedId", "malformedVersionId", Partner.TERRA.name(), "malformedExecutionId"));
 
         // Update token ID sequence number so that it doesn't collide with existing tokens.
         testingPostgres.runUpdateStatement("alter sequence token_id_seq increment by 50 restart with 100");
@@ -537,5 +538,11 @@ class UserResourceOpenApiIT extends BaseIT {
     private void assertThrowsCode(int statusCode, Executable executable) {
         ApiException exception = assertThrows(ApiException.class, executable);
         assertEquals(statusCode, exception.getCode());
+    }
+
+    private void assertThrowsCodeAndMessage(int statusCode, String message, Executable executable) {
+        ApiException exception = assertThrows(ApiException.class, executable);
+        assertEquals(statusCode, exception.getCode());
+        assertEquals(message, exception.getMessage());
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/api/PrivilegeRequest.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/api/PrivilegeRequest.java
@@ -13,7 +13,7 @@ public class PrivilegeRequest {
     private boolean admin;
     private boolean curator;
     private Partner platformPartner;
-    private boolean metricsRobot;
+    private Partner metricsRobotPartner;
 
     @JsonProperty
     public boolean isAdmin() {
@@ -43,11 +43,11 @@ public class PrivilegeRequest {
     }
 
     @JsonProperty
-    public boolean isMetricsRobot() {
-        return metricsRobot;
+    public Partner getMetricsRobotPartner() {
+        return metricsRobotPartner;
     }
 
-    public void setMetricsRobot(boolean metricsRobot) {
-        this.metricsRobot = metricsRobot;
+    public void setMetricsRobotPartner(Partner metricsRobotPartner) {
+        this.metricsRobotPartner = metricsRobotPartner;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/User.java
@@ -168,9 +168,9 @@ public class User implements Principal, Comparable<User>, Serializable {
     @Schema(description = INDICATES_WHETHER_THIS_ACCOUNT_CORRESPONDS_TO_A_PLATFORM_PARTNER)
     private Partner platformPartner;
 
-    @Column(nullable = false, columnDefinition = "boolean default 'false'")
+    @Enumerated(EnumType.STRING)
     @Schema(description = "Indicates whether this user is a robot that submits metrics")
-    private boolean metricsRobot;
+    private Partner metricsRobotPartner;
 
     @Column(columnDefinition = "boolean default 'false'")
     @ApiModelProperty(value = "Indicates whether this user has accepted their username", required = true, position = 12)
@@ -588,11 +588,15 @@ public class User implements Principal, Comparable<User>, Serializable {
     }
 
     public boolean isMetricsRobot() {
-        return metricsRobot;
+        return metricsRobotPartner != null;
     }
 
-    public void setMetricsRobot(boolean metricsRobot) {
-        this.metricsRobot = metricsRobot;
+    public void setMetricsRobotPartner(Partner metricsRobotPartner) {
+        this.metricsRobotPartner = metricsRobotPartner;
+    }
+
+    public Partner getMetricsRobotPartner() {
+        return metricsRobotPartner;
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/JupyterHandler.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/JupyterHandler.java
@@ -234,7 +234,7 @@ public class JupyterHandler implements LanguageHandlerInterface {
             String entryLanguage = workflow.getDescriptorTypeSubclass().toString();
             String notebookLanguage = extractProgrammingLanguage(notebook);
             if (!entryLanguage.equalsIgnoreCase(notebookLanguage)) {
-                return negativeValidation(notebookPath, String.format("The notebook programming language must be '%s'", entryLanguage));
+                return negativeValidation(notebookPath, String.format("The notebook's programming language must match the 'language' field specified in .dockstore.yml ('%s')", entryLanguage));
             }
         } catch (JsonParseException ex) {
             return negativeValidation(notebookPath, "Error reading the notebook programming language", ex);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/UserResource.java
@@ -1209,7 +1209,7 @@ public class UserResource implements AuthenticatedResourceInterface, SourceContr
         targetUser.setIsAdmin(privilegeRequest.isAdmin());
         targetUser.setCurator(privilegeRequest.isCurator());
         targetUser.setPlatformPartner(privilegeRequest.getPlatformPartner());
-        targetUser.setMetricsRobot(privilegeRequest.isMetricsRobot());
+        targetUser.setMetricsRobotPartner(privilegeRequest.getMetricsRobotPartner());
 
         // A metrics robot user cannot have any other privileges.
         if (targetUser.isMetricsRobot() && (targetUser.getIsAdmin() || targetUser.isCurator() || targetUser.isPlatformPartner())) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -501,7 +501,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
     @Override
     public Response submitMetricsData(String id, String versionId, Partner platform, User owner, String description, ExecutionsRequestBody executions) {
         checkActualPlatform(platform);
-        checkPlatformForPlatformPartnerUser(owner, platform);
+        checkPlatformForRole(owner, platform);
 
         // Check that the entry and version exists
         Entry<?, ?> entry;
@@ -593,7 +593,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
 
     @Override
     public Response getExecution(String id, String versionId, Partner platform, String executionId, User user) {
-        checkPlatformForPlatformPartnerUser(user, platform);
+        checkPlatformForRole(user, platform);
 
         Entry<?, ?> entry;
         try {
@@ -626,7 +626,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
 
     @Override
     public Response updateExecutionMetrics(String id, String versionId, Partner platform, User owner, String description, ExecutionsRequestBody executions) {
-        checkPlatformForPlatformPartnerUser(owner, platform);
+        checkPlatformForRole(owner, platform);
         final long ownerId = owner.getId();
 
         // Check that the entry and version exists

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -794,7 +794,7 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
      */
     private void checkPlatformForRole(User user, Partner platform) {
         if (user.isPlatformPartner() && user.getPlatformPartner() != platform
-           || user.isMetricsRobot() && user.getMetricsRobotPartner() != platform) {
+            || user.isMetricsRobot() && user.getMetricsRobotPartner() != platform) {
             throw new CustomWebApplicationException(FORBIDDEN_PLATFORM, HttpStatus.SC_FORBIDDEN);
         }
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -788,12 +788,13 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
     }
 
     /**
-     * Checks if the user is a platform partner and if the platform they're trying to access is the platform they have permissions for.
+     * Checks if the user is a platform partner or metrics robot and if the platform they're trying to access is the platform they have permissions for.
      * @param user
      * @param platform
      */
-    private void checkPlatformForPlatformPartnerUser(User user, Partner platform) {
-        if (user.isPlatformPartner() && user.getPlatformPartner() != platform) {
+    private void checkPlatformForRole(User user, Partner platform) {
+        if (user.isPlatformPartner() && user.getPlatformPartner() != platform
+           || user.isMetricsRobot() && user.getMetricsRobotPartner() != platform) {
             throw new CustomWebApplicationException(FORBIDDEN_PLATFORM, HttpStatus.SC_FORBIDDEN);
         }
     }

--- a/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
@@ -52,7 +52,7 @@
         </sql>
         <sql dbms="postgresql">
             CREATE TRIGGER update_metrics_robot_to_non_metrics_robot BEFORE UPDATE ON enduser FOR EACH ROW WHEN (OLD.metricsrobotpartner IS NOT NULL AND NEW.metricsrobotpartner IS NULL) EXECUTE FUNCTION raise_metrics_robot_privileges_exception();
-            CREATE TRIGGER update_metrics_robot_to_add_privileges BEFORE UPDATE ON enduser FOR EACH ROW WHEN (NEW.metricsrobotpartner IS NOT NULL AND (NEW.isadmin OR NEW.curator OR NEW.platformpartner IS NOT NULL)) EXECUTE FUNCTION raise_metrics_robot_privileges_exception();
+            ALTER TABLE enduser ADD CONSTRAINT metrics_robot_cannot_have_other_privileges CHECK (NOT (metricsrobotpartner IS NOT NULL AND (isadmin OR curator OR platformpartner IS NOT NULL)));
         </sql>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
@@ -51,7 +51,7 @@
             UPDATE enduser SET metricsrobotpartner = CASE WHEN metricsrobotpartner = 'true' THEN 'TOIL' ELSE NULL END;
         </sql>
         <sql dbms="postgresql">
-            CREATE TRIGGER update_metrics_robot_to_non_metrics_robot BEFORE UPDATE ON enduser FOR EACH ROW WHEN (OLD.metricsrobotpartner IS NOT NULL AND NOT NEW.metricsrobotpartner IS NULL) EXECUTE FUNCTION raise_metrics_robot_privileges_exception();
+            CREATE TRIGGER update_metrics_robot_to_non_metrics_robot BEFORE UPDATE ON enduser FOR EACH ROW WHEN (OLD.metricsrobotpartner IS NOT NULL AND NEW.metricsrobotpartner IS NULL) EXECUTE FUNCTION raise_metrics_robot_privileges_exception();
             CREATE TRIGGER update_metrics_robot_to_add_privileges BEFORE UPDATE ON enduser FOR EACH ROW WHEN (NEW.metricsrobotpartner IS NOT NULL AND (NEW.isadmin OR NEW.curator OR NEW.platformpartner IS NOT NULL)) EXECUTE FUNCTION raise_metrics_robot_privileges_exception();
         </sql>
     </changeSet>

--- a/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
@@ -38,4 +38,21 @@
             CREATE TRIGGER update_metrics_robot_to_add_privileges BEFORE UPDATE ON enduser FOR EACH ROW WHEN (NEW.metricsrobot AND (NEW.isadmin OR NEW.curator OR NEW.platformpartner IS NOT NULL)) EXECUTE FUNCTION raise_metrics_robot_privileges_exception();
         </sql>
     </changeSet>
+    <changeSet author="svonworl" id="tweakMetricsRobotProperty">
+        <sql dbms="postgresql">
+            DROP TRIGGER update_metrics_robot_to_non_metrics_robot ON enduser;
+            DROP TRIGGER update_metrics_robot_to_add_privileges ON enduser;
+        </sql>
+        <modifyDataType columnName="metricsrobot" tableName="enduser" newDataType="varchar(255)"/>
+        <dropDefaultValue columnName="metricsrobot" tableName="enduser"/>
+        <dropNotNullConstraint columnName="metricsrobot" tableName="enduser"/>
+        <renameColumn oldColumnName="metricsrobot" newColumnName="metricsrobotpartner" tableName="enduser"/>
+        <sql dbms="postgresql">
+            UPDATE enduser SET metricsrobotpartner = CASE WHEN metricsrobotpartner = 'true' THEN 'TOIL' ELSE NULL END;
+        </sql>
+        <sql dbms="postgresql">
+            CREATE TRIGGER update_metrics_robot_to_non_metrics_robot BEFORE UPDATE ON enduser FOR EACH ROW WHEN (OLD.metricsrobotpartner IS NOT NULL AND NOT NEW.metricsrobotpartner IS NULL) EXECUTE FUNCTION raise_metrics_robot_privileges_exception();
+            CREATE TRIGGER update_metrics_robot_to_add_privileges BEFORE UPDATE ON enduser FOR EACH ROW WHEN (NEW.metricsrobotpartner IS NOT NULL AND (NEW.isadmin OR NEW.curator OR NEW.platformpartner IS NOT NULL)) EXECUTE FUNCTION raise_metrics_robot_privileges_exception();
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -10975,8 +10975,23 @@ components:
           type: boolean
         curator:
           type: boolean
-        metricsRobot:
-          type: boolean
+        metricsRobotPartner:
+          type: string
+          enum:
+          - GALAXY
+          - TERRA
+          - DNA_STACK
+          - DNA_NEXUS
+          - CGC
+          - NHLBI_BIODATA_CATALYST
+          - ANVIL
+          - CAVATICA
+          - NEXTFLOW_TOWER
+          - ELWAZI
+          - AGC
+          - TOIL
+          - OTHER
+          - ALL
         platformPartner:
           type: string
           enum:
@@ -12085,7 +12100,24 @@ components:
             false unless requested for oneself or by an admin
         metricsRobot:
           type: boolean
+        metricsRobotPartner:
+          type: string
           description: Indicates whether this user is a robot that submits metrics
+          enum:
+          - GALAXY
+          - TERRA
+          - DNA_STACK
+          - DNA_NEXUS
+          - CGC
+          - NHLBI_BIODATA_CATALYST
+          - ANVIL
+          - CAVATICA
+          - NEXTFLOW_TOWER
+          - ELWAZI
+          - AGC
+          - TOIL
+          - OTHER
+          - ALL
         name:
           type: string
         orcid:


### PR DESCRIPTION
**Description**
This PR adjusts the design of the "metrics robot" role.  In the preceding PR https://github.com/dockstore/dockstore/pull/6089, we created a new metrics robots role.  Alas, the new role was denoted by a boolean flag in `User`, and was not tied to a particular `Partner`, thus allowing a metrics robot to submit metrics for any partner, which should not be permitted.  Thanks to Kathy for finding the problem whilst emptying her review bucket!

This PR prevents the problem by associating a metrics robot with a `Partner`, to which it is solely authorized to submit metrics, in a manner similar to how the "platform partner" role works.

Regarding compatibility with the existing naming conventions, should it be `metricsRobotPartner`, or `metricsRobotPlatform`?  There's valid arguments for either, I think.  If you don't like the former, let me know, and we can change to the latter.

Sidebar:

Whenever I make a significant mistake whilst creating software, I try to go back and determine why it happened, so I can do better next time.  In this case, the scenario matches a failure mode which we might call "full mid-stream redesign".  Originally, I'd proposed a simple implementation that added a boolean `isRobot` to `User`, which would allow such a user to only access endpoints that were specifically annotated for the user's role.  We decided to go with another design (the one wrapped up by this PR) instead. 

In such a situation, it can be useful to go completely back to square one to evaluate the new design and its implementation requirements, to avoid conflating with the assumptions/conclusions from the previous design.  Also, if you're adapting the code that was implemented for the previous design, extra attention to correctness/consistency/completeness is merited.  I shoulda done more of all of the above.

**Review Instructions**
Create a user on qa, make them a metrics robot via the setUserPrivileges endpoint, and confirm that you can use their token to submit metrics, but cannot access authorized non-metrics endpoints.  Also, attempt to submit metrics for a partner that's not authorized, and confirm that you cannot.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6978

**Security and Privacy**

See above.  Please scrutinize the mechanics of the new "metrics robot" role. 

- [ ] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
