### PR TITLE
SEAB-7624: Improve representative version code

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/WebhookIT.java
@@ -1023,10 +1023,15 @@ class WebhookIT extends BaseIT {
         workflow = client.getWorkflowByPath(filterNoneWorkflowPath, WorkflowSubClass.BIOWORKFLOW, "versions");
         assertEquals(2, workflow.getWorkflowVersions().size(), "should have 2 versions");
 
-        // Delete 1.0 tag, should reassign 2.0 as the default version
+        // Add master branch
+        handleGitHubRelease(client, DockstoreTestUser2.DOCKSTOREYML_GITHUB_FILTERS_TEST, "refs/heads/master", USER_2_USERNAME);
+        workflow = client.getWorkflowByPath(filterNoneWorkflowPath, WorkflowSubClass.BIOWORKFLOW, "versions");
+        assertEquals(3, workflow.getWorkflowVersions().size(), "should have 3 versions");
+
+        // Delete 1.0 tag, should reassign master as the default version
         handleGitHubBranchDeletion(client, DockstoreTestUser2.DOCKSTOREYML_GITHUB_FILTERS_TEST, USER_2_USERNAME, "refs/tags/1.0");
         workflow = client.getWorkflowByPath(filterNoneWorkflowPath, WorkflowSubClass.BIOWORKFLOW, "versions");
-        assertEquals(1, workflow.getWorkflowVersions().size(), "should have 1 version after deletion");
+        assertEquals(2, workflow.getWorkflowVersions().size(), "should have 2 versions after deletion");
         assertNotNull(workflow.getDefaultVersion(), "should have reassigned the default version during deletion");
 
         // Publish workflow
@@ -1035,7 +1040,13 @@ class WebhookIT extends BaseIT {
         workflow = client.getWorkflowByPath(filterNoneWorkflowPath, WorkflowSubClass.BIOWORKFLOW, "versions");
         assertTrue(workflow.isIsPublished());
 
-        // Delete 2.0 tag, unset default version
+        // Delete master branch, unset default version
+        handleGitHubBranchDeletion(client, DockstoreTestUser2.DOCKSTOREYML_GITHUB_FILTERS_TEST, USER_2_USERNAME, "refs/heads/master");
+        workflow = client.getWorkflowByPath(filterNoneWorkflowPath, WorkflowSubClass.BIOWORKFLOW, "versions");
+        assertEquals(1, workflow.getWorkflowVersions().size(), "should have 1 version after deletion");
+        assertNull(workflow.getDefaultVersion(), "should have no default version after master branch is deleted");
+
+        // Delete 2.0 tag, should unpublish
         handleGitHubBranchDeletion(client, DockstoreTestUser2.DOCKSTOREYML_GITHUB_FILTERS_TEST, USER_2_USERNAME, "refs/tags/2.0");
         workflow = client.getWorkflowByPath(filterNoneWorkflowPath, WorkflowSubClass.BIOWORKFLOW, "versions");
         assertEquals(0, workflow.getWorkflowVersions().size(), "should have 0 versions after deletion");

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -471,28 +471,38 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
      * (Search fields, AI topic, and perhaps other things)
      */
     static Optional<Version> determineRepresentativeVersion(Entry entry) {
-        return determineRepresentativeVersion(entry.getWorkflowVersions());
+        return determineRepresentativeVersion(entry.getWorkflowVersions(), entry.getActualDefaultVersion());
     }
 
     /**
-     * Determine which of the specified Versions, which should be of the same Entry,
+     * Determine which of the specified Versions, all of which should be from the same Entry,
      * is most representative of the Entry.
      */
     static <V extends Version> Optional<V> determineRepresentativeVersion(Set<V> versions) {
-        // Prefer "mainline" Versions over valid Versions over all Versions, with ties going to the most-recently-created Version.
-        Set<String> mainlineVersionNames = Set.of("master", "main", "develop");
-        Set<V> nonHiddenVersions = versions.stream().filter(v -> !v.isHidden()).collect(Collectors.toSet());
-        Stream<V> mainlineVersions = nonHiddenVersions.stream().filter(version -> mainlineVersionNames.contains(version.getName()));
-        Stream<V> validVersions = nonHiddenVersions.stream().filter(Version::isValid);
-        Stream<V> allVersions = nonHiddenVersions.stream();
-        return youngestVersion(mainlineVersions)
-            .or(() -> youngestVersion(validVersions))
-            .or(() -> youngestVersion(allVersions));
+        return determineRepresentativeVersion(versions, null);
     }
 
-    private static <V extends Version> Optional<V> youngestVersion(Stream<V> versions) {
-        // Because we assign IDs sequentially, in increasing order, the Version with the highest ID was created most recently.
-        return versions.max(Comparator.comparing(Version::getId));
+    private static <V extends Version> Optional<V> determineRepresentativeVersion(Set<V> versions, V defaultVersion) {
+        Set<V> nonHidden = versions.stream().filter(v -> !v.isHidden()).collect(Collectors.toSet());
+
+        Stream<V> mainlinePlusValidTagsPlusDefault = nonHidden.stream().filter(v ->
+            "main".equals(v.getName()) || "master".equals(v.getName())
+            || (v.isValid() && v.getReferenceType() == Version.ReferenceType.TAG)
+            || v.equals(defaultVersion));
+        Stream<V> develop = nonHidden.stream().filter(v -> "develop".equals(v.getName()));
+        Stream<V> valid = nonHidden.stream().filter(Version::isValid);
+        Stream<V> all = nonHidden.stream();
+
+        return mostRecentlyUpdated(mainlinePlusValidTagsPlusDefault)
+            .or(() -> mostRecentlyUpdated(develop))
+            .or(() -> mostRecentlyUpdated(valid))
+            .or(() -> mostRecentlyUpdated(all));
+    }
+
+    private static <V extends Version> Optional<V> mostRecentlyUpdated(Stream<V> versions) {
+        // Use dbUpdateDate as the primary sort key; fall back to ID (assigned sequentially) when dbUpdateDate is unavailable.
+        Comparator<V> byUpdateDate = Comparator.comparing(Version::getDbUpdateDate, Comparator.nullsFirst(Comparator.naturalOrder()));
+        return versions.max(byUpdateDate.thenComparing(Version::getId));
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -466,21 +466,12 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
     }
 
     /**
-     * Return the ID of the version that is most representative of the Entry,
-     * or -1 if no such version exists.
-     */
-    static long determineRepresentativeVersionId(Entry entry) {
-        return determineRepresentativeVersion(entry).map(Version::getId).orElse(-1L);
-    }
-
-    /**
      * Determine which Version of the specified Entry is most representative of the Entry.
      * The resulting Version is used to generate identifying information about the Entry
      * (Search fields, AI topic, and perhaps other things)
      */
     static Optional<Version> determineRepresentativeVersion(Entry entry) {
-        return Optional.ofNullable(entry.getActualDefaultVersion())
-            .or(() -> determineRepresentativeVersion(entry.getWorkflowVersions()));
+        return determineRepresentativeVersion(entry.getWorkflowVersions());
     }
 
     /**

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -487,7 +487,7 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
         // 3. all valid versions
         // 4. all versions
         // Return the most recently-updated version from the first group, and if the group has no versions,
-        // move on to the next group, and repeat the process.  Exclude hidden versions.
+        // move on to the next group, and repeat the process, and so on.  Exclude hidden versions.
         Set<V> nonHidden = versions.stream().filter(v -> !v.isHidden()).collect(Collectors.toSet());
 
         Stream<V> mainlinePlusValidTagsPlusDefault = nonHidden.stream().filter(v ->

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -475,25 +475,19 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
     }
 
     /**
-     * Determine which of the specified Versions, all of which should be from the same Entry,
-     * is most representative of the Entry.
-     */
-    static <V extends Version> Optional<V> determineRepresentativeVersion(Set<V> versions) {
-        return determineRepresentativeVersion(versions, null);
-    }
-
-    /**
-     * Determines a "representative" version from a set of versions — the most suitable version for use
-     * when a single version must be chosen. Candidates are ranked in priority order:
-     * mainline branches ("main"/"master"), valid tags, and {@code defaultVersion} (if provided);
-     * then "develop"; then any valid version; then any non-hidden version. Within each tier,
-     * the most recently updated version wins.
-     *
+     * Determines a "representative" Version from a set of Versions, given the specified default version.
      * @param versions the set of versions to select from
-     * @param defaultVersion the entry's designated default version, included as a top-tier candidate; may be null
+     * @param defaultVersion the entry's designated default version; may be null
      * @return the representative version, or empty if {@code versions} is empty or all versions are hidden
      */
     private static <V extends Version> Optional<V> determineRepresentativeVersion(Set<V> versions, V defaultVersion) {
+        // Attempt to select the "representative" version from successive sets of groups:
+        // 1. mainline branches ("main"/"master"), valid tags, and {@code defaultVersion} (if provided)
+        // 2. "develop" branch
+        // 3. all valid versions
+        // 4. all versions
+        // Return the most recently-updated version from the first group, and if the group has no versions,
+        // move on to the next group, and repeat the process.  Exclude hidden versions.
         Set<V> nonHidden = versions.stream().filter(v -> !v.isHidden()).collect(Collectors.toSet());
 
         Stream<V> mainlinePlusValidTagsPlusDefault = nonHidden.stream().filter(v ->

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -482,6 +482,17 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
         return determineRepresentativeVersion(versions, null);
     }
 
+    /**
+     * Determines a "representative" version from a set of versions — the most suitable version for use
+     * when a single version must be chosen. Candidates are ranked in priority order:
+     * mainline branches ("main"/"master"), valid tags, and {@code defaultVersion} (if provided);
+     * then "develop"; then any valid version; then any non-hidden version. Within each tier,
+     * the most recently updated version wins.
+     *
+     * @param versions the set of versions to select from
+     * @param defaultVersion the entry's designated default version, included as a top-tier candidate; may be null
+     * @return the representative version, or empty if {@code versions} is empty or all versions are hidden
+     */
     private static <V extends Version> Optional<V> determineRepresentativeVersion(Set<V> versions, V defaultVersion) {
         Set<V> nonHidden = versions.stream().filter(v -> !v.isHidden()).collect(Collectors.toSet());
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/EntryVersionHelper.java
@@ -490,18 +490,13 @@ public interface EntryVersionHelper<T extends Entry<T, U>, U extends Version, W 
         // move on to the next group, and repeat the process, and so on.  Exclude hidden versions.
         Set<V> nonHidden = versions.stream().filter(v -> !v.isHidden()).collect(Collectors.toSet());
 
-        Stream<V> mainlinePlusValidTagsPlusDefault = nonHidden.stream().filter(v ->
-            "main".equals(v.getName()) || "master".equals(v.getName())
-            || (v.isValid() && v.getReferenceType() == Version.ReferenceType.TAG)
-            || v.equals(defaultVersion));
-        Stream<V> develop = nonHidden.stream().filter(v -> "develop".equals(v.getName()));
-        Stream<V> valid = nonHidden.stream().filter(Version::isValid);
-        Stream<V> all = nonHidden.stream();
-
-        return mostRecentlyUpdated(mainlinePlusValidTagsPlusDefault)
-            .or(() -> mostRecentlyUpdated(develop))
-            .or(() -> mostRecentlyUpdated(valid))
-            .or(() -> mostRecentlyUpdated(all));
+        return mostRecentlyUpdated(nonHidden.stream().filter(v ->
+                "main".equals(v.getName()) || "master".equals(v.getName())
+                || (v.isValid() && v.getReferenceType() == Version.ReferenceType.TAG)
+                || v.equals(defaultVersion)))
+            .or(() -> mostRecentlyUpdated(nonHidden.stream().filter(v -> "develop".equals(v.getName()))))
+            .or(() -> mostRecentlyUpdated(nonHidden.stream().filter(Version::isValid)))
+            .or(() -> mostRecentlyUpdated(nonHidden.stream()));
     }
 
     private static <V extends Version> Optional<V> mostRecentlyUpdated(Stream<V> versions) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -45,7 +45,6 @@ import io.dockstore.webservice.core.webhook.GitCommit;
 import io.dockstore.webservice.core.webhook.PushPayload;
 import io.dockstore.webservice.helpers.CachingFileTree;
 import io.dockstore.webservice.helpers.CheckUrlInterface;
-import io.dockstore.webservice.helpers.EntryVersionHelper;
 import io.dockstore.webservice.helpers.ExceptionHelper;
 import io.dockstore.webservice.helpers.FileFormatHelper;
 import io.dockstore.webservice.helpers.FileTree;
@@ -392,7 +391,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                     Version defaultVersion = workflow.getActualDefaultVersion();
                     if (defaultVersion != null && shouldDeleteVersion.test(defaultVersion)) {
                         Set<WorkflowVersion> remainingVersions = workflow.getWorkflowVersions().stream().filter(v -> !Objects.equals(v.getName(), gitReferenceName.get())).collect(Collectors.toSet());
-                        Optional<WorkflowVersion> newDefaultVersion = EntryVersionHelper.determineRepresentativeVersion(remainingVersions);
+                        Optional<WorkflowVersion> newDefaultVersion = selectDefaultVersionIfPossible(remainingVersions);
                         workflow.setActualDefaultVersion(newDefaultVersion.orElse(null));
                     }
 
@@ -421,6 +420,16 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
                 rethrowIfFatal(ex);
             }
         }
+    }
+
+    private Optional<WorkflowVersion> selectDefaultVersionIfPossible(Set<WorkflowVersion> remainingVersions) {
+        for (String name : List.of("main", "master", "develop")) {
+            Optional<WorkflowVersion> match = remainingVersions.stream().filter(v -> name.equals(v.getName())).findFirst();
+            if (match.isPresent()) {
+                return match;
+            }
+        }
+        return Optional.empty();
     }
 
     protected List<String> identifyImportantBranches(String repository, GitHubSourceCodeRepo gitHubSourceCodeRepo) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -925,6 +925,9 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         workflow.getWorkflowVersions().forEach(version -> sessionFactory.getCurrentSession().detach(version));
     }
 
+    /**
+     * Returns the id of the default version, falling back to a "representative" version id if no default is set.
+     */
     private long determineDefaultVersionId(Entry entry) {
         return Optional.ofNullable(entry.getActualDefaultVersion())
             .or(() -> EntryVersionHelper.determineRepresentativeVersion(entry))

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -423,7 +423,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         response.addHeader(X_TOTAL_COUNT, String.valueOf(versionDAO.getVersionsCount(workflowId)));
         response.addHeader(ACCESS_CONTROL_EXPOSE_HEADERS, X_TOTAL_COUNT);
 
-        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, false, EntryVersionHelper.determineRepresentativeVersionId(workflow));
+        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, false, determineDefaultVersionId(workflow));
         versions.forEach(version -> initializeAdditionalFields(include, version));
         return new LinkedHashSet<>(versions);
     }
@@ -451,7 +451,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         response.addHeader(X_TOTAL_COUNT, String.valueOf(versionDAO.getPublicVersionsCount(workflowId)));
         response.addHeader(ACCESS_CONTROL_EXPOSE_HEADERS, X_TOTAL_COUNT);
 
-        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, true, EntryVersionHelper.determineRepresentativeVersionId(workflow));
+        List<WorkflowVersion> versions = this.workflowVersionDAO.getWorkflowVersionsByWorkflowId(workflow.getId(), limit, offset, sortOrder, sortCol, true, determineDefaultVersionId(workflow));
         versions.forEach(version -> initializeAdditionalFields(include, version));
         return new LinkedHashSet<>(versions);
     }
@@ -907,7 +907,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
 
     @SuppressWarnings("checkstyle:MagicNumber")
     private void setWorkflowVersionSubset(Workflow workflow, String include, String versionName) {
-        long representativeVersionId = EntryVersionHelper.determineRepresentativeVersionId(workflow);
+        long representativeVersionId = determineDefaultVersionId(workflow);
         sessionFactory.getCurrentSession().detach(workflow);
 
         // Almost all observed workflows have under 200 version, this number should be lowered once the frontend actually supports pagination
@@ -923,6 +923,12 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
         workflow.setWorkflowVersionsOverride(workflowVersions);
         workflow.getWorkflowVersions().forEach(version -> initializeAdditionalFields(include, version));
         workflow.getWorkflowVersions().forEach(version -> sessionFactory.getCurrentSession().detach(version));
+    }
+
+    private long determineDefaultVersionId(Entry entry) {
+        return Optional.ofNullable(entry.getActualDefaultVersion())
+            .or(() -> EntryVersionHelper.determineRepresentativeVersion(entry))
+            .map(Version::getId).orElse(-1L);
     }
 
     /**

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/EntryVersionHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/EntryVersionHelperTest.java
@@ -11,6 +11,7 @@ import io.dockstore.webservice.core.WorkflowVersion;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.sql.Timestamp;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -102,12 +103,49 @@ class EntryVersionHelperTest {
         // add "master" -> mainline versions take top priority
         workflow.addWorkflowVersion(createVersion("master", false, 1));
         assertEquals("master", EntryVersionHelper.determineRepresentativeVersion(workflow).get().getName());
-        // add "main" with a higher id -> "main" is picked as more recently updated
+        // add "main" with a higher id -> "main" wins via the id fallback (dbUpdateDate is null for both)
         workflow.addWorkflowVersion(createVersion("main", false, 2));
         assertEquals("main", EntryVersionHelper.determineRepresentativeVersion(workflow).get().getName());
         // add "develop" -> mainline still wins with "main"; "develop" pool is not reached
         workflow.addWorkflowVersion(createVersion("develop", false, 3));
         assertEquals("main", EntryVersionHelper.determineRepresentativeVersion(workflow).get().getName());
+    }
+
+    @Test
+    void testRepresentativeVersionMostRecentlyUpdated() throws IllegalAccessException {
+        Timestamp older = Timestamp.valueOf("2024-01-01 00:00:00");
+        Timestamp younger = Timestamp.valueOf("2025-06-01 00:00:00");
+
+        // Within the mainline pool: newer dbUpdateDate beats higher id
+        BioWorkflow workflow = new BioWorkflow();
+        workflow.addWorkflowVersion(createVersion("main", false, 10, older));
+        workflow.addWorkflowVersion(createVersion("master", false, 5, younger));
+        assertEquals("master", EntryVersionHelper.determineRepresentativeVersion(workflow).get().getName());
+
+        // Within the mainline pool: non-null dbUpdateDate beats null dbUpdateDate, even with a lower id
+        BioWorkflow workflow2 = new BioWorkflow();
+        workflow2.addWorkflowVersion(createVersion("main", false, 10, null));
+        workflow2.addWorkflowVersion(createVersion("master", false, 5, older));
+        assertEquals("master", EntryVersionHelper.determineRepresentativeVersion(workflow2).get().getName());
+
+        // dbUpdateDate is only a tiebreaker within a pool; a more-recently-updated version
+        // in a lower-priority pool cannot beat an older version in a higher-priority pool
+        BioWorkflow workflow3 = new BioWorkflow();
+        workflow3.addWorkflowVersion(createVersion("master", false, 1, older));
+        workflow3.addWorkflowVersion(createVersion("develop", false, 100, younger));
+        assertEquals("master", EntryVersionHelper.determineRepresentativeVersion(workflow3).get().getName());
+
+        // Within the valid pool: newer dbUpdateDate wins over higher id
+        BioWorkflow workflow4 = new BioWorkflow();
+        workflow4.addWorkflowVersion(createVersion("v1.0", true, 10, older));
+        workflow4.addWorkflowVersion(createVersion("v2.0", true, 5, younger));
+        assertEquals("v2.0", EntryVersionHelper.determineRepresentativeVersion(workflow4).get().getName());
+
+        // Within the fallback (all) pool: newer dbUpdateDate wins over higher id
+        BioWorkflow workflow5 = new BioWorkflow();
+        workflow5.addWorkflowVersion(createVersion("feature-a", false, 10, older));
+        workflow5.addWorkflowVersion(createVersion("feature-b", false, 5, younger));
+        assertEquals("feature-b", EntryVersionHelper.determineRepresentativeVersion(workflow5).get().getName());
     }
 
     @Test
@@ -120,10 +158,15 @@ class EntryVersionHelperTest {
     }
 
     private WorkflowVersion createVersion(String name, boolean valid, long id) throws IllegalAccessException {
+        return createVersion(name, valid, id, null);
+    }
+
+    private WorkflowVersion createVersion(String name, boolean valid, long id, Timestamp dbUpdateDate) throws IllegalAccessException {
         WorkflowVersion version = new WorkflowVersion();
         version.setName(name);
         version.setValid(valid);
         FieldUtils.writeField(version, "id", id, true);
+        version.setDbUpdateDate(dbUpdateDate);
         return version;
     }
 }

--- a/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/EntryVersionHelperTest.java
+++ b/dockstore-webservice/src/test/java/io/dockstore/webservice/helpers/EntryVersionHelperTest.java
@@ -93,18 +93,29 @@ class EntryVersionHelperTest {
         // workflow with no versions
         BioWorkflow workflow = new BioWorkflow();
         assertEquals(Optional.empty(), EntryVersionHelper.determineRepresentativeVersion(workflow));
-        // workflow with one invalid version
+        // workflow with one invalid version -> falls back to all versions
         workflow.addWorkflowVersion(createVersion("invalid", false, 13));
         assertEquals("invalid", EntryVersionHelper.determineRepresentativeVersion(workflow).get().getName());
-        // workflow with one valid and one invalid version
+        // add a valid version -> valid versions are preferred over all
         workflow.addWorkflowVersion(createVersion("valid", true, 11));
         assertEquals("valid", EntryVersionHelper.determineRepresentativeVersion(workflow).get().getName());
-        // workflow with "master" version and some other versions
+        // add "master" -> mainline versions take top priority
         workflow.addWorkflowVersion(createVersion("master", false, 1));
         assertEquals("master", EntryVersionHelper.determineRepresentativeVersion(workflow).get().getName());
-        // workflow with "master", "main", and "develop" versions, should select one of those three with the highest id
+        // add "main" with a higher id -> "main" is picked as more recently updated
         workflow.addWorkflowVersion(createVersion("main", false, 2));
+        assertEquals("main", EntryVersionHelper.determineRepresentativeVersion(workflow).get().getName());
+        // add "develop" -> mainline still wins with "main"; "develop" pool is not reached
         workflow.addWorkflowVersion(createVersion("develop", false, 3));
+        assertEquals("main", EntryVersionHelper.determineRepresentativeVersion(workflow).get().getName());
+    }
+
+    @Test
+    void testRepresentativeVersionSelectionDevelop() throws IllegalAccessException {
+        // When there are no mainline/valid-tag/default candidates, "develop" is chosen.
+        BioWorkflow workflow = new BioWorkflow();
+        workflow.addWorkflowVersion(createVersion("feature-x", false, 1));
+        workflow.addWorkflowVersion(createVersion("develop", false, 2));
         assertEquals("develop", EntryVersionHelper.determineRepresentativeVersion(workflow).get().getName());
     }
 


### PR DESCRIPTION
**Description**
This PR changes the webservice's `determineRepresentativeVersion` code to do better when the default version has been set, but corresponds to an old ref that is now stale.

See the javadoc for `determineRepresentativeVersion` for details about the updated algorithm.  The TLDR is that in most cases, we compute the representative version by calculating the set of versions composed of "main", "master", all valid tags, and the default version (if set), and then selecting the most-recently updated version from it.

Previously, `determineRepresentativeVersion` determined the representative version for four purposes:
1. to generate a topic sentence.
2. for categorization purposes.
3. to set a new default version, when the previous default version was deleted.
4. as a backup to the default version. to display at the top of the versions table, when sorted under the default order.

For uses 1 and 2, we really do want to find the most representative version, and we call `determineRepresentativeVersion` directly in those cases.

For use 3, we probably want to only select a new default version that is going to remain up-to-date, such as a mainline or develop branch, rather than a tag.  The code is adjusted accordingly.

For use 4, when the default version is set, we use it in all cases, and the representative version is used as a fallback.  We create a new helper in WorkflowResource with those semantics.

**Review Instructions**
Confirm that the versions that the webservice is producing in the various cases are correct.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7624

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
