### PR TITLE
Make EntryMetadata lazily retrieved

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -701,7 +701,7 @@ commands:
       - run:
           name: setup codecov uploader
           command: |
-            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            curl https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
             curl -Os https://uploader.codecov.io/latest/linux/codecov
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Entry.java
@@ -378,7 +378,7 @@ public abstract class Entry<S extends Entry, T extends Version> implements Compa
     private Map<Partner, Metrics> metricsByPlatform = new EnumMap<>(Partner.class);
 
     @JsonIgnore
-    @OneToOne(cascade = CascadeType.ALL, mappedBy = "parent", orphanRemoval = true)
+    @OneToOne(cascade = CascadeType.ALL, mappedBy = "parent", orphanRemoval = true, fetch = FetchType.LAZY, optional = false)
     @Cascade(org.hibernate.annotations.CascadeType.ALL)
     @PrimaryKeyJoinColumn
     private EntryMetadata entryMetadata = new EntryMetadata();


### PR DESCRIPTION
**Description**
Recently, we noticed that the webservice was a little laggy, and that some of the endpoints were taking much longer to respond than previously.  The problem was introduced in https://github.com/dockstore/dockstore/pull/6256, and is due to the introduction of the `EntryMetadata` entity, causing the HQL query `Entry.getGenericEntryById` to take much longer than before.

This PR changes the `Entry.entryMetaData` field to be lazily-retrieved, which is possible because each `Entry` entity always has a corresponding `EntryMetadata` entity.  Lazy retrieval avoids the problematic extra queries (required to handle the case where an EntryMetadata did not exist for an Entry) that were slowing down the webservice.

For us, the main concern is that we'll attempt to serialize uninitialized lazy fields after the `Session` has been closed, but before they've been retrieved.  Due to the way `EntryMetadata` is used, that's not currently an issue.

At some point, we might try to apply a similar change to `VersionMetadata` and `SourcefileMetadata`.

**Review Instructions**
View the warp/Optimus entry page, and in the developer tools network trace, confirm that the only endpoint that takes more than 1 second to respond is `workflowVersions`.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7630

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
