### PR TITLE
SEAB-7194: Correct openapi description of new "max weekly execution counts" endpoint

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -2374,7 +2374,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     public long getMaxWeeklyExecutionCountForAnyVersion(
         @Parameter(hidden = true, name = "user") @Auth Optional<User> user,
         @Parameter(name = "workflowId", description = "id of the workflow", required = true, in = ParameterIn.PATH) @PathParam("workflowId") long workflowId,
-        @Parameter(name = "onOrAfterEpochSecond", description = "include counts on or after this time, expressed in UTC Java epoch seconds", required = true, in = ParameterIn.QUERY) long onOrAfterEpochSecond) {
+        @Parameter(name = "onOrAfterEpochSecond", description = "include counts on or after this time, expressed in UTC Java epoch seconds", required = true) long onOrAfterEpochSecond) {
         Workflow workflow = workflowDAO.findById(workflowId);
         checkNotNullEntry(workflow);
         checkCanRead(user, workflow);

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -8329,14 +8329,15 @@ paths:
         schema:
           type: integer
           format: int64
-      - description: "include counts on or after this time, expressed in UTC Java\
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: integer
+              format: int64
+        description: "include counts on or after this time, expressed in UTC Java\
           \ epoch seconds"
-        in: query
-        name: onOrAfterEpochSecond
         required: true
-        schema:
-          type: integer
-          format: int64
       responses:
         default:
           content:


### PR DESCRIPTION
**Description**
This PR corrects the annotations on the "max weekly execution counts" resource method, which propagate to `openapi.yaml`, thus allowing the UI to generate the correct code to hit the associated endpoint.

**Review Instructions**
Confirm that the UI is invoking the endpoint in the versions table, and that the response is success (status code 200).

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7194

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
