### PR TITLE
SEAB-7543: Add endpoint to retrieve all published entries

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
@@ -183,24 +183,27 @@ class EntryResourceIT extends BaseIT {
 
     @Test
     void testGetAllEntries() throws ApiException {
-        EntriesApi entriesApi = new EntriesApi(getAnonymousOpenAPIWebClient());
+        // Mark all of the tools as published.  There are 4 tools at time of this writing.
+        testingPostgres.runUpdateStatement("update tool set ispublished = true");
 
+        EntriesApi entriesApi = new EntriesApi(getAnonymousOpenAPIWebClient());
         List<EntryLiteAndVersionName> entries = entriesApi.getAllEntries(0, 100);
         long total = getXTotalCount(entriesApi);
 
-        // cleanStatePrivate2 has 1 published tool and 2 published workflows
-        assertTrue(total >= 3);
+        assertTrue(total >= 4);
         assertEquals(total, entries.size());
         entries.forEach(e -> assertNotNull(e.getEntryLite().getTrsId()));
     }
 
     @Test
     void testGetAllEntriesPagination() throws ApiException {
-        EntriesApi entriesApi = new EntriesApi(getAnonymousOpenAPIWebClient());
+        // Mark all of the tools as published.  There are 4 tools at time of this writing.
+        testingPostgres.runUpdateStatement("update tool set ispublished = true");
 
+        EntriesApi entriesApi = new EntriesApi(getAnonymousOpenAPIWebClient());
         entriesApi.getAllEntries(0, 100);
         long total = getXTotalCount(entriesApi);
-        assertTrue(total >= 3);
+        assertTrue(total >= 4);
 
         // limit restricts page size but X-Total-Count still reflects the full total
         List<EntryLiteAndVersionName> limited = entriesApi.getAllEntries(0, 1);
@@ -208,9 +211,10 @@ class EntryResourceIT extends BaseIT {
         assertEquals(total, getXTotalCount(entriesApi));
 
         // offset paginates without overlap
-        List<EntryLiteAndVersionName> page0 = entriesApi.getAllEntries(0, 2);
-        List<EntryLiteAndVersionName> page1 = entriesApi.getAllEntries(2, 2);
-        assertEquals(2, page0.size());
+        List<EntryLiteAndVersionName> page0 = entriesApi.getAllEntries(0, 3);
+        List<EntryLiteAndVersionName> page1 = entriesApi.getAllEntries(3, 100);
+        assertEquals(3, page0.size());
+        assertTrue(page1.size() < 100);
         Set<String> ids0 = page0.stream().map(e -> e.getEntryLite().getTrsId()).collect(Collectors.toSet());
         Set<String> ids1 = page1.stream().map(e -> e.getEntryLite().getTrsId()).collect(Collectors.toSet());
         assertTrue(Collections.disjoint(ids0, ids1));

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
@@ -185,7 +185,7 @@ class EntryResourceIT extends BaseIT {
     void testGetAllEntries() throws ApiException {
         EntriesApi entriesApi = new EntriesApi(getAnonymousOpenAPIWebClient());
 
-        List<EntryLiteAndVersionName> entries = entriesApi.getAllEntries(0, 1000);
+        List<EntryLiteAndVersionName> entries = entriesApi.getAllEntries(0, 100);
         long total = getXTotalCount(entriesApi);
 
         // cleanStatePrivate2 has 1 published tool and 2 published workflows
@@ -198,7 +198,7 @@ class EntryResourceIT extends BaseIT {
     void testGetAllEntriesPagination() throws ApiException {
         EntriesApi entriesApi = new EntriesApi(getAnonymousOpenAPIWebClient());
 
-        entriesApi.getAllEntries(0, 1000);
+        entriesApi.getAllEntries(0, 100);
         long total = getXTotalCount(entriesApi);
         assertTrue(total >= 3);
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
@@ -1,6 +1,8 @@
 package io.dockstore.client.cli;
 
+import static io.dockstore.webservice.resources.LambdaEventResource.X_TOTAL_COUNT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -18,10 +20,14 @@ import io.dockstore.openapi.client.api.UsersApi;
 import io.dockstore.openapi.client.api.WorkflowsApi;
 import io.dockstore.openapi.client.model.DescriptionMetrics;
 import io.dockstore.openapi.client.model.DockstoreTool;
+import io.dockstore.openapi.client.model.EntryLiteAndVersionName;
 import io.dockstore.openapi.client.model.User;
 import io.dockstore.openapi.client.model.Workflow;
 import io.dockstore.openapi.client.model.WorkflowVersion;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -173,5 +179,44 @@ class EntryResourceIT extends BaseIT {
         return testingPostgres.runSelectStatement(
             "select count(*) from version_metadata where descriptortypeversions is not null",
             Long.class);
+    }
+
+    @Test
+    void testGetAllEntries() throws ApiException {
+        EntriesApi entriesApi = new EntriesApi(getAnonymousOpenAPIWebClient());
+
+        List<EntryLiteAndVersionName> entries = entriesApi.getAllEntries(0, 1000);
+        long total = getXTotalCount(entriesApi);
+
+        // cleanStatePrivate2 has 1 published tool and 2 published workflows
+        assertTrue(total >= 3);
+        assertEquals(total, entries.size());
+        entries.forEach(e -> assertNotNull(e.getEntryLite().getTrsId()));
+    }
+
+    @Test
+    void testGetAllEntriesPagination() throws ApiException {
+        EntriesApi entriesApi = new EntriesApi(getAnonymousOpenAPIWebClient());
+
+        entriesApi.getAllEntries(0, 1000);
+        long total = getXTotalCount(entriesApi);
+        assertTrue(total >= 3);
+
+        // limit restricts page size but X-Total-Count still reflects the full total
+        List<EntryLiteAndVersionName> limited = entriesApi.getAllEntries(0, 1);
+        assertEquals(1, limited.size());
+        assertEquals(total, getXTotalCount(entriesApi));
+
+        // offset paginates without overlap
+        List<EntryLiteAndVersionName> page0 = entriesApi.getAllEntries(0, 2);
+        List<EntryLiteAndVersionName> page1 = entriesApi.getAllEntries(2, 2);
+        assertEquals(2, page0.size());
+        Set<String> ids0 = page0.stream().map(e -> e.getEntryLite().getTrsId()).collect(Collectors.toSet());
+        Set<String> ids1 = page1.stream().map(e -> e.getEntryLite().getTrsId()).collect(Collectors.toSet());
+        assertTrue(Collections.disjoint(ids0, ids1));
+    }
+
+    private long getXTotalCount(EntriesApi entriesApi) {
+        return Long.parseLong(entriesApi.getApiClient().getResponseHeaders().get(X_TOTAL_COUNT).get(0));
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/EntryResourceIT.java
@@ -1,8 +1,6 @@
 package io.dockstore.client.cli;
 
-import static io.dockstore.webservice.resources.LambdaEventResource.X_TOTAL_COUNT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -20,14 +18,10 @@ import io.dockstore.openapi.client.api.UsersApi;
 import io.dockstore.openapi.client.api.WorkflowsApi;
 import io.dockstore.openapi.client.model.DescriptionMetrics;
 import io.dockstore.openapi.client.model.DockstoreTool;
-import io.dockstore.openapi.client.model.EntryLiteAndVersionName;
 import io.dockstore.openapi.client.model.User;
 import io.dockstore.openapi.client.model.Workflow;
 import io.dockstore.openapi.client.model.WorkflowVersion;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -181,46 +175,4 @@ class EntryResourceIT extends BaseIT {
             Long.class);
     }
 
-    @Test
-    void testGetAllEntries() throws ApiException {
-        // Mark all of the tools as published.  There are 4 tools at time of this writing.
-        testingPostgres.runUpdateStatement("update tool set ispublished = true");
-
-        EntriesApi entriesApi = new EntriesApi(getAnonymousOpenAPIWebClient());
-        List<EntryLiteAndVersionName> entries = entriesApi.getAllEntries(0, 100);
-        long total = getXTotalCount(entriesApi);
-
-        assertTrue(total >= 4);
-        assertEquals(total, entries.size());
-        entries.forEach(e -> assertNotNull(e.getEntryLite().getTrsId()));
-    }
-
-    @Test
-    void testGetAllEntriesPagination() throws ApiException {
-        // Mark all of the tools as published.  There are 4 tools at time of this writing.
-        testingPostgres.runUpdateStatement("update tool set ispublished = true");
-
-        EntriesApi entriesApi = new EntriesApi(getAnonymousOpenAPIWebClient());
-        entriesApi.getAllEntries(0, 100);
-        long total = getXTotalCount(entriesApi);
-        assertTrue(total >= 4);
-
-        // limit restricts page size but X-Total-Count still reflects the full total
-        List<EntryLiteAndVersionName> limited = entriesApi.getAllEntries(0, 1);
-        assertEquals(1, limited.size());
-        assertEquals(total, getXTotalCount(entriesApi));
-
-        // offset paginates without overlap
-        List<EntryLiteAndVersionName> page0 = entriesApi.getAllEntries(0, 3);
-        List<EntryLiteAndVersionName> page1 = entriesApi.getAllEntries(3, 100);
-        assertEquals(3, page0.size());
-        assertTrue(page1.size() < 100);
-        Set<String> ids0 = page0.stream().map(e -> e.getEntryLite().getTrsId()).collect(Collectors.toSet());
-        Set<String> ids1 = page1.stream().map(e -> e.getEntryLite().getTrsId()).collect(Collectors.toSet());
-        assertTrue(Collections.disjoint(ids0, ids1));
-    }
-
-    private long getXTotalCount(EntriesApi entriesApi) {
-        return Long.parseLong(entriesApi.getApiClient().getResponseHeaders().get(X_TOTAL_COUNT).get(0));
-    }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/ExtendedTRSApiIT.java
@@ -46,8 +46,10 @@ import io.dockstore.openapi.client.model.WorkflowVersion;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
@@ -208,6 +210,49 @@ class ExtendedTRSApiIT extends BaseIT {
         aiTopicCandidates = extendedGa4GhApi.getAITopicCandidates(null, null);
         assertTrue(aiTopicCandidates.isEmpty());
         checkXTotalCountHeader(extendedGa4GhApi, 0);
+    }
+
+    @Test
+    void testGetAllEntries() throws ApiException {
+        // Mark all of the tools as published.  At the time of this writing, there are 4 tools.
+        testingPostgres.runUpdateStatement("update tool set ispublished = true");
+
+        ExtendedGa4GhApi extendedGa4GhApi = new ExtendedGa4GhApi(getAnonymousOpenAPIWebClient());
+        List<EntryLiteAndVersionName> entries = extendedGa4GhApi.getAllEntries(0, 100);
+        long total = getXTotalCount(extendedGa4GhApi);
+
+        assertTrue(total >= 4);
+        assertEquals(total, entries.size());
+        entries.forEach(e -> assertNotNull(e.getEntryLite().getTrsId()));
+    }
+
+    @Test
+    void testGetAllEntriesPagination() throws ApiException {
+        // Mark all of the tools as published.  At the time of this writing, there are 4 tools.
+        testingPostgres.runUpdateStatement("update tool set ispublished = true");
+
+        ExtendedGa4GhApi extendedGa4GhApi = new ExtendedGa4GhApi(getAnonymousOpenAPIWebClient());
+        extendedGa4GhApi.getAllEntries(0, 100);
+        long total = getXTotalCount(extendedGa4GhApi);
+        assertTrue(total >= 4);
+
+        // limit restricts page size but X-Total-Count still reflects the full total
+        List<EntryLiteAndVersionName> limited = extendedGa4GhApi.getAllEntries(0, 1);
+        assertEquals(1, limited.size());
+        assertEquals(total, getXTotalCount(extendedGa4GhApi));
+
+        // offset paginates without overlap
+        List<EntryLiteAndVersionName> page0 = extendedGa4GhApi.getAllEntries(0, 3);
+        List<EntryLiteAndVersionName> page1 = extendedGa4GhApi.getAllEntries(3, 100);
+        assertEquals(3, page0.size());
+        assertTrue(page1.size() < 100);
+        Set<String> ids0 = page0.stream().map(e -> e.getEntryLite().getTrsId()).collect(Collectors.toSet());
+        Set<String> ids1 = page1.stream().map(e -> e.getEntryLite().getTrsId()).collect(Collectors.toSet());
+        assertTrue(Collections.disjoint(ids0, ids1));
+    }
+
+    private long getXTotalCount(ExtendedGa4GhApi extendedGa4GhApi) {
+        return Long.parseLong(extendedGa4GhApi.getApiClient().getResponseHeaders().get(X_TOTAL_COUNT).get(0));
     }
 
     private void checkXTotalCountHeader(ExtendedGa4GhApi extendedGa4GhApi, int expectedCount) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -140,7 +140,9 @@ import org.hibernate.annotations.UpdateTimestamp;
     @NamedQuery(name = Entry.GET_PUBLISHED_ENTRIES_WITH_NO_TOPICS, query = "SELECT e FROM Entry e WHERE e.isPublished = TRUE AND e.archived = false AND e.topicManual IS NULL AND e.topicAutomatic IS NULL AND e.topicAI IS NULL"),
     @NamedQuery(name = Entry.COUNT_PUBLISHED_ENTRIES_WITH_NO_TOPICS, query = "SELECT COUNT(e.id) FROM Entry e WHERE e.isPublished = TRUE AND e.archived = false AND e.topicManual IS NULL AND e.topicAutomatic IS NULL AND e.topicAI IS NULL"),
     @NamedQuery(name = Entry.FIND_ENTRIES_TO_CATEGORIZE, query = "SELECT e FROM Entry e JOIN e.entryMetadata m WHERE e.isPublished = TRUE AND (m.lastCategorizedDate IS NULL OR (e.dbUpdateDate > m.lastCategorizedDate AND m.lastCategorizedDate < :cutoff))"),
-    @NamedQuery(name = Entry.COUNT_ENTRIES_TO_CATEGORIZE, query = "SELECT COUNT(e.id) FROM Entry e JOIN e.entryMetadata m WHERE e.isPublished = TRUE AND (m.lastCategorizedDate IS NULL OR (e.dbUpdateDate > m.lastCategorizedDate AND m.lastCategorizedDate < :cutoff))")
+    @NamedQuery(name = Entry.COUNT_ENTRIES_TO_CATEGORIZE, query = "SELECT COUNT(e.id) FROM Entry e JOIN e.entryMetadata m WHERE e.isPublished = TRUE AND (m.lastCategorizedDate IS NULL OR (e.dbUpdateDate > m.lastCategorizedDate AND m.lastCategorizedDate < :cutoff))"),
+    @NamedQuery(name = Entry.FIND_PUBLISHED_ENTRIES, query = "SELECT e FROM Entry e WHERE e.isPublished = TRUE ORDER BY e.id"),
+    @NamedQuery(name = Entry.COUNT_PUBLISHED_ENTRIES, query = "SELECT COUNT(e.id) FROM Entry e WHERE e.isPublished = TRUE")
 })
 // TODO: Replace this with JPA when possible
 @NamedNativeQueries({
@@ -165,6 +167,8 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     public static final String COUNT_PUBLISHED_ENTRIES_WITH_NO_TOPICS = "Entry.countPublishedEntriesWithNoTopics";
     public static final String FIND_ENTRIES_TO_CATEGORIZE = "Entry.findEntriesToCategorize";
     public static final String COUNT_ENTRIES_TO_CATEGORIZE = "Entry.countEntriesToCategorize";
+    public static final String FIND_PUBLISHED_ENTRIES = "Entry.findPublishedEntries";
+    public static final String COUNT_PUBLISHED_ENTRIES = "Entry.countPublishedEntries";
     private static final int TOPIC_LENGTH = 250;
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EntryDAO.java
@@ -36,6 +36,7 @@ import io.dockstore.webservice.core.Tool;
 import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.core.Workflow;
 import io.dockstore.webservice.core.database.EntryLite;
+import io.dockstore.webservice.helpers.EntryVersionHelper;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -430,6 +431,22 @@ public abstract class EntryDAO<T extends Entry> extends AbstractDockstoreDAO<T> 
         return this.currentSession().createNamedQuery(Entry.COUNT_ENTRIES_TO_CATEGORIZE, Long.class)
             .setParameter("cutoff", cutoff)
             .getSingleResult();
+    }
+
+    public List<EntryLiteAndVersionName> findPublishedEntries(int offset, int limit) {
+        List<Entry> entries = this.currentSession().createNamedQuery(Entry.FIND_PUBLISHED_ENTRIES, Entry.class)
+            .setFirstResult(offset)
+            .setMaxResults(limit)
+            .list();
+        return entries.stream()
+            .map(entry -> new EntryLiteAndVersionName(
+                entry.createEntryLite(),
+                EntryVersionHelper.determineRepresentativeVersion(entry).map(Version::getName).orElse("")))
+            .toList();
+    }
+
+    public long countPublishedEntries() {
+        return this.currentSession().createNamedQuery(Entry.COUNT_PUBLISHED_ENTRIES, Long.class).getSingleResult();
     }
 
     private void processQuery(String filter, String sortCol, String sortOrder, CriteriaBuilder cb, CriteriaQuery query, Root<T> entry) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -19,6 +19,7 @@ import static io.dockstore.webservice.helpers.ORCIDHelper.getPutCodeFromLocation
 import static io.dockstore.webservice.resources.AuthenticatedResourceInterface.throwIf;
 import static io.dockstore.webservice.resources.LambdaEventResource.X_TOTAL_COUNT;
 import static io.dockstore.webservice.resources.ResourceConstants.JWT_SECURITY_DEFINITION_NAME;
+import static io.dockstore.webservice.resources.ResourceConstants.MAX_PAGINATION_LIMIT;
 
 import com.codahale.metrics.annotation.Timed;
 import io.dockstore.common.DescriptorLanguage;
@@ -83,6 +84,8 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.security.SecuritySchemes;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
@@ -431,6 +434,20 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
                 EntryVersionHelper.determineRepresentativeVersion(entry).map(Version::getName).orElse("")))
             .toList();
         long totalCount = toolDAO.countEntriesToCategorize(cutoff);
+        return Response.ok(result).header(X_TOTAL_COUNT, totalCount).build();
+    }
+
+    @GET
+    @Timed
+    @UnitOfWork(readOnly = true)
+    @Path("")
+    @Operation(operationId = "getAllEntries", description = "Get TRS IDs and default version names of all published entries.")
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully retrieved entries", content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = EntryLiteAndVersionName.class))))
+    public Response getAllEntries(
+            @Parameter(description = "Pagination offset") @QueryParam("offset") @Min(0) @DefaultValue("0") int offset,
+            @Parameter(description = "Pagination limit") @QueryParam("limit") @Min(1) @Max(MAX_PAGINATION_LIMIT) @DefaultValue("100") int limit) {
+        List<EntryLiteAndVersionName> result = toolDAO.findPublishedEntries(offset, limit);
+        long totalCount = toolDAO.countPublishedEntries();
         return Response.ok(result).header(X_TOTAL_COUNT, totalCount).build();
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -19,7 +19,6 @@ import static io.dockstore.webservice.helpers.ORCIDHelper.getPutCodeFromLocation
 import static io.dockstore.webservice.resources.AuthenticatedResourceInterface.throwIf;
 import static io.dockstore.webservice.resources.LambdaEventResource.X_TOTAL_COUNT;
 import static io.dockstore.webservice.resources.ResourceConstants.JWT_SECURITY_DEFINITION_NAME;
-import static io.dockstore.webservice.resources.ResourceConstants.MAX_PAGINATION_LIMIT;
 
 import com.codahale.metrics.annotation.Timed;
 import io.dockstore.common.DescriptorLanguage;
@@ -84,8 +83,6 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.security.SecuritySchemes;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.RolesAllowed;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
@@ -434,20 +431,6 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
                 EntryVersionHelper.determineRepresentativeVersion(entry).map(Version::getName).orElse("")))
             .toList();
         long totalCount = toolDAO.countEntriesToCategorize(cutoff);
-        return Response.ok(result).header(X_TOTAL_COUNT, totalCount).build();
-    }
-
-    @GET
-    @Timed
-    @UnitOfWork(readOnly = true)
-    @Path("")
-    @Operation(operationId = "getAllEntries", description = "Retrieve an abbreviated description and the default version name of each published entry.")
-    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully retrieved entries", content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = EntryLiteAndVersionName.class))))
-    public Response getAllEntries(
-            @Parameter(description = "Pagination offset") @QueryParam("offset") @Min(0) @DefaultValue("0") int offset,
-            @Parameter(description = "Pagination limit") @QueryParam("limit") @Min(1) @Max(MAX_PAGINATION_LIMIT) @DefaultValue("100") int limit) {
-        List<EntryLiteAndVersionName> result = toolDAO.findPublishedEntries(offset, limit);
-        long totalCount = toolDAO.countPublishedEntries();
         return Response.ok(result).header(X_TOTAL_COUNT, totalCount).build();
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/EntryResource.java
@@ -441,7 +441,7 @@ public class EntryResource implements AuthenticatedResourceInterface, AliasableR
     @Timed
     @UnitOfWork(readOnly = true)
     @Path("")
-    @Operation(operationId = "getAllEntries", description = "Get TRS IDs and default version names of all published entries.")
+    @Operation(operationId = "getAllEntries", description = "Retrieve an abbreviated description and the default version name of each published entry.")
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully retrieved entries", content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = EntryLiteAndVersionName.class))))
     public Response getAllEntries(
             @Parameter(description = "Pagination offset") @QueryParam("offset") @Min(0) @DefaultValue("0") int offset,

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsApiExtendedServiceImpl.java
@@ -776,6 +776,13 @@ public class ToolsApiExtendedServiceImpl extends ToolsExtendedApiService {
         return Response.ok(aiTopicCandidates).header(X_TOTAL_COUNT, totalCount).build();
     }
 
+    @Override
+    public Response getAllEntries(int offset, int limit) {
+        List<EntryLiteAndVersionName> result = toolDAO.findPublishedEntries(offset, limit);
+        long totalCount = toolDAO.countPublishedEntries();
+        return Response.ok(result).header(X_TOTAL_COUNT, totalCount).build();
+    }
+
     private Entry<?, ?> getEntry(String id, Optional<User> user) throws UnsupportedEncodingException, IllegalArgumentException {
         ToolsApiServiceImpl.ParsedRegistryID parsedID =  new ToolsApiServiceImpl.ParsedRegistryID(id);
         return TOOLS_API_SERVICE_IMPL.getEntry(parsedID, user);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApi.java
@@ -451,6 +451,18 @@ public class ToolsExtendedApi {
         return delegate.getAITopicCandidates(offset, limit);
     }
 
+    @GET
+    @UnitOfWork(readOnly = true)
+    @Path("/entries")
+    @Operation(operationId = "getAllEntries", description = "Retrieve an abbreviated description and the default version name of each published entry.", responses = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully retrieved entries", content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = EntryLiteAndVersionName.class))))
+    })
+    public Response getAllEntries(
+            @Parameter(in = ParameterIn.QUERY, description = "Pagination offset") @Min(0) @DefaultValue("0") @QueryParam("offset") Integer offset,
+            @Parameter(in = ParameterIn.QUERY, description = "Pagination limit") @Min(1) @Max(ResourceConstants.MAX_PAGINATION_LIMIT) @DefaultValue("100") @QueryParam("limit") Integer limit) {
+        return delegate.getAllEntries(offset, limit);
+    }
+
     private static final class GetAITopicCandidates {
         public static final String OK_RESPONSE = "Retrieved published tools that are AI topic candidates and a single representative version name if it exists, otherwise an empty string is returned as the version name.";
         public static final String UNAUTHORIZED_RESPONSE = "Credentials not provided or incorrect.";

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApiService.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/proposedGA4GH/ToolsExtendedApiService.java
@@ -59,4 +59,5 @@ public abstract class ToolsExtendedApiService {
 
     public abstract Response getAITopicCandidate(String id);
     public abstract Response getAITopicCandidates(int offset, int limit);
+    public abstract Response getAllEntries(int offset, int limit);
 }

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3316,6 +3316,39 @@ paths:
       - BEARER: []
       tags:
       - curation
+  /entries:
+    get:
+      description: Get TRS IDs and default version names of all published entries.
+      operationId: getAllEntries
+      parameters:
+      - description: Pagination offset
+        in: query
+        name: offset
+        schema:
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+      - description: Pagination limit
+        in: query
+        name: limit
+        schema:
+          type: integer
+          format: int32
+          default: 100
+          maximum: 100
+          minimum: 1
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EntryLiteAndVersionName'
+          description: Successfully retrieved entries
+      tags:
+      - entries
   /entries/toCategorize:
     get:
       description: "Get published entries that are new and uncategorized, or that\

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -491,6 +491,40 @@ paths:
       summary: List entries of an organization
       tags:
       - extendedGA4GH
+  /api/ga4gh/v2/extended/entries:
+    get:
+      description: Retrieve an abbreviated description and the default version name
+        of each published entry.
+      operationId: getAllEntries
+      parameters:
+      - description: Pagination offset
+        in: query
+        name: offset
+        schema:
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+      - description: Pagination limit
+        in: query
+        name: limit
+        schema:
+          type: integer
+          format: int32
+          default: 100
+          maximum: 100
+          minimum: 1
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EntryLiteAndVersionName'
+          description: Successfully retrieved entries
+      tags:
+      - extendedGA4GH
   /api/ga4gh/v2/extended/entryVersionsToAggregate:
     get:
       description: This endpoint gets entry versions that have new execution metrics
@@ -3316,40 +3350,6 @@ paths:
       - BEARER: []
       tags:
       - curation
-  /entries:
-    get:
-      description: Retrieve an abbreviated description and the default version name
-        of each published entry.
-      operationId: getAllEntries
-      parameters:
-      - description: Pagination offset
-        in: query
-        name: offset
-        schema:
-          type: integer
-          format: int32
-          default: 0
-          minimum: 0
-      - description: Pagination limit
-        in: query
-        name: limit
-        schema:
-          type: integer
-          format: int32
-          default: 100
-          maximum: 100
-          minimum: 1
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/EntryLiteAndVersionName'
-          description: Successfully retrieved entries
-      tags:
-      - entries
   /entries/toCategorize:
     get:
       description: "Get published entries that are new and uncategorized, or that\

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -3318,7 +3318,8 @@ paths:
       - curation
   /entries:
     get:
-      description: Get TRS IDs and default version names of all published entries.
+      description: Retrieve an abbreviated description and the default version name
+        of each published entry.
       operationId: getAllEntries
       parameters:
       - description: Pagination offset


### PR DESCRIPTION
**Description**
This PR adds an endpoint that produces a paginated list of every published entry on Dockstore.  Each is represented by an instance of `EntryLiteAndVersionName`, which contains an abbreviated entry representation and the name of the default version, or a representative version if the default version wasn't set.

The categorizer will use this endpoint to retrieve all of the entries that could be categorized, and the best version to categorize for each, should we choose to do so.

"But Steve, there's already endpoints that do that?!?"

And, yes, there is a TRS endpoint that retrieves all of the entries.  But after you've hit that endpoint, to figure out the representative version, you need to hit the TRS versions endpoint, once per entry, and then apply the "default/representative version" logic.

The categorizer could do that, but with 5000 entries, we'll risk triggering the WAF, and we'll have to duplicate the version selection code [in the categorizer].

Thus, we choose the "kinda overlappy" solution...

I could be wrong about this one, very possible that I missed something that already works like this...

**Review Instructions**
Hit the new endpoint and confirm that it returns the correct number of entries and looks sane.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7543

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
