### PR TITLE
Handle null values in RSS output

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/rss/RSSWriter.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/resources/rss/RSSWriter.java
@@ -74,7 +74,7 @@ public final class RSSWriter {
         StartElement sElement = eventFactory.createStartElement("", "", name);
         eventWriter.add(sElement);
 
-        Characters characters = eventFactory.createCharacters(value);
+        Characters characters = eventFactory.createCharacters(value == null ? "" : value);
         eventWriter.add(characters);
 
         EndElement eElement = eventFactory.createEndElement("", "", name);


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/61006461.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Render absent RSS text values as empty strings so XML generation does not fail when optional data is null.

<!-- Include the Testing section only when a relevant test exists and was run. Otherwise remove this comment and the entire section below. -->
## Review instructions

Review the null-to-empty normalization in RSSWriter. No user data, access control, encryption, dependency, or endpoint behavior is changed.

## Security and privacy

- [x] Security and privacy assessed; no security- or privacy-sensitive behavior is affected.
