### PR TITLE
SEAB-7448: Tweak search "relevance" measure

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/statelisteners/ElasticListener.java
@@ -453,7 +453,7 @@ public class ElasticListener implements StateListenerInterface {
         // The following coefficients are tuned to the current state of Dockstore, wherein the maximum
         // execution count for any entry is approximately 1500000, and the maximum star count is 15.
         // The goal is to get a good mix of entry types, some with stars and/or in categories, on the first page of Search results.
-        double numerator = 5 + Math.sqrt(executionCount + recentExecutionCount) + 80. * starCount + (inCategory ? 300. : 0.);
+        double numerator = 2 + Math.sqrt(executionCount + recentExecutionCount) + 80. * starCount + (inCategory ? 300. : 0.);
         double denominator = (200. + daysSinceLastChange) * (isArchived ? 3 : 1);
         return numerator / denominator;
     }


### PR DESCRIPTION
**Description**
This PR adjusts the search "relevance" formula so that workflows with at least one execution are not always sorted as more "relevant" than workflows that have no executions.  The mechanism is to adjust the "relevance" formula denominator so that its value is more similar, between entries that have very few executions and those that have none, when everything else is the same.

Originally, I'd also planned to tweak the formula so that some Galaxy workflows appear in the first set of search results.  However, after searching the latest prod db, I realize that the "popular" Galaxy workflows haven't been updated in more than half a year, and when they are, some of them will jump in relevance and appear near the top.

**Review Instructions**
On qa, search and sort the results by relevance, and confirm that they appear to be ordered correctly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7448

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
