### PR TITLE
SEAB-7157: Fix TRS 500

### DIFF
--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -819,7 +819,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         String url = ToolsImplCommon.getUrlFromId(config, entry);
         String[] splitPath = selfPath.split(URLEncoder.encode(entry, StandardCharsets.UTF_8));
         if (splitPath.length < 2) {
-            throw new CustomWebApplicationException("not found", HttpStatus.SC_NOT_FOUND);
+            throw new CustomWebApplicationException("not found (the request may be encoded incorrectly)", HttpStatus.SC_NOT_FOUND);
         }
         return url + splitPath[1];
     }

--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -817,7 +817,11 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
      */
     private static String computeURLFromEntryAndRequestURI(String entry, String selfPath) {
         String url = ToolsImplCommon.getUrlFromId(config, entry);
-        return url + selfPath.split(URLEncoder.encode(entry, StandardCharsets.UTF_8))[1];
+        String[] splitPath = selfPath.split(URLEncoder.encode(entry, StandardCharsets.UTF_8));
+        if (splitPath.length < 2) {
+            throw new CustomWebApplicationException("not found", HttpStatus.SC_NOT_FOUND);
+        }
+        return url + splitPath[1];
     }
 
     public static List<Checksum> convertToTRSChecksums(final SourceFile sourceFile) {


### PR DESCRIPTION
**Description**
Recently, we observed some 500s that are caused by some TRS path/url processing code going sideways because the original request was doubly-URL-encoded.  For example, consider the request from the ticket:
```
GET /ga4gh/trs/v2/tools/quay.io%252Fcollaboratory%252Fdockstore-tool-bedtools-genomecov/versions/0.3/CWL/descriptor/Dockerfile
```
The above triggers the 500 at this line https://github.com/dockstore/dockstore/blob/48ff1a9cca89b7727121a8940b9be4c919014158/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java#L820 because the string to be split and the split separator string don't match because one is doubly-encoded.

However, the proper singly-URL-encoded request:
```
GET /ga4gh/trs/v2/tools/quay.io%2Fcollaboratory%2Fdockstore-tool-bedtools-genomecov/versions/0.3/CWL/descriptor/Dockerfile
```
works fine.

In this PR, we modify the malfunctioning function, so that if the split doesn't work, we return a `NOT_FOUND` response.  IMHO, this is reasonable, because due to the double encoding, the file path is nonsensical, despite the fact that, somehow, the code successfully got to this spot.

**Review Instructions**
The singly-encoded request should succeed.

The doubly-encoded request should fail with a 404.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7157

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
