### PR TITLE
SEAB-7544: Add "metadata" storage to Collection/Category

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
@@ -289,26 +289,24 @@ class AutoCategorizationIT extends BaseIT {
     }
 
     @Test
-    void testAdminCanSetCollectionMetadataOnCreate() throws ApiException {
+    void testAdminCanManageCollectionMetadata() throws ApiException {
         ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         OrganizationsApi orgsApi = new OrganizationsApi(adminClient);
         Organization org = orgsApi.createOrganization(stubOrg());
-        Collection stub = stubCollection("Alignment");
-        stub.setMetadata(Map.of("source", "test"));
-        Collection collection = orgsApi.createCollection(stub, org.getId());
-        assertNotNull(collection.getMetadata());
-    }
 
-    @Test
-    void testAdminCanUpdateCollectionMetadata() throws ApiException {
-        ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
-        OrganizationsApi orgsApi = new OrganizationsApi(adminClient);
-        Organization org = orgsApi.createOrganization(stubOrg());
-        Collection collection = orgsApi.createCollection(stubCollection("Alignment"), org.getId());
+        // Admin can set metadata on create
+        Collection withMetadata = stubCollection("Alignment");
+        withMetadata.setMetadata(Map.of("source", "test"));
+        assertNotNull(orgsApi.createCollection(withMetadata, org.getId()).getMetadata());
+
+        // Creating without metadata starts null; admin can update to set it
+        Collection collection = orgsApi.createCollection(stubCollection("Categorization"), org.getId());
         assertNull(collection.getMetadata());
-        collection.setMetadata(Map.of("source", "test"));
-        Collection updated = orgsApi.updateCollection(collection, org.getId(), collection.getId());
-        assertNotNull(updated.getMetadata());
+        collection.setMetadata(Map.of("source", "autocategorization"));
+        assertNotNull(orgsApi.updateCollection(collection, org.getId(), collection.getId()).getMetadata());
+
+        // Source field persists correctly on retrieval
+        assertEquals("autocategorization", orgsApi.getCollectionById(org.getId(), collection.getId()).getMetadata().get("source"));
     }
 
     @Test
@@ -340,20 +338,6 @@ class AutoCategorizationIT extends BaseIT {
         withAdminMetadata.setMetadata(null);
         Collection unchanged = userOrgsApi.updateCollection(withAdminMetadata, orgId, withAdminMetadata.getId());
         assertNotNull(unchanged.getMetadata(), "Non-admin/curator should not be able to clear metadata");
-    }
-
-    @Test
-    void testCollectionMetadataSourceField() throws ApiException {
-        ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
-        OrganizationsApi orgsApi = new OrganizationsApi(adminClient);
-        Organization org = orgsApi.createOrganization(stubOrg());
-        Collection collection = orgsApi.createCollection(stubCollection("Alignment"), org.getId());
-
-        collection.setMetadata(Map.of("source", "autocategorization"));
-        orgsApi.updateCollection(collection, org.getId(), collection.getId());
-
-        Collection retrieved = orgsApi.getCollectionById(org.getId(), collection.getId());
-        assertEquals("autocategorization", retrieved.getMetadata().get("source"));
     }
 
     private Organization stubOrg() {

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/AutoCategorizationIT.java
@@ -31,12 +31,16 @@ import io.dockstore.common.SourceControl;
 import io.dockstore.openapi.client.ApiClient;
 import io.dockstore.openapi.client.ApiException;
 import io.dockstore.openapi.client.api.EntriesApi;
+import io.dockstore.openapi.client.api.OrganizationsApi;
 import io.dockstore.openapi.client.api.WorkflowsApi;
+import io.dockstore.openapi.client.model.Collection;
 import io.dockstore.openapi.client.model.EntryLiteAndVersionName;
+import io.dockstore.openapi.client.model.Organization;
 import io.dockstore.openapi.client.model.Workflow;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.http.HttpStatus;
@@ -273,5 +277,102 @@ class AutoCategorizationIT extends BaseIT {
 
     private Set<String> entryPaths(List<EntryLiteAndVersionName> entries) {
         return entries.stream().map(e -> e.getEntryLite().getEntryPath()).collect(Collectors.toSet());
+    }
+
+    @Test
+    void testCollectionMetadataIsNullByDefault() throws ApiException {
+        ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        OrganizationsApi orgsApi = new OrganizationsApi(adminClient);
+        Organization org = orgsApi.createOrganization(stubOrg());
+        Collection collection = orgsApi.createCollection(stubCollection("Alignment"), org.getId());
+        assertNull(collection.getMetadata());
+    }
+
+    @Test
+    void testAdminCanSetCollectionMetadataOnCreate() throws ApiException {
+        ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        OrganizationsApi orgsApi = new OrganizationsApi(adminClient);
+        Organization org = orgsApi.createOrganization(stubOrg());
+        Collection stub = stubCollection("Alignment");
+        stub.setMetadata(Map.of("source", "test"));
+        Collection collection = orgsApi.createCollection(stub, org.getId());
+        assertNotNull(collection.getMetadata());
+    }
+
+    @Test
+    void testAdminCanUpdateCollectionMetadata() throws ApiException {
+        ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        OrganizationsApi orgsApi = new OrganizationsApi(adminClient);
+        Organization org = orgsApi.createOrganization(stubOrg());
+        Collection collection = orgsApi.createCollection(stubCollection("Alignment"), org.getId());
+        assertNull(collection.getMetadata());
+        collection.setMetadata(Map.of("source", "test"));
+        Collection updated = orgsApi.updateCollection(collection, org.getId(), collection.getId());
+        assertNotNull(updated.getMetadata());
+    }
+
+    @Test
+    void testNonAdminCannotSetCollectionMetadata() throws ApiException {
+        ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        ApiClient userClient = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
+        OrganizationsApi adminOrgsApi = new OrganizationsApi(adminClient);
+        OrganizationsApi userOrgsApi = new OrganizationsApi(userClient);
+
+        Organization org = adminOrgsApi.createOrganization(stubOrg());
+        long orgId = org.getId();
+
+        // Make OTHER_USERNAME an org maintainer and have them accept
+        adminOrgsApi.addUserToOrgByUsername("MAINTAINER", OTHER_USERNAME, orgId);
+        userOrgsApi.acceptOrRejectInvitation(orgId, true);
+
+        // Non-admin/curator creates collection with metadata — metadata is silently discarded
+        Collection withMetadata = stubCollection("Alignment");
+        withMetadata.setMetadata(Map.of("source", "test"));
+        Collection created = userOrgsApi.createCollection(withMetadata, orgId);
+        assertNull(created.getMetadata(), "Non-admin/curator should not be able to set metadata on create");
+
+        // Admin sets metadata via update
+        created.setMetadata(Map.of("source", "test"));
+        Collection withAdminMetadata = adminOrgsApi.updateCollection(created, orgId, created.getId());
+        assertNotNull(withAdminMetadata.getMetadata());
+
+        // Non-admin/curator tries to clear metadata via update — should be silently ignored
+        withAdminMetadata.setMetadata(null);
+        Collection unchanged = userOrgsApi.updateCollection(withAdminMetadata, orgId, withAdminMetadata.getId());
+        assertNotNull(unchanged.getMetadata(), "Non-admin/curator should not be able to clear metadata");
+    }
+
+    @Test
+    void testCollectionMetadataSourceField() throws ApiException {
+        ApiClient adminClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        OrganizationsApi orgsApi = new OrganizationsApi(adminClient);
+        Organization org = orgsApi.createOrganization(stubOrg());
+        Collection collection = orgsApi.createCollection(stubCollection("Alignment"), org.getId());
+
+        collection.setMetadata(Map.of("source", "autocategorization"));
+        orgsApi.updateCollection(collection, org.getId(), collection.getId());
+
+        Collection retrieved = orgsApi.getCollectionById(org.getId(), collection.getId());
+        assertEquals("autocategorization", retrieved.getMetadata().get("source"));
+    }
+
+    private Organization stubOrg() {
+        Organization org = new Organization();
+        org.setName("TestOrg");
+        org.setDisplayName("Test Organization");
+        org.setEmail("test@org.com");
+        org.setDescription("A test organization");
+        org.setLink("https://www.example.com");
+        org.setLocation("location");
+        org.setTopic("topic");
+        return org;
+    }
+
+    private Collection stubCollection(String name) {
+        Collection c = new Collection();
+        c.setName(name);
+        c.setDisplayName(name + " Display");
+        c.setDescription("A test collection");
+        return c;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -2,7 +2,6 @@ package io.dockstore.webservice.core;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import io.swagger.annotations.ApiModel;
@@ -179,7 +178,7 @@ public class Collection implements Serializable, Aliasable {
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "jsonb")
     @Schema(description = "Arbitrary metadata for this collection, settable only by admins and curators")
-    private JsonNode metadata;
+    private Map<String, String> metadata;
 
     @JsonProperty("organizationName")
     @ApiModelProperty(value = "The name of the organization the collection belongs to")
@@ -333,11 +332,11 @@ public class Collection implements Serializable, Aliasable {
         this.deleted = deleted;
     }
 
-    public JsonNode getMetadata() {
+    public Map<String, String> getMetadata() {
         return metadata;
     }
 
-    public void setMetadata(JsonNode metadata) {
+    public void setMetadata(Map<String, String> metadata) {
         this.metadata = metadata;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -2,6 +2,7 @@ package io.dockstore.webservice.core;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import io.swagger.annotations.ApiModel;
@@ -46,7 +47,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.type.SqlTypes;
 
 /**
  * This describes a Dockstore collection that can be associated with an organization.
@@ -172,6 +175,11 @@ public class Collection implements Serializable, Aliasable {
     @JsonIgnore
     @Column
     private boolean deleted;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    @Schema(description = "Arbitrary metadata for this collection, settable only by admins and curators")
+    private JsonNode metadata;
 
     @JsonProperty("organizationName")
     @ApiModelProperty(value = "The name of the organization the collection belongs to")
@@ -323,5 +331,13 @@ public class Collection implements Serializable, Aliasable {
 
     public void setDeleted(boolean deleted) {
         this.deleted = deleted;
+    }
+
+    public JsonNode getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(JsonNode metadata) {
+        this.metadata = metadata;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -466,6 +466,11 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
             collectionOrCategory = collection;
         }
 
+        // Only admins/curators may set metadata
+        if (!user.getIsAdmin() && !user.isCurator()) {
+            collectionOrCategory.setMetadata(null);
+        }
+
         // Save the collection
         long id = collectionDAO.create(collectionOrCategory);
         organization.addCollection(collectionOrCategory);
@@ -525,6 +530,10 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
         existingCollection.setDisplayName(collection.getDisplayName());
         existingCollection.setDescription(collection.getDescription());
         existingCollection.setTopic(collection.getTopic());
+        // Only admins/curators may update metadata
+        if (user.getIsAdmin() || user.isCurator()) {
+            existingCollection.setMetadata(collection.getMetadata());
+        }
 
         // Event for update
         Event updateCollectionEvent = new Event.Builder()
@@ -720,6 +729,7 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
         category.setDescription(collection.getDescription());
         category.setDisplayName(collection.getDisplayName());
         category.setTopic(collection.getTopic());
+        category.setMetadata(collection.getMetadata());
         category.setOrganization(collection.getOrganization());
         return category;
     }

--- a/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
@@ -40,4 +40,9 @@
             SELECT id FROM workflow
         </sql>
     </changeSet>
+    <changeSet author="svonworl" id="addMetadataToCollection">
+        <addColumn tableName="collection">
+            <column name="metadata" type="JSONB"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -9559,6 +9559,14 @@ components:
           type: integer
           format: int64
           description: Implementation specific ID for the collection in this web service
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+            description: "Arbitrary metadata for this collection, settable only by\
+              \ admins and curators"
+          description: "Arbitrary metadata for this collection, settable only by admins\
+            \ and curators"
         name:
           type: string
           description: Name of the collection
@@ -9698,6 +9706,14 @@ components:
           type: integer
           format: int64
           description: Implementation specific ID for the collection in this web service
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+            description: "Arbitrary metadata for this collection, settable only by\
+              \ admins and curators"
+          description: "Arbitrary metadata for this collection, settable only by admins\
+            \ and curators"
         name:
           type: string
           description: Name of the collection


### PR DESCRIPTION
**Description**
This PR adds the ability to store arbitrary metadata in Collection/Category objects, in the form of a new JSONB database column `metadata` that maps to a Java `Map<String, String>` object (a map of string keys to string values).

We'll use this to store additional information for each AI category.  Currently, we're not sure exactly what, but at least something like a `source` value that points back to the EDAM ontology node, where applicable.  Later, to implement hierarchical facets, we can store stuff like the paths to the node through the parent ontology nodes, etc.

This is less strongly-typed than we typically prefer.  The advantage is that we can iterate more quickly.  The disadvantage is that it's less strongly typed.  Later, we can always move an item into its own column/field, should we deem it beneficial.

Only admins and curators can set and modify the metadata.

**Review Instructions**
Observe the new `metadata` property/field in openapi.yaml and webservice responses.  Via the API, use an admin Dockstore token to create a category with some metadata, and retrieve it.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7544

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
