### PR TITLE
add null check

### DIFF
--- a/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
+++ b/dockstore-webservice/src/main/java/io/openapi/api/impl/ToolsApiServiceImpl.java
@@ -892,7 +892,7 @@ public class ToolsApiServiceImpl extends ToolsApiService implements Authenticate
         // check for incompatible format option and header combination
         boolean zipFormat = "zip".equalsIgnoreCase(format);
         boolean jsonOnly = value.getAcceptableMediaTypes().stream().allMatch(mediaType -> mediaType.equals(MediaType.APPLICATION_JSON_TYPE));
-        if (zipFormat && jsonOnly) {
+        if ((zipFormat && jsonOnly) || type == null) {
             return Response.status(Status.BAD_REQUEST).build();
         }
 


### PR DESCRIPTION
**Description**
Add null check. The puzzling thing is that I was unable to reproduce this in a local test although the URL in prod clearly 500s. The IDE also complains that the library code (generated webservice) does not match  what is displayed but is unable to  fix, so there may be some funny business about. 

Nonetheless, the simple bull check seems harmless if it passes tests.

**Review Instructions**
Should be sufficient to try accessing a URL like https://dockstore.org/api/api/ga4gh/v2/tools/%23workflow%2Fgithub.com%2Fiwc-workflows%2Fsars-cov-2-pe-illumina-artic-variant-calling%2FCOVID-19-PE-ARTIC-ILLUMINA/versions/main/PLAIN_GXFORMAT2/files after deployment

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7725

**Security and Privacy**

None

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
