### PR TITLE
add support version to ui config object

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceConfiguration.java
@@ -887,6 +887,8 @@ public class DockstoreWebserviceConfiguration extends Configuration {
 
         private String deployVersion;
 
+        private String supportVersion;
+
         private String cwlParsingLambdaVersion;
         private String wdlParsingLambdaVersion;
         private String nextflowParsingLambdaVersion;
@@ -1196,6 +1198,14 @@ public class DockstoreWebserviceConfiguration extends Configuration {
 
         public void setCheckUrlLambdaVersion(String checkUrlLambdaVersion) {
             this.checkUrlLambdaVersion = checkUrlLambdaVersion;
+        }
+
+        public String getSupportVersion() {
+            return supportVersion;
+        }
+
+        public void setSupportVersion(String supportVersion) {
+            this.supportVersion = supportVersion;
         }
     }
 }

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -9772,6 +9772,8 @@ components:
           type: string
         quayIoScope:
           type: string
+        supportVersion:
+          type: string
         tagManagerId:
           type: string
         terraImportUrl:


### PR DESCRIPTION
**Description**
Add dockstore-support to UI footer "Copy build info" button


**Review Instructions**
Can run webservice with matching web.yml and see new field coming back from http://<your hostname here>:4200/api/static/swagger-ui/index.html#/metadata/getConfig

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7384
See also https://github.com/dockstore/dockstore-ui2/pull/2160
See also https://github.com/dockstore/compose_setup/pull/261
See also https://github.com/dockstore/dockstore-deploy/pull/869

**Security and Privacy**

None

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
