### PR TITLE
fix odd sonar behaviour

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,7 +477,7 @@ jobs:
           command: ./mvnw clean install -DskipTests
       - run:
           name: SonarCloud scan - coverage
-          command: ./mvnw -Dsonar.coverage.jacoco.xmlReportPaths=../coverage/* sonar:sonar
+          command: ./mvnw -Dsonar.coverage.jacoco.xmlReportPaths=../coverage/* org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
       - store_artifacts:
           path: misses
 


### PR DESCRIPTION
**Description**
Noticed https://sonarsource.atlassian.net/browse/SCANMAVEN-334
Not exactly related, but it looks like their shorthand broke somehow
(Was able to replicate broken shorthand locally)

**Review Instructions**
See subsequent build with working sonar build and report back to github

**Issue**
n/a

**Security and Privacy**

None

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
