### PR TITLE
SEAB-7543: Add AI "categorizer" organization

### DIFF
--- a/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
@@ -43,4 +43,13 @@
     <changeSet author="dyuen" id="null_long_sentences">
         <sql>update workflow set topicai = null where topicselection = 'AI' and length(topicai) = 250 and ispublished;</sql>
     </changeSet>
+    <changeSet author="svonworl" id="add_ai_categorizer_organization">
+        <sql dbms="postgresql">
+            insert into organization (name, displayname, description, status, categorizer, link, email, dbcreatedate, dbupdatedate) values ('ai', 'AI', 'Each of this organization''s Collections is an AI-generated Category.', 'HIDDEN', true, 'https://dockstore.org/', 'support@dockstore.org', LOCALTIMESTAMP, LOCALTIMESTAMP);
+        </sql>
+        <!-- Add all existing admins, except for the webservice/ui integration test admin users, to the "ai" org. -->
+        <sql dbms="postgresql">
+            insert into organization_user (organizationid, userid, accepted, role) select (select id from organization where name = 'ai'), id, true, 'ADMIN' from enduser where isadmin and username not in ('admin@admin.com', 'DockstoreTestUser', 'DockstoreTestUser2', 'user_admin', 'user_A');
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
@@ -49,7 +49,7 @@
         </sql>
         <!-- Add all existing admins, except for the webservice/ui integration test admin users, to the "ai" org. -->
         <sql dbms="postgresql">
-            insert into organization_user (organizationid, userid, accepted, role) select (select id from organization where name = 'ai'), id, true, 'ADMIN' from enduser where isadmin and username not in ('admin@admin.com', 'DockstoreTestUser', 'DockstoreTestUser2', 'user_admin', 'user_A');
+            insert into organization_user (organizationid, userid, status, role) select (select id from organization where name = 'ai'), id, 'ACCEPTED', 'ADMIN' from enduser where isadmin and username not in ('admin@admin.com', 'DockstoreTestUser', 'DockstoreTestUser2', 'user_admin', 'user_A');
         </sql>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**Description**
This PR adds a migration that creates a new hidden categorizer organization named "ai", which is intended to own our AI-managed categories.  It is very similar to the existing "dockstore" organization, which, going forward, will own our human-managed categories.

As when we create the "dockstore" org, the migration attempts to add existing non-test admin users as org admins.

**Review Instructions**
Log into qa as an admin, and confirm you are a member of the "AI" organization.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7543

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
