### PR TITLE
SEAB-7543: Add delete collections endpoint

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -3016,6 +3016,83 @@ public class OrganizationIT extends BaseIT {
      * Test Category deletion.
      */
     @Test
+    void testDeleteCollectionsWithMatchingNames() {
+        final io.dockstore.openapi.client.ApiClient webClientAdmin = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        final io.dockstore.openapi.client.api.OrganizationsApi organizationsApiAdmin = new io.dockstore.openapi.client.api.OrganizationsApi(webClientAdmin);
+
+        // Create and approve an organization.
+        io.dockstore.openapi.client.model.Organization organization = organizationsApiAdmin.createOrganization(openApiStubOrgObject());
+        long organizationId = organization.getId();
+        organizationsApiAdmin.approveOrganization(organizationId);
+
+        // Create collections with distinct names: two that will be deleted, three that will not.
+        for (String name : List.of("aaz", "zaa", "baa", "baaa", "baa123")) {
+            io.dockstore.openapi.client.model.Collection stub = new io.dockstore.openapi.client.model.Collection();
+            stub.setName(name);
+            stub.setDisplayName(name);
+            stub.setDescription("Test collection");
+            organizationsApiAdmin.createCollection(stub, organizationId);
+        }
+        assertEquals(5, organizationsApiAdmin.getCollectionsFromOrganization(organizationId, "").size());
+
+        // Non-admin/non-curator users cannot call the endpoint.
+        final io.dockstore.openapi.client.ApiClient webClientOtherUser = getOpenAPIWebClient(OTHER_USERNAME, testingPostgres);
+        final io.dockstore.openapi.client.api.OrganizationsApi organizationsApiOtherUser = new io.dockstore.openapi.client.api.OrganizationsApi(webClientOtherUser);
+        try {
+            organizationsApiOtherUser.deleteCollectionsWithMatchingNames(organizationId, ".*");
+            fail("Non-admin/non-curator should not be able to delete collections.");
+        } catch (io.dockstore.openapi.client.ApiException e) {
+            assertEquals(HttpStatus.SC_UNAUTHORIZED, e.getCode());
+        }
+        assertEquals(5, organizationsApiAdmin.getCollectionsFromOrganization(organizationId, "").size());
+
+        // Nonexistent organization → 404.
+        try {
+            organizationsApiAdmin.deleteCollectionsWithMatchingNames(NONEXISTENT_ID, ".*");
+            fail("Should fail with 404 for nonexistent organization.");
+        } catch (io.dockstore.openapi.client.ApiException e) {
+            assertEquals(HttpStatus.SC_NOT_FOUND, e.getCode());
+        }
+
+        // Empty regex → 400.
+        try {
+            organizationsApiAdmin.deleteCollectionsWithMatchingNames(organizationId, "");
+            fail("Should fail with 400 for empty regex.");
+        } catch (io.dockstore.openapi.client.ApiException e) {
+            assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
+        }
+
+        // Invalid regex pattern → 400.
+        try {
+            organizationsApiAdmin.deleteCollectionsWithMatchingNames(organizationId, "[invalid");
+            fail("Should fail with 400 for invalid regex.");
+        } catch (io.dockstore.openapi.client.ApiException e) {
+            assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
+        }
+
+        // Regex matching no collections → empty result, collections unchanged.
+        List<String> deleted = organizationsApiAdmin.deleteCollectionsWithMatchingNames(organizationId, "zzzz.*");
+        assertEquals(0, deleted.size());
+        assertEquals(5, organizationsApiAdmin.getCollectionsFromOrganization(organizationId, "").size());
+
+        // Delete collections whose names fully match "baa.*".
+        deleted = organizationsApiAdmin.deleteCollectionsWithMatchingNames(organizationId, "baa.*");
+        assertEquals(3, deleted.size());
+        assertTrue(deleted.containsAll(List.of("baa", "baaa", "baa123")));
+
+        // The two non-matching collections should remain.
+        List<io.dockstore.openapi.client.model.Collection> remaining = organizationsApiAdmin.getCollectionsFromOrganization(organizationId, "");
+        assertEquals(2, remaining.size());
+        List<String> remainingNames = remaining.stream().map(io.dockstore.openapi.client.model.Collection::getName).toList();
+        assertTrue(remainingNames.containsAll(List.of("aaz", "zaa")));
+
+        // A DELETE_COLLECTION event should have been generated for each deleted collection.
+        List<io.dockstore.openapi.client.model.Event> events = organizationsApiAdmin.getOrganizationEvents(organizationId, 0, Integer.MAX_VALUE);
+        long deleteEventCount = events.stream().filter(e -> e.getType() == io.dockstore.openapi.client.model.Event.TypeEnum.DELETE_COLLECTION).count();
+        assertEquals(3, deleteEventCount);
+    }
+
+    @Test
     void testCategoryDeletion() {
         addAdminToOrg(ADMIN_USERNAME, "dockstore");
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OrganizationIT.java
@@ -3042,11 +3042,11 @@ public class OrganizationIT extends BaseIT {
             organizationsApiOtherUser.deleteCollectionsWithMatchingNames(organizationId, ".*");
             fail("Non-admin/non-curator should not be able to delete collections.");
         } catch (io.dockstore.openapi.client.ApiException e) {
-            assertEquals(HttpStatus.SC_UNAUTHORIZED, e.getCode());
+            assertEquals(HttpStatus.SC_FORBIDDEN, e.getCode());
         }
         assertEquals(5, organizationsApiAdmin.getCollectionsFromOrganization(organizationId, "").size());
 
-        // Nonexistent organization → 404.
+        // Nonexistent organization: code 404.
         try {
             organizationsApiAdmin.deleteCollectionsWithMatchingNames(NONEXISTENT_ID, ".*");
             fail("Should fail with 404 for nonexistent organization.");
@@ -3054,7 +3054,7 @@ public class OrganizationIT extends BaseIT {
             assertEquals(HttpStatus.SC_NOT_FOUND, e.getCode());
         }
 
-        // Empty regex → 400.
+        // Empty regex: code 400.
         try {
             organizationsApiAdmin.deleteCollectionsWithMatchingNames(organizationId, "");
             fail("Should fail with 400 for empty regex.");
@@ -3062,7 +3062,7 @@ public class OrganizationIT extends BaseIT {
             assertEquals(HttpStatus.SC_BAD_REQUEST, e.getCode());
         }
 
-        // Invalid regex pattern → 400.
+        // Invalid regex pattern: code 400.
         try {
             organizationsApiAdmin.deleteCollectionsWithMatchingNames(organizationId, "[invalid");
             fail("Should fail with 400 for invalid regex.");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
@@ -28,6 +28,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -54,6 +55,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -471,6 +474,53 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
         } else { // else if the organization is not pending nor rejected, then throw an error
             throw new CustomWebApplicationException("You can only delete organizations that are pending or have been rejected", HttpStatus.SC_BAD_REQUEST);
         }
+    }
+
+    @DELETE
+    @Timed
+    @UnitOfWork
+    @Path("/{organizationId}/collections")
+    @RolesAllowed({"curator", "admin"})
+    @Operation(operationId = "deleteCollectionsWithMatchingNames", summary = "Delete collections with names matching a regexp.", description = "Delete all collections belonging to the given organization whose names match the provided Java regular expression. Returns the list of deleted collection names. Admin/curator only.", security = @SecurityRequirement(name = JWT_SECURITY_DEFINITION_NAME))
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = String.class)))),
+        @ApiResponse(responseCode = "400", description = "BAD REQUEST"),
+        @ApiResponse(responseCode = "404", description = "NOT FOUND")
+    })
+    public List<String> deleteCollectionsWithMatchingNames(
+        @Parameter(hidden = true, name = "user") @Auth User user,
+        @Parameter(description = "Organization ID.", name = "organizationId", in = ParameterIn.PATH, required = true) @PathParam("organizationId") Long organizationId,
+        @Parameter(description = "Java regular expression to match collection names against.", name = "nameRegex", in = ParameterIn.QUERY, required = true) @QueryParam("nameRegex") String nameRegex) {
+
+        Organization organization = organizationDAO.findById(organizationId);
+        throwExceptionForNullOrganization(organization);
+
+        if (nameRegex == null || nameRegex.isEmpty()) {
+            throw new CustomWebApplicationException("nameRegex parameter is required", HttpStatus.SC_BAD_REQUEST);
+        }
+
+        Pattern pattern;
+        try {
+            pattern = Pattern.compile(nameRegex);
+        } catch (PatternSyntaxException e) {
+            throw new CustomWebApplicationException("Invalid regular expression: " + e.getMessage(), HttpStatus.SC_BAD_REQUEST);
+        }
+
+        List<Collection> matching = collectionDAO.findAllByOrg(organizationId).stream()
+            .filter(c -> pattern.matcher(c.getName()).matches())
+            .toList();
+
+        for (Collection collection : matching) {
+            collection.setDeleted(true);
+            eventDAO.create(new Event.Builder()
+                .withOrganization(organization)
+                .withCollection(collection)
+                .withInitiatorUser(user)
+                .withType(Event.EventType.DELETE_COLLECTION)
+                .build());
+        }
+
+        return matching.stream().map(Collection::getName).toList();
     }
 
     @GET

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/OrganizationResource.java
@@ -490,18 +490,18 @@ public class OrganizationResource implements AuthenticatedResourceInterface, Ali
     public List<String> deleteCollectionsWithMatchingNames(
         @Parameter(hidden = true, name = "user") @Auth User user,
         @Parameter(description = "Organization ID.", name = "organizationId", in = ParameterIn.PATH, required = true) @PathParam("organizationId") Long organizationId,
-        @Parameter(description = "Java regular expression to match collection names against.", name = "nameRegex", in = ParameterIn.QUERY, required = true) @QueryParam("nameRegex") String nameRegex) {
+        @Parameter(description = "Java regular expression to match collection names against.", name = "regex", in = ParameterIn.QUERY, required = true) @QueryParam("regex") String regex) {
 
         Organization organization = organizationDAO.findById(organizationId);
         throwExceptionForNullOrganization(organization);
 
-        if (nameRegex == null || nameRegex.isEmpty()) {
-            throw new CustomWebApplicationException("nameRegex parameter is required", HttpStatus.SC_BAD_REQUEST);
+        if (regex == null || regex.isEmpty()) {
+            throw new CustomWebApplicationException("regex parameter is required", HttpStatus.SC_BAD_REQUEST);
         }
 
         Pattern pattern;
         try {
-            pattern = Pattern.compile(nameRegex);
+            pattern = Pattern.compile(regex);
         } catch (PatternSyntaxException e) {
             throw new CustomWebApplicationException("Invalid regular expression: " + e.getMessage(), HttpStatus.SC_BAD_REQUEST);
         }

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -5142,6 +5142,43 @@ paths:
       tags:
       - organizations
   /organizations/{organizationId}/collections:
+    delete:
+      description: Delete all collections belonging to the given organization whose
+        names match the provided Java regular expression. Returns the list of deleted
+        collection names. Admin/curator only.
+      operationId: deleteCollectionsWithMatchingNames
+      parameters:
+      - description: Organization ID.
+        in: path
+        name: organizationId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - description: Java regular expression to match collection names against.
+        in: query
+        name: nameRegex
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+          description: OK
+        "400":
+          description: BAD REQUEST
+        "404":
+          description: NOT FOUND
+      security:
+      - BEARER: []
+      summary: Delete collections with names matching a regexp.
+      tags:
+      - organizations
     get:
       description: Retrieve all collections for an organization. Supports optional
         authentication.

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -5157,7 +5157,7 @@ paths:
           format: int64
       - description: Java regular expression to match collection names against.
         in: query
-        name: nameRegex
+        name: regex
         required: true
         schema:
           type: string


### PR DESCRIPTION
**Description**
This PR introduces a new `deleteCollectionsWithMatchingNames` endpoint that deletes all collections/categories in the specified organization that have names which match the specified Java regex.  This endpoint is only invocable by admins/curators.

Theoretically, we could use this endpoint to intentionally DOS ourselves by feeding it a degenerately-compute-intensive regex, but us DOSing ourselves intentionally is generally not a worry.

**Review Instructions**
Confirm that as an admin user, you can use the endpoint to successfully delete some collections/categories.  Try to access the endpoint as a non-admin user and confirm that you are forbidden.
 
**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7543

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
