### PR TITLE
Align Jetty session dependency for #6324

### DIFF
--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -1106,6 +1106,11 @@ POM as their parent.
                 <version>${jetty-servlet.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-session</artifactId>
+                <version>${jetty-servlet.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.eclipse.jetty.ee10</groupId>
                 <artifactId>jetty-ee10-servlet</artifactId>
                 <version>${jetty-servlet.version}</version>


### PR DESCRIPTION
**Description**

Completes #6324 by managing `org.eclipse.jetty:jetty-session` at the existing
`${jetty-servlet.version}`. The Jetty Security patch update otherwise leaves
the session artifact out of alignment and fails dependency convergence.

**Review Instructions**

This is internal BOM alignment only; there is no user-facing behavior change.
Review the added dependency-management entry and the clean verification result.

**Issue**

#6324

**Security and Privacy**

- [x] Security and Privacy assessed; no data handling, access control,
  authentication, authorization, encryption, endpoint, or cookie behavior is
  changed.

Verification (JAIPilot Remote, JDK 21):

- `./mvnw -pl dockstore-common -am clean verify` — passed, including dependency
  analysis and SpotBugs (0 bugs)
- `git diff --check` — passed

- [ ] Check that you pass the basic style checks and unit tests by running `mvn clean install`
  (the narrower clean verify command above passed)
- [x] Ensure that the PR targets the correct branch: the #6324 Dependabot branch
- [ ] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities (awaiting repository CI)

Development assistance: prepared in Codex with the maintainer-intent,
fast-execution, remote-Java, and diff-review skills from
[JAIPilot](https://github.com/JAIPilot/jaipilot). The exact source was executed
in a disposable remote workspace that was destroyed after verification. Execution profile:
`gpt-5.6-sol · xhigh · fast`.
