### PR TITLE
fix docker hub pull of tag images

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GitHubWorkflowIT.java
@@ -464,14 +464,13 @@ class GitHubWorkflowIT extends BaseIT {
         trsVersion.getImages().forEach(image -> assertEquals("library/ubuntu:16.04", image.getImageName()));
 
         // Workflow with Docker Hub image specified using a digest
-        String dockerHubDigestVersionName = "dockerHubDigestImage";
+        String dockerHubDigestVersionName = "DockerHubImageWithDigest224";
         snapshotVersion = snapshotWorkflowVersion(workflowsApi, workflow, dockerHubDigestVersionName);
-        assertEquals(1, snapshotVersion.getImages().size(), "Should only be one image in this workflow");
+        assertEquals(5, snapshotVersion.getImages().size(), "Should only be 12 images in this workflow");
         trsVersion = ga4Ghv20Api.toolsIdVersionsVersionIdGet("#workflow/github.com/" + DockstoreTesting.HELLO_WDL_WORKFLOW, dockerHubDigestVersionName);
-        assertEquals(1, trsVersion.getImages().size(), "Should be one image in this TRS version");
-        // library/ubuntu@sha256:d7bb0589725587f2f67d0340edb81fd1fcba6c5f38166639cf2a252c939aa30c refers to ubuntu version 16.04, amd64 os/arch
-        trsVersion.getImages().forEach(image ->
-            assertEquals("library/ubuntu@sha256:d7bb0589725587f2f67d0340edb81fd1fcba6c5f38166639cf2a252c939aa30c", image.getImageName()));
+        assertEquals(5, trsVersion.getImages().size(), "Should be 12 images in this TRS version");
+        // library/ubuntu@sha256:3f85b7caad41a95462cf5b787d8a04604c8262cdcdf9a472b8c52ef83375fe15 refers to library/ubuntu:noble-20240429
+        assertTrue(trsVersion.getImages().stream().anyMatch(image -> "library/ubuntu:noble-20240429".equals(image.getImageName())));
     }
 
     @Test

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/dockerhub/Results.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/dockerhub/Results.java
@@ -37,6 +37,8 @@ public class Results {
 
     private String repository;
 
+    private String digest;
+
     @SerializedName("image_id")
     private String imageID;
 
@@ -128,5 +130,13 @@ public class Results {
 
     public void setV2(String v2) {
         this.v2 = v2;
+    }
+
+    public String getDigest() {
+        return digest;
+    }
+
+    public void setDigest(String digest) {
+        this.digest = digest;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/languages/LanguageHandlerInterface.java
@@ -749,6 +749,14 @@ public interface LanguageHandlerInterface {
         return dockerHubImages;
     }
 
+    /**
+     * Get DockerHub images from a specific repo
+     * @param repo repository
+     * @param specifierType tag or digest
+     * @param specifierName branch or tag name
+     * @param dockerHubImages collection to add images to
+     * @param repoUrl docker hub url
+     */
     static void getImages(String repo, DockerSpecifier specifierType, String specifierName, Set<Image> dockerHubImages, String repoUrl) {
         Map<String, String> errorMap = new HashMap<>();
         Optional<String> response;


### PR DESCRIPTION
**Description**
Docker hub has changed how it's API returns image information breaking tests on develop. 
We can now (and in fact have to) retrieve image information by specifying a specific tag. 
Unfortunately, there is no way to do the same with digest information (at least according to official API docs at https://docs.docker.com/reference/api/hub/latest/#tag/repositories )

So one step forward, one backwards. We can speed up retrieval of images for specific Docker tags specified in workflows instead of paging (woo!). But we need to page in order to translate digests into tag/branch names (crummy). 

Had to create https://github.com/dockstore-testing/hello-wdl-workflow/blob/DockerHubImageWithDigest224/Dockstore.wdl (maybe their older image wasn't indexed)

**Review Instructions**
Monitor tests `testGrabChecksumFromDockerHub`, `testTRSImageName` and `testGettingImagesFromDockerHub`

**Issue**
https://github.com/dockstore/dockstore/issues/6139

**Security and Privacy**

None

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
