### PR TITLE
SEAB-7194: Use UTC for time series

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/TimeSeriesMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/TimeSeriesMetric.java
@@ -27,11 +27,10 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.TimeZoneStorage;
-import org.hibernate.annotations.TimeZoneStorageType;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.type.SqlTypes;
 
@@ -45,11 +44,10 @@ public class TimeSeriesMetric extends Metric {
     @ArraySchema(arraySchema = @Schema(description = "List of sample values, oldest values first"), schema = @Schema(description = "Sample value"))
     private List<Double> values;
 
-    @TimeZoneStorage(TimeZoneStorageType.NORMALIZE_UTC)
     @Column(nullable = false)
     @NotNull
-    @Schema(description = "Time that the first point was sampled at", requiredMode = RequiredMode.REQUIRED)
-    private Timestamp begins;
+    @Schema(description = "Time of the midpoint of the bin corresponding to the oldest sample value", requiredMode = RequiredMode.REQUIRED)
+    private Instant begins;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
@@ -94,11 +92,11 @@ public class TimeSeriesMetric extends Metric {
         this.values = values;
     }
 
-    public Timestamp getBegins() {
+    public Instant getBegins() {
         return begins;
     }
 
-    public void setBegins(Timestamp begins) {
+    public void setBegins(Instant begins) {
         this.begins = begins;
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/TimeSeriesMetric.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/metrics/TimeSeriesMetric.java
@@ -30,6 +30,8 @@ import java.sql.Timestamp;
 import java.util.List;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.TimeZoneStorage;
+import org.hibernate.annotations.TimeZoneStorageType;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.type.SqlTypes;
 
@@ -43,6 +45,7 @@ public class TimeSeriesMetric extends Metric {
     @ArraySchema(arraySchema = @Schema(description = "List of sample values, oldest values first"), schema = @Schema(description = "Sample value"))
     private List<Double> values;
 
+    @TimeZoneStorage(TimeZoneStorageType.NORMALIZE_UTC)
     @Column(nullable = false)
     @NotNull
     @Schema(description = "Time that the first point was sampled at", requiredMode = RequiredMode.REQUIRED)

--- a/dockstore-webservice/src/main/resources/migrations.1.18.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.18.0.xml
@@ -47,4 +47,7 @@
         </addColumn>
         <addForeignKeyConstraint baseColumnNames="weeklyexecutioncountsid" baseTableName="metrics_by_status" constraintName="fk_metrics_by_status_weeklyexecutioncountsid" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="timeseriesmetric"/>
     </changeSet>
+    <changeSet author="svonworl" id="changeTimeSeriesToUtc">
+        <modifyDataType tableName="timeseriesmetric" columnName="begins" newDataType="TIMESTAMP WITH TIME ZONE"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -11576,7 +11576,8 @@ components:
           begins:
             type: string
             format: date-time
-            description: Time that the first point was sampled at
+            description: Time of the midpoint of the bin corresponding to the oldest
+              sample value
           id:
             type: integer
             format: int64


### PR DESCRIPTION
**Description**
This PR changes the "begins" property of a `TimeSeriesMetric` to be represented by a `java.time.Instant` and stored in the db as a `TIMESTAMP WITH TIME ZONE`, aka as UTC.  This should prevent any weird time zone skews, which cause problems when we try to display the time series in the UI.

**Review Instructions**
After running the metrics aggregator, check that the values of the time series "begins" property start at 4am or 4pm UTC.

**Issue**
A link to a github issue or SEAB- ticket (using that as a prefix)

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
