### PR TITLE
SEAB-7545: Add ES keyword field for categories.displayName

### DIFF
--- a/dockstore-webservice/src/main/resources/queries/mapping_notebook.json
+++ b/dockstore-webservice/src/main/resources/queries/mapping_notebook.json
@@ -95,7 +95,13 @@
             "type": "text"
           },
           "displayName": {
-            "type": "text"
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 50
+              }
+            }
           },
           "id": {
             "type": "long"

--- a/dockstore-webservice/src/main/resources/queries/mapping_tool.json
+++ b/dockstore-webservice/src/main/resources/queries/mapping_tool.json
@@ -95,7 +95,13 @@
             "type": "text"
           },
           "displayName": {
-            "type": "text"
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 50
+              }
+            }
           },
           "id": {
             "type": "long"

--- a/dockstore-webservice/src/main/resources/queries/mapping_workflow.json
+++ b/dockstore-webservice/src/main/resources/queries/mapping_workflow.json
@@ -95,7 +95,13 @@
             "type": "text"
           },
           "displayName": {
-            "type": "text"
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 50
+              }
+            }
           },
           "id": {
             "type": "long"


### PR DESCRIPTION
**Description**
This PR changes the ES indexes so that they contain a `keyword` field for `categories.displayName`, which will allow us to construct more efficient queries on that value.  This PR is intended to support displaying the category display names in the search facets.

**Review Instructions**
Confirm that search still works correctly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7545

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
