### PR TITLE
Fx some .dockstore.yml inference bugs, reset version

### DIFF
--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-common</artifactId>
-  <version>1.18.0-rc.0</version>
+  <version>1.18.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-integration-testing</artifactId>
-  <version>1.18.0-rc.0</version>
+  <version>1.18.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -72,25 +72,25 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>openapi-java-client</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-language-plugin-parent</artifactId>
-  <version>1.18.0-rc.0</version>
+  <version>1.18.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-webservice</artifactId>
-  <version>1.18.0-rc.0</version>
+  <version>1.18.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -90,13 +90,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-language-plugin-parent</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZipGitHubFileTree.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZipGitHubFileTree.java
@@ -66,7 +66,7 @@ public class ZipGitHubFileTree implements FileTree {
         this.ref = ref;
         // Read the Zip contents and create an in-memory ZipFile.
         byte[] zipBytes = gitHubSourceCodeRepo.readZip(repository, ref);
-        LOG.info("downloaded Zip of GitHub repository: %n bytes".formatted(zipBytes.length));
+        LOG.info("downloaded Zip of GitHub repository: %d bytes".formatted(zipBytes.length));
         SeekableInMemoryByteChannel zipChannel = new SeekableInMemoryByteChannel(zipBytes);
         try {
             zipFile = new ZipFile(zipChannel);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/infer/DescriptorLanguageInferrer.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/infer/DescriptorLanguageInferrer.java
@@ -151,8 +151,12 @@ public abstract class DescriptorLanguageInferrer implements Inferrer {
     }
 
     private Optional<Path> toAbsolutePath(Path currentPath, String relativeOrAbsolutePath) {
+        Path parentPath = currentPath.getParent();
+        if (parentPath == null) {
+            parentPath = currentPath.getRoot();
+        }
         try {
-            return Optional.of(currentPath.resolve(relativeOrAbsolutePath).normalize());
+            return Optional.of(parentPath.resolve(relativeOrAbsolutePath).normalize());
         } catch (InvalidPathException e) {
             // If either path was invalid, ignore and continue.
             return Optional.empty();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -2168,7 +2168,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             if (importantBranches.isEmpty()) {
                 throw new CustomWebApplicationException("Could not determine GitHub branch to use for inference", HttpStatus.SC_BAD_REQUEST);
             }
-            ref = importantBranches.get(0);
+            ref = "refs/heads/" + importantBranches.get(0);
         }
 
         // Create FileTree.

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -13,7 +13,7 @@ info:
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
   termsOfService: https://github.com/dockstore/dockstore-ui2/raw/develop/src/assets/docs/Dockstore_Terms_of_Service.pdf
   title: Dockstore API
-  version: 1.18.0-rc.0
+  version: 1.18.0-SNAPSHOT
 servers:
 - description: Current server when hosted on AWS
   url: /api

--- a/openapi-java-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>openapi-java-client</artifactId>
-  <version>1.18.0-rc.0</version>
+  <version>1.18.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/reports/generated/src/main/resources/pom.xml
+++ b/reports/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>reports</artifactId>
-  <version>1.18.0-rc.0</version>
+  <version>1.18.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,19 +30,19 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-integration-testing</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/swagger-java-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-client</artifactId>
-  <version>1.18.0-rc.0</version>
+  <version>1.18.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
**Description**
This PR fixes a few bugs in the `.dockstore.yml` inference code:
* During the inference process, workflow files that are referenced from other workflow files should be eliminated from consideration as entries.  This was broken, causing each workflow files to be considered as the primary descriptor of an entry.  The root cause is an errant path manipulation that was probably introduced during the `Path` conversion.  Fixed.
* Corrects the calculations of the default reference for the inference endpoint.
* Fixes debug output which records the size of the github ref's Zip.

It also resets to the `SNAPSHOT` version.

**Review Instructions**
Infer a `.dockstore.yml` for github.com/PacificBiosciences/HiFi-human-WGS-WDL and confirm that the `.dockstore.yml` contains two entries.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6531

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
