### PR TITLE
add simple workaround for overly lengthy topic sentences

### DIFF
--- a/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
@@ -40,4 +40,7 @@
             SELECT id FROM workflow
         </sql>
     </changeSet>
+    <changeSet author="dyuen" id="null_long_sentences">
+        <sql>update workflow set topicai = null where topicselection = 'AI' and length(topicai) = 250 and ispublished;</sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**Description**
The new model introduced in https://github.com/dockstore/dockstore-support/pull/545 takes an existing prompt much more seriously. As a result, the topic sentences that are generated are never truncated. 
As a result, all we have to do is blank the long sentences and re-run the ai topic generator which will happen naturally. 

This is tested with results in https://docs.google.com/spreadsheets/d/1iT3yO7GKJTbUcN_-nxQmgwADd_rgBclkA0TNRCs-B5M/edit?usp=sharing


**Review Instructions**
When we deploy staging with a new copy of prod, the migration will wipe out the long sentences. Wait a day or two and then check on the new sentences

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6740

**Security and Privacy**

None

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
