### PR TITLE
SEAB-7543: Optionally disable reindexing upon category membership changes

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIOrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIOrganizationIT.java
@@ -106,7 +106,7 @@ public class OpenAPIOrganizationIT extends BaseIT {
         workflowsApi.refresh1(workflowByPathGithub.getId(), false);
         workflowsApi.publish1(workflow.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
 
-        organizationsApiAdmin.addEntryToCollection(organization.getId(), collection.getId(), workflow.getId(), null);
+        organizationsApiAdmin.addEntryToCollection(organization.getId(), collection.getId(), workflow.getId(), null, null);
         Collection addedCollection = organizationsApiAdmin.getCollectionById(organization.getId(), collection.getId());
 
         assertEquals("viral-ngs: complete pipelines", addedCollection.getEntries().get(0).getTopic());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -2309,7 +2309,7 @@ public class OrganizationIT extends BaseIT {
 
     private void testDeleteCollectionFail(final io.dockstore.openapi.client.api.OrganizationsApi organizationsApi, long organizationId, long collectionId, int status) {
         try {
-            organizationsApi.deleteCollection(organizationId, collectionId);
+            organizationsApi.deleteCollection(organizationId, collectionId, null);
             fail("Collection deletion should have failed with status code " + status + ".");
         } catch (io.dockstore.openapi.client.ApiException ex) {
             // This is the expected behavior
@@ -2348,7 +2348,7 @@ public class OrganizationIT extends BaseIT {
         ContainersApi containersApi = new ContainersApi(getWebClient(USER_2_USERNAME, testingPostgres));
         PublishRequest publishRequest = CommonTestUtilities.createPublishRequest(true);
         containersApi.publish(entryId, publishRequest);
-        organizationsApi.addEntryToCollection(organizationId, collectionId, entryId, null);
+        organizationsApi.addEntryToCollection(organizationId, collectionId, entryId, null, null);
 
         // Make sure the tool is in the collection.
         final io.dockstore.openapi.client.api.EntriesApi entriesApi = new io.dockstore.openapi.client.api.EntriesApi(webClientUser);
@@ -2377,7 +2377,7 @@ public class OrganizationIT extends BaseIT {
         assertTrue(existsCollection(organizationId, collectionId));
 
         // An org admin should be able to delete the collection
-        organizationsApi.deleteCollection(organizationId, collectionId);
+        organizationsApi.deleteCollection(organizationId, collectionId, null);
         assertFalse(existsCollection(organizationId, collectionId));
 
         // We've soft-deleted the collection, by marking it as "deleted" but keeping it in the db table.
@@ -3037,7 +3037,7 @@ public class OrganizationIT extends BaseIT {
 
         // Delete a category.
         io.dockstore.openapi.client.model.Organization organization = organizationsApiAdmin.getOrganizationByName("dockstore");
-        organizationsApiAdmin.deleteCollection(organization.getId(), categoriesApi.getCategories("test", null).get(0).getId());
+        organizationsApiAdmin.deleteCollection(organization.getId(), categoriesApi.getCategories("test", null).get(0).getId(), null);
 
         // Verify that the proper number of categories are visible.
         assertEquals(1, categoriesApi.getCategories(null, null).size());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -446,7 +446,7 @@ class NotebookIT extends BaseIT {
         //add notebook to collection
         Set<String> expectedCollectionNames = new HashSet<>();
         expectedCollectionNames.add("Collection");
-        organizationsApi.addEntryToCollection(nonCategorizerOrg.getId(), collection.getId(), notebookID, null);
+        organizationsApi.addEntryToCollection(nonCategorizerOrg.getId(), collection.getId(), notebookID, null, null);
         List<CollectionOrganization> entryCollection = entriesApi.entryCollections(notebookID);
         assertEquals(expectedCollectionNames,  entryCollection.stream().map(CollectionOrganization::getCollectionName).collect(Collectors.toSet()));
         assertEquals(1, entryCollection.stream().map(CollectionOrganization::getCollectionName).collect(Collectors.toSet()).size());
@@ -465,7 +465,7 @@ class NotebookIT extends BaseIT {
         //add notebook to category
         Set<String> expectedCategoryNames = new HashSet<>();
         expectedCategoryNames.add("Category");
-        organizationsApi.addEntryToCollection(categorizerOrg.getId(), category.getId(), notebookID, null);
+        organizationsApi.addEntryToCollection(categorizerOrg.getId(), category.getId(), notebookID, null, null);
         List<Category> entryCategory = entriesApi.entryCategories(notebookID);
         assertEquals(expectedCategoryNames,  entryCategory.stream().map(Category::getName).collect(Collectors.toSet()));
         assertEquals(1,  entryCategory.stream().map(Category::getName).collect(Collectors.toSet()).size());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/NotebookIT.java
@@ -454,7 +454,7 @@ class NotebookIT extends BaseIT {
         assertEquals(1, organizationsApi.getCollectionByName(nonCategorizerOrg.getName(), collection.getName()).getNotebooksLength());
 
         //remove notebook from collection
-        organizationsApi.deleteEntryFromCollection(nonCategorizerOrg.getId(), collection.getId(), notebookID, null);
+        organizationsApi.deleteEntryFromCollection(nonCategorizerOrg.getId(), collection.getId(), notebookID, null, null);
         expectedCollectionNames.remove("Collection");
         entryCollection = entriesApi.entryCollections(notebookID);
         assertEquals(expectedCollectionNames,  entryCollection.stream().map(CollectionOrganization::getCollectionName).collect(Collectors.toSet()));
@@ -474,7 +474,7 @@ class NotebookIT extends BaseIT {
 
 
         //remove notebook from category
-        organizationsApi.deleteEntryFromCollection(categorizerOrg.getId(), category.getId(), notebookID, null);
+        organizationsApi.deleteEntryFromCollection(categorizerOrg.getId(), category.getId(), notebookID, null, null);
         expectedCategoryNames.remove("Category");
         entryCategory = entriesApi.entryCategories(notebookID);
         assertEquals(expectedCategoryNames,  entryCategory.stream().map(Category::getName).collect(Collectors.toSet()));

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerServiceIT.java
@@ -152,7 +152,7 @@ class SwaggerServiceIT extends BaseIT {
         //add service to collection
         Set<String> expectedCollectionNames = new HashSet<>();
         expectedCollectionNames.add("Collection");
-        organizationsApi.addEntryToCollection(collectionOrg.getId(), collection.getId(), serviceID, null);
+        organizationsApi.addEntryToCollection(collectionOrg.getId(), collection.getId(), serviceID, null, null);
         List<io.dockstore.openapi.client.model.CollectionOrganization> entryCollection = entriesApi.entryCollections(serviceID);
         assertEquals(expectedCollectionNames,  entryCollection.stream().map(io.dockstore.openapi.client.model.CollectionOrganization::getCollectionName).collect(Collectors.toSet()));
         assertEquals(1, entryCollection.stream().map(io.dockstore.openapi.client.model.CollectionOrganization::getCollectionName).collect(Collectors.toSet()).size());

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerServiceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/SwaggerServiceIT.java
@@ -160,7 +160,7 @@ class SwaggerServiceIT extends BaseIT {
         assertEquals(1, organizationsApi.getCollectionByName(collectionOrg.getName(), collection.getName()).getServicesLength());
 
         //remove service from collection
-        organizationsApi.deleteEntryFromCollection(collectionOrg.getId(), collection.getId(), serviceID, null);
+        organizationsApi.deleteEntryFromCollection(collectionOrg.getId(), collection.getId(), serviceID, null, null);
         expectedCollectionNames.remove("Collection");
         entryCollection = entriesApi.entryCollections(serviceID);
         assertEquals(expectedCollectionNames,  entryCollection.stream().map(io.dockstore.openapi.client.model.CollectionOrganization::getCollectionName).collect(Collectors.toSet()));

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -161,7 +161,7 @@ class WebhookIT extends BaseIT {
         // Attach collection
         final Collection createdCollection = organizationsApiAdmin.createCollection(stubCollection, registeredOrganization.getId());
         // Add tool to collection
-        organizationsApiAdmin.addEntryToCollection(registeredOrganization.getId(), createdCollection.getId(), appTool.getId(), null);
+        organizationsApiAdmin.addEntryToCollection(registeredOrganization.getId(), createdCollection.getId(), appTool.getId(), null, null);
 
         Collection collection = organizationsApiAdmin.getCollectionById(registeredOrganization.getId(), createdCollection.getId());
         assertTrue((collection.getEntries().stream().anyMatch(entry -> Objects.equals(entry.getId(), appTool.getId()))));

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -285,7 +285,11 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
         @ApiParam(value = "Organization ID.", required = true) @Parameter(description = "Organization ID.", name = "organizationId", in = ParameterIn.PATH, required = true) @PathParam("organizationId") Long organizationId,
         @ApiParam(value = "Collection ID.", required = true) @Parameter(description = "Collection ID.", name = "collectionId", in = ParameterIn.PATH, required = true) @PathParam("collectionId") Long collectionId,
         @ApiParam(value = "Entry ID", required = true) @Parameter(description = "Entry ID.", name = "entryId", in = ParameterIn.QUERY, required = true) @QueryParam("entryId") Long entryId,
-        @ApiParam(value = "Version Name", required = false) @Parameter(description = "Version Name.", name = "versionName", in = ParameterIn.QUERY, required = false) @QueryParam("versionName") String versionName) {
+        @ApiParam(value = "Version Name", required = false) @Parameter(description = "Version Name.", name = "versionName", in = ParameterIn.QUERY, required = false) @QueryParam("versionName") String versionName,
+        @Parameter(description = "Reindex entry if necessary. Only admins and curators may set this to false.", name = "reindex", in = ParameterIn.QUERY) @DefaultValue("true") @QueryParam("reindex") boolean reindex) {
+        if (!reindex && !(user.getIsAdmin() || user.isCurator())) {
+            throw new CustomWebApplicationException("Only admins and curators can disable reindexing.", HttpStatus.SC_FORBIDDEN);
+        }
         // Call common code to check if entry and collection exist and return them
         ImmutablePair<Entry, Collection> entryAndCollection = commonModifyCollection(organizationId, entryId, collectionId, user);
 
@@ -318,7 +322,7 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
         eventDAO.create(removeFromCollectionEvent);
 
         // If deleted from a Category, update the Entry in the index
-        if (entryAndCollection.getRight() instanceof Category) {
+        if (reindex && entryAndCollection.getRight() instanceof Category) {
             handleIndexUpdate(entryAndCollection.getLeft());
         }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -43,6 +43,7 @@ import io.swagger.v3.oas.annotations.security.SecuritySchemes;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
@@ -238,7 +239,11 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
         @ApiParam(value = "Organization ID.", required = true) @Parameter(description = "Organization ID.", name = "organizationId", in = ParameterIn.PATH, required = true) @PathParam("organizationId") Long organizationId,
         @ApiParam(value = "Collection ID.", required = true) @Parameter(description = "Collection ID.", name = "collectionId", in = ParameterIn.PATH, required = true) @PathParam("collectionId") Long collectionId,
         @ApiParam(value = "Entry ID", required = true) @Parameter(description = "Entry ID.", name = "entryId", in = ParameterIn.QUERY, required = true) @QueryParam("entryId") Long entryId,
-        @ApiParam(value = "Version ID", required = false) @Parameter(description = "Version ID.", name = "versionId", in = ParameterIn.QUERY, required = false) @QueryParam("versionId") Long versionId) {
+        @ApiParam(value = "Version ID", required = false) @Parameter(description = "Version ID.", name = "versionId", in = ParameterIn.QUERY, required = false) @QueryParam("versionId") Long versionId,
+        @Parameter(description = "Reindex entry if necessary. Only admins and curators may set this to false.", name = "reindex", in = ParameterIn.QUERY) @DefaultValue("true") @QueryParam("reindex") boolean reindex) {
+        if (!reindex && !(user.getIsAdmin() || user.isCurator())) {
+            throw new CustomWebApplicationException("Only admins and curators can disable reindexing.", HttpStatus.SC_FORBIDDEN);
+        }
         // Call common code to check if entry and collection exist and return them
         ImmutablePair<Entry, Collection> entryAndCollection = commonModifyCollection(organizationId, entryId, collectionId, user);
         if (versionId == null) {
@@ -263,7 +268,7 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
         eventDAO.create(addToCollectionEvent);
 
         // If added to a Category, update the Entry in the index
-        if (entryAndCollection.getRight() instanceof Category) {
+        if (reindex && entryAndCollection.getRight() instanceof Category) {
             handleIndexUpdate(entryAndCollection.getLeft());
         }
 
@@ -571,7 +576,11 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
     @ApiResponse(responseCode = HttpStatus.SC_UNAUTHORIZED + "", description = "Unauthorized")
     public void deleteCollection(@ApiParam(hidden = true) @Parameter(hidden = true, name = "user") @Auth User user,
         @Parameter(description = "Organization ID.", name = "organizationId", in = ParameterIn.PATH, required = true) @PathParam("organizationId") Long organizationId,
-        @Parameter(description = "Collection ID.", name = "collectionId", in = ParameterIn.PATH, required = true) @PathParam("collectionId") Long collectionId) {
+        @Parameter(description = "Collection ID.", name = "collectionId", in = ParameterIn.PATH, required = true) @PathParam("collectionId") Long collectionId,
+        @Parameter(description = "Reindex entries as necessary. Only admins and curators may set this to false.", name = "reindex", in = ParameterIn.QUERY) @DefaultValue("true") @QueryParam("reindex") boolean reindex) {
+        if (!reindex && !(user.getIsAdmin() || user.isCurator())) {
+            throw new CustomWebApplicationException("Only admins and curators can disable reindexing.", HttpStatus.SC_FORBIDDEN);
+        }
         // Ensure collection exists to the user
         Collection collection = this.getAndCheckCollection(Optional.of(organizationId), collectionId, user);
         Organization organization = getOrganizationAndCheckModificationRights(user, collection);
@@ -580,7 +589,7 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
         collection.setDeleted(true);
 
         // If the collection was a Category, reindex the entries.
-        if (collection instanceof Category) {
+        if (reindex && collection instanceof Category) {
             reindexEntries(collection);
         }
 

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -5411,6 +5411,13 @@ paths:
         name: versionName
         schema:
           type: string
+      - description: Reindex entry if necessary. Only admins and curators may set
+          this to false.
+        in: query
+        name: reindex
+        schema:
+          type: boolean
+          default: true
       responses:
         default:
           content:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -5223,6 +5223,13 @@ paths:
         schema:
           type: integer
           format: int64
+      - description: Reindex entries as necessary. Only admins and curators may set
+          this to false.
+        in: query
+        name: reindex
+        schema:
+          type: boolean
+          default: true
       responses:
         "204":
           description: Successfully deleted the collection
@@ -5447,6 +5454,13 @@ paths:
         schema:
           type: integer
           format: int64
+      - description: Reindex entry if necessary. Only admins and curators may set
+          this to false.
+        in: query
+        name: reindex
+        schema:
+          type: boolean
+          default: true
       responses:
         default:
           content:


### PR DESCRIPTION
**Description**
Currently, when a Category is deleted or its membership changes, we reindex the associated entries in ES.

This PR adds an optional `reindex` parameter to the `addEntryToCollection`, `deleteEntryFromCollection`, and `deleteCollection` endpoints, so that when the categorizer does a bulk category update (adds entries, deletes entries, deletes categories), we can avoid triggering potentially tens of thousands of individual ES reindexing requests.  Instead, when we finish the bulk update, we can trigger a bulk reindex.

The `reindex` parameter defaults to `true`.  Only admins and curators can disable reindexing.  The categorizer is probably the only part of the system that will ever disable reindexing.

**Review Instructions**
Try to use the new parameter.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7543

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
