### PR TITLE
clean-up pkce info and add test

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
@@ -228,6 +228,9 @@ public class TokenResourceIT {
         TokensApi tokensApi1 = new TokensApi(getWebClient(false, "n/a", testingPostgres));
         testingPostgres.runUpdateStatement("insert into PKCE values (now(), now(),  'fakeState', 'fakeVerifier')");
         tokensApi1.addToken(getSatellizer(SUFFIX1, true));
+        long count = testingPostgres.runSelectStatement("select count(*) from PKCE", long.class);
+        assertEquals(0, count, "PKCE cache should be clear after token is exchanged");
+
         UsersApi usersApi1 = new UsersApi(getWebClient(true, CUSTOM_USERNAME1, testingPostgres));
 
         // registering user 1 again should fail
@@ -356,6 +359,7 @@ public class TokenResourceIT {
         TokensApi unAuthenticatedTokensApi = new TokensApi(getWebClient(false, "n/a", testingPostgres));
         testingPostgres.runUpdateStatement("insert into PKCE values (now(), now(),  'fakeState', 'fakeVerifier')");
         createAccount1(unAuthenticatedTokensApi);
+
         registerNewUsersAfterSelfDestruct(unAuthenticatedTokensApi);
     }
 

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
@@ -254,9 +254,14 @@ public class TokenResourceIT {
         }
         assertTrue(shouldFail);
 
+        // re-create deleted PKCE information
+        testingPostgres.runUpdateStatement("insert into PKCE values (now(), now(),  'fakeState', 'fakeVerifier')");
         // now register user2, should autogenerate a name
         TokensApi tokensApi2 = new TokensApi(getWebClient(false, "n/a", testingPostgres));
         io.swagger.client.model.TokenAuth token = tokensApi2.addToken(getSatellizer(SUFFIX2, true));
+        count = testingPostgres.runSelectStatement("select count(*) from PKCE", long.class);
+        assertEquals(0, count, "PKCE cache should be clear after token is exchanged");
+
         UsersApi usersApi2 = new UsersApi(getWebClient(true, token.getUsername(), testingPostgres));
         assertNotEquals(CUSTOM_USERNAME2, usersApi2.getUser().getUsername());
         assertEquals("better.name", usersApi2.changeUsername("better.name").getUsername());

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/PKCEDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/PKCEDAO.java
@@ -36,8 +36,7 @@ public class PKCEDAO extends AbstractDAO<PKCE> {
     }
 
     public void delete(PKCE pkce) {
-        Session session = currentSession();
-        session.delete(pkce);
-        session.flush();
+        Session session = currentSession(); // IDE will suggested try ... with resources but this causes issues with dropwizard UnitOfWork
+        session.remove(pkce);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/TokenResource.java
@@ -664,6 +664,7 @@ public class TokenResource implements AuthenticatedResourceInterface, SourceCont
                 throw new CustomWebApplicationException("Auth error, state did not match", HttpStatus.SC_BAD_REQUEST);
             }
             verifier = pkce.getVerifier();
+            pkceDAO.delete(pkce);
         }
         return verifier;
     }


### PR DESCRIPTION
**Description**
Clean-up PKCE information in  DB after login and linking to prevent it from building up or be re-used, 

**Review Instructions**
PSQL into DB and check size of table before and after login/linking

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7594

**Security and Privacy**

PKCE information will remain if a login/link event is aborted mid-way. 
Should not happen much, not entirely sure if it would be an issue. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
