### PR TITLE
SEAB-7194: Add "time series" metric database entity

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -93,7 +93,7 @@ public final class CommonTestUtilities {
     private static final Logger LOG = LoggerFactory.getLogger(CommonTestUtilities.class);
     public static final String OLD_DOCKSTORE_VERSION = "1.15.1";
     public static final List<String> COMMON_MIGRATIONS = List.of("1.3.0.generated", "1.3.1.consistency", "1.4.0", "1.5.0", "1.6.0", "1.7.0",
-            "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0", "1.14.0", "1.15.0", "1.16.0", "1.17.0");
+            "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0", "1.14.0", "1.15.0", "1.16.0", "1.17.0", "1.18.0");
     // Travis is slow, need to wait up to 1 min for webservice to return
     public static final int WAIT_TIME = 60000;
     public static final String PUBLIC_CONFIG_PATH = getUniversalResourceFileAbsolutePath("dockstore.yml").orElse(null);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -81,6 +81,7 @@ import io.dockstore.webservice.core.metrics.ExecutionTimeStatisticMetric;
 import io.dockstore.webservice.core.metrics.MemoryStatisticMetric;
 import io.dockstore.webservice.core.metrics.Metrics;
 import io.dockstore.webservice.core.metrics.MetricsByStatus;
+import io.dockstore.webservice.core.metrics.TimeSeriesMetric;
 import io.dockstore.webservice.core.metrics.ValidationStatusCountMetric;
 import io.dockstore.webservice.core.metrics.ValidatorInfo;
 import io.dockstore.webservice.core.metrics.ValidatorVersionInfo;
@@ -261,7 +262,7 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             Organization.class, Notification.class, OrganizationUser.class, Event.class, Collection.class, Validation.class, BioWorkflow.class, Service.class, VersionMetadata.class, Image.class, Checksum.class, LambdaEvent.class,
             ParsedInformation.class, EntryVersion.class, DeletedUsername.class, CloudInstance.class, Author.class, OrcidAuthor.class,
             AppTool.class, Category.class, FullWorkflowPath.class, Notebook.class, SourceFileMetadata.class, Metrics.class, CpuStatisticMetric.class, MemoryStatisticMetric.class, ExecutionTimeStatisticMetric.class, CostStatisticMetric.class,
-            ExecutionStatusCountMetric.class, ValidationStatusCountMetric.class, ValidatorInfo.class, ValidatorVersionInfo.class, MetricsByStatus.class, Doi.class) {
+            ExecutionStatusCountMetric.class, ValidationStatusCountMetric.class, ValidatorInfo.class, ValidatorVersionInfo.class, MetricsByStatus.class, Doi.class, TimeSeriesMetric.class) {
         @Override
         public DataSourceFactory getDataSourceFactory(DockstoreWebserviceConfiguration configuration) {
             return configuration.getDataSourceFactory();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/MetricsByStatus.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/MetricsByStatus.java
@@ -71,9 +71,9 @@ public class MetricsByStatus {
 
     @Valid
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "dailyruncounttimeseriesid", referencedColumnName = "id")
-    @Schema(description = "daily run count time series for the status")
-    private TimeSeriesMetric dailyRunCountTimeSeries;
+    @JoinColumn(name = "dailyexecutioncountsid", referencedColumnName = "id")
+    @Schema(description = "daily execution count time series for the status")
+    private TimeSeriesMetric dailyExecutionCounts;
 
     public MetricsByStatus() {
 
@@ -131,11 +131,11 @@ public class MetricsByStatus {
         this.cost = cost;
     }
 
-    public TimeSeriesMetric getDailyRunCountTimeSeries() {
-        return dailyRunCountTimeSeries;
+    public TimeSeriesMetric getDailyExecutionCounts() {
+        return dailyExecutionCounts;
     }
 
-    public void setDailyRunCountTimeSeries(TimeSeriesMetric dailyRunCountTimeSeries) {
-        this.dailyRunCountTimeSeries = dailyRunCountTimeSeries;
+    public void setDailyExecutionCounts(TimeSeriesMetric dailyExecutionCounts) {
+        this.dailyExecutionCounts = dailyExecutionCounts;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/MetricsByStatus.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/MetricsByStatus.java
@@ -69,6 +69,12 @@ public class MetricsByStatus {
     @Schema(description = "Aggregated cost metrics in USD for the status")
     private CostStatisticMetric cost;
 
+    @Valid
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "dailyruncounttimeseriesid", referencedColumnName = "id")
+    @Schema(description = "daily run count time series for the status")
+    private TimeSeriesMetric dailyRunCountTimeSeries;
+
     public MetricsByStatus() {
 
     }
@@ -123,5 +129,13 @@ public class MetricsByStatus {
 
     public void setCost(CostStatisticMetric cost) {
         this.cost = cost;
+    }
+
+    public TimeSeriesMetric getDailyRunCountTimeSeries() {
+        return dailyRunCountTimeSeries;
+    }
+
+    public void setDailyRunCountTimeSeries(TimeSeriesMetric dailyRunCountTimeSeries) {
+        this.dailyRunCountTimeSeries = dailyRunCountTimeSeries;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/TimeSeriesMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/TimeSeriesMetric.java
@@ -34,7 +34,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.type.SqlTypes;
 
 @Entity
-@Schema(name = "TimeSeriesMetric", description = "Describes a metric that consists of a series of data values sampled at evenly-spaced points in time")
+@Schema(name = "TimeSeriesMetric", description = "Describes a metric that consists of a series of data values sampled at evenly-spaced points in time", allOf = Metric.class)
 public class TimeSeriesMetric extends Metric {
 
     @JdbcTypeCode(SqlTypes.JSON)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/TimeSeriesMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/TimeSeriesMetric.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 OICR and UCSC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.dockstore.webservice.core.metrics;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotNull;
+import java.sql.Timestamp;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Schema(name = "TimeSeriesMetric", description = "Describes a metric that consists of a series of data values sampled at evenly-spaced points in time")
+public class TimeSeriesMetric extends Metric {
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(nullable = false)
+    @NotNull
+    @Schema(description = "Array of sample values, oldest values first.", requiredMode = RequiredMode.REQUIRED)
+    private Double[] values;
+
+    @Column(nullable = false)
+    @NotNull
+    @Schema(description = "Time that the first point was sampled at", requiredMode = RequiredMode.REQUIRED)
+    private Timestamp begins;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Schema(description = "Time between samples.", requiredMode = RequiredMode.REQUIRED)
+    private TimeSeriesMetricInterval interval;
+
+    // database timestamps
+    @Column(updatable = false)
+    @CreationTimestamp
+    @JsonIgnore
+    private Timestamp dbCreateDate;
+
+    @Column()
+    @UpdateTimestamp
+    @JsonIgnore
+    private Timestamp dbUpdateDate;
+
+    public TimeSeriesMetric() {
+    }
+
+    public Timestamp getDbCreateDate() {
+        return dbCreateDate;
+    }
+
+    public void setDbCreateDate(Timestamp dbCreateDate) {
+        this.dbCreateDate = dbCreateDate;
+    }
+
+    public Timestamp getDbUpdateDate() {
+        return dbUpdateDate;
+    }
+
+    public void setDbUpdateDate(Timestamp dbUpdateDate) {
+        this.dbUpdateDate = dbUpdateDate;
+    }
+
+    public Double[] getValues() {
+        return values;
+    }
+
+    public void setValues(Double[] values) {
+        this.values = values;
+    }
+
+    public Timestamp getBegins() {
+        return begins;
+    }
+
+    public void setBegins(Timestamp begins) {
+        this.begins = begins;
+    }
+
+    public TimeSeriesMetricInterval getInterval() {
+        return interval;
+    }
+
+    public void setInterval(TimeSeriesMetricInterval interval) {
+        this.interval = interval;
+    }
+
+    public enum TimeSeriesMetricInterval {
+        SECOND,
+        MINUTE,
+        HOUR,
+        DAY,
+        WEEK,
+        MONTH
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/TimeSeriesMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/TimeSeriesMetric.java
@@ -18,6 +18,7 @@
 package io.dockstore.webservice.core.metrics;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.persistence.Column;
@@ -26,6 +27,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
 import java.sql.Timestamp;
+import java.util.List;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -38,8 +40,8 @@ public class TimeSeriesMetric extends Metric {
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(nullable = false)
     @NotNull
-    @Schema(description = "Array of sample values, oldest values first.", requiredMode = RequiredMode.REQUIRED)
-    private Double[] values;
+    @ArraySchema(arraySchema = @Schema(description = "List of sample values, oldest values first"), schema = @Schema(description = "Sample value"))
+    private List<Double> values;
 
     @Column(nullable = false)
     @NotNull
@@ -48,7 +50,7 @@ public class TimeSeriesMetric extends Metric {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    @Schema(description = "Time between samples.", requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "Time between samples", requiredMode = RequiredMode.REQUIRED)
     private TimeSeriesMetricInterval interval;
 
     // database timestamps
@@ -81,11 +83,11 @@ public class TimeSeriesMetric extends Metric {
         this.dbUpdateDate = dbUpdateDate;
     }
 
-    public Double[] getValues() {
+    public List<Double> getValues() {
         return values;
     }
 
-    public void setValues(Double[] values) {
+    public void setValues(List<Double> values) {
         this.values = values;
     }
 

--- a/dockstore-webservice/src/main/resources/migrations.1.18.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.18.0.xml
@@ -39,5 +39,6 @@
         <addColumn tableName="metrics_by_status">
             <column name="dailyexecutioncountsid" type="BIGINT"/>
         </addColumn>
+        <addForeignKeyConstraint baseColumnNames="dailyexecutioncountsid" baseTableName="metrics_by_status" constraintName="fk_metrics_by_status_dailyexecutioncountsid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="timeseriesmetric" validate="true"/>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.18.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.18.0.xml
@@ -37,7 +37,7 @@
         </createTable>
         <addForeignKeyConstraint baseColumnNames="id" baseTableName="timeseriesmetric" constraintName="fk_timeseriesmetric_metric" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="metric"/>
         <addColumn tableName="metrics_by_status">
-            <column name="dailyruncounttimeseriesid" type="BIGINT"/>
+            <column name="dailyexecutioncountsid" type="BIGINT"/>
         </addColumn>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.18.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.18.0.xml
@@ -18,4 +18,26 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
                    context="1.18.0">
+    <changeSet author="svonworl" id="addTimeSeries">
+        <createTable tableName="timeseriesmetric">
+            <column name="dbcreatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="dbupdatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="timeseriesmetric_pkey"/>
+            </column>
+            <column name="values" type="JSONB">
+                <constraints nullable="false"/>
+            </column>
+            <column name="begins" type="TIMESTAMP WITHOUT TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="interval" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addForeignKeyConstraint baseColumnNames="id" baseTableName="timeseriesmetric" constraintName="fk_timeseriesmetric_metric" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="metric"/>
+        <addColumn tableName="metrics_by_status">
+            <column name="dailyruncounttimeseriesid" type="BIGINT"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.18.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.18.0.xml
@@ -1,0 +1,21 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<!--
+  ~    Copyright 2025 OICR and UCSC
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
+                   context="1.18.0">
+</databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.18.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.18.0.xml
@@ -39,6 +39,6 @@
         <addColumn tableName="metrics_by_status">
             <column name="dailyexecutioncountsid" type="BIGINT"/>
         </addColumn>
-        <addForeignKeyConstraint baseColumnNames="dailyexecutioncountsid" baseTableName="metrics_by_status" constraintName="fk_metrics_by_status_dailyexecutioncountsid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="timeseriesmetric" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="dailyexecutioncountsid" baseTableName="metrics_by_status" constraintName="fk_metrics_by_status_dailyexecutioncountsid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="timeseriesmetric"/>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.xml
+++ b/dockstore-webservice/src/main/resources/migrations.xml
@@ -49,4 +49,5 @@
     <include file="migrations.1.15.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.16.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.17.0.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.1.18.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -10735,6 +10735,8 @@ components:
           $ref: '#/components/schemas/CostMetric'
         cpu:
           $ref: '#/components/schemas/CpuMetric'
+        dailyExecutionCounts:
+          $ref: '#/components/schemas/TimeSeriesMetric'
         executionStatusCount:
           type: integer
           format: int32
@@ -11563,6 +11565,46 @@ components:
       required:
       - dateExecuted
       - executionId
+    TimeSeriesMetric:
+      type: object
+      description: Describes a metric that consists of a series of data values sampled
+        at evenly-spaced points in time
+      properties:
+        begins:
+          type: string
+          format: date-time
+          description: Time that the first point was sampled at
+        id:
+          type: integer
+          format: int64
+          description: Implementation specific ID for metrics in this webservice
+        interval:
+          type: string
+          description: Time between samples.
+          enum:
+          - SECOND
+          - MINUTE
+          - HOUR
+          - DAY
+          - WEEK
+          - MONTH
+        numberOfSkippedExecutions:
+          type: integer
+          format: int32
+          default: 0
+          description: The number of executions that were skipped during aggregation
+            because they were invalid
+        values:
+          type: array
+          description: "Array of sample values, oldest values first."
+          items:
+            type: number
+            format: double
+            description: "Array of sample values, oldest values first."
+      required:
+      - begins
+      - interval
+      - values
     Token_Auth:
       type: object
       properties:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -11567,40 +11567,43 @@ components:
       - executionId
     TimeSeriesMetric:
       type: object
+      allOf:
+      - $ref: '#/components/schemas/Metric'
+      - type: object
+        properties:
+          begins:
+            type: string
+            format: date-time
+            description: Time that the first point was sampled at
+          id:
+            type: integer
+            format: int64
+            description: Implementation specific ID for metrics in this webservice
+          interval:
+            type: string
+            description: Time between samples
+            enum:
+            - SECOND
+            - MINUTE
+            - HOUR
+            - DAY
+            - WEEK
+            - MONTH
+          numberOfSkippedExecutions:
+            type: integer
+            format: int32
+            default: 0
+            description: The number of executions that were skipped during aggregation
+              because they were invalid
+          values:
+            type: array
+            description: "List of sample values, oldest values first"
+            items:
+              type: number
+              format: double
+              description: Sample value
       description: Describes a metric that consists of a series of data values sampled
         at evenly-spaced points in time
-      properties:
-        begins:
-          type: string
-          format: date-time
-          description: Time that the first point was sampled at
-        id:
-          type: integer
-          format: int64
-          description: Implementation specific ID for metrics in this webservice
-        interval:
-          type: string
-          description: Time between samples
-          enum:
-          - SECOND
-          - MINUTE
-          - HOUR
-          - DAY
-          - WEEK
-          - MONTH
-        numberOfSkippedExecutions:
-          type: integer
-          format: int32
-          default: 0
-          description: The number of executions that were skipped during aggregation
-            because they were invalid
-        values:
-          type: array
-          description: "List of sample values, oldest values first"
-          items:
-            type: number
-            format: double
-            description: Sample value
       required:
       - begins
       - interval

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -11580,7 +11580,7 @@ components:
           description: Implementation specific ID for metrics in this webservice
         interval:
           type: string
-          description: Time between samples.
+          description: Time between samples
           enum:
           - SECOND
           - MINUTE
@@ -11596,11 +11596,11 @@ components:
             because they were invalid
         values:
           type: array
-          description: "Array of sample values, oldest values first."
+          description: "List of sample values, oldest values first"
           items:
             type: number
             format: double
-            description: "Array of sample values, oldest values first."
+            description: Sample value
       required:
       - begins
       - interval

--- a/propose_migration.sh
+++ b/propose_migration.sh
@@ -27,8 +27,8 @@ rm dockstore-webservice/target/detected-migrations.xml || true
 
 ## load up the old database based on current migration
 rm dockstore-webservice/target/dockstore-webservice-*sources.jar || true
-# java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.consistency,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0 # uncomment this line if you want to diff with an already loaded db dump
-java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.generated,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0 # uncomment this line if you want to generate a DB from scratch with migrations
+# java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.consistency,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0,1.18.0 # uncomment this line if you want to diff with an already loaded db dump
+java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.generated,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0,1.18.0 # uncomment this line if you want to generate a DB from scratch with migrations
 
 ## create the new database based on JPA (ugly, should really create a proper dw command if this works)
 ## remove timeout for mac devices, will have to break manually


### PR DESCRIPTION
**Description**
This PR adds a new `TimeSeriesMetric` entity and corresponding database table to the webservice.  It also adds a `dailyExecutionCounts` time series property to `MetricsByStatus`.

In this configuration, our metrics system will be able to store the daily run counts for any combination of platform (including `ALL`) and execution status.  However, to avoid bloating the database and the metrics responses, the initial plan is to modify the aggregator to only generate a single time series per workflow version, corresponding to daily successful executions on all platforms. 

We define a time series as a list of numeric values sampled at a regular time interval.  Per that definition, a time series consists of a list of sample values, the date/time of the first sample, and the interval between samples (hour, day, month, etc).  Per the storytime discussion, rather than sliding bins, we'll aggregate into fixed bins that span each hour, day, etc.  For example, 10:00-10:59, 11:00-11:59, 12:00-12:59, or Monday, Tuesday, Wednesday, etc

We have a choice regarding how to store the samples: either as individual rows in a `samples` table which we would join to each `time series`, or as an array in a column in the time series table itself.  We chose the latter, because it's more compact and less work for the db server.  If we intended to do elaborate queries on the samples themselves, or update/add/delete individual samples, piecemeal, we'd probably choose the former.

For now, I went with a jsonb representation for the list of sample values.  Alternatively, we could use sql arrays.  It's not yet clear which representation is better supported by Hibernate/HQL, so this may change.

There's intentionally not much testing at the moment.  After a prototype is done, I'll survey the coverage, and add tests as necessary.

Note that the branch name contains the wrong ticket name/number.

**Review Instructions**
Confirm the presence of the new database table and that `openapi.yaml` contains a description of the new entity.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7194

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
