### PR TITLE
make the token field  bigger

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
@@ -98,7 +98,7 @@ public class Token implements Comparable<Token> {
     @JsonView(TokenViews.User.class)
     private TokenType tokenSource;
 
-    @Column(nullable = false)
+    @Column(nullable = false,  length = 256)
     @ApiModelProperty(value = "Contents of the access token", position = 2)
     @JsonView(TokenViews.Auth.class)
     private String content;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Token.java
@@ -98,7 +98,7 @@ public class Token implements Comparable<Token> {
     @JsonView(TokenViews.User.class)
     private TokenType tokenSource;
 
-    @Column(nullable = false,  length = 256)
+    @Column(nullable = false, length = 4096)
     @ApiModelProperty(value = "Contents of the access token", position = 2)
     @JsonView(TokenViews.Auth.class)
     private String content;
@@ -112,7 +112,7 @@ public class Token implements Comparable<Token> {
     @JsonIgnore
     private String onlineProfileId;
 
-    @Column
+    @Column(length = 4096)
     @ApiModelProperty(position = 4)
     @JsonView(TokenViews.Auth.class)
     private String refreshToken;

--- a/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
@@ -127,6 +127,7 @@
         <addForeignKeyConstraint baseColumnNames="doiid,doiinitiator" baseTableName="version_metadata_doi" constraintName="version_doi_initiator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id,initiator" referencedTableName="doi"/>
     </changeSet>
     <changeSet author="dyuen (generated)" id="slightlyMoreGoogleToken">
-        <modifyDataType columnName="content" newDataType="varchar(256)" tableName="token"/>
+        <modifyDataType columnName="content" newDataType="varchar(4096)" tableName="token"/>
+        <modifyDataType columnName="refreshtoken" newDataType="varchar(4096)" tableName="token"/>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.17.0.xml
@@ -126,4 +126,7 @@
         <addForeignKeyConstraint baseColumnNames="doiid,doiinitiator" baseTableName="entry_concept_doi" constraintName="entry_doi_initiator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id,initiator" referencedTableName="doi"/>
         <addForeignKeyConstraint baseColumnNames="doiid,doiinitiator" baseTableName="version_metadata_doi" constraintName="version_doi_initiator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id,initiator" referencedTableName="doi"/>
     </changeSet>
+    <changeSet author="dyuen (generated)" id="slightlyMoreGoogleToken">
+        <modifyDataType columnName="content" newDataType="varchar(256)" tableName="token"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**Description**
Bump the field larger for Google-based workflow sharing

**Review Instructions**
Load up a db, migrate, should see much larger limits for token fields

**Issue**
n/a

**Security and Privacy**
None

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
