### PR TITLE
gpg codecov issue and add more state - merge conflict 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -701,7 +701,7 @@ commands:
       - run:
           name: setup codecov uploader
           command: |
-            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            curl https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
             curl -Os https://uploader.codecov.io/latest/linux/codecov
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
@@ -172,7 +172,7 @@ public class TokenResourceIT {
     void getGoogleTokenNewUser(Hoverfly hoverfly) {
         hoverfly.simulate(SIMULATION_SOURCE);
         TokensApi tokensApi = new TokensApi(getWebClient(false, "n/a", testingPostgres));
-        testingPostgres.runUpdateStatement("insert into PKCE values (now(), now(),  'fakeState', 'fakeVerifier')");
+        insertPKCENoCheck();
         io.swagger.client.model.TokenAuth token = tokensApi.addGoogleToken(getSatellizer(SUFFIX3, true));
 
         // check that the user has the correct two tokens
@@ -227,7 +227,7 @@ public class TokenResourceIT {
     void testNinjaedGitHubUser(Hoverfly hoverfly) {
         hoverfly.simulate(SIMULATION_SOURCE);
         TokensApi tokensApi1 = new TokensApi(getWebClient(false, "n/a", testingPostgres));
-        testingPostgres.runUpdateStatement("insert into PKCE values (now(), now(),  'fakeState', 'fakeVerifier')");
+        insertPKCENoCheck();
         tokensApi1.addToken(getSatellizer(SUFFIX1, true));
         long count = testingPostgres.runSelectStatement("select count(*) from PKCE", long.class);
         assertEquals(0, count, "PKCE cache should be clear after token is exchanged");
@@ -256,7 +256,7 @@ public class TokenResourceIT {
         assertTrue(shouldFail);
 
         // re-create deleted PKCE information
-        testingPostgres.runUpdateStatement("insert into PKCE values (now(), now(),  'fakeState', 'fakeVerifier')");
+        insertPKCENoCheck();
         // now register user2, should autogenerate a name
         TokensApi tokensApi2 = new TokensApi(getWebClient(false, "n/a", testingPostgres));
         io.swagger.client.model.TokenAuth token = tokensApi2.addToken(getSatellizer(SUFFIX2, true));
@@ -302,12 +302,12 @@ public class TokenResourceIT {
     void loginRegisterTestWithMultipleAccounts(Hoverfly hoverfly) {
         hoverfly.simulate(SIMULATION_SOURCE);
         TokensApi unAuthenticatedTokensApi = new TokensApi(getWebClient(false, "n/a", testingPostgres));
-        testingPostgres.runUpdateStatement("insert into PKCE (dbcreatedate, dbupdatedate, state, verifier) select now(), now(),  'fakeState', 'fakeVerifier' where (select count(*) from PKCE) = 0");
+        insertPKCEWithCheck();
         createAccount1(unAuthenticatedTokensApi);
         // re-create PKCE info
-        testingPostgres.runUpdateStatement("insert into PKCE (dbcreatedate, dbupdatedate, state, verifier) select now(), now(),  'fakeState', 'fakeVerifier' where (select count(*) from PKCE) = 0");
+        insertPKCEWithCheck();
         createAccount2(unAuthenticatedTokensApi);
-        testingPostgres.runUpdateStatement("insert into PKCE (dbcreatedate, dbupdatedate, state, verifier) select now(), now(),  'fakeState', 'fakeVerifier' where (select count(*) from PKCE) = 0");
+        insertPKCEWithCheck();
         registerAndLinkUnavailableTokens(unAuthenticatedTokensApi);
 
         // Change Account 1 username to CUSTOM_USERNAME2
@@ -322,7 +322,7 @@ public class TokenResourceIT {
         assertEquals(CUSTOM_USERNAME2, token.getUsername());
         assertEquals(TokenType.DOCKSTORE.toString(), token.getTokenSource());
 
-        testingPostgres.runUpdateStatement("insert into PKCE (dbcreatedate, dbupdatedate, state, verifier) select now(), now(),  'fakeState', 'fakeVerifier' where (select count(*) from PKCE) = 0");
+        insertPKCEWithCheck();
         // Login with GitHub still works
         io.swagger.client.model.TokenAuth fakeGitHubCode = unAuthenticatedTokensApi.addToken(getSatellizer(SUFFIX1, false));
         assertEquals(CUSTOM_USERNAME2, fakeGitHubCode.getUsername());
@@ -333,12 +333,12 @@ public class TokenResourceIT {
     void adminsAndCuratorsMayNotLoginWithGoogle(Hoverfly hoverfly) {
         hoverfly.simulate(SIMULATION_SOURCE);
         TokensApi unAuthenticatedTokensApi = new TokensApi(getWebClient(false, "n/a", testingPostgres));
-        testingPostgres.runUpdateStatement("insert into PKCE (dbcreatedate, dbupdatedate, state, verifier) select now(), now(),  'fakeState', 'fakeVerifier' where (select count(*) from PKCE) = 0");
+        insertPKCEWithCheck();
         createAccount1(unAuthenticatedTokensApi);
         setAdmin(true);
         try {
             // re-create PKCE info
-            testingPostgres.runUpdateStatement("insert into PKCE (dbcreatedate, dbupdatedate, state, verifier) select now(), now(),  'fakeState', 'fakeVerifier' where (select count(*) from PKCE) = 0");
+            insertPKCEWithCheck();
             unAuthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
             fail("An admin should not be able to log in via Google");
         } catch (ApiException ex) {
@@ -359,7 +359,7 @@ public class TokenResourceIT {
         registerNewUsersWithExisting(unAuthenticatedTokensApi);
         // Can't link tokens to other Dockstore accounts
         // re-create PKCE info
-        testingPostgres.runUpdateStatement("insert into PKCE (dbcreatedate, dbupdatedate, state, verifier) select now(), now(),  'fakeState', 'fakeVerifier' where (select count(*) from PKCE) = 0");
+        insertPKCEWithCheck();
         addUnavailableGitHubTokenToGoogleUser();
         addUnavailableGoogleTokenToGitHubUser();
     }
@@ -368,9 +368,9 @@ public class TokenResourceIT {
     void recreateAccountsAfterSelfDestruct(Hoverfly hoverfly) {
         hoverfly.simulate(SIMULATION_SOURCE);
         TokensApi unAuthenticatedTokensApi = new TokensApi(getWebClient(false, "n/a", testingPostgres));
-        testingPostgres.runUpdateStatement("insert into PKCE values (now(), now(),  'fakeState', 'fakeVerifier')");
+        insertPKCENoCheck();
         createAccount1(unAuthenticatedTokensApi);
-        testingPostgres.runUpdateStatement("insert into PKCE values (now(), now(),  'fakeState', 'fakeVerifier')");
+        insertPKCENoCheck();
         registerNewUsersAfterSelfDestruct(unAuthenticatedTokensApi);
     }
 
@@ -428,7 +428,7 @@ public class TokenResourceIT {
         Boolean aBoolean = mainUsersApi.selfDestruct(null);
         assertTrue(aBoolean);
         io.swagger.client.model.TokenAuth recreatedGoogleToken = unAuthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, true));
-        testingPostgres.runUpdateStatement("insert into PKCE (dbcreatedate, dbupdatedate, state, verifier) select now(), now(),  'fakeState', 'fakeVerifier' where (select count(*) from PKCE) = 0");
+        insertPKCEWithCheck();
         io.swagger.client.model.TokenAuth recreatedGitHubToken = unAuthenticatedTokensApi.addToken(getSatellizer(SUFFIX1, true));
         assertNotSame(recreatedGitHubToken.getUserId(), recreatedGoogleToken.getUserId());
     }
@@ -608,7 +608,7 @@ public class TokenResourceIT {
         List<Token> byUserId = tokenDAO.findByUserId(getFakeUser().getId());
         assertEquals(1, byUserId.size());
         assertTrue(byUserId.stream().anyMatch(t -> t.getTokenSource() == TokenType.DOCKSTORE));
-        testingPostgres.runUpdateStatement("insert into PKCE values (now(), now(),  'fakeState', 'fakeVerifier')");
+        insertPKCENoCheck();
         TokensApi tokensApi = new TokensApi(getWebClient(true, GITHUB_ACCOUNT_USERNAME, testingPostgres));
         io.swagger.client.model.TokenAuth token = tokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
 
@@ -639,7 +639,7 @@ public class TokenResourceIT {
         assertEquals(1, byUserId.size());
         assertTrue(byUserId.stream().anyMatch(t -> t.getTokenSource() == TokenType.DOCKSTORE));
 
-        testingPostgres.runUpdateStatement("insert into PKCE values (now(), now(),  'fakeState', 'fakeVerifier')");
+        insertPKCENoCheck();
         TokensApi tokensApi = new TokensApi(getWebClient(true, getFakeUser().getUsername(), testingPostgres));
         tokensApi.addGoogleToken(getSatellizer(SUFFIX3, false));
 
@@ -693,5 +693,21 @@ public class TokenResourceIT {
         assertTrue(googleProfile.email.equals(GOOGLE_ACCOUNT_USERNAME1) && googleProfile.avatarURL
             .equals("https://dockstore.org/assets/images/dockstore/logo.png") && googleProfile.company == null
             && googleProfile.location == null && googleProfile.name.equals("Beef Stew"));
+    }
+
+    /**
+     * Add dummy PKCE information into PKCE table to allow a login.
+     * Do not check whether information already exists
+     */
+    private static void insertPKCENoCheck() {
+        testingPostgres.runUpdateStatement("insert into PKCE values (now(), now(),  'fakeState', 'fakeVerifier')");
+    }
+
+    /**
+     * Add dummy PKCE information into PKCE table to allow a login.
+     * Check whether information already exists
+     */
+    private static void insertPKCEWithCheck() {
+        testingPostgres.runUpdateStatement("insert into PKCE (dbcreatedate, dbupdatedate, state, verifier) select now(), now(),  'fakeState', 'fakeVerifier' where (select count(*) from PKCE) = 0");
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
@@ -322,6 +322,7 @@ public class TokenResourceIT {
         assertEquals(CUSTOM_USERNAME2, token.getUsername());
         assertEquals(TokenType.DOCKSTORE.toString(), token.getTokenSource());
 
+        testingPostgres.runUpdateStatement("insert into PKCE (dbcreatedate, dbupdatedate, state, verifier) select now(), now(),  'fakeState', 'fakeVerifier' where (select count(*) from PKCE) = 0");
         // Login with GitHub still works
         io.swagger.client.model.TokenAuth fakeGitHubCode = unAuthenticatedTokensApi.addToken(getSatellizer(SUFFIX1, false));
         assertEquals(CUSTOM_USERNAME2, fakeGitHubCode.getUsername());
@@ -427,6 +428,7 @@ public class TokenResourceIT {
         Boolean aBoolean = mainUsersApi.selfDestruct(null);
         assertTrue(aBoolean);
         io.swagger.client.model.TokenAuth recreatedGoogleToken = unAuthenticatedTokensApi.addGoogleToken(getSatellizer(SUFFIX3, true));
+        testingPostgres.runUpdateStatement("insert into PKCE (dbcreatedate, dbupdatedate, state, verifier) select now(), now(),  'fakeState', 'fakeVerifier' where (select count(*) from PKCE) = 0");
         io.swagger.client.model.TokenAuth recreatedGitHubToken = unAuthenticatedTokensApi.addToken(getSatellizer(SUFFIX1, true));
         assertNotSame(recreatedGitHubToken.getUserId(), recreatedGoogleToken.getUserId());
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/TokenResourceIT.java
@@ -307,7 +307,7 @@ public class TokenResourceIT {
         // re-create PKCE info
         testingPostgres.runUpdateStatement("insert into PKCE (dbcreatedate, dbupdatedate, state, verifier) select now(), now(),  'fakeState', 'fakeVerifier' where (select count(*) from PKCE) = 0");
         createAccount2(unAuthenticatedTokensApi);
-
+        testingPostgres.runUpdateStatement("insert into PKCE (dbcreatedate, dbupdatedate, state, verifier) select now(), now(),  'fakeState', 'fakeVerifier' where (select count(*) from PKCE) = 0");
         registerAndLinkUnavailableTokens(unAuthenticatedTokensApi);
 
         // Change Account 1 username to CUSTOM_USERNAME2
@@ -369,7 +369,7 @@ public class TokenResourceIT {
         TokensApi unAuthenticatedTokensApi = new TokensApi(getWebClient(false, "n/a", testingPostgres));
         testingPostgres.runUpdateStatement("insert into PKCE values (now(), now(),  'fakeState', 'fakeVerifier')");
         createAccount1(unAuthenticatedTokensApi);
-
+        testingPostgres.runUpdateStatement("insert into PKCE values (now(), now(),  'fakeState', 'fakeVerifier')");
         registerNewUsersAfterSelfDestruct(unAuthenticatedTokensApi);
     }
 


### PR DESCRIPTION
**Description**
Deal with possible merge conflict issue
Was there an issue between https://github.com/dockstore/dockstore/pull/6289 and https://github.com/dockstore/dockstore/pull/6286 i.e. they passed individually, but an issue happens with them together?  

Also coincidentally ran into an issue with codecov (linked below)

**Review Instructions**
Build passes

**Issue**
n/a

**Security and Privacy**

None

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
