### PR TITLE
bump sonar - disable scm blame

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,8 @@
         <sonar.coverage.jacoco.xmlReportPaths>
             ${project.basedir}/target/jacoco.xml,${project.basedir}/target/jacoco-it.xml,${project.basedir}/../reports/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
+		<!-- re-enable when sonar seems to have fixed this, maybe old regression? https://community.sonarsource.com/t/can-i-desable-scm-blame-is-in-progress/106570 --> 
+		<sonar.scm.disabled>true</sonar.scm.disabled>
         <!-- end sonarcloud properties -->
     </properties>
 


### PR DESCRIPTION
**Description**
Seems like sonar has gone awry, hanging for extremely long periods of time. 
* Bumped sonar maven plugin (doesn't fix, but  doesn't seem to hurt, so may as well keep it). 
* Attempt to disable git blame (will make results much less useful) 

**Review Instructions**
Build should suceeed past sonar step

**Issue**
n/a

**Security and Privacy**

None

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
