### PR TITLE
update postges to 16.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ parameters:
     default: "21.0.9"
   postgres-tag:
     type: string
-    default: "16.9"
+    default: "16.15"
 orbs:
   aws-s3: circleci/aws-s3@3.0.0
 executors:

--- a/.github/workflows/deploy_artifacts.yml
+++ b/.github/workflows/deploy_artifacts.yml
@@ -34,7 +34,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres:16.9
+        image: postgres:16.15
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: dockstore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     # networks:
       # - elastic
   postgres_db:
-    image: postgres:16.9
+    image: postgres:16.15
     command: postgres -c jit=off -c default_toast_compression=lz4
     container_name: postgres1
     environment:


### PR DESCRIPTION
**Description**
Another iteration of https://github.com/dockstore/dockstore/pull/6133
This time we're on 16.9 which will reach the end of support on October 31, we will be forcibly upgraded to 16.13 .
We may was well get ahead and upgrade/test with 16.15 which will be supported till September 2027. 


**Review Instructions**
Check that Dockstore builds and runs as usual. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7751
See also https://github.com/dockstore/dockstore-deploy/pull/914

**Security and Privacy**

None

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
