### PR TITLE
SEAB-5761: Improve efficiency of Version-related database queries

### DIFF
--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/EntryMetadata.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/EntryMetadata.java
@@ -18,6 +18,7 @@ package io.dockstore.webservice.core;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapsId;
@@ -41,7 +42,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 public class EntryMetadata {
 
     @MapsId
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id")
     protected Entry<?, ?> parent;
 

--- a/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
+++ b/dockstore-webservice/src/main/java/io/dockstore/webservice/core/VersionMetadata.java
@@ -46,7 +46,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.UpdateTimestamp;
 
 /**
@@ -60,7 +63,10 @@ import org.hibernate.annotations.UpdateTimestamp;
  */
 @Entity
 @Table(name = "version_metadata")
+@BatchSize(size = VersionMetadata.BATCH_SIZE)
 public class VersionMetadata {
+
+    public static final int BATCH_SIZE = 25;
 
     private static final String PUBLIC_ACCESSIBLE_DESCRIPTION = "Whether the version has everything needed to run without restricted access permissions";
 
@@ -85,6 +91,8 @@ public class VersionMetadata {
     @MapKeyEnumerated(EnumType.STRING)
     @Size(max = MAX_NUMBER_OF_DOI_INITIATORS)
     @Schema(description = "The DOIs for the version of the entry")
+    @Fetch(FetchMode.SELECT)
+    @BatchSize(size = BATCH_SIZE)
     protected Map<DoiInitiator, Doi> dois = new HashMap<>();
 
     @Column()
@@ -105,7 +113,7 @@ public class VersionMetadata {
     protected DescriptionSource descriptionSource;
 
     @MapsId
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id")
     protected Version parent;
 
@@ -115,6 +123,8 @@ public class VersionMetadata {
             name = "PARSED_INFORMATION",
             joinColumns = @JoinColumn(name = "VERSION_METADATA_ID")
     )
+    @Fetch(FetchMode.SELECT)
+    @BatchSize(size = BATCH_SIZE)
     protected List<ParsedInformation> parsedInformationSet = new ArrayList<>();
 
     @ElementCollection(targetClass = OrcidPutCode.class, fetch = FetchType.EAGER)
@@ -123,6 +133,8 @@ public class VersionMetadata {
     @MapKeyColumn(name = "userid", columnDefinition = "bigint")
     @ApiModelProperty(value = "The presence of the put code for a userid indicates the version was exported to ORCID for the corresponding Dockstore user.")
     @Schema(description = "The presence of the put code for a userid indicates the version was exported to ORCID for the corresponding Dockstore user.")
+    @Fetch(FetchMode.SELECT)
+    @BatchSize(size = BATCH_SIZE)
     protected Map<Long, OrcidPutCode> userIdToOrcidPutCode = new HashMap<>();
 
     @Id


### PR DESCRIPTION
**Description**
This PR improves the performance of Version-related database queries by adding/modifying some Hibernate entity annotations, making the entry and version retrieval endpoints respond signficantly faster.  After this change, the UI entry pages for entries with many versions feel much snappier, and IMHO, this is all we need to do regarding https://ucsc-cgl.atlassian.net/browse/SEAB-5761 at the moment.

The main performance issue was a series of large joins that Hibernate was using to retrieve entry versions.  These retrieved core version data plus orcidputcodes, dois, and other stuff, at the same time, which made them slow.

In this PR, we set `FetchMode.SELECT` on some Version collections, thus converting the formentioned join to a much faster set of initial queries, followed up with some efficient SELECTs to fill in the orcidputcodes, dois, etc.

We also set `FetchType.LAZY` on the `parent` relationship in `VersionMetadata` and `EntryMetadata`, which supposedly helps the Hibernate query planner sometimes.

Previously, on my local install, the following request:

```
http://localhost:4200/api/workflows/path/workflow/github.com%2Fbroadinstitute%2Fwarp%2FOptimus/published?include=validations%2Cauthors%2Cmetrics&subclass=BIOWORKFLOW&versionName=Optimus_v5.4.3
```

took 1.3 seconds to respond, now it runs in 0.17 seconds.  The big joins appeared to disrupt the performance of other simultaneously-executing queries, so the effect when loading the entry page in the Dockstore UI is even larger.

The paged version table requests also run about 4x faster.

**Review Instructions**
Confirm that the entry page load and version tables feel less laggy, and that the related parts of the UI seem to be functioning properly.  There is the off chance that these changes introduce some sort of performance regression elsewhere, so keep an eye out for that...

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5761

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here and check the box when complete. 

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
