### PR TITLE
SEAB-7542: Track time of last categorization

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
@@ -83,7 +83,7 @@ class AutoCategorizationIT extends BaseIT {
 
     @Test
     void testGetLastCategorizedDateIsInitiallyNull() throws ApiException {
-        ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         Workflow workflow = publishedWorkflow(new WorkflowsApi(adminClient), "");
         assertNull(getLastCategorizedDate(userClient, workflow.getId()));
@@ -91,7 +91,7 @@ class AutoCategorizationIT extends BaseIT {
 
     @Test
     void testSetAndGetLastCategorizedDate() throws ApiException {
-        ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         Workflow workflow = publishedWorkflow(new WorkflowsApi(adminClient), "");
         long id = workflow.getId();
@@ -107,7 +107,7 @@ class AutoCategorizationIT extends BaseIT {
 
     @Test
     void testSetLastCategorizedDateDefaultsToNow() throws ApiException {
-        ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         Workflow workflow = publishedWorkflow(new WorkflowsApi(adminClient), "");
 
@@ -122,7 +122,7 @@ class AutoCategorizationIT extends BaseIT {
 
     @Test
     void testSetLastCategorizedDateRequiresAdminOrCurator() throws ApiException {
-        ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         Workflow workflow = publishedWorkflow(new WorkflowsApi(adminClient), "");
 
@@ -133,7 +133,7 @@ class AutoCategorizationIT extends BaseIT {
 
     @Test
     void testGetAndSetLastCategorizedDateForArchivedEntry() throws ApiException {
-        ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         Workflow workflow = publishedWorkflow(new WorkflowsApi(adminClient), "");
         long id = workflow.getId();
@@ -153,7 +153,7 @@ class AutoCategorizationIT extends BaseIT {
 
     @Test
     void testFindEntriesToCategorize() throws ApiException {
-        ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(adminClient);
 
@@ -194,7 +194,7 @@ class AutoCategorizationIT extends BaseIT {
 
     @Test
     void testFindEntriesToCategorizeRequiresCutoff() {
-        ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         EntriesApi entriesApi = new EntriesApi(adminClient);
 
         ApiException ex = assertThrows(ApiException.class,

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
@@ -157,21 +157,21 @@ class AutoCategorizationIT extends BaseIT {
         ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(adminClient);
 
-        // Entry A: published, never categorized → must appear
+        // Entry A: published, never categorized, must appear
         Workflow entryA = publishedWorkflow(workflowsApi, "a");
 
-        // Entry B: published, categorized long ago; refresh set dbUpdateDate >> farPast → must appear
+        // Entry B: published, categorized long ago; refresh set dbUpdateDate >> farPast, must appear
         Workflow entryB = publishedWorkflow(workflowsApi, "b");
         setLastCategorizedDate(adminClient, entryB.getId(), EPOCH_FAR_PAST);
 
-        // Entry C: published, categorized far in the future → must NOT appear
+        // Entry C: published, categorized far in the future, must NOT appear
         Workflow entryC = publishedWorkflow(workflowsApi, "c");
         setLastCategorizedDate(adminClient, entryC.getId(), EPOCH_FAR_FUTURE);
 
-        // Entry D: registered but not published → must NOT appear
-        Workflow entryDStub = workflowsApi.manualRegister(SourceControl.GITHUB.name(), WORKFLOW_PATH,
-            DESCRIPTOR_PATH, "d", DescriptorLanguage.WDL.getShortName(), "");
-        workflowsApi.refresh1(entryDStub.getId(), false);
+        // Entry D: registered but not published, must NOT appear
+        Workflow entryD = workflowsApi.manualRegister(SourceControl.GITHUB.name(), WORKFLOW_PATH,
+            DESCRIPTOR_PATH, "d", DescriptorLanguage.CWL.getShortName(), "");
+        workflowsApi.refresh1(entryD.getId(), false);
 
         long cutoffNow = System.currentTimeMillis() / 1000L;
         List<Long> toCategorize = findEntriesToCategorize(adminClient, cutoffNow);
@@ -179,7 +179,7 @@ class AutoCategorizationIT extends BaseIT {
         assertTrue(toCategorize.contains(entryA.getId()), "Never-categorized published entry should appear");
         assertTrue(toCategorize.contains(entryB.getId()), "Stale-categorized published entry should appear");
         assertFalse(toCategorize.contains(entryC.getId()), "Future-dated categorized entry should not appear");
-        assertFalse(toCategorize.contains(entryDStub.getId()), "Unpublished entry should not appear");
+        assertFalse(toCategorize.contains(entryD.getId()), "Unpublished entry should not appear");
     }
 
     @Test

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2024 OICR and UCSC
+ *    Copyright 2026 OICR and UCSC
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ class AutoCategorizationIT extends BaseIT {
     private static final String WORKFLOW_PATH = "DockstoreTestUser/dockstore-whalesay-2";
     private static final String DESCRIPTOR_PATH = "/dockstore.wdl";
     private static final long EPOCH_FAR_PAST = 1_000_000_000L;   // Sep 2001
-    private static final long EPOCH_FAR_FUTURE = 99_999_999_999L; // year 5138
+    private static final long EPOCH_FAR_FUTURE = 99_999_999_999L; // Year 5138
 
     @SystemStub
     public final SystemOut systemOut = new SystemOut();
@@ -83,8 +83,9 @@ class AutoCategorizationIT extends BaseIT {
 
     @Test
     void testGetLastCategorizedDateIsInitiallyNull() throws ApiException {
+        ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
         ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
-        Workflow workflow = publishedWorkflow(new WorkflowsApi(userClient), "");
+        Workflow workflow = publishedWorkflow(new WorkflowsApi(adminClient), "");
         assertNull(getLastCategorizedDate(userClient, workflow.getId()));
     }
 
@@ -92,7 +93,7 @@ class AutoCategorizationIT extends BaseIT {
     void testSetAndGetLastCategorizedDate() throws ApiException {
         ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
         ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
-        Workflow workflow = publishedWorkflow(new WorkflowsApi(userClient), "");
+        Workflow workflow = publishedWorkflow(new WorkflowsApi(adminClient), "");
         long id = workflow.getId();
 
         Date set = setLastCategorizedDate(adminClient, id, EPOCH_FAR_PAST);
@@ -108,7 +109,7 @@ class AutoCategorizationIT extends BaseIT {
     void testSetLastCategorizedDateDefaultsToNow() throws ApiException {
         ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
         ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
-        Workflow workflow = publishedWorkflow(new WorkflowsApi(userClient), "");
+        Workflow workflow = publishedWorkflow(new WorkflowsApi(adminClient), "");
 
         long before = System.currentTimeMillis();
         Date set = setLastCategorizedDate(adminClient, workflow.getId(), null);
@@ -121,8 +122,9 @@ class AutoCategorizationIT extends BaseIT {
 
     @Test
     void testSetLastCategorizedDateRequiresAdminOrCurator() throws ApiException {
+        ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
         ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
-        Workflow workflow = publishedWorkflow(new WorkflowsApi(userClient), "");
+        Workflow workflow = publishedWorkflow(new WorkflowsApi(adminClient), "");
 
         ApiException ex = assertThrows(ApiException.class,
             () -> setLastCategorizedDate(userClient, workflow.getId(), null));
@@ -133,7 +135,7 @@ class AutoCategorizationIT extends BaseIT {
     void testGetAndSetLastCategorizedDateForArchivedEntry() throws ApiException {
         ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
         ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
-        Workflow workflow = publishedWorkflow(new WorkflowsApi(userClient), "");
+        Workflow workflow = publishedWorkflow(new WorkflowsApi(adminClient), "");
         long id = workflow.getId();
 
         new EntriesApi(adminClient).archiveEntry(id);
@@ -153,7 +155,7 @@ class AutoCategorizationIT extends BaseIT {
     void testFindEntriesToCategorize() throws ApiException {
         ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
         ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
-        WorkflowsApi workflowsApi = new WorkflowsApi(userClient);
+        WorkflowsApi workflowsApi = new WorkflowsApi(adminClient);
 
         // Entry A: published, never categorized → must appear
         Workflow entryA = publishedWorkflow(workflowsApi, "a");

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
@@ -74,7 +74,7 @@ class AutoCategorizationIT extends BaseIT {
     }
 
     private Date setLastCategorizedDate(ApiClient client, long id, Long when) throws ApiException {
-        return new EntriesApi(client).setLastCategorizedDate(id, when);
+        return new EntriesApi(client).setLastCategorizedDate(id, "", when);
     }
 
     private List<Long> findEntriesToCategorize(ApiClient client, long cutoff) throws ApiException {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
@@ -48,8 +48,8 @@ import uk.org.webcompere.systemstubs.stream.SystemOut;
 @ExtendWith(TestStatus.class)
 class AutoCategorizationIT extends BaseIT {
 
-    private static final String WORKFLOW_PATH = "DockstoreTestUser/dockstore-whalesay-2";
-    private static final String DESCRIPTOR_PATH = "/dockstore.wdl";
+    private static final String WORKFLOW_PATH = "dockstore-testing/hello_world";
+    private static final String DESCRIPTOR_PATH = "/hello_world.cwl";
     private static final long EPOCH_FAR_PAST = 1_000_000_000L;   // Sep 2001
     private static final long EPOCH_FAR_FUTURE = 99_999_999_999L; // Year 5138
 
@@ -66,7 +66,7 @@ class AutoCategorizationIT extends BaseIT {
 
     private Workflow publishedWorkflow(WorkflowsApi workflowsApi, String name) {
         return openManualRegisterAndPublish(workflowsApi, WORKFLOW_PATH, name,
-            DescriptorLanguage.WDL.getShortName(), SourceControl.GITHUB, DESCRIPTOR_PATH, true);
+            DescriptorLanguage.CWL.getShortName(), SourceControl.GITHUB, DESCRIPTOR_PATH, true);
     }
 
     private Date getLastCategorizedDate(ApiClient client, long id) throws ApiException {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
@@ -50,8 +50,8 @@ class AutoCategorizationIT extends BaseIT {
 
     private static final String WORKFLOW_PATH = "dockstore-testing/hello_world";
     private static final String DESCRIPTOR_PATH = "/hello_world.cwl";
-    private static final long EPOCH_FAR_PAST = 1_000_000_000L;   // Sep 2001
-    private static final long EPOCH_FAR_FUTURE = 99_999_999_999L; // Year 5138
+    private static final long EPOCH_PAST = 1_000_000_000L;   // Sep 2001
+    private static final long EPOCH_FUTURE = 99_999_999_999L; // Year 5138
 
     @SystemStub
     public final SystemOut systemOut = new SystemOut();
@@ -96,13 +96,13 @@ class AutoCategorizationIT extends BaseIT {
         Workflow workflow = publishedWorkflow(new WorkflowsApi(adminClient), "");
         long id = workflow.getId();
 
-        Date set = setLastCategorizedDate(adminClient, id, EPOCH_FAR_PAST);
+        Date set = setLastCategorizedDate(adminClient, id, EPOCH_PAST);
         assertNotNull(set);
-        assertEquals(EPOCH_FAR_PAST * 1000L, set.getTime());
+        assertEquals(EPOCH_PAST * 1000L, set.getTime());
 
         Date got = getLastCategorizedDate(userClient, id);
         assertNotNull(got);
-        assertEquals(EPOCH_FAR_PAST * 1000L, got.getTime());
+        assertEquals(EPOCH_PAST * 1000L, got.getTime());
     }
 
     @Test
@@ -143,11 +143,11 @@ class AutoCategorizationIT extends BaseIT {
         assertNull(getLastCategorizedDate(userClient, id));
 
         // admin can set the date on an archived entry
-        Date set = setLastCategorizedDate(adminClient, id, EPOCH_FAR_PAST);
-        assertEquals(EPOCH_FAR_PAST * 1000L, set.getTime());
+        Date set = setLastCategorizedDate(adminClient, id, EPOCH_PAST);
+        assertEquals(EPOCH_PAST * 1000L, set.getTime());
 
         Date got = getLastCategorizedDate(userClient, id);
-        assertEquals(EPOCH_FAR_PAST * 1000L, got.getTime());
+        assertEquals(EPOCH_PAST * 1000L, got.getTime());
     }
 
     @Test
@@ -160,11 +160,11 @@ class AutoCategorizationIT extends BaseIT {
 
         // Entry B: published, categorized long ago; refresh set dbUpdateDate >> farPast, must appear
         Workflow entryB = publishedWorkflow(workflowsApi, "b");
-        setLastCategorizedDate(adminClient, entryB.getId(), EPOCH_FAR_PAST);
+        setLastCategorizedDate(adminClient, entryB.getId(), EPOCH_PAST);
 
         // Entry C: published, categorized far in the future, must NOT appear
         Workflow entryC = publishedWorkflow(workflowsApi, "c");
-        setLastCategorizedDate(adminClient, entryC.getId(), EPOCH_FAR_FUTURE);
+        setLastCategorizedDate(adminClient, entryC.getId(), EPOCH_FUTURE);
 
         // Entry D: registered but not published, must NOT appear
         Workflow entryD = workflowsApi.manualRegister(SourceControl.GITHUB.name(), WORKFLOW_PATH,

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
@@ -48,7 +48,7 @@ import uk.org.webcompere.systemstubs.stream.SystemOut;
 @ExtendWith(TestStatus.class)
 class AutoCategorizationIT extends BaseIT {
 
-    private static final String WORKFLOW_PATH = "DockstoreTestUser/dockstore-whalesay-wdl";
+    private static final String WORKFLOW_PATH = "DockstoreTestUser/dockstore-whalesay-2";
     private static final String DESCRIPTOR_PATH = "/dockstore.wdl";
     private static final long EPOCH_FAR_PAST = 1_000_000_000L;   // Sep 2001
     private static final long EPOCH_FAR_FUTURE = 99_999_999_999L; // year 5138
@@ -83,7 +83,7 @@ class AutoCategorizationIT extends BaseIT {
 
     @Test
     void testGetLastCategorizedDateIsInitiallyNull() throws ApiException {
-        ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         Workflow workflow = publishedWorkflow(new WorkflowsApi(userClient), "");
         assertNull(getLastCategorizedDate(userClient, workflow.getId()));
     }
@@ -91,7 +91,7 @@ class AutoCategorizationIT extends BaseIT {
     @Test
     void testSetAndGetLastCategorizedDate() throws ApiException {
         ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
-        ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         Workflow workflow = publishedWorkflow(new WorkflowsApi(userClient), "");
         long id = workflow.getId();
 
@@ -107,7 +107,7 @@ class AutoCategorizationIT extends BaseIT {
     @Test
     void testSetLastCategorizedDateDefaultsToNow() throws ApiException {
         ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
-        ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         Workflow workflow = publishedWorkflow(new WorkflowsApi(userClient), "");
 
         long before = System.currentTimeMillis();
@@ -121,7 +121,7 @@ class AutoCategorizationIT extends BaseIT {
 
     @Test
     void testSetLastCategorizedDateRequiresAdminOrCurator() throws ApiException {
-        ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         Workflow workflow = publishedWorkflow(new WorkflowsApi(userClient), "");
 
         ApiException ex = assertThrows(ApiException.class,
@@ -132,7 +132,7 @@ class AutoCategorizationIT extends BaseIT {
     @Test
     void testGetAndSetLastCategorizedDateForArchivedEntry() throws ApiException {
         ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
-        ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         Workflow workflow = publishedWorkflow(new WorkflowsApi(userClient), "");
         long id = workflow.getId();
 
@@ -152,7 +152,7 @@ class AutoCategorizationIT extends BaseIT {
     @Test
     void testFindEntriesToCategorize() throws ApiException {
         ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
-        ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(userClient);
 
         // Entry A: published, never categorized → must appear
@@ -182,7 +182,7 @@ class AutoCategorizationIT extends BaseIT {
 
     @Test
     void testFindEntriesToCategorizeRequiresAdminOrCurator() {
-        ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         long cutoff = System.currentTimeMillis() / 1000L;
 
         ApiException ex = assertThrows(ApiException.class,

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
@@ -108,7 +108,6 @@ class AutoCategorizationIT extends BaseIT {
     @Test
     void testSetLastCategorizedDateDefaultsToNow() throws ApiException {
         ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
-        ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         Workflow workflow = publishedWorkflow(new WorkflowsApi(adminClient), "");
 
         long before = System.currentTimeMillis();
@@ -154,7 +153,6 @@ class AutoCategorizationIT extends BaseIT {
     @Test
     void testFindEntriesToCategorize() throws ApiException {
         ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
-        ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(adminClient);
 
         // Entry A: published, never categorized, must appear

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
@@ -1,0 +1,202 @@
+/*
+ *    Copyright 2024 OICR and UCSC
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.dockstore.client.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.dockstore.client.cli.BaseIT.TestStatus;
+import io.dockstore.common.CommonTestUtilities;
+import io.dockstore.common.DescriptorLanguage;
+import io.dockstore.common.MuteForSuccessfulTests;
+import io.dockstore.common.SourceControl;
+import io.dockstore.openapi.client.ApiClient;
+import io.dockstore.openapi.client.ApiException;
+import io.dockstore.openapi.client.api.EntriesApi;
+import io.dockstore.openapi.client.api.WorkflowsApi;
+import io.dockstore.openapi.client.model.Workflow;
+import java.util.Date;
+import java.util.List;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.stream.SystemErr;
+import uk.org.webcompere.systemstubs.stream.SystemOut;
+
+@ExtendWith(SystemStubsExtension.class)
+@ExtendWith(MuteForSuccessfulTests.class)
+@ExtendWith(TestStatus.class)
+class AutoCategorizationIT extends BaseIT {
+
+    private static final String WORKFLOW_PATH = "DockstoreTestUser/dockstore-whalesay-wdl";
+    private static final String DESCRIPTOR_PATH = "/dockstore.wdl";
+    private static final long EPOCH_FAR_PAST = 1_000_000_000L;   // Sep 2001
+    private static final long EPOCH_FAR_FUTURE = 99_999_999_999L; // year 5138
+
+    @SystemStub
+    public final SystemOut systemOut = new SystemOut();
+    @SystemStub
+    public final SystemErr systemErr = new SystemErr();
+
+    @BeforeEach
+    @Override
+    public void resetDBBetweenTests() throws Exception {
+        CommonTestUtilities.cleanStatePrivate2(SUPPORT, false, testingPostgres);
+    }
+
+    private Workflow publishedWorkflow(WorkflowsApi workflowsApi, String name) {
+        return openManualRegisterAndPublish(workflowsApi, WORKFLOW_PATH, name,
+            DescriptorLanguage.WDL.getShortName(), SourceControl.GITHUB, DESCRIPTOR_PATH, true);
+    }
+
+    private Date getLastCategorizedDate(ApiClient client, long id) throws ApiException {
+        return new EntriesApi(client).getLastCategorizedDate(id);
+    }
+
+    private Date setLastCategorizedDate(ApiClient client, long id, Long when) throws ApiException {
+        return new EntriesApi(client).setLastCategorizedDate(id, when);
+    }
+
+    private List<Long> findEntriesToCategorize(ApiClient client, long cutoff) throws ApiException {
+        return new EntriesApi(client).findEntriesToCategorize(cutoff);
+    }
+
+    @Test
+    void testGetLastCategorizedDateIsInitiallyNull() throws ApiException {
+        ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        Workflow workflow = publishedWorkflow(new WorkflowsApi(userClient), "");
+        assertNull(getLastCategorizedDate(userClient, workflow.getId()));
+    }
+
+    @Test
+    void testSetAndGetLastCategorizedDate() throws ApiException {
+        ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        Workflow workflow = publishedWorkflow(new WorkflowsApi(userClient), "");
+        long id = workflow.getId();
+
+        Date set = setLastCategorizedDate(adminClient, id, EPOCH_FAR_PAST);
+        assertNotNull(set);
+        assertEquals(EPOCH_FAR_PAST * 1000L, set.getTime());
+
+        Date got = getLastCategorizedDate(userClient, id);
+        assertNotNull(got);
+        assertEquals(EPOCH_FAR_PAST * 1000L, got.getTime());
+    }
+
+    @Test
+    void testSetLastCategorizedDateDefaultsToNow() throws ApiException {
+        ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        Workflow workflow = publishedWorkflow(new WorkflowsApi(userClient), "");
+
+        long before = System.currentTimeMillis();
+        Date set = setLastCategorizedDate(adminClient, workflow.getId(), null);
+        long after = System.currentTimeMillis();
+
+        assertNotNull(set);
+        assertTrue(set.getTime() >= before && set.getTime() <= after,
+            "Returned date should be approximately now");
+    }
+
+    @Test
+    void testSetLastCategorizedDateRequiresAdminOrCurator() throws ApiException {
+        ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        Workflow workflow = publishedWorkflow(new WorkflowsApi(userClient), "");
+
+        ApiException ex = assertThrows(ApiException.class,
+            () -> setLastCategorizedDate(userClient, workflow.getId(), null));
+        assertEquals(HttpStatus.SC_FORBIDDEN, ex.getCode());
+    }
+
+    @Test
+    void testGetAndSetLastCategorizedDateForArchivedEntry() throws ApiException {
+        ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        Workflow workflow = publishedWorkflow(new WorkflowsApi(userClient), "");
+        long id = workflow.getId();
+
+        new EntriesApi(adminClient).archiveEntry(id);
+
+        // archived-but-published entry is still readable by a regular user
+        assertNull(getLastCategorizedDate(userClient, id));
+
+        // admin can set the date on an archived entry
+        Date set = setLastCategorizedDate(adminClient, id, EPOCH_FAR_PAST);
+        assertEquals(EPOCH_FAR_PAST * 1000L, set.getTime());
+
+        Date got = getLastCategorizedDate(userClient, id);
+        assertEquals(EPOCH_FAR_PAST * 1000L, got.getTime());
+    }
+
+    @Test
+    void testFindEntriesToCategorize() throws ApiException {
+        ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowsApi = new WorkflowsApi(userClient);
+
+        // Entry A: published, never categorized → must appear
+        Workflow entryA = publishedWorkflow(workflowsApi, "a");
+
+        // Entry B: published, categorized long ago; refresh set dbUpdateDate >> farPast → must appear
+        Workflow entryB = publishedWorkflow(workflowsApi, "b");
+        setLastCategorizedDate(adminClient, entryB.getId(), EPOCH_FAR_PAST);
+
+        // Entry C: published, categorized far in the future → must NOT appear
+        Workflow entryC = publishedWorkflow(workflowsApi, "c");
+        setLastCategorizedDate(adminClient, entryC.getId(), EPOCH_FAR_FUTURE);
+
+        // Entry D: registered but not published → must NOT appear
+        Workflow entryDStub = workflowsApi.manualRegister(SourceControl.GITHUB.name(), WORKFLOW_PATH,
+            DESCRIPTOR_PATH, "d", DescriptorLanguage.WDL.getShortName(), "");
+        workflowsApi.refresh1(entryDStub.getId(), false);
+
+        long cutoffNow = System.currentTimeMillis() / 1000L;
+        List<Long> toCategorize = findEntriesToCategorize(adminClient, cutoffNow);
+
+        assertTrue(toCategorize.contains(entryA.getId()), "Never-categorized published entry should appear");
+        assertTrue(toCategorize.contains(entryB.getId()), "Stale-categorized published entry should appear");
+        assertFalse(toCategorize.contains(entryC.getId()), "Future-dated categorized entry should not appear");
+        assertFalse(toCategorize.contains(entryDStub.getId()), "Unpublished entry should not appear");
+    }
+
+    @Test
+    void testFindEntriesToCategorizeRequiresAdminOrCurator() {
+        ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        long cutoff = System.currentTimeMillis() / 1000L;
+
+        ApiException ex = assertThrows(ApiException.class,
+            () -> findEntriesToCategorize(userClient, cutoff));
+        assertEquals(HttpStatus.SC_FORBIDDEN, ex.getCode());
+    }
+
+    @Test
+    void testFindEntriesToCategorizeRequiresCutoff() {
+        ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        EntriesApi entriesApi = new EntriesApi(adminClient);
+
+        ApiException ex = assertThrows(ApiException.class,
+            () -> entriesApi.findEntriesToCategorize(null));
+        assertEquals(HttpStatus.SC_BAD_REQUEST, ex.getCode());
+    }
+}

--- a/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java
@@ -93,7 +93,7 @@ public final class CommonTestUtilities {
     private static final Logger LOG = LoggerFactory.getLogger(CommonTestUtilities.class);
     public static final String OLD_DOCKSTORE_VERSION = "1.15.1";
     public static final List<String> COMMON_MIGRATIONS = List.of("1.3.0.generated", "1.3.1.consistency", "1.4.0", "1.5.0", "1.6.0", "1.7.0",
-            "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0", "1.14.0", "1.15.0", "1.16.0", "1.17.0", "1.18.0", "1.19.0");
+            "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0", "1.14.0", "1.15.0", "1.16.0", "1.17.0", "1.18.0", "1.19.0", "1.20.0");
     // Travis is slow, need to wait up to 1 min for webservice to return
     public static final int WAIT_TIME = 60000;
     public static final String PUBLIC_CONFIG_PATH = getUniversalResourceFileAbsolutePath("dockstore.yml").orElse(null);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/DockstoreWebserviceApplication.java
@@ -50,6 +50,7 @@ import io.dockstore.webservice.core.Collection;
 import io.dockstore.webservice.core.CollectionOrganization;
 import io.dockstore.webservice.core.DeletedUsername;
 import io.dockstore.webservice.core.Doi;
+import io.dockstore.webservice.core.EntryMetadata;
 import io.dockstore.webservice.core.EntryVersion;
 import io.dockstore.webservice.core.Event;
 import io.dockstore.webservice.core.FileFormat;
@@ -264,7 +265,8 @@ public class DockstoreWebserviceApplication extends Application<DockstoreWebserv
             Organization.class, PublicNotification.class, GitHubAppNotification.class, OrganizationUser.class, Event.class, Collection.class, Validation.class, BioWorkflow.class, Service.class, VersionMetadata.class, Image.class, Checksum.class, LambdaEvent.class,
             ParsedInformation.class, EntryVersion.class, DeletedUsername.class, CloudInstance.class, Author.class, OrcidAuthor.class,
             AppTool.class, Category.class, FullWorkflowPath.class, Notebook.class, SourceFileMetadata.class, Metrics.class, CpuStatisticMetric.class, MemoryStatisticMetric.class, ExecutionTimeStatisticMetric.class, CostStatisticMetric.class,
-            ExecutionStatusCountMetric.class, ValidationStatusCountMetric.class, ValidatorInfo.class, ValidatorVersionInfo.class, MetricsByStatus.class, Doi.class, TimeSeriesMetric.class, HistogramMetric.class) {
+            ExecutionStatusCountMetric.class, ValidationStatusCountMetric.class, ValidatorInfo.class, ValidatorVersionInfo.class, MetricsByStatus.class, Doi.class, TimeSeriesMetric.class, HistogramMetric.class,
+            EntryMetadata.class) {
         @Override
         public DataSourceFactory getDataSourceFactory(DockstoreWebserviceConfiguration configuration) {
             return configuration.getDataSourceFactory();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -371,6 +371,7 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     @ApiModelProperty(value = "The aggregated metrics for executions of this entry, grouped by platform", position = 26)
     private Map<Partner, Metrics> metricsByPlatform = new EnumMap<>(Partner.class);
 
+    @JsonIgnore
     @OneToOne(cascade = CascadeType.ALL, mappedBy = "parent", orphanRemoval = true)
     @Cascade(org.hibernate.annotations.CascadeType.ALL)
     @PrimaryKeyJoinColumn

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -61,6 +61,7 @@ import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Transient;
 import jakarta.persistence.UniqueConstraint;
@@ -83,6 +84,7 @@ import java.util.TreeSet;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -366,6 +368,11 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     @MapKeyEnumerated(EnumType.STRING)
     @ApiModelProperty(value = "The aggregated metrics for executions of this entry, grouped by platform", position = 26)
     private Map<Partner, Metrics> metricsByPlatform = new EnumMap<>(Partner.class);
+
+    @OneToOne(cascade = CascadeType.ALL, mappedBy = "parent", orphanRemoval = true)
+    @Cascade(org.hibernate.annotations.CascadeType.ALL)
+    @PrimaryKeyJoinColumn
+    private EntryMetadata entryMetadata = new EntryMetadata();
 
     public enum GitVisibility {
         /**
@@ -984,6 +991,18 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
 
     public void setMetricsByPlatform(Map<Partner, Metrics> metricsByPlatform) {
         this.metricsByPlatform = metricsByPlatform;
+    }
+
+    public EntryMetadata getEntryMetadata() {
+        if (entryMetadata == null) {
+            entryMetadata = new EntryMetadata();
+            entryMetadata.setId(this.id);
+        }
+        return entryMetadata;
+    }
+
+    public void setEntryMetadata(EntryMetadata entryMetadata) {
+        this.entryMetadata = entryMetadata;
     }
 
     @JsonProperty

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -138,7 +138,8 @@ import org.hibernate.annotations.UpdateTimestamp;
     @NamedQuery(name = ENTRY_GET_VALIDATION_METRIC_PARTNERS, query = "select new io.dockstore.webservice.core.Entry$EntryIdAndPartner(v.parent.id, KEY(v.metricsByPlatform)) from Version v "
             + "where KEY(v.metricsByPlatform) != io.dockstore.common.Partner.ALL and value(v.metricsByPlatform).validationStatus is not null and v.parent.id in (:entryIds) group by v.parent.id, key(v.metricsByPlatform)"),
     @NamedQuery(name = Entry.GET_PUBLISHED_ENTRIES_WITH_NO_TOPICS, query = "SELECT e FROM Entry e WHERE e.isPublished = TRUE AND e.archived = false AND e.topicManual IS NULL AND e.topicAutomatic IS NULL AND e.topicAI IS NULL"),
-    @NamedQuery(name = Entry.COUNT_PUBLISHED_ENTRIES_WITH_NO_TOPICS, query = "SELECT COUNT(e.id) FROM Entry e WHERE e.isPublished = TRUE AND e.archived = false AND e.topicManual IS NULL AND e.topicAutomatic IS NULL AND e.topicAI IS NULL")
+    @NamedQuery(name = Entry.COUNT_PUBLISHED_ENTRIES_WITH_NO_TOPICS, query = "SELECT COUNT(e.id) FROM Entry e WHERE e.isPublished = TRUE AND e.archived = false AND e.topicManual IS NULL AND e.topicAutomatic IS NULL AND e.topicAI IS NULL"),
+    @NamedQuery(name = Entry.FIND_ENTRIES_TO_CATEGORIZE, query = "SELECT e.id FROM Entry e JOIN e.entryMetadata m WHERE e.isPublished = TRUE AND (m.lastCategorizedDate IS NULL OR (e.dbUpdateDate > m.lastCategorizedDate AND m.lastCategorizedDate < :cutoff))")
 })
 // TODO: Replace this with JPA when possible
 @NamedNativeQueries({
@@ -161,6 +162,7 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     public static final String ENTRY_GET_VALIDATION_METRIC_PARTNERS = "Entry.getValidationMetricsPartners";
     public static final String GET_PUBLISHED_ENTRIES_WITH_NO_TOPICS = "Entry.getPublishedEntriesWithNoTopics";
     public static final String COUNT_PUBLISHED_ENTRIES_WITH_NO_TOPICS = "Entry.countPublishedEntriesWithNoTopics";
+    public static final String FIND_ENTRIES_TO_CATEGORIZE = "Entry.findEntriesToCategorize";
     private static final int TOPIC_LENGTH = 250;
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -402,12 +402,14 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     public Entry() {
         users = new TreeSet<>();
         starredUsers = new TreeSet<>();
+        entryMetadata.parent = this;
     }
 
     public Entry(long id) {
         this.id = id;
         users = new TreeSet<>();
         starredUsers = new TreeSet<>();
+        entryMetadata.parent = this;
     }
 
     public abstract Entry<?, ?> createEmptyEntry();

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/EntryMetadata.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/EntryMetadata.java
@@ -1,0 +1,79 @@
+/*
+ *    Copyright 2026 OICR and UCSC
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.dockstore.webservice.core;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.sql.Timestamp;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * Data about entries in Dockstore rather than about the original workflow/tool.
+ *
+ * Stays modifiable even when the parent (entry) becomes immutable via postgres security policies,
+ * allowing us to modify things like categorization timestamps for archived entries.
+ *
+ * Note that this entity is not directly serialized; instead individual fields are exposed in the
+ * Entry model.
+ */
+@Entity
+@Table(name = "entry_metadata")
+public class EntryMetadata {
+
+    @MapsId
+    @OneToOne
+    @JoinColumn(name = "id")
+    protected Entry<?, ?> parent;
+
+    @Id
+    @Column(name = "id")
+    private long id;
+
+    @Column(updatable = false)
+    @CreationTimestamp
+    private Timestamp dbCreateDate;
+
+    @Column()
+    @UpdateTimestamp
+    private Timestamp dbUpdateDate;
+
+    @Column()
+    @Schema(description = "The timestamp of the last categorization of this entry")
+    private Timestamp lastCategorizedDate;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public Timestamp getLastCategorizedDate() {
+        return lastCategorizedDate;
+    }
+
+    public void setLastCategorizedDate(Timestamp lastCategorizedDate) {
+        this.lastCategorizedDate = lastCategorizedDate;
+    }
+}

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -45,6 +45,7 @@ import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Subquery;
 import jakarta.persistence.metamodel.Attribute;
 import java.lang.reflect.ParameterizedType;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -415,6 +416,12 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
 
     public long countPublishedEntriesWithNoTopics() {
         return this.currentSession().createNamedQuery(Entry.COUNT_PUBLISHED_ENTRIES_WITH_NO_TOPICS, Long.class).getSingleResult();
+    }
+
+    public List<Long> findEntriesToCategorize(Timestamp cutoff) {
+        return this.currentSession().createNamedQuery(Entry.FIND_ENTRIES_TO_CATEGORIZE, Long.class)
+                .setParameter("cutoff", cutoff)
+                .list();
     }
 
     private void processQuery(String filter, String sortCol, String sortOrder, CriteriaBuilder cb, CriteriaQuery query, Root<T> entry) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -84,6 +84,7 @@ import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -91,6 +92,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.xml.bind.JAXBException;
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -367,6 +369,37 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
         List<Category> categories = this.toolDAO.findCategoriesByEntryId(entry.getId());
         collectionHelper.evictAndSummarize(categories);
         return categories;
+    }
+
+    @GET
+    @Timed
+    @UnitOfWork(readOnly = true)
+    @Path("/{id}/lastCategorizedDate")
+    @Operation(operationId = "getLastCategorizedDate", description = "Get the date of the last categorization of an entry.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully retrieved the last categorized date", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Timestamp.class)))
+    public Timestamp getLastCategorizedDate(@Parameter(hidden = true, name = "user") @Auth Optional<User> user,
+            @Parameter(description = "Entry ID", name = "id", in = ParameterIn.PATH, required = true) @PathParam("id") Long id) {
+        Entry<?, ?> entry = toolDAO.getGenericEntryById(id);
+        checkNotNullEntry(entry);
+        checkCanRead(user, entry);
+        return entry.getEntryMetadata().getLastCategorizedDate();
+    }
+
+    @PUT
+    @Timed
+    @UnitOfWork
+    @Path("/{id}/lastCategorizedDate")
+    @RolesAllowed({"curator", "admin"})
+    @Operation(operationId = "setLastCategorizedDate", description = "Set the date of the last categorization of an entry.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully set the last categorized date", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Timestamp.class)))
+    public Timestamp setLastCategorizedDate(@Parameter(hidden = true, name = "user") @Auth User user,
+            @Parameter(description = "Entry ID", name = "id", in = ParameterIn.PATH, required = true) @PathParam("id") Long id,
+            @Parameter(description = "UTC epoch seconds; defaults to now") @QueryParam("when") Long when) {
+        Entry<?, ?> entry = toolDAO.getGenericEntryById(id);
+        checkNotNullEntry(entry);
+        Timestamp timestamp = when != null ? new Timestamp(when * 1000L) : new Timestamp(System.currentTimeMillis());
+        entry.getEntryMetadata().setLastCategorizedDate(timestamp);
+        return entry.getEntryMetadata().getLastCategorizedDate();
     }
 
     @GET

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -395,7 +395,8 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
     @SuppressWarnings("checkstyle:MagicNumber")
     public Timestamp setLastCategorizedDate(@Parameter(hidden = true, name = "user") @Auth User user,
             @Parameter(description = "Entry ID", name = "id", in = ParameterIn.PATH, required = true) @PathParam("id") Long id,
-            @Parameter(description = "UTC epoch seconds; defaults to now") @QueryParam("when") Long when) {
+            @Parameter(description = "UTC epoch seconds; defaults to now") @QueryParam("when") Long when,
+            @Parameter(description = "This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.", name = "emptyBody") String emptyBody) {
         Entry<?, ?> entry = toolDAO.getGenericEntryById(id);
         checkNotNullEntry(entry);
         Timestamp timestamp = when != null ? new Timestamp(when * 1000L) : new Timestamp(System.currentTimeMillis());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -404,6 +404,22 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
     }
 
     @GET
+    @Timed
+    @UnitOfWork(readOnly = true)
+    @Path("/toCategorize")
+    @RolesAllowed({"curator", "admin"})
+    @Operation(operationId = "findEntriesToCategorize", description = "Get IDs of published entries that are new and uncategorized, or that have changed since last categorization and were last categorized before the given cutoff.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully retrieved entry IDs", content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = Long.class))))
+    @SuppressWarnings("checkstyle:MagicNumber")
+    public List<Long> findEntriesToCategorize(@Parameter(hidden = true, name = "user") @Auth User user,
+            @Parameter(description = "Cutoff UTC epoch seconds; entries last categorized before this time are eligible for re-categorization if changed", required = true) @QueryParam("cutoff") Long cutoff) {
+        if (cutoff == null) {
+            throw new CustomWebApplicationException("cutoff query parameter is required", HttpStatus.SC_BAD_REQUEST);
+        }
+        return toolDAO.findEntriesToCategorize(new Timestamp(cutoff * 1000L));
+    }
+
+    @GET
     @Path("/{entryId}/verifiedPlatforms")
     @UnitOfWork
     @ApiOperation(value = "Get the verified platforms for each version of an entry.",  hidden = true)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -92,11 +92,11 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.xml.bind.JAXBException;
 import java.io.IOException;
-import java.sql.Timestamp;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.http.HttpResponse;
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
 import java.util.SortedSet;
@@ -392,6 +392,7 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
     @RolesAllowed({"curator", "admin"})
     @Operation(operationId = "setLastCategorizedDate", description = "Set the date of the last categorization of an entry.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully set the last categorized date", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Timestamp.class)))
+    @SuppressWarnings("checkstyle:MagicNumber")
     public Timestamp setLastCategorizedDate(@Parameter(hidden = true, name = "user") @Auth User user,
             @Parameter(description = "Entry ID", name = "id", in = ParameterIn.PATH, required = true) @PathParam("id") Long id,
             @Parameter(description = "UTC epoch seconds; defaults to now") @QueryParam("when") Long when) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -395,11 +395,11 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
     @SuppressWarnings("checkstyle:MagicNumber")
     public Timestamp setLastCategorizedDate(@Parameter(hidden = true, name = "user") @Auth User user,
             @Parameter(description = "Entry ID", name = "id", in = ParameterIn.PATH, required = true) @PathParam("id") Long id,
-            @Parameter(description = "UTC epoch seconds; defaults to now") @QueryParam("when") Long when,
+            @Parameter(description = "Date in UTC epoch seconds; defaults to now") @QueryParam("whenSeconds") Long whenSeconds,
             @Parameter(description = "This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.", name = "emptyBody") String emptyBody) {
         Entry<?, ?> entry = toolDAO.getGenericEntryById(id);
         checkNotNullEntry(entry);
-        Timestamp timestamp = when != null ? new Timestamp(when * 1000L) : new Timestamp(System.currentTimeMillis());
+        Timestamp timestamp = whenSeconds != null ? new Timestamp(whenSeconds * 1000L) : new Timestamp(System.currentTimeMillis());
         entry.getEntryMetadata().setLastCategorizedDate(timestamp);
         return entry.getEntryMetadata().getLastCategorizedDate();
     }
@@ -413,11 +413,11 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully retrieved entry IDs", content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = Long.class))))
     @SuppressWarnings("checkstyle:MagicNumber")
     public List<Long> findEntriesToCategorize(@Parameter(hidden = true, name = "user") @Auth User user,
-            @Parameter(description = "Cutoff UTC epoch seconds; entries last categorized before this time are eligible for re-categorization if changed", required = true) @QueryParam("cutoff") Long cutoff) {
-        if (cutoff == null) {
-            throw new CustomWebApplicationException("cutoff query parameter is required", HttpStatus.SC_BAD_REQUEST);
+            @Parameter(description = "Cutoff in UTC epoch seconds; entries last categorized before this time are eligible for re-categorization if changed", required = true) @QueryParam("cutoffSeconds") Long cutoffSeconds) {
+        if (cutoffSeconds == null) {
+            throw new CustomWebApplicationException("cutoffSeconds query parameter is required", HttpStatus.SC_BAD_REQUEST);
         }
-        return toolDAO.findEntriesToCategorize(new Timestamp(cutoff * 1000L));
+        return toolDAO.findEntriesToCategorize(new Timestamp(cutoffSeconds * 1000L));
     }
 
     @GET

--- a/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
@@ -1,0 +1,31 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<!--
+  ~    Copyright 2026 OICR and UCSC
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd"
+                   context="1.20.0">
+    <changeSet author="svonworl" id="create_entry_metadata">
+        <createTable tableName="entry_metadata">
+            <column name="id" type="BIGINT">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="dbcreatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="dbupdatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="lastcategorizeddate" type="TIMESTAMP WITHOUT TIME ZONE"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
@@ -27,5 +27,17 @@
             <column name="dbupdatedate" type="TIMESTAMP WITHOUT TIME ZONE"/>
             <column name="lastcategorizeddate" type="TIMESTAMP WITHOUT TIME ZONE"/>
         </createTable>
+        <sql>
+            INSERT INTO entry_metadata (id)
+            SELECT id FROM tool
+            UNION ALL
+            SELECT id FROM apptool
+            UNION ALL
+            SELECT id FROM notebook
+            UNION ALL
+            SELECT id FROM service
+            UNION ALL
+            SELECT id FROM workflow
+        </sql>
     </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.xml
+++ b/dockstore-webservice/src/main/resources/migrations.xml
@@ -51,4 +51,5 @@
     <include file="migrations.1.17.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.18.0.xml" relativeToChangelogFile="true"/>
     <include file="migrations.1.19.0.xml" relativeToChangelogFile="true"/>
+    <include file="migrations.1.20.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3323,10 +3323,10 @@ paths:
         \ the given cutoff."
       operationId: findEntriesToCategorize
       parameters:
-      - description: Cutoff UTC epoch seconds; entries last categorized before this
-          time are eligible for re-categorization if changed
+      - description: Cutoff in UTC epoch seconds; entries last categorized before
+          this time are eligible for re-categorization if changed
         in: query
-        name: cutoff
+        name: cutoffSeconds
         required: true
         schema:
           type: integer
@@ -3741,9 +3741,9 @@ paths:
         schema:
           type: integer
           format: int64
-      - description: UTC epoch seconds; defaults to now
+      - description: Date in UTC epoch seconds; defaults to now
         in: query
-        name: when
+        name: whenSeconds
         schema:
           type: integer
           format: int64

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -9998,6 +9998,8 @@ components:
           - USER
           - DOCKSTORE
           - GITHUB
+        entryMetadata:
+          $ref: '#/components/schemas/EntryMetadata'
         entryType:
           $ref: '#/components/schemas/EntryType'
         entryTypeMetadata:
@@ -10230,6 +10232,8 @@ components:
           - USER
           - DOCKSTORE
           - GITHUB
+        entryMetadata:
+          $ref: '#/components/schemas/EntryMetadata'
         entryType:
           $ref: '#/components/schemas/EntryType'
         entryTypeMetadata:
@@ -10354,6 +10358,16 @@ components:
           $ref: '#/components/schemas/EntryLite'
         versionName:
           type: string
+    EntryMetadata:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        lastCategorizedDate:
+          type: string
+          format: date-time
+          description: The timestamp of the last categorization of this entry
     EntryType:
       type: string
       description: Entry type
@@ -13223,6 +13237,8 @@ components:
           - USER
           - DOCKSTORE
           - GITHUB
+        entryMetadata:
+          $ref: '#/components/schemas/EntryMetadata'
         entryType:
           $ref: '#/components/schemas/EntryType'
         entryTypeMetadata:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3677,6 +3677,59 @@ paths:
           description: default response
       tags:
       - entries
+  /entries/{id}/lastCategorizedDate:
+    get:
+      description: Get the date of the last categorization of an entry.
+      operationId: getLastCategorizedDate
+      parameters:
+      - description: Entry ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+                format: date-time
+          description: Successfully retrieved the last categorized date
+      security:
+      - BEARER: []
+      tags:
+      - entries
+    put:
+      description: Set the date of the last categorization of an entry.
+      operationId: setLastCategorizedDate
+      parameters:
+      - description: Entry ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - description: Milliseconds since epoch; defaults to now
+        in: query
+        name: date
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+                format: date-time
+          description: Successfully set the last categorized date
+      security:
+      - BEARER: []
+      tags:
+      - entries
   /entries/{id}/topic:
     post:
       description: Create a discourse topic for an entry.

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3316,6 +3316,35 @@ paths:
       - BEARER: []
       tags:
       - curation
+  /entries/toCategorize:
+    get:
+      description: "Get IDs of published entries that are new and uncategorized, or\
+        \ that have changed since last categorization and were last categorized before\
+        \ the given cutoff."
+      operationId: findEntriesToCategorize
+      parameters:
+      - description: Cutoff UTC epoch seconds; entries last categorized before this
+          time are eligible for re-categorization if changed
+        in: query
+        name: cutoff
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+          description: Successfully retrieved entry IDs
+      security:
+      - BEARER: []
+      tags:
+      - entries
   /entries/updateLanguageVersions:
     post:
       description: Update language versions

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3712,9 +3712,9 @@ paths:
         schema:
           type: integer
           format: int64
-      - description: Milliseconds since epoch; defaults to now
+      - description: UTC epoch seconds; defaults to now
         in: query
-        name: date
+        name: when
         schema:
           type: integer
           format: int64

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -10087,8 +10087,6 @@ components:
           - USER
           - DOCKSTORE
           - GITHUB
-        entryMetadata:
-          $ref: '#/components/schemas/EntryMetadata'
         entryType:
           $ref: '#/components/schemas/EntryType'
         entryTypeMetadata:
@@ -10321,8 +10319,6 @@ components:
           - USER
           - DOCKSTORE
           - GITHUB
-        entryMetadata:
-          $ref: '#/components/schemas/EntryMetadata'
         entryType:
           $ref: '#/components/schemas/EntryType'
         entryTypeMetadata:
@@ -10447,16 +10443,6 @@ components:
           $ref: '#/components/schemas/EntryLite'
         versionName:
           type: string
-    EntryMetadata:
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int64
-        lastCategorizedDate:
-          type: string
-          format: date-time
-          description: The timestamp of the last categorization of this entry
     EntryType:
       type: string
       description: Entry type
@@ -13326,8 +13312,6 @@ components:
           - USER
           - DOCKSTORE
           - GITHUB
-        entryMetadata:
-          $ref: '#/components/schemas/EntryMetadata'
         entryType:
           $ref: '#/components/schemas/EntryType'
         entryTypeMetadata:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3747,6 +3747,13 @@ paths:
         schema:
           type: integer
           format: int64
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: string
+        description: "This is here to appease Swagger. It requires PUT methods to\
+          \ have a body, even if it is empty. Please leave it empty."
       responses:
         "200":
           content:

--- a/propose_migration.sh
+++ b/propose_migration.sh
@@ -27,8 +27,8 @@ rm dockstore-webservice/target/detected-migrations.xml || true
 
 ## load up the old database based on current migration
 rm dockstore-webservice/target/dockstore-webservice-*sources.jar || true
-# java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.consistency,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0,1.18.0,1.19.0 # uncomment this line if you want to diff with an already loaded db dump
-java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.generated,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0,1.18.0,1.19.0 # uncomment this line if you want to generate a DB from scratch with migrations
+# java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.consistency,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0,1.18.0,1.19.0,1.20.0 # uncomment this line if you want to diff with an already loaded db dump
+java -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate dockstore-integration-testing/src/test/resources/dockstore.yml --include 1.3.0.generated,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0,1.18.0,1.19.0,1.20.0 # uncomment this line if you want to generate a DB from scratch with migrations
 
 ## create the new database based on JPA (ugly, should really create a proper dw command if this works)
 ## remove timeout for mac devices, will have to break manually


### PR DESCRIPTION
**Description**
This PR modifies the webservice to track the "time of last categorization" for each entry.  To do so, we:

* Add a new `EntryMetadata` entity which maps `OneToOne` to each entry, intended to contain attributes that can be modified even if the entry is archived (similar to how `VersionMetadata` relates to `Version`)
* Include a `lastCategorizedDate` property in Entry that tracks when the entry was last categorized.
* Add some endpoints that allow the `lastCategorizedDate` to be set and retrieved.
* Add an endpoint that allows the entries that need categorization to be retrieved.

Currently, the `setLastCategorizedTime` and `findEntriesToCategorize` are accessible only to curators/admins.

The new `EntryMetadata` entity is a property of `Entry`, but its contents are suppressed via `@JsonIgnore`.  Similar to `VersionMetadata`, we can expose any entry metadata properties as necessary via an accessor.

Back when we implemented workflow-level metrics aggregation, I made my first attempt at implementing `EntryMetadata`, basically in the same way as this PR, but it triggered the bug described in https://github.com/dockstore/dockstore/pull/6237, and I didn't understand what was going wrong.  So, I stopped and implemented it a different way.  This time, with the fix merged, everything went well.

**Review Instructions**
Confirm the db migrations are working and the webservice runs.  Grab a curator/admin token from qa, set and get the `lastCategorizedTime` for some entries.  Hit the `findEntriesToCategorize` endpoint and make sure that the results make sense.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7542

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

Reviewers should pay particular attention to the access controls on the new endpoints.

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
