### PR TITLE
different openapi validator

### DIFF
--- a/.github/workflows/validate_openapi.yaml
+++ b/.github/workflows/validate_openapi.yaml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Validate OpenAPI definition
-        uses: swaggerexpert/apidom-validate@v1.4.0
+        uses: swaggerexpert/swagger-editor-validate@v1
         with:
           definition-file: dockstore-webservice/src/main/resources/openapi3/openapi.yaml

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -48,7 +48,7 @@ POM as their parent.
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- the following properties set sane defaults when no revision properties are set from the command-line -->
-        <revision>1.18</revision>
+        <revision>1.19</revision>
         <changelist>.0-SNAPSHOT</changelist>
 
         <dropwizard.version>4.0.15</dropwizard.version>

--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-common</artifactId>
-  <version>1.18.0-rc.0</version>
+  <version>1.18.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/dockstore-common/generated/src/main/resources/pom.xml
+++ b/dockstore-common/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-common</artifactId>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.19.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-integration-testing</artifactId>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.19.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -72,25 +72,25 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.18.0-SNAPSHOT</version>
+      <version>1.19.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.18.0-SNAPSHOT</version>
+      <version>1.19.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.18.0-SNAPSHOT</version>
+      <version>1.19.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>openapi-java-client</artifactId>
-      <version>1.18.0-SNAPSHOT</version>
+      <version>1.19.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-integration-testing/generated/src/main/resources/pom.xml
+++ b/dockstore-integration-testing/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-integration-testing</artifactId>
-  <version>1.18.0-rc.0</version>
+  <version>1.18.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -72,25 +72,25 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-client</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>openapi-java-client</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-language-plugin-parent</artifactId>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.19.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.18.0-SNAPSHOT</version>
+      <version>1.19.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
+++ b/dockstore-language-plugin-parent/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-language-plugin-parent</artifactId>
-  <version>1.18.0-rc.0</version>
+  <version>1.18.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-webservice</artifactId>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.19.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -90,13 +90,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.18.0-SNAPSHOT</version>
+      <version>1.19.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-language-plugin-parent</artifactId>
-      <version>1.18.0-SNAPSHOT</version>
+      <version>1.19.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>dockstore-webservice</artifactId>
-  <version>1.18.0-rc.0</version>
+  <version>1.18.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -90,13 +90,13 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-language-plugin-parent</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -13,7 +13,7 @@ info:
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
   termsOfService: https://github.com/dockstore/dockstore-ui2/raw/develop/src/assets/docs/Dockstore_Terms_of_Service.pdf
   title: Dockstore API
-  version: 1.18.0-SNAPSHOT
+  version: 1.19.0-SNAPSHOT
 servers:
 - description: Current server when hosted on AWS
   url: /api

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -13,7 +13,7 @@ info:
     url: https://github.com/dockstore/dockstore/blob/develop/LICENSE
   termsOfService: https://github.com/dockstore/dockstore-ui2/raw/develop/src/assets/docs/Dockstore_Terms_of_Service.pdf
   title: Dockstore API
-  version: 1.18.0-rc.0
+  version: 1.18.0-SNAPSHOT
 servers:
 - description: Current server when hosted on AWS
   url: /api

--- a/openapi-java-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>openapi-java-client</artifactId>
-  <version>1.18.0-rc.0</version>
+  <version>1.18.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/openapi-java-client/generated/src/main/resources/pom.xml
+++ b/openapi-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>openapi-java-client</artifactId>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.19.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.18.0-SNAPSHOT</version>
+      <version>1.19.0-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <github.url>scm:git:git@github.com:dockstore/dockstore.git</github.url>
 
         <!-- the following properties set sane defaults when no revision properties are set from the command-line -->
-        <revision>1.18</revision>
+        <revision>1.19</revision>
         <changelist>.0-SNAPSHOT</changelist>
 
         <!--

--- a/reports/generated/src/main/resources/pom.xml
+++ b/reports/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>reports</artifactId>
-  <version>1.18.0-rc.0</version>
+  <version>1.18.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,19 +30,19 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-integration-testing</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/reports/generated/src/main/resources/pom.xml
+++ b/reports/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>reports</artifactId>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.19.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -30,19 +30,19 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.18.0-SNAPSHOT</version>
+      <version>1.19.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-common</artifactId>
-      <version>1.18.0-SNAPSHOT</version>
+      <version>1.19.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-integration-testing</artifactId>
-      <version>1.18.0-SNAPSHOT</version>
+      <version>1.19.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/swagger-java-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-client</artifactId>
-  <version>1.18.0-rc.0</version>
+  <version>1.18.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.18.0-rc.0</version>
+      <version>1.18.0-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/swagger-java-client/generated/src/main/resources/pom.xml
+++ b/swagger-java-client/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-client</artifactId>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.19.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>dockstore-webservice</artifactId>
-      <version>1.18.0-SNAPSHOT</version>
+      <version>1.19.0-SNAPSHOT</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
**Description**
Looking back at previous PR, not entirely sure why we went with the ApiDOM validator, this switches to the better known swagger editor validator

**Review Instructions**
Build should pass

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7289

**Security and Privacy**

None

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
