### PR TITLE
SEAB-7551: Do not allow AI to add an entry to a category if the owner has removed it

### DIFF
--- a/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIOrganizationIT.java
+++ b/dockstore-integration-testing/src/test/java/io/dockstore/client/cli/OpenAPIOrganizationIT.java
@@ -253,6 +253,47 @@ public class OpenAPIOrganizationIT extends BaseIT {
     }
 
     @Test
+    void testCannotReAddEntryAfterOwnerRemovesItFromCategory() {
+        final ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
+        OrganizationsApi organizationsApiAdmin = new OrganizationsApi(adminClient);
+        CategoriesApi categoriesApiAdmin = new CategoriesApi(adminClient);
+
+        Organization org = OrganizationIT.openApiStubOrgObject();
+        org.setCategorizer(true);
+        org = organizationsApiAdmin.createOrganization(org);
+        organizationsApiAdmin.approveOrganization(org.getId());
+        Collection category = organizationsApiAdmin.createCollection(OrganizationIT.openApiStubCollectionObject(), org.getId());
+        final long orgId = org.getId();
+        final long categoryId = category.getId();
+
+        final ApiClient userClient = getOpenAPIWebClient(USER_2_USERNAME, testingPostgres);
+        WorkflowsApi workflowsApi = new WorkflowsApi(userClient);
+        Workflow workflow = workflowsApi.manualRegister(SourceControl.GITHUB.name(), "dockstore-testing/viral-pipelines",
+                "/pipes/WDL/workflows/multi_sample_assemble_kraken.wdl", "", DescriptorLanguage.WDL.getShortName(), "");
+        workflowsApi.refresh1(workflow.getId(), false);
+        workflowsApi.publish1(workflow.getId(), CommonTestUtilities.createOpenAPIPublishRequest(true));
+        final long workflowId = workflow.getId();
+
+        // AI curates the entry into the category
+        organizationsApiAdmin.addEntryToCollection(orgId, categoryId, workflowId, null, "AI", null);
+
+        // Owner of the entry removes it from the category, generating a REMOVE_FROM_CATEGORY event
+        CategoriesApi categoriesApiUser2 = new CategoriesApi(userClient);
+        categoriesApiUser2.removeAiCuratedEntryFromCategory(categoryId, workflowId);
+        assertTrue(categoriesApiAdmin.getCategoryById(categoryId).getEntries().isEmpty());
+
+        // Re-adding the entry to the same category via AI curation should now be forbidden
+        ApiException aiReAddEx = assertThrows(ApiException.class, () ->
+                organizationsApiAdmin.addEntryToCollection(orgId, categoryId, workflowId, null, "AI", null));
+        assertEquals(HttpStatus.SC_FORBIDDEN, aiReAddEx.getCode());
+        assertTrue(categoriesApiAdmin.getCategoryById(categoryId).getEntries().isEmpty());
+
+        // Re-adding the entry with a non-AI curator (e.g. a human/DOCKSTORE curator) is still allowed
+        organizationsApiAdmin.addEntryToCollection(orgId, categoryId, workflowId, null, "USER", null);
+        assertEquals(1, categoriesApiAdmin.getCategoryById(categoryId).getEntries().size());
+    }
+
+    @Test
     void testApproveAiCuratedEntryInCategory() {
         final ApiClient adminClient = getOpenAPIWebClient(ADMIN_USERNAME, testingPostgres);
         OrganizationsApi organizationsApiAdmin = new OrganizationsApi(adminClient);

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
@@ -68,19 +68,20 @@ public class EventDAO extends AbstractDAO<Event> {
         return findEvents(loggedInUser, entryPredicateBuilder(entryIds), offset, limit);
     }
 
-    public boolean existsRemoveFromCategoryEvent(long entryId, long categoryId) {
+    public Optional<Event> findLatestApproveOrRemoveFromCategoryEvent(long entryId, long categoryId) {
         CriteriaBuilder cb = currentSession().getCriteriaBuilder();
-        CriteriaQuery<Long> query = cb.createQuery(Long.class);
+        CriteriaQuery<Event> query = cb.createQuery(Event.class);
         Root<Event> event = query.from(Event.class);
 
         Predicate entryPredicate = entryPredicateBuilder(Set.of(entryId)).build(cb, event);
         Predicate categoryPredicate = cb.equal(event.get("category").get("id"), categoryId);
-        Predicate typePredicate = cb.equal(event.get("type"), EventType.REMOVE_FROM_CATEGORY);
+        Predicate typePredicate = event.get("type").in(Set.of(EventType.APPROVE_IN_CATEGORY, EventType.REMOVE_FROM_CATEGORY));
 
-        query.select(event.get("id"));
+        query.select(event);
         query.where(cb.and(entryPredicate, categoryPredicate, typePredicate));
+        query.orderBy(cb.desc(event.get("id")));
 
-        return !currentSession().createQuery(query).setMaxResults(1).getResultList().isEmpty();
+        return currentSession().createQuery(query).setMaxResults(1).uniqueResultOptional();
     }
 
     public List<Event> findAllByOrganizationIds(User loggedInUser, Set<Long> organizationIds, Integer offset, int limit) {

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/jdbi/EventDAO.java
@@ -68,6 +68,21 @@ public class EventDAO extends AbstractDAO<Event> {
         return findEvents(loggedInUser, entryPredicateBuilder(entryIds), offset, limit);
     }
 
+    public boolean existsRemoveFromCategoryEvent(long entryId, long categoryId) {
+        CriteriaBuilder cb = currentSession().getCriteriaBuilder();
+        CriteriaQuery<Long> query = cb.createQuery(Long.class);
+        Root<Event> event = query.from(Event.class);
+
+        Predicate entryPredicate = entryPredicateBuilder(Set.of(entryId)).build(cb, event);
+        Predicate categoryPredicate = cb.equal(event.get("category").get("id"), categoryId);
+        Predicate typePredicate = cb.equal(event.get("type"), EventType.REMOVE_FROM_CATEGORY);
+
+        query.select(event.get("id"));
+        query.where(cb.and(entryPredicate, categoryPredicate, typePredicate));
+
+        return !currentSession().createQuery(query).setMaxResults(1).getResultList().isEmpty();
+    }
+
     public List<Event> findAllByOrganizationIds(User loggedInUser, Set<Long> organizationIds, Integer offset, int limit) {
         return findEvents(loggedInUser, organizationPredicateBuilder(organizationIds), offset, limit);
     }

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -258,11 +258,13 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
         if (curator != EntryVersion.Curator.USER && !(user.isCurator() || user.getIsAdmin())) {
             throw new CustomWebApplicationException("Only curators and admins can add entries with a non-USER curator value.", HttpStatus.SC_UNAUTHORIZED);
         }
-        // If the AI is adding the entry to a category, and the entry owner has previously removed the entry from the category, we should not add it again.
-        // Check for a corresponding REMOVE_FROM_CATEGORY event, and throw if it exists.
-        if (curator == EntryVersion.Curator.AI && entryAndCollection.getRight() instanceof Category
-            && eventDAO.existsRemoveFromCategoryEvent(entryAndCollection.getLeft().getId(), entryAndCollection.getRight().getId())) {
-            throw new CustomWebApplicationException("This entry was previously removed from the category by its owner and cannot be re-added by AI curation.", HttpStatus.SC_FORBIDDEN);
+        // If the AI is adding the entry to a category, check the most recent APPROVE_IN_CATEGORY/REMOVE_FROM_CATEGORY event for the entry and category.
+        // If the entry owner most recently removed the entry from the category, we should not let the AI add it again.
+        if (curator == EntryVersion.Curator.AI && entryAndCollection.getRight() instanceof Category) {
+            Optional<Event> latestEvent = eventDAO.findLatestApproveOrRemoveFromCategoryEvent(entryAndCollection.getLeft().getId(), entryAndCollection.getRight().getId());
+            if (latestEvent.isPresent() && latestEvent.get().getType() == Event.EventType.REMOVE_FROM_CATEGORY) {
+                throw new CustomWebApplicationException("This entry was previously removed from the category by its owner and cannot be re-added by AI curation.", HttpStatus.SC_FORBIDDEN);
+            }
         }
 
         // Add the entry (and version, if specified) to the collection

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -258,11 +258,11 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
         if (curator != EntryVersion.Curator.USER && !(user.isCurator() || user.getIsAdmin())) {
             throw new CustomWebApplicationException("Only curators and admins can add entries with a non-USER curator value.", HttpStatus.SC_UNAUTHORIZED);
         }
-        // If we're attempting to add the entry to a category, and a user has previously removed the entry from the category, we should not add it again.
+        // If the AI is adding the entry to a category, and the entry owner has previously removed the entry from the category, we should not add it again.
         // Check for a corresponding REMOVE_FROM_CATEGORY event, and throw if it exists.
-        if (entryAndCollection.getRight() instanceof Category
+        if (curator == EntryVersion.Curator.AI && entryAndCollection.getRight() instanceof Category
             && eventDAO.existsRemoveFromCategoryEvent(entryAndCollection.getLeft().getId(), entryAndCollection.getRight().getId())) {
-            throw new CustomWebApplicationException("This entry was previously removed from the category by its owner and cannot be re-added.", HttpStatus.SC_FORBIDDEN);
+            throw new CustomWebApplicationException("This entry was previously removed from the category by its owner and cannot be re-added by AI curation.", HttpStatus.SC_FORBIDDEN);
         }
 
         // Add the entry (and version, if specified) to the collection

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/CollectionResource.java
@@ -258,6 +258,13 @@ public class CollectionResource implements AuthenticatedResourceInterface, Alias
         if (curator != EntryVersion.Curator.USER && !(user.isCurator() || user.getIsAdmin())) {
             throw new CustomWebApplicationException("Only curators and admins can add entries with a non-USER curator value.", HttpStatus.SC_UNAUTHORIZED);
         }
+        // If we're attempting to add the entry to a category, and a user has previously removed the entry from the category, we should not add it again.
+        // Check for a corresponding REMOVE_FROM_CATEGORY event, and throw if it exists.
+        if (entryAndCollection.getRight() instanceof Category
+            && eventDAO.existsRemoveFromCategoryEvent(entryAndCollection.getLeft().getId(), entryAndCollection.getRight().getId())) {
+            throw new CustomWebApplicationException("This entry was previously removed from the category by its owner and cannot be re-added.", HttpStatus.SC_FORBIDDEN);
+        }
+
         // Add the entry (and version, if specified) to the collection
         if (versionId == null) {
             // Add the entry to the collection


### PR DESCRIPTION
**Description**
This PR changes the `addEntryToCollection` endpoint so that, when the AI attempts to add an entry to a category, if the owner has previously removed the entry from the category, the entry is not added again, and the endpoint responds with a `FORBIDDEN` error.

The underlying mechanism retrieves the latest `APPROVE_IN_COLLECTION` or `REMOVE_FROM_COLLECTION` event corresponding to the entry and category.  These are created when the owner approves/removes using the "Manage Categories" dialog.  If the latest event exists and is of type `REMOVE_FROM_COLLECTION`, the addition is rejected.

Side note: Most of the columns of the `event` table are not indexed.  We should probably index each of them, performance will improve and I can't think of any significant drawbacks.  Let's do it in a separate PR, though.

**Review Instructions**
1. Use the categorizer to add one of your entries to an AI-curated category.
2. On the private entry page, use the "Manage Categories" button/dialog to remove the entry from the category.
3. Use the categorizer to add the entry to the category, and confirm that it cannot.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7551

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
