### PR TITLE
SEAB- 7551: Add endpoints to allow owner to adjust categorizations

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIOrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIOrganizationIT.java
@@ -224,7 +224,7 @@ public class OpenAPIOrganizationIT extends BaseIT {
         // Non-owner cannot delete an AI-curated entry
         CategoriesApi categoriesApiOther = new CategoriesApi(getOpenAPIWebClient(OTHER_USERNAME, testingPostgres));
         ApiException forbiddenEx = assertThrows(ApiException.class, () ->
-                categoriesApiOther.deleteAiCuratedEntryFromCategory(categoryId, workflowId));
+                categoriesApiOther.removeAiCuratedEntryFromCategory(categoryId, workflowId));
         assertEquals(HttpStatus.SC_FORBIDDEN, forbiddenEx.getCode());
 
         // Owner cannot delete an entry that is not AI-curated
@@ -232,12 +232,12 @@ public class OpenAPIOrganizationIT extends BaseIT {
         organizationsApiAdmin.addEntryToCollection(orgId, categoryId, workflowId, null, "USER", null);
         CategoriesApi categoriesApiUser2 = new CategoriesApi(userClient);
         ApiException notAiEx = assertThrows(ApiException.class, () ->
-                categoriesApiUser2.deleteAiCuratedEntryFromCategory(categoryId, workflowId));
+                categoriesApiUser2.removeAiCuratedEntryFromCategory(categoryId, workflowId));
         assertEquals(HttpStatus.SC_FORBIDDEN, notAiEx.getCode());
 
         // Nonexistent category returns NOT_FOUND
         ApiException notFoundEx = assertThrows(ApiException.class, () ->
-                categoriesApiUser2.deleteAiCuratedEntryFromCategory(Long.MAX_VALUE, workflowId));
+                categoriesApiUser2.removeAiCuratedEntryFromCategory(Long.MAX_VALUE, workflowId));
         assertEquals(HttpStatus.SC_NOT_FOUND, notFoundEx.getCode());
 
         // Re-add with AI curator for the success case
@@ -245,7 +245,7 @@ public class OpenAPIOrganizationIT extends BaseIT {
         organizationsApiAdmin.addEntryToCollection(orgId, categoryId, workflowId, null, "AI", null);
 
         // Owner can delete an AI-curated entry
-        categoriesApiUser2.deleteAiCuratedEntryFromCategory(categoryId, workflowId);
+        categoriesApiUser2.removeAiCuratedEntryFromCategory(categoryId, workflowId);
         assertTrue(categoriesApiAdmin.getCategoryById(categoryId).getEntries().isEmpty());
         long removeFromCategoryCount = testingPostgres.runSelectStatement(
             "select count(*) from event where type = 'REMOVE_FROM_CATEGORY'", long.class);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIOrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIOrganizationIT.java
@@ -28,9 +28,11 @@ import io.dockstore.common.MuteForSuccessfulTests;
 import io.dockstore.common.SourceControl;
 import io.dockstore.openapi.client.ApiClient;
 import io.dockstore.openapi.client.ApiException;
+import io.dockstore.openapi.client.api.CategoriesApi;
 import io.dockstore.openapi.client.api.EventsApi;
 import io.dockstore.openapi.client.api.OrganizationsApi;
 import io.dockstore.openapi.client.api.WorkflowsApi;
+import io.dockstore.openapi.client.model.Category;
 import io.dockstore.openapi.client.model.Collection;
 import io.dockstore.openapi.client.model.CollectionEntry;
 import io.dockstore.openapi.client.model.Event;
@@ -193,5 +195,105 @@ public class OpenAPIOrganizationIT extends BaseIT {
         ApiException exception = assertThrows(ApiException.class, () ->
                 organizationsApiOtherUser.addEntryToCollection(organizationId, collectionId, workflowId, null, "DOCKSTORE", null));
         assertEquals(HttpStatus.SC_UNAUTHORIZED, exception.getCode());
+    }
+
+    @Test
+    void testDeleteAiCuratedEntryFromCategory() {
+        final ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        OrganizationsApi organizationsApiAdmin = new OrganizationsApi(adminClient);
+        CategoriesApi categoriesApiAdmin = new CategoriesApi(adminClient);
+
+        Organization org = OrganizationIT.openApiStubOrgObject();
+        org.setCategorizer(true);
+        org = organizationsApiAdmin.createOrganization(org);
+        organizationsApiAdmin.approveOrganization(org.getId());
+        Collection category = organizationsApiAdmin.createCollection(OrganizationIT.openApiStubCollectionObject(), org.getId());
+        final long orgId = org.getId();
+        final long categoryId = category.getId();
+
+        final ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowsApi = new WorkflowsApi(userClient);
+        Workflow workflow = workflowsApi.manualRegister(SourceControl.GITHUB.name(), "dockstore-testing/viral-pipelines",
+                "/pipes/WDL/workflows/multi_sample_assemble_kraken.wdl", "", DescriptorLanguage.WDL.getShortName(), "");
+        workflowsApi.refresh1(workflow.getId(), false);
+        workflowsApi.publish1(workflow.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
+        final long workflowId = workflow.getId();
+
+        organizationsApiAdmin.addEntryToCollection(orgId, categoryId, workflowId, null, "AI", null);
+
+        // Non-owner cannot delete an AI-curated entry
+        CategoriesApi categoriesApiOther = new CategoriesApi(getOpenAPIWebClient(OTHER_USERNAME, testingPostgres));
+        ApiException forbiddenEx = assertThrows(ApiException.class, () ->
+                categoriesApiOther.deleteAiCuratedEntryFromCategory(categoryId, workflowId));
+        assertEquals(HttpStatus.SC_FORBIDDEN, forbiddenEx.getCode());
+
+        // Owner cannot delete an entry that is not AI-curated
+        organizationsApiAdmin.deleteEntryFromCollection(orgId, categoryId, workflowId, null, null);
+        organizationsApiAdmin.addEntryToCollection(orgId, categoryId, workflowId, null, "USER", null);
+        CategoriesApi categoriesApiUser2 = new CategoriesApi(userClient);
+        ApiException notAiEx = assertThrows(ApiException.class, () ->
+                categoriesApiUser2.deleteAiCuratedEntryFromCategory(categoryId, workflowId));
+        assertEquals(HttpStatus.SC_FORBIDDEN, notAiEx.getCode());
+
+        // Nonexistent category returns NOT_FOUND
+        ApiException notFoundEx = assertThrows(ApiException.class, () ->
+                categoriesApiUser2.deleteAiCuratedEntryFromCategory(Long.MAX_VALUE, workflowId));
+        assertEquals(HttpStatus.SC_NOT_FOUND, notFoundEx.getCode());
+
+        // Re-add with AI curator for the success case
+        organizationsApiAdmin.deleteEntryFromCollection(orgId, categoryId, workflowId, null, null);
+        organizationsApiAdmin.addEntryToCollection(orgId, categoryId, workflowId, null, "AI", null);
+
+        // Owner can delete an AI-curated entry
+        categoriesApiUser2.deleteAiCuratedEntryFromCategory(categoryId, workflowId);
+        assertTrue(categoriesApiAdmin.getCategoryById(categoryId).getEntries().isEmpty());
+    }
+
+    @Test
+    void testApproveAiCuratedEntryInCategory() {
+        final ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        OrganizationsApi organizationsApiAdmin = new OrganizationsApi(adminClient);
+        CategoriesApi categoriesApiAdmin = new CategoriesApi(adminClient);
+
+        Organization org = OrganizationIT.openApiStubOrgObject();
+        org.setCategorizer(true);
+        org = organizationsApiAdmin.createOrganization(org);
+        organizationsApiAdmin.approveOrganization(org.getId());
+        Collection category = organizationsApiAdmin.createCollection(OrganizationIT.openApiStubCollectionObject(), org.getId());
+        final long orgId = org.getId();
+        final long categoryId = category.getId();
+
+        final ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowsApi = new WorkflowsApi(userClient);
+        Workflow workflow = workflowsApi.manualRegister(SourceControl.GITHUB.name(), "dockstore-testing/viral-pipelines",
+                "/pipes/WDL/workflows/multi_sample_assemble_kraken.wdl", "", DescriptorLanguage.WDL.getShortName(), "");
+        workflowsApi.refresh1(workflow.getId(), false);
+        workflowsApi.publish1(workflow.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
+        final long workflowId = workflow.getId();
+
+        organizationsApiAdmin.addEntryToCollection(orgId, categoryId, workflowId, null, "AI", null);
+
+        // Non-owner cannot approve an AI-curated entry
+        CategoriesApi categoriesApiOther = new CategoriesApi(getOpenAPIWebClient(OTHER_USERNAME, testingPostgres));
+        ApiException forbiddenEx = assertThrows(ApiException.class, () ->
+                categoriesApiOther.approveAiCuratedEntryInCategory(workflowId, categoryId, null));
+        assertEquals(HttpStatus.SC_FORBIDDEN, forbiddenEx.getCode());
+
+        // Nonexistent category returns NOT_FOUND
+        ApiException notFoundEx = assertThrows(ApiException.class, () ->
+                new CategoriesApi(userClient).approveAiCuratedEntryInCategory(workflowId, Long.MAX_VALUE, null));
+        assertEquals(HttpStatus.SC_NOT_FOUND, notFoundEx.getCode());
+
+        // Owner can approve an AI-curated entry; curator changes from AI to USER
+        CategoriesApi categoriesApiUser2 = new CategoriesApi(userClient);
+        categoriesApiUser2.approveAiCuratedEntryInCategory(workflowId, categoryId, null);
+        Category updated = categoriesApiAdmin.getCategoryById(categoryId);
+        assertEquals(1, updated.getEntries().size());
+        assertEquals(CollectionEntry.CuratorEnum.USER, updated.getEntries().get(0).getCurator());
+
+        // Cannot approve again: entry is no longer AI-curated
+        ApiException notAiEx = assertThrows(ApiException.class, () ->
+                categoriesApiUser2.approveAiCuratedEntryInCategory(workflowId, categoryId, null));
+        assertEquals(HttpStatus.SC_FORBIDDEN, notAiEx.getCode());
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIOrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIOrganizationIT.java
@@ -283,13 +283,13 @@ public class OpenAPIOrganizationIT extends BaseIT {
         assertEquals(HttpStatus.SC_FORBIDDEN, forbiddenEx.getCode());
 
         // Nonexistent category returns NOT_FOUND
+        CategoriesApi categoriesApiUser2 = new CategoriesApi(userClient);
         ApiException notFoundEx = assertThrows(ApiException.class, () ->
-                new CategoriesApi(userClient).approveAiCuratedEntryInCategory(workflowId, Long.MAX_VALUE, null));
+                categoriesApiUser2.approveAiCuratedEntryInCategory(workflowId, Long.MAX_VALUE, ""));
         assertEquals(HttpStatus.SC_NOT_FOUND, notFoundEx.getCode());
 
         // Owner can approve an AI-curated entry; curator changes from AI to USER
-        CategoriesApi categoriesApiUser2 = new CategoriesApi(userClient);
-        categoriesApiUser2.approveAiCuratedEntryInCategory(workflowId, categoryId, null);
+        categoriesApiUser2.approveAiCuratedEntryInCategory(workflowId, categoryId, "");
         Category updated = categoriesApiAdmin.getCategoryById(categoryId);
         assertEquals(1, updated.getEntries().size());
         assertEquals(CollectionEntry.CuratorEnum.USER, updated.getEntries().get(0).getCurator());
@@ -299,7 +299,7 @@ public class OpenAPIOrganizationIT extends BaseIT {
 
         // Cannot approve again: entry is no longer AI-curated
         ApiException notAiEx = assertThrows(ApiException.class, () ->
-                categoriesApiUser2.approveAiCuratedEntryInCategory(workflowId, categoryId, null));
+                categoriesApiUser2.approveAiCuratedEntryInCategory(workflowId, categoryId, ""));
         assertEquals(HttpStatus.SC_FORBIDDEN, notAiEx.getCode());
     }
 }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIOrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIOrganizationIT.java
@@ -247,6 +247,9 @@ public class OpenAPIOrganizationIT extends BaseIT {
         // Owner can delete an AI-curated entry
         categoriesApiUser2.deleteAiCuratedEntryFromCategory(categoryId, workflowId);
         assertTrue(categoriesApiAdmin.getCategoryById(categoryId).getEntries().isEmpty());
+        long removeFromCategoryCount = testingPostgres.runSelectStatement(
+            "select count(*) from event where type = 'REMOVE_FROM_CATEGORY'", long.class);
+        assertEquals(1, removeFromCategoryCount, "There should be 1 REMOVE_FROM_CATEGORY event");
     }
 
     @Test
@@ -290,6 +293,9 @@ public class OpenAPIOrganizationIT extends BaseIT {
         Category updated = categoriesApiAdmin.getCategoryById(categoryId);
         assertEquals(1, updated.getEntries().size());
         assertEquals(CollectionEntry.CuratorEnum.USER, updated.getEntries().get(0).getCurator());
+        long approveInCategoryCount = testingPostgres.runSelectStatement(
+            "select count(*) from event where type = 'APPROVE_IN_CATEGORY'", long.class);
+        assertEquals(1, approveInCategoryCount, "There should be 1 APPROVE_IN_CATEGORY event");
 
         // Cannot approve again: entry is no longer AI-curated
         ApiException notAiEx = assertThrows(ApiException.class, () ->

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIOrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIOrganizationIT.java
@@ -279,7 +279,7 @@ public class OpenAPIOrganizationIT extends BaseIT {
         // Non-owner cannot approve an AI-curated entry
         CategoriesApi categoriesApiOther = new CategoriesApi(getOpenAPIWebClient(OTHER_USERNAME, testingPostgres));
         ApiException forbiddenEx = assertThrows(ApiException.class, () ->
-                categoriesApiOther.approveAiCuratedEntryInCategory(workflowId, categoryId, null));
+                categoriesApiOther.approveAiCuratedEntryInCategory(workflowId, categoryId, ""));
         assertEquals(HttpStatus.SC_FORBIDDEN, forbiddenEx.getCode());
 
         // Nonexistent category returns NOT_FOUND

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -228,12 +228,8 @@ public class Collection implements Serializable, Aliasable {
         this.entries.removeIf(entryVersion -> entryVersion.equals(entryId, versionId));
     }
 
-    public Optional<EntryVersion.Curator> getCurator(Long entryId, Long versionId) {
-        return entries.stream().filter(ev -> ev.equals(entryId, versionId)).map(EntryVersion::getCurator).findFirst();
-    }
-
-    public void setCurator(Long entryId, Long versionId, EntryVersion.Curator curator) {
-        entries.stream().filter(ev -> ev.equals(entryId, versionId)).findFirst().ifPresent(ev -> ev.setCurator(curator));
+    public Optional<EntryVersion> getEntry(Long entryId, Long versionId) {
+        return entries.stream().filter(ev -> ev.equals(entryId, versionId)).findFirst();
     }
 
     public Organization getOrganization() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -232,6 +232,10 @@ public class Collection implements Serializable, Aliasable {
         return entries.stream().filter(ev -> ev.equals(entryId, versionId)).map(EntryVersion::getCurator).findFirst();
     }
 
+    public void setCurator(Long entryId, Long versionId, EntryVersion.Curator curator) {
+        entries.stream().filter(ev -> ev.equals(entryId, versionId)).findFirst().ifPresent(ev -> ev.setCurator(curator));
+    }
+
     public Organization getOrganization() {
         return organization;
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Collection.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.hibernate.annotations.CreationTimestamp;
@@ -225,6 +226,10 @@ public class Collection implements Serializable, Aliasable {
 
     public void removeEntry(Long entryId, Long versionId) {
         this.entries.removeIf(entryVersion -> entryVersion.equals(entryId, versionId));
+    }
+
+    public Optional<EntryVersion.Curator> getCurator(Long entryId, Long versionId) {
+        return entries.stream().filter(ev -> ev.equals(entryId, versionId)).map(EntryVersion::getCurator).findFirst();
     }
 
     public Organization getOrganization() {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/Event.java
@@ -101,6 +101,11 @@ public class Event {
     private Collection collection;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "categoryId", referencedColumnName = "id", columnDefinition = "bigint")
+    @ApiModelProperty(value = "Category that the event is acting on.", position = 12)
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "initiatorUserId", referencedColumnName = "id", columnDefinition = "bigint")
     @ApiModelProperty(value = "User initiating the event.", position = 6)
     private User initiatorUser;
@@ -204,6 +209,14 @@ public class Event {
         this.collection = collection;
     }
 
+    public Category getCategory() {
+        return category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
+
     public User getInitiatorUser() {
         return initiatorUser;
     }
@@ -261,7 +274,9 @@ public class Event {
         PUBLISH_ENTRY,
         UNPUBLISH_ENTRY,
         ARCHIVE_ENTRY,
-        UNARCHIVE_ENTRY
+        UNARCHIVE_ENTRY,
+        APPROVE_IN_CATEGORY,
+        REMOVE_FROM_CATEGORY
     }
 
     public static class Builder {
@@ -273,6 +288,7 @@ public class Event {
         private Service service;
         private Notebook notebook;
         private Collection collection;
+        private Category category;
         private User initiatorUser;
         private EventType type;
         private Version version;
@@ -324,6 +340,11 @@ public class Event {
             return this;
         }
 
+        public Builder withCategory(Category category) {
+            this.category = category;
+            return this;
+        }
+
         public Builder withInitiatorUser(User initiatorUser) {
             this.initiatorUser = initiatorUser;
             return this;
@@ -344,6 +365,7 @@ public class Event {
             event.service = this.service;
             event.notebook = this.notebook;
             event.collection = this.collection;
+            event.category = this.category;
             event.initiatorUser = this.initiatorUser;
             event.type = this.type;
             event.version = this.version;

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
@@ -157,7 +157,9 @@ public class CategoryResource implements AuthenticatedResourceInterface {
 
         checkIsOwner(user, entry);
 
-        if (category.getCurator(entry.getId(), null).orElse(null) != EntryVersion.Curator.AI) {
+        EntryVersion deleteEntryVersion = category.getEntry(entry.getId(), null)
+            .orElseThrow(() -> new CustomWebApplicationException("Entry is not a member of this category.", HttpStatus.SC_FORBIDDEN));
+        if (deleteEntryVersion.getCurator() != EntryVersion.Curator.AI) {
             throw new CustomWebApplicationException("Entry was not added to this category by AI.", HttpStatus.SC_FORBIDDEN);
         }
 
@@ -205,11 +207,13 @@ public class CategoryResource implements AuthenticatedResourceInterface {
 
         checkIsOwner(user, entry);
 
-        if (category.getCurator(entry.getId(), null).orElse(null) != EntryVersion.Curator.AI) {
+        EntryVersion approveEntryVersion = category.getEntry(entry.getId(), null)
+            .orElseThrow(() -> new CustomWebApplicationException("Entry is not a member of this category.", HttpStatus.SC_FORBIDDEN));
+        if (approveEntryVersion.getCurator() != EntryVersion.Curator.AI) {
             throw new CustomWebApplicationException("Entry was not added to this category by AI.", HttpStatus.SC_FORBIDDEN);
         }
 
-        category.setCurator(entry.getId(), null, EntryVersion.Curator.USER);
+        approveEntryVersion.setCurator(EntryVersion.Curator.USER);
 
         // TODO this is probably not the correct type of event, correct
         Event approveEvent = entry.getEventBuilder()

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
@@ -153,13 +153,13 @@ public class CategoryResource implements AuthenticatedResourceInterface {
 
         category.removeEntry(entry.getId(), null);
 
-        Event removeFromCategoryEvent = entry.getEventBuilder()
+        Event removeEvent = entry.getEventBuilder()
             .withOrganization(category.getOrganization())
             .withCategory(category)
             .withInitiatorUser(user)
             .withType(Event.EventType.REMOVE_FROM_CATEGORY)
             .build();
-        eventDAO.create(removeFromCategoryEvent);
+        eventDAO.create(removeEvent);
 
         PublicStateManager.getInstance().handleIndexUpdate(entry, StateManagerMode.UPDATE);
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
@@ -48,6 +48,7 @@ import io.swagger.v3.oas.annotations.security.SecuritySchemes;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -169,6 +170,55 @@ public class CategoryResource implements AuthenticatedResourceInterface {
             .withType(Event.EventType.REMOVE_FROM_COLLECTION)
             .build();
         eventDAO.create(removeFromCategoryEvent);
+
+        PublicStateManager.getInstance().handleIndexUpdate(entry, StateManagerMode.UPDATE);
+
+        return categoryDAO.findById(categoryId);
+    }
+
+    @PUT
+    @Timed
+    @UnitOfWork
+    @Path("/{categoryId}/entry")
+    @Operation(operationId = "approveAiCuratedEntryInCategory", summary = "Approve an AI-curated entry in a category.", description = "Approve an AI-curated entry in a category, changing its curator from AI to human. The entry must have been added to the category by AI. Only the owner of the entry may perform this action.", security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME))
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully approved AI-curated entry in category", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Category.class)))
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "Category or entry not found")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "User is not an owner of the entry, or the entry was not added to the category by AI")
+    public Category approveAiCuratedEntryInCategory(@Parameter(hidden = true, name = "user") @Auth User user,
+        @Parameter(description = "Category ID.", name = "categoryId", in = ParameterIn.PATH, required = true) @PathParam("categoryId") Long categoryId,
+        @Parameter(description = "Entry ID.", name = "entryId", in = ParameterIn.QUERY, required = true) @QueryParam("entryId") Long entryId,
+        @Parameter(description = "This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.", name = "emptyBody") String emptyBody) {
+
+        Entry<? extends Entry, ? extends Version> entry = workflowDAO.getGenericEntryById(entryId);
+        if (entry == null || !entry.getIsPublished()) {
+            String msg = "Entry not found.";
+            LOG.info(msg);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+        }
+
+        Category category = categoryDAO.findById(categoryId);
+        if (category == null) {
+            String msg = "Category not found.";
+            LOG.info(msg);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
+        }
+
+        checkIsOwner(user, entry);
+
+        if (category.getCurator(entry.getId(), null).orElse(null) != EntryVersion.Curator.AI) {
+            throw new CustomWebApplicationException("Entry was not added to this category by AI.", HttpStatus.SC_FORBIDDEN);
+        }
+
+        category.setCurator(entry.getId(), null, EntryVersion.Curator.USER);
+
+        // TODO this is probably not the correct type of event, correct
+        Event approveEvent = entry.getEventBuilder()
+            .withOrganization(category.getOrganization())
+            .withCollection(category)
+            .withInitiatorUser(user)
+            .withType(Event.EventType.MODIFY_COLLECTION)
+            .build();
+        eventDAO.create(approveEvent);
 
         PublicStateManager.getInstance().handleIndexUpdate(entry, StateManagerMode.UPDATE);
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
@@ -17,20 +17,36 @@
 package io.dockstore.webservice.resources;
 
 import com.codahale.metrics.annotation.Timed;
+import io.dockstore.webservice.CustomWebApplicationException;
 import io.dockstore.webservice.core.Category;
+import io.dockstore.webservice.core.Entry;
+import io.dockstore.webservice.core.EntryVersion;
+import io.dockstore.webservice.core.Event;
+import io.dockstore.webservice.core.User;
+import io.dockstore.webservice.core.Version;
 import io.dockstore.webservice.helpers.ParamHelper;
+import io.dockstore.webservice.helpers.PublicStateManager;
+import io.dockstore.webservice.helpers.StateManagerMode;
 import io.dockstore.webservice.jdbi.CategoryDAO;
+import io.dockstore.webservice.jdbi.EventDAO;
 import io.dockstore.webservice.jdbi.ToolDAO;
 import io.dockstore.webservice.jdbi.VersionDAO;
+import io.dockstore.webservice.jdbi.WorkflowDAO;
+import io.dropwizard.auth.Auth;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.security.SecuritySchemes;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -43,6 +59,8 @@ import java.util.List;
 import org.apache.http.HttpStatus;
 import org.hibernate.Hibernate;
 import org.hibernate.SessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Category endpoints
@@ -50,15 +68,21 @@ import org.hibernate.SessionFactory;
 @Path("/categories")
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "categories", description = ResourceConstants.CATEGORIES)
+@SecuritySchemes({@SecurityScheme(type = SecuritySchemeType.HTTP, name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME, scheme = "bearer")})
 public class CategoryResource implements AuthenticatedResourceInterface {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CategoryResource.class);
 
     private final CategoryDAO categoryDAO;
     private final CollectionHelper collectionHelper;
+    private final WorkflowDAO workflowDAO;
+    private final EventDAO eventDAO;
 
     public CategoryResource(SessionFactory sessionFactory) {
         this.categoryDAO = new CategoryDAO(sessionFactory);
         this.collectionHelper = new CollectionHelper(sessionFactory, new ToolDAO(sessionFactory), new VersionDAO(sessionFactory));
-
+        this.workflowDAO = new WorkflowDAO(sessionFactory);
+        this.eventDAO = new EventDAO(sessionFactory);
     }
 
     @GET
@@ -102,5 +126,52 @@ public class CategoryResource implements AuthenticatedResourceInterface {
         Hibernate.initialize(category.getAliases());
         collectionHelper.evictAndAddEntries(category);
         return (category);
+    }
+
+    @DELETE
+    @Timed
+    @UnitOfWork
+    @Path("/{categoryId}/entry")
+    @Operation(operationId = "deleteAiCuratedEntryFromCategory", summary = "Delete an AI-curated entry from a category.", description = "Delete an AI-curated entry from a category. The entry must have been added to the category by AI. Only the owner of the entry may perform this action.", security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME))
+    @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully deleted AI-curated entry from category", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Category.class)))
+    @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "Category or entry not found")
+    @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "User is not an owner of the entry, or the entry was not added to the category by AI")
+    public Category deleteAiCuratedEntryFromCategory(@Parameter(hidden = true, name = "user") @Auth User user,
+        @Parameter(description = "Category ID.", name = "categoryId", in = ParameterIn.PATH, required = true) @PathParam("categoryId") Long categoryId,
+        @Parameter(description = "Entry ID.", name = "entryId", in = ParameterIn.QUERY, required = true) @QueryParam("entryId") Long entryId) {
+
+        Entry<? extends Entry, ? extends Version> entry = workflowDAO.getGenericEntryById(entryId);
+        if (entry == null || !entry.getIsPublished()) {
+            String msg = "Entry not found.";
+            LOG.info(msg);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+        }
+
+        Category category = categoryDAO.findById(categoryId);
+        if (category == null) {
+            String msg = "Category not found.";
+            LOG.info(msg);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
+        }
+
+        checkIsOwner(user, entry);
+
+        if (category.getCurator(entry.getId(), null).orElse(null) != EntryVersion.Curator.AI) {
+            throw new CustomWebApplicationException("Entry was not added to this category by AI.", HttpStatus.SC_FORBIDDEN);
+        }
+
+        category.removeEntry(entry.getId(), null);
+
+        Event removeFromCategoryEvent = entry.getEventBuilder()
+            .withOrganization(category.getOrganization())
+            .withCollection(category)
+            .withInitiatorUser(user)
+            .withType(Event.EventType.REMOVE_FROM_COLLECTION)
+            .build();
+        eventDAO.create(removeFromCategoryEvent);
+
+        PublicStateManager.getInstance().handleIndexUpdate(entry, StateManagerMode.UPDATE);
+
+        return categoryDAO.findById(categoryId);
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
@@ -144,7 +144,7 @@ public class CategoryResource implements AuthenticatedResourceInterface {
         Entry<? extends Entry, ? extends Version> entry = getPublishedEntry(entryId);
         Category category = getCategory(categoryId);
         checkIsOwner(user, entry);
-        EntryVersion entryVersion = getAiCuratedEntryVersion(category, entry);
+        getAiCuratedEntryVersion(category, entry);
 
         category.removeEntry(entry.getId(), null);
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
@@ -141,27 +141,10 @@ public class CategoryResource implements AuthenticatedResourceInterface {
         @Parameter(description = "Category ID.", name = "categoryId", in = ParameterIn.PATH, required = true) @PathParam("categoryId") Long categoryId,
         @Parameter(description = "Entry ID.", name = "entryId", in = ParameterIn.QUERY, required = true) @QueryParam("entryId") Long entryId) {
 
-        Entry<? extends Entry, ? extends Version> entry = workflowDAO.getGenericEntryById(entryId);
-        if (entry == null || !entry.getIsPublished()) {
-            String msg = "Entry not found.";
-            LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
-        }
-
-        Category category = categoryDAO.findById(categoryId);
-        if (category == null) {
-            String msg = "Category not found.";
-            LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
-        }
-
+        Entry<? extends Entry, ? extends Version> entry = getPublishedEntry(entryId);
+        Category category = getCategory(categoryId);
         checkIsOwner(user, entry);
-
-        EntryVersion deleteEntryVersion = category.getEntry(entry.getId(), null)
-            .orElseThrow(() -> new CustomWebApplicationException("Entry is not a member of this category.", HttpStatus.SC_FORBIDDEN));
-        if (deleteEntryVersion.getCurator() != EntryVersion.Curator.AI) {
-            throw new CustomWebApplicationException("Entry was not added to this category by AI.", HttpStatus.SC_FORBIDDEN);
-        }
+        EntryVersion entryVersion = getAiCuratedEntryVersion(category, entry);
 
         category.removeEntry(entry.getId(), null);
 
@@ -191,29 +174,12 @@ public class CategoryResource implements AuthenticatedResourceInterface {
         @Parameter(description = "Entry ID.", name = "entryId", in = ParameterIn.QUERY, required = true) @QueryParam("entryId") Long entryId,
         @Parameter(description = "This is here to appease Swagger. It requires PUT methods to have a body, even if it is empty. Please leave it empty.", name = "emptyBody") String emptyBody) {
 
-        Entry<? extends Entry, ? extends Version> entry = workflowDAO.getGenericEntryById(entryId);
-        if (entry == null || !entry.getIsPublished()) {
-            String msg = "Entry not found.";
-            LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
-        }
-
-        Category category = categoryDAO.findById(categoryId);
-        if (category == null) {
-            String msg = "Category not found.";
-            LOG.info(msg);
-            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
-        }
-
+        Entry<? extends Entry, ? extends Version> entry = getPublishedEntry(entryId);
+        Category category = getCategory(categoryId);
         checkIsOwner(user, entry);
+        EntryVersion entryVersion = getAiCuratedEntryVersion(category, entry);
 
-        EntryVersion approveEntryVersion = category.getEntry(entry.getId(), null)
-            .orElseThrow(() -> new CustomWebApplicationException("Entry is not a member of this category.", HttpStatus.SC_FORBIDDEN));
-        if (approveEntryVersion.getCurator() != EntryVersion.Curator.AI) {
-            throw new CustomWebApplicationException("Entry was not added to this category by AI.", HttpStatus.SC_FORBIDDEN);
-        }
-
-        approveEntryVersion.setCurator(EntryVersion.Curator.USER);
+        entryVersion.setCurator(EntryVersion.Curator.USER);
 
         // TODO this is probably not the correct type of event, correct
         Event approveEvent = entry.getEventBuilder()
@@ -227,5 +193,34 @@ public class CategoryResource implements AuthenticatedResourceInterface {
         PublicStateManager.getInstance().handleIndexUpdate(entry, StateManagerMode.UPDATE);
 
         return categoryDAO.findById(categoryId);
+    }
+
+    private Entry<? extends Entry, ? extends Version> getPublishedEntry(Long entryId) {
+        Entry<? extends Entry, ? extends Version> entry = workflowDAO.getGenericEntryById(entryId);
+        if (entry == null || !entry.getIsPublished()) {
+            String msg = "Entry not found.";
+            LOG.info(msg);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_BAD_REQUEST);
+        }
+        return entry;
+    }
+
+    private Category getCategory(Long categoryId) {
+        Category category = categoryDAO.findById(categoryId);
+        if (category == null) {
+            String msg = "Category not found.";
+            LOG.info(msg);
+            throw new CustomWebApplicationException(msg, HttpStatus.SC_NOT_FOUND);
+        }
+        return category;
+    }
+
+    private EntryVersion getAiCuratedEntryVersion(Category category, Entry<? extends Entry, ? extends Version> entry) {
+        EntryVersion entryVersion = category.getEntry(entry.getId(), null)
+            .orElseThrow(() -> new CustomWebApplicationException("Entry is not a member of this category.", HttpStatus.SC_FORBIDDEN));
+        if (entryVersion.getCurator() != EntryVersion.Curator.AI) {
+            throw new CustomWebApplicationException("Entry was not added to this category by AI.", HttpStatus.SC_FORBIDDEN);
+        }
+        return entryVersion;
     }
 }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
@@ -133,11 +133,11 @@ public class CategoryResource implements AuthenticatedResourceInterface {
     @Timed
     @UnitOfWork
     @Path("/{categoryId}/entry")
-    @Operation(operationId = "deleteAiCuratedEntryFromCategory", summary = "Delete an AI-curated entry from a category.", description = "Delete an AI-curated entry from a category. The entry must have been added to the category by AI. Only the owner of the entry may perform this action.", security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME))
+    @Operation(operationId = "removeAiCuratedEntryFromCategory", summary = "Delete an AI-curated entry from a category.", description = "Delete an AI-curated entry from a category. The entry must have been added to the category by AI. Only the owner of the entry may perform this action.", security = @SecurityRequirement(name = ResourceConstants.JWT_SECURITY_DEFINITION_NAME))
     @ApiResponse(responseCode = HttpStatus.SC_OK + "", description = "Successfully deleted AI-curated entry from category", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = Category.class)))
     @ApiResponse(responseCode = HttpStatus.SC_NOT_FOUND + "", description = "Category or entry not found")
     @ApiResponse(responseCode = HttpStatus.SC_FORBIDDEN + "", description = "User is not an owner of the entry, or the entry was not added to the category by AI")
-    public Category deleteAiCuratedEntryFromCategory(@Parameter(hidden = true, name = "user") @Auth User user,
+    public Category removeAiCuratedEntryFromCategory(@Parameter(hidden = true, name = "user") @Auth User user,
         @Parameter(description = "Category ID.", name = "categoryId", in = ParameterIn.PATH, required = true) @PathParam("categoryId") Long categoryId,
         @Parameter(description = "Entry ID.", name = "entryId", in = ParameterIn.QUERY, required = true) @QueryParam("entryId") Long entryId) {
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CategoryResource.java
@@ -150,9 +150,9 @@ public class CategoryResource implements AuthenticatedResourceInterface {
 
         Event removeFromCategoryEvent = entry.getEventBuilder()
             .withOrganization(category.getOrganization())
-            .withCollection(category)
+            .withCategory(category)
             .withInitiatorUser(user)
-            .withType(Event.EventType.REMOVE_FROM_COLLECTION)
+            .withType(Event.EventType.REMOVE_FROM_CATEGORY)
             .build();
         eventDAO.create(removeFromCategoryEvent);
 
@@ -181,12 +181,11 @@ public class CategoryResource implements AuthenticatedResourceInterface {
 
         entryVersion.setCurator(EntryVersion.Curator.USER);
 
-        // TODO this is probably not the correct type of event, correct
         Event approveEvent = entry.getEventBuilder()
             .withOrganization(category.getOrganization())
-            .withCollection(category)
+            .withCategory(category)
             .withInitiatorUser(user)
-            .withType(Event.EventType.MODIFY_COLLECTION)
+            .withType(Event.EventType.APPROVE_IN_CATEGORY)
             .build();
         eventDAO.create(approveEvent);
 

--- a/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
@@ -96,4 +96,12 @@
             WHERE collection_id IN (SELECT id FROM collection WHERE dtype = 'Category')
         </sql>
     </changeSet>
+    <changeSet author="svonworl" id="add_categoryid_to_event">
+        <addColumn tableName="event">
+            <column name="categoryid" type="bigint"/>
+        </addColumn>
+        <addForeignKeyConstraint baseTableName="event" baseColumnNames="categoryid"
+                                 referencedTableName="collection" referencedColumnNames="id"
+                                 constraintName="fk_event_categoryid"/>
+    </changeSet>
 </databaseChangeLog>

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -10762,6 +10762,8 @@ components:
       properties:
         apptool:
           $ref: '#/components/schemas/AppTool'
+        category:
+          $ref: '#/components/schemas/Category'
         collection:
           $ref: '#/components/schemas/Collection'
         dbCreateDate:
@@ -10807,6 +10809,8 @@ components:
           - UNPUBLISH_ENTRY
           - ARCHIVE_ENTRY
           - UNARCHIVE_ENTRY
+          - APPROVE_IN_CATEGORY
+          - REMOVE_FROM_CATEGORY
         user:
           $ref: '#/components/schemas/User'
         version:

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1925,7 +1925,7 @@ paths:
       description: Delete an AI-curated entry from a category. The entry must have
         been added to the category by AI. Only the owner of the entry may perform
         this action.
-      operationId: deleteAiCuratedEntryFromCategory
+      operationId: removeAiCuratedEntryFromCategory
       parameters:
       - description: Category ID.
         in: path

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1920,6 +1920,44 @@ paths:
       summary: Retrieve all categories.
       tags:
       - categories
+  /categories/{categoryId}/entry:
+    delete:
+      description: Delete an AI-curated entry from a category. The entry must have
+        been added to the category by AI. Only the owner of the entry may perform
+        this action.
+      operationId: deleteAiCuratedEntryFromCategory
+      parameters:
+      - description: Category ID.
+        in: path
+        name: categoryId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - description: Entry ID.
+        in: query
+        name: entryId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Category'
+          description: Successfully deleted AI-curated entry from category
+        "403":
+          description: "User is not an owner of the entry, or the entry was not added\
+            \ to the category by AI"
+        "404":
+          description: Category or entry not found
+      security:
+      - BEARER: []
+      summary: Delete an AI-curated entry from a category.
+      tags:
+      - categories
   /categories/{id}:
     get:
       description: Retrieve a category by ID.

--- a/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
+++ b/dockstore-webservice/src/main/resources/openapi3/openapi.yaml
@@ -1958,6 +1958,50 @@ paths:
       summary: Delete an AI-curated entry from a category.
       tags:
       - categories
+    put:
+      description: "Approve an AI-curated entry in a category, changing its curator\
+        \ from AI to human. The entry must have been added to the category by AI.\
+        \ Only the owner of the entry may perform this action."
+      operationId: approveAiCuratedEntryInCategory
+      parameters:
+      - description: Category ID.
+        in: path
+        name: categoryId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - description: Entry ID.
+        in: query
+        name: entryId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: string
+        description: "This is here to appease Swagger. It requires PUT methods to\
+          \ have a body, even if it is empty. Please leave it empty."
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Category'
+          description: Successfully approved AI-curated entry in category
+        "403":
+          description: "User is not an owner of the entry, or the entry was not added\
+            \ to the category by AI"
+        "404":
+          description: Category or entry not found
+      security:
+      - BEARER: []
+      summary: Approve an AI-curated entry in a category.
+      tags:
+      - categories
   /categories/{id}:
     get:
       description: Retrieve a category by ID.


### PR DESCRIPTION
**Description**
In the new AI categorization feature, we intend to allow an entry owner to adjust their entry's membership in an AI-managed category, either by:
* approving it, in which case the curator is changed to "USER" and it is no longer marked as AI-curated, or
* removing it from the category.

This PR adds the endpoints that to enable said actions, and two new Event types to track them.

Later, the existing `addEntryToCollection` and `removeEntryFromCollection` endpoints may use those events to prevent the AI from adding an entry to a category that's previously been removed by the owner, and from removing an entry from a category that the owner has approved.

These endpoints/events follow one of the guiding principles of the collection/category design, which is that, behind the scenes, categories may be manipulated via the existing collection endpoints, but to the public, categories appear to be a distinct type of object, separate from collections, with their own set of endpoints.

**Review Instructions**
For one of your published entries, use the new endpoints and confirm that they appear to function as advertised.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7551

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
