### PR TITLE
more notifications to committers

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/InferNotificationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/InferNotificationIT.java
@@ -87,8 +87,8 @@ class InferNotificationIT extends BaseIT {
             && rootTest.equals(inferredDockstoreYml.getGitReference())
         );
 
-        // Track release event that creates notification
-        ApiException exception = assertThrows(ApiException.class, () -> handleGitHubRelease(workflowsApi, DockstoreTestUser2.DOCKSTORE_WORKFLOW_CNV, rootTest, USER_2_USERNAME)
+        // Track release event that creates notification, dockstore-bot as sender but committer is the test user to mimic prod
+        ApiException exception = assertThrows(ApiException.class, () -> handleGitHubRelease(workflowsApi, DockstoreTestUser2.DOCKSTORE_WORKFLOW_CNV, rootTest, "dockstore-bot", null, List.of(DOCKSTORE_TEST_USER_2))
         );
         assertTrue(exception.getMessage().contains(COULD_NOT_RETRIEVE_DOCKSTORE_YML));
         // after a release, inference now generates one GitHub app notification

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/helpers/GitHubAppHelper.java
@@ -58,6 +58,7 @@ public final class GitHubAppHelper {
             final GitCommit gitCommit = new GitCommit();
             gitCommit.setAuthor(gitHubUser);
             gitCommit.setCommitter(gitHubUser);
+            pushPayload.setHeadCommit(gitCommit);
             return gitCommit;
         }).toList();
         pushPayload.setCommits(gitCommits);


### PR DESCRIPTION
**Description**
Fixing a subtle bug and adjusting tests to match. 
Our release events and push events always have the `sender` as `dockstore-bot` due to the way we relay events via AWS. 
The notifications need to go to committers and others. Adding a check so that we at least notify committers for push events. On merge will also create a ticket for install events, but that will probably be more disruptive at this late stage. 

**Review Instructions**
Install and then push to a repo without a .dockstore.yml, should get a notification under "Recommended Actions" in the UI. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7282

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [ ] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [ ] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [ ] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [ ] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [ ] Do not serve user-uploaded binary images through the Dockstore API
- [ ] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [ ] Do not create cookies, although this may change in the future
- [ ] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
