### PR TITLE
SEAB-7331: Fix "get published workflow by path" bug

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -1919,10 +1919,14 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
     }
 
     /**
-     * If include contains validations field, initialize the workflows validations for all of its workflow versions If include contains aliases field, initialize the aliases for all of its workflow
-     * versions If include contains images field, initialize the images for all of its workflow versions If include contains versions field, initialize the versions for the workflow If include
-     * contains authors field, initialize the authors for all of its workflow versions If include contains orcid_put_codes field, initialize the authors for all of its workflow versions
-     * Does not initialize the fields of any workflow versions if initializeVersions is false
+     * Initialize some of the lazy fields of the specified workflow and its versions.
+     * If include contains versions field, initialize the versions for the workflow.
+     * If include contains validations field, initialize the workflows validations for all of its workflow versions.
+     * If include contains aliases field, initialize the aliases for all of its workflow versions.
+     * If include contains images field, initialize the images for all of its workflow versions.
+     * If include contains authors field, initialize the authors for all of its workflow versions.
+     * If include contains orcid_put_codes field, initialize the authors for all of its workflow versions.
+     * Do not initialize any workflow versions if initializeVersions is false.
      *
      * @param include
      * @param workflow


### PR DESCRIPTION
**Description**
This PR fixes a bug in the webservice wherein the `getPublishedWorkflowByPath` endpoint would 500 if the request contained an `include` parameter that caused workflow-level fields to be initialized.  For example, on qa:
```
https://qa.dockstore.org/api/workflows/path/workflow/github.com%2Fbroadinstitute%2Fwarp%2FOptimus/published?include=validations%2Cauthors%2Cmetrics%2Corcidputcodes&subclass=BIOWORKFLOW&versionName=Optimus_v5.4.3
```

The handling method detaches the workflow from the session before calling`Hibernate.initialize` to initialize its fields, triggering a "no session" error.

This PR fixes the ordering of the operations in that one function.

This bug isn't currently triggered by our UI code, but it would be after adding workflow-level metrics support to the UI (because we'll need to initialize the workflow-level metrics).

This bug was introduced when we changed the method to return a limited number of versions.  The motivation was to more gracefully handle the Broad workflows that have many versions.  Now that we page the versions, someday, we can probably change the implementation to be more simple and consistent with the other related methods.

**Review Instructions**
On qa, submit the offending request and confirm that the endpoint now responds correctly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7331

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
