### PR TITLE
SEAB-7464: Use LZ4 for TOAST compression in local postgres server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       # - elastic
   postgres_db:
     image: postgres:16.9
-    command: postgres -c jit=off
+    command: postgres -c jit=off -c default_toast_compression=lz4
     container_name: postgres1
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust


### PR DESCRIPTION
**Description**
This PR modifies `docker-compose.yml` to invoke the postgres db server so that it uses LZ4 for TOAST compression.  This change reduces my local db load time from 390s to 230s.  Also, RDS apparently uses LZ4 for TOAST, so this makes our development environment match a little better.  I can't think of any drawbacks, besides a very slight increase in local db memory usage.

**Review Instructions**
Run Dockstore locally and confirm that it seems to be working ok.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7464

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
