### PR TITLE
new location for broad artifacts

### DIFF
--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -400,9 +400,9 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>artifactory.broadinstitute.org</id>
-      <name>artifactory.broadinstitute.org</name>
-      <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
+      <id>dsp-artifact-registry</id>
+      <name>dsp-artifact-registry/</name>
+      <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
     </repository>
   </repositories>
 </project>

--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -400,8 +400,8 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>dsp-artifact-registry</id>
-      <name>dsp-artifact-registry/</name>
+      <id>artifactory.broadinstitute.org</id>
+      <name>artifactory.broadinstitute.org</name>
       <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
     </repository>
   </repositories>

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -162,9 +162,9 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>artifactory.broadinstitute.org</id>
-      <name>artifactory.broadinstitute.org</name>
-      <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
+      <id>dsp-artifact-registry</id>
+      <name>dsp-artifact-registry/</name>
+      <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
     </repository>
   </repositories>
 </project>

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -162,8 +162,8 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>dsp-artifact-registry</id>
-      <name>dsp-artifact-registry/</name>
+      <id>artifactory.broadinstitute.org</id>
+      <name>artifactory.broadinstitute.org</name>
       <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
     </repository>
   </repositories>

--- a/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
@@ -58,8 +58,8 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>dsp-artifact-registry</id>
-      <name>dsp-artifact-registry/</name>
+      <id>artifactory.broadinstitute.org</id>
+      <name>artifactory.broadinstitute.org</name>
       <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
     </repository>
   </repositories>

--- a/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
@@ -58,9 +58,9 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>artifactory.broadinstitute.org</id>
-      <name>artifactory.broadinstitute.org</name>
-      <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
+      <id>dsp-artifact-registry</id>
+      <name>dsp-artifact-registry/</name>
+      <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
     </repository>
   </repositories>
 </project>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -1024,9 +1024,9 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>artifactory.broadinstitute.org</id>
-      <name>artifactory.broadinstitute.org</name>
-      <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
+      <id>dsp-artifact-registry</id>
+      <name>dsp-artifact-registry/</name>
+      <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
     </repository>
   </repositories>
 </project>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -1024,8 +1024,8 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>dsp-artifact-registry</id>
-      <name>dsp-artifact-registry/</name>
+      <id>artifactory.broadinstitute.org</id>
+      <name>artifactory.broadinstitute.org</name>
       <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
     </repository>
   </repositories>

--- a/openapi-java-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-client/generated/src/main/resources/pom.xml
@@ -130,8 +130,8 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>dsp-artifact-registry</id>
-      <name>dsp-artifact-registry/</name>
+      <id>artifactory.broadinstitute.org</id>
+      <name>artifactory.broadinstitute.org</name>
       <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
     </repository>
   </repositories>

--- a/openapi-java-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-client/generated/src/main/resources/pom.xml
@@ -130,9 +130,9 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>artifactory.broadinstitute.org</id>
-      <name>artifactory.broadinstitute.org</name>
-      <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
+      <id>dsp-artifact-registry</id>
+      <name>dsp-artifact-registry/</name>
+      <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
     </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,8 @@
         </repository>
         <!-- broad -->
         <repository>
-            <id>dsp-artifact-registry</id>
-            <name>dsp-artifact-registry/</name>
+            <id>artifactory.broadinstitute.org</id>
+            <name>artifactory.broadinstitute.org</name>
             <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
             <releases>
                 <enabled>true</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -88,9 +88,9 @@
         </repository>
         <!-- broad -->
         <repository>
-            <id>artifactory.broadinstitute.org</id>
-            <name>artifactory.broadinstitute.org</name>
-            <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
+            <id>dsp-artifact-registry</id>
+            <name>dsp-artifact-registry/</name>
+            <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/reports/generated/src/main/resources/pom.xml
+++ b/reports/generated/src/main/resources/pom.xml
@@ -64,8 +64,8 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>dsp-artifact-registry</id>
-      <name>dsp-artifact-registry/</name>
+      <id>artifactory.broadinstitute.org</id>
+      <name>artifactory.broadinstitute.org</name>
       <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
     </repository>
   </repositories>

--- a/reports/generated/src/main/resources/pom.xml
+++ b/reports/generated/src/main/resources/pom.xml
@@ -64,9 +64,9 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>artifactory.broadinstitute.org</id>
-      <name>artifactory.broadinstitute.org</name>
-      <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
+      <id>dsp-artifact-registry</id>
+      <name>dsp-artifact-registry/</name>
+      <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
     </repository>
   </repositories>
 </project>

--- a/swagger-java-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-client/generated/src/main/resources/pom.xml
@@ -130,8 +130,8 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>dsp-artifact-registry</id>
-      <name>dsp-artifact-registry/</name>
+      <id>artifactory.broadinstitute.org</id>
+      <name>artifactory.broadinstitute.org</name>
       <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
     </repository>
   </repositories>

--- a/swagger-java-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-client/generated/src/main/resources/pom.xml
@@ -130,9 +130,9 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>artifactory.broadinstitute.org</id>
-      <name>artifactory.broadinstitute.org</name>
-      <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
+      <id>dsp-artifact-registry</id>
+      <name>dsp-artifact-registry/</name>
+      <url>https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/</url>
     </repository>
   </repositories>
 </project>


### PR DESCRIPTION
**Description**
Redirect Broad artifactory to a new location. 

**Review Instructions**
No change, build should remain successful.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7229

**Security and Privacy**

None

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
