### PR TITLE
SEAB-6531: Notify trigger user when processing install event if no .dockstore.yml

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -2283,7 +2283,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
                     boolean inspectedAllBranches = importantBranches.size() <= maximumBranchCount;
                     if (inspectedAllBranches) {
                         // Create recommended action
-                        notifyIfPotentiallyContainsEntries(Optional.of(user), repository, installationId, importantBranches);
+                        notifyIfPotentiallyContainsEntries(triggerUser, repository, installationId, importantBranches);
                     }
                 } else {
                     for (String gitReference: releasableReferences) {


### PR DESCRIPTION
**Description**
During an INSTALL event, we attempt to register the entries on some branches within the repo.  We recently changed the code to notify the user if we don't find a `.dockstore.yml` on any branches that we inspect.

The notification code was invoked with the authenticated endpoint user (always `dockstore-bot`) rather than the triggering user, aka the actual user that performed the GitHub App install on the repo.

This PR fixes the bug.

**Review Instructions**
Confirm that the notification is associated with the triggering user, rather than `dockstore-bot`.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6531

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
