### PR TITLE
add constraint for github app notifications

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/InferNotificationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/InferNotificationIT.java
@@ -101,6 +101,22 @@ class InferNotificationIT extends BaseIT {
     }
 
     @Test
+    void testDuplicateRepoOnInstallAndRelease() {
+        final ApiClient openApiClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowsApi = new WorkflowsApi(openApiClient);
+        CurationApi curationApi = new CurationApi(openApiClient);
+
+        // Simulate an install on a repo that does not contain a .dockstore.yml and has a small number of branches
+        // A notification should be created but not two
+        handleGitHubInstallation(workflowsApi, List.of("dockstore-testing/testWorkflow", "dockstore-testing/testWorkflow"), USER_2_USERNAME);
+        assertEquals(1, curationApi.getGitHubAppNotifications(0, 100).size());
+        assertThrows(ApiException.class, () -> {
+            handleGitHubRelease(workflowsApi, "dockstore-testing/testWorkflow", "refs/heads/master", USER_2_USERNAME);
+        });
+        assertEquals(1, curationApi.getGitHubAppNotifications(0, 100).size());
+    }
+
+    @Test
     void testNotificationsOnRelease() {
         final ApiClient openApiClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
         WorkflowsApi workflowsApi = new WorkflowsApi(openApiClient);

--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/InferNotificationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/InferNotificationIT.java
@@ -47,6 +47,7 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 class InferNotificationIT extends BaseIT {
 
     private static final String ROOTTEST = "rootTest";
+    public static final String DOCKSTORE_TESTING_TEST_WORKFLOW = "dockstore-testing/testWorkflow";
     private UserNotificationDAO userNotificationDAO;
     private Session session;
     private UserDAO userDAO;
@@ -96,7 +97,7 @@ class InferNotificationIT extends BaseIT {
 
         // Simulate an install on a repo that does not contain a .dockstore.yml and has a small number of branches
         // A notification should be created
-        handleGitHubInstallation(workflowsApi, List.of("dockstore-testing/testWorkflow"), USER_2_USERNAME);
+        handleGitHubInstallation(workflowsApi, List.of(DOCKSTORE_TESTING_TEST_WORKFLOW), USER_2_USERNAME);
         assertEquals(1, curationApi.getGitHubAppNotifications(0, 100).size());
     }
 
@@ -108,10 +109,12 @@ class InferNotificationIT extends BaseIT {
 
         // Simulate an install on a repo that does not contain a .dockstore.yml and has a small number of branches
         // A notification should be created but not two
-        handleGitHubInstallation(workflowsApi, List.of("dockstore-testing/testWorkflow", "dockstore-testing/testWorkflow"), USER_2_USERNAME);
+        // separately from this test, can confirm this endpoint returns with a 500 if there is a simultaneous github app notification created, when there is a constraint
+        handleGitHubInstallation(workflowsApi, List.of(DOCKSTORE_TESTING_TEST_WORKFLOW,  DOCKSTORE_TESTING_TEST_WORKFLOW), USER_2_USERNAME);
         assertEquals(1, curationApi.getGitHubAppNotifications(0, 100).size());
         assertThrows(ApiException.class, () -> {
-            handleGitHubRelease(workflowsApi, "dockstore-testing/testWorkflow", "refs/heads/master", USER_2_USERNAME);
+            // separately from this test, can confirm this endpoint returns with a 500 if there is a simultaneous github app notification created, when there is a constraint
+            handleGitHubRelease(workflowsApi, DOCKSTORE_TESTING_TEST_WORKFLOW, "refs/heads/master", USER_2_USERNAME);
         });
         assertEquals(1, curationApi.getGitHubAppNotifications(0, 100).size());
     }

--- a/dockstore-integration-testing/src/test/java/io/dockstore/webservice/GithubNotificationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/webservice/GithubNotificationIT.java
@@ -1,0 +1,112 @@
+/*
+ *    Copyright 2019 OICR
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.dockstore.webservice;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.dockstore.client.cli.BaseIT;
+import io.dockstore.client.cli.BaseIT.TestStatus;
+import io.dockstore.common.MuteForSuccessfulTests;
+import io.dockstore.common.SourceControl;
+import io.dockstore.webservice.core.GitHubAppNotification;
+import io.dockstore.webservice.core.User;
+import io.dockstore.webservice.core.UserNotification.Action;
+import io.dockstore.webservice.jdbi.GitHubAppNotificationDAO;
+import io.dockstore.webservice.jdbi.UserDAO;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.context.internal.ManagedSessionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.stream.SystemErr;
+import uk.org.webcompere.systemstubs.stream.SystemOut;
+
+/**
+ * @author dyuen
+ */
+@ExtendWith(SystemStubsExtension.class)
+@ExtendWith(MuteForSuccessfulTests.class)
+@ExtendWith(TestStatus.class)
+class GithubNotificationIT extends BaseIT {
+
+    public static final String FOO_ORG = "foo-org";
+    public static final String FOO_REPO = "foo-repo";
+    @SystemStub
+    public final SystemOut systemOut = new SystemOut();
+    @SystemStub
+    public final SystemErr systemErr = new SystemErr();
+
+    private GitHubAppNotificationDAO gitHubAppNotificationDAO;
+
+    private Session session;
+    private UserDAO userDAO;
+
+    @BeforeEach
+    public void setup() {
+        DockstoreWebserviceApplication application = SUPPORT.getApplication();
+        SessionFactory sessionFactory = application.getHibernate().getSessionFactory();
+
+        this.gitHubAppNotificationDAO = new GitHubAppNotificationDAO(sessionFactory);
+        this.userDAO = new UserDAO(sessionFactory);
+
+        // non-confidential test database sequences seem messed up and need to be iterated past, but other tests may depend on ids
+        testingPostgres.runUpdateStatement("alter sequence enduser_id_seq increment by 50 restart with 100");
+        testingPostgres.runUpdateStatement("alter sequence token_id_seq increment by 50 restart with 100");
+
+        // used to allow us to use DAO outside of the web service
+        this.session = application.getHibernate().getSessionFactory().openSession();
+        ManagedSessionContext.bind(session);
+    }
+
+    @Test
+    void checkNotificationGuard() {
+        CreateContent createContent = new CreateContent().invoke();
+        GitHubAppNotification latestByRepositoryAndUserIncludingHidden = gitHubAppNotificationDAO.findLatestByRepositoryAndUserIncludingHidden(SourceControl.GITHUB, FOO_ORG, FOO_REPO, userDAO.findById(1L));
+        assertNotNull(latestByRepositoryAndUserIncludingHidden);
+        session.close();
+    }
+
+
+    private class CreateContent {
+
+
+        CreateContent invoke() {
+            final Transaction transaction = session.beginTransaction();
+
+            GitHubAppNotification n1 = new GitHubAppNotification();
+            n1.setOrganization(FOO_ORG);
+            n1.setRepository(FOO_REPO);
+            n1.setSourceControl(SourceControl.GITHUB);
+            n1.setAction(Action.INFER_DOCKSTORE_YML);
+            n1.setHidden(false);
+
+            // add all users to all things for now
+            User user = userDAO.findById(1L);
+            n1.setUser(user);
+
+            long notification1ID = gitHubAppNotificationDAO.create(n1);
+
+
+            session.flush();
+            transaction.commit();
+            return this;
+        }
+    }
+}

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -1193,7 +1193,7 @@
                     <diffExcludeObjects>column:sha256</diffExcludeObjects>
                     <!-- something weird is going on, remove next line after issues at https://github.com/dockstore/dockstore/pull/6167#issuecomment-3330713937 are resolved
                      see also https://docs.liquibase.com/oss/integration-guide/diff -->
-		    <!-- <diffTypes>Tables, views, columns, foreignkeys</diffTypes> -->
+		    <diffTypes>Tables, views, columns, foreignkeys</diffTypes>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -1193,7 +1193,7 @@
                     <diffExcludeObjects>column:sha256</diffExcludeObjects>
                     <!-- something weird is going on, remove next line after issues at https://github.com/dockstore/dockstore/pull/6167#issuecomment-3330713937 are resolved
                      see also https://docs.liquibase.com/oss/integration-guide/diff -->
-					<diffTypes>Tables, views, columns, foreignkeys</diffTypes>
+                    <diffTypes>Tables, views, columns, foreignkeys</diffTypes>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -1193,7 +1193,7 @@
                     <diffExcludeObjects>column:sha256</diffExcludeObjects>
                     <!-- something weird is going on, remove next line after issues at https://github.com/dockstore/dockstore/pull/6167#issuecomment-3330713937 are resolved
                      see also https://docs.liquibase.com/oss/integration-guide/diff -->
-		    <diffTypes>Tables, views, columns, foreignkeys</diffTypes>
+					<diffTypes>Tables, views, columns, foreignkeys</diffTypes>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -1193,7 +1193,7 @@
                     <diffExcludeObjects>column:sha256</diffExcludeObjects>
                     <!-- something weird is going on, remove next line after issues at https://github.com/dockstore/dockstore/pull/6167#issuecomment-3330713937 are resolved
                      see also https://docs.liquibase.com/oss/integration-guide/diff -->
-                    <diffTypes>Tables, views, columns, foreignkeys</diffTypes>
+		    <!-- <diffTypes>Tables, views, columns, foreignkeys</diffTypes> -->
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/GitHubAppNotification.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/GitHubAppNotification.java
@@ -13,7 +13,7 @@ import jakarta.persistence.UniqueConstraint;
 
 @Schema(description = "Notifications for a GitHub App repository")
 @Entity
-@Table(name = "github_app_notification", uniqueConstraints = @UniqueConstraint(name = "unique_notifications", columnNames = { "organization", "repository", "sourcecontrol", "userid" }))
+@Table(name = "github_app_notification", uniqueConstraints = @UniqueConstraint(name = GitHubAppNotification.UNIQUE_NOTIFICATIONS, columnNames = { "organization", "repository", "sourcecontrol", "userid" }))
 @NamedQueries({
     @NamedQuery(
         name = "io.dockstore.webservice.core.GitHubAppNotification.getLatestByRepositoryAndUserIncludingHidden",
@@ -25,6 +25,7 @@ import jakarta.persistence.UniqueConstraint;
 })
 public class GitHubAppNotification extends UserNotification {
 
+    public static final String UNIQUE_NOTIFICATIONS = "unique_notifications";
     @Column(nullable = false, columnDefinition = "text")
     @Convert(converter = SourceControlConverter.class)
     @Schema(description = "The source control provider", requiredMode = RequiredMode.REQUIRED)

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/GitHubAppNotification.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/GitHubAppNotification.java
@@ -9,10 +9,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 @Schema(description = "Notifications for a GitHub App repository")
 @Entity
-@Table(name = "github_app_notification")
+@Table(name = "github_app_notification", uniqueConstraints = @UniqueConstraint(name = "unique_notifications", columnNames = { "organization", "repository", "sourcecontrol", "userid" }))
 @NamedQueries({
     @NamedQuery(
         name = "io.dockstore.webservice.core.GitHubAppNotification.getLatestByRepositoryAndUserIncludingHidden",

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/InstallationRepositoriesPayload.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/webhook/InstallationRepositoriesPayload.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 /**
  * A subset of fields available in a GitHub webhook installation_repositories payload. The fields in this class are fields that the webservice uses.
- * Add more fields as we need them. Fields are from https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#installation_repositories
+ * Add more fields as we need them. Fields are from <a href="https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#installation_repositories">here</a>
  */
 @Schema(description = "A model for a GitHub webhook installation event", allOf = Payload.class, exampleClasses = InstallationRepositoriesPayload.class)
 public class InstallationRepositoriesPayload extends Payload {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ExceptionHelper.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/helpers/ExceptionHelper.java
@@ -17,11 +17,14 @@
 
 package io.dockstore.webservice.helpers;
 
+import static io.dockstore.webservice.core.GitHubAppNotification.UNIQUE_NOTIFICATIONS;
+
 import io.dockstore.webservice.CustomWebApplicationException;
 import jakarta.persistence.PersistenceException;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.http.HttpStatus;
 import org.hibernate.exception.ConstraintViolationException;
@@ -108,6 +111,10 @@ public class ExceptionHelper {
 
     private Optional<Info> mapConstraintViolationException(ConstraintViolationException c) {
         String message = mapConstraintName(c.getConstraintName());
+        // override github app notification constraint violations to be retryable since this has been observed to occur during simultaneous requests
+        if (Objects.equals(c.getConstraintName(), UNIQUE_NOTIFICATIONS)) {
+            return result(message, HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        }
         return result(message, HttpStatus.SC_CONFLICT);
     }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/AbstractWorkflowResource.java
@@ -439,7 +439,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
     }
 
     /**
-     * Identify git references that may be worth trying to handle as a github apps release event
+     * Identify git references that may be worth trying to handle as a github apps release event since they have a .dockstore.yml
      * @param repository
      * @param installationId
      * @return
@@ -454,7 +454,7 @@ public abstract class AbstractWorkflowResource<T extends Workflow> implements So
 
     protected void notifyIfPotentiallyContainsEntries(Optional<User> user, String repositoryId, long installationId, List<String> importantBranches) {
         // If there's no user for which to create a notification, abort.
-        if (!user.isPresent()) {
+        if (user.isEmpty()) {
             return;
         }
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/WorkflowResource.java
@@ -2310,6 +2310,7 @@ public class WorkflowResource extends AbstractWorkflowResource<Workflow>
             for (String repository: repositories) {
                 final int maximumBranchCount = 5;
                 final List<String> importantBranches = identifyImportantBranches(repository, gitHubSourceCodeRepo);
+                // releaseable as in these have a dockstore.yml
                 final List<String> releasableReferences = identifyGitReferencesToRelease(repository, installationId, subList(importantBranches, maximumBranchCount));
                 if (releasableReferences.isEmpty()) {
                     boolean inspectedAllBranches = importantBranches.size() <= maximumBranchCount;

--- a/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
+++ b/dockstore-webservice/src/main/resources/migrations.1.20.0.xml
@@ -104,4 +104,11 @@
                                  referencedTableName="collection" referencedColumnNames="id"
                                  constraintName="fk_event_categoryid"/>
     </changeSet>
+    <changeSet author="dyuen" id="unique_notifications">
+        <sql>
+            DELETE FROM github_app_notification n1 USING github_app_notification n2
+                   WHERE n1.id  > n2.id AND n1.organization=n2.organization AND n1.repository=n2.repository AND n1.sourcecontrol = n2.sourcecontrol AND n1.userid=n2.userid;
+        </sql>
+        <addUniqueConstraint columnNames="organization, repository, sourcecontrol, userid" constraintName="unique_notifications" tableName="github_app_notification"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**Description**
Add constraint preventing duplicate notifications. I can confirm that there are duplicates in the DB (exactly 2 duplicates) . Was tricky to actually reproduce, but this gets at the core of the matter (i.e. there should not be duplicates) by adding a constraint.


After adding some tests, I've concluded that the existing guards should work in the case of sequential requests but I was able to reproduce when there are simultaneous requests. 
i.e. Request A and B start. Request A gets pass the check for previous notifications,thread switch to  request B which  also gets past, adds a notification, then A thread switched and resumes and also attempts to add a notification. 

I've also modified the return code for when this happens to a 500 so that the triggering lambda will retry at a later time (it normally stops with 400 series codes) , avoiding the conflict

**Review Instructions**
Can go into debug mode and add a github app notification while one of the new tests is running.
This is somewhat of an edge case and a pain to reproduce. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2634

**Security and Privacy**

None

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
