### PR TITLE
Switch openjdk image in test migrations

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2CwltoolIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/GA4GHV2CwltoolIT.java
@@ -103,7 +103,7 @@ class GA4GHV2CwltoolIT {
         CommonTestUtilities.setupTestWorkflow(SUPPORT);
         String command = "cwl-runner";
         String originalUrl =
-                baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/java_21/plain-CWL/descriptor//Dockstore.cwl";
+                baseURL + "tools/%23workflow%2Fgithub.com%2Fdockstore-testing%2FtestWorkflow/versions/master/plain-CWL/descriptor//Dockstore.cwl";
         String descriptorPath = TestUtility.mimicNginxRewrite(originalUrl, basePath);
         String testParameterFilePath = ResourceHelpers.resourceFilePath("testWorkflow.json");
         ImmutablePair<String, String> stringStringImmutablePair = Utilities

--- a/dockstore-webservice/src/main/resources/migrations.test.testworkflow.xml
+++ b/dockstore-webservice/src/main/resources/migrations.test.testworkflow.xml
@@ -26,7 +26,7 @@
         </insert>
         <insert tableName="sourcefile">
             <column name="id" valueNumeric="33"/>
-            <column name="content" value="cwlVersion: v1.0&#10;class: CommandLineTool&#10;hints:&#10;  - class: DockerRequirement&#10;    dockerPull: openjdk:17&#10;baseCommand: javac&#10;arguments:&#10;  - prefix: &quot;-d&quot;&#10;    valueFrom: $(runtime.outdir)&#10;inputs:&#10;  - id: src&#10;    type: File&#10;    inputBinding:&#10;      position: 1&#10;outputs:&#10;  - id: classfile&#10;    type: File&#10;    outputBinding:&#10;      glob: &quot;*.class&quot;&#10;"/>
+            <column name="content" value="cwlVersion: v1.0&#10;class: CommandLineTool&#10;hints:&#10;  - class: DockerRequirement&#10;    dockerPull: eclipse-temurin:17.0.16_8-jdk&#10;baseCommand: javac&#10;arguments:&#10;  - prefix: &quot;-d&quot;&#10;    valueFrom: $(runtime.outdir)&#10;inputs:&#10;  - id: src&#10;    type: File&#10;    inputBinding:&#10;      position: 1&#10;outputs:&#10;  - id: classfile&#10;    type: File&#10;    outputBinding:&#10;      glob: &quot;*.class&quot;&#10;"/>
             <column name="path" value="cwl/arguments.cwl"/>
             <column name="type" value="DOCKSTORE_CWL"/>
         </insert>


### PR DESCRIPTION
**Description**
We're using a workflow referencing an old Docker image which seems to have disappeared. 
Warning, it looks tempting to switch the workflow source as per https://github.com/dockstore-testing/testWorkflow/blob/java_21/cwl/arguments.cwl#L6C17-L6C46 but the code in question seems to be inside a test migration. 

**Review Instructions**
Build should succeed. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7363

**Security and Privacy**

None

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
