### PR TITLE
test zenodo client update

### DIFF
--- a/dockstore-webservice/generated/src/main/resources/pom.xml
+++ b/dockstore-webservice/generated/src/main/resources/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>io.dockstore</groupId>
       <artifactId>swagger-java-zenodo-client</artifactId>
-      <version>2.1.4</version>
+      <version>2.1.7</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>swagger-java-zenodo-client</artifactId>
-            <version>2.1.4</version>
+            <version>2.1.7</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ZenodoHelper.java
@@ -320,7 +320,7 @@ public final class ZenodoHelper {
                 // The response body of this action is NOT the new version deposit,
                 // but the original resource. The new version deposition can be
                 // accessed through the "latest_draft" under "links" in the response body.
-                String depositURL = returnDeposit.getLinks().get("latest_draft");
+                String depositURL = returnDeposit.getLinks().getLatestDraft();
                 String depositionIDStr = depositURL.substring(depositURL.lastIndexOf("/") + 1).trim();
                 // Get the deposit object for the new workflow version DOI
                 depositionID = Integer.parseInt(depositionIDStr);


### PR DESCRIPTION
**Description**
2.1.5 ran into a bad merge 
2.1.6 ran into a build issue (shade had been modified to make the draft deletion script executable, but conflicted with our dockstore build)

This tests 2.1.7 zenodo client now with InvenioRDM endpoints that should really be namespaced into a separate tag/namespace

**Review Instructions**
Build, use, deploy to QA.
Try out zenodo operations

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7226

**Security and Privacy**

None


Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
