### PR TITLE
Narrow liquibase diff to foreignkeys only as workaround for dropwizard 5

### DIFF
--- a/dockstore-webservice/pom.xml
+++ b/dockstore-webservice/pom.xml
@@ -1177,7 +1177,7 @@
                 -->
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                <version>4.30.0</version>
+                <version>5.0.4</version>
                 <configuration>
                     <driver>org.postgresql.Driver</driver>
                     <referenceDriver>org.postgresql.Driver</referenceDriver>
@@ -1192,8 +1192,8 @@
                     <diffChangeLogFile>target/detected-migrations.xml</diffChangeLogFile>
                     <diffExcludeObjects>column:sha256</diffExcludeObjects>
                     <!-- something weird is going on, remove next line after issues at https://github.com/dockstore/dockstore/pull/6167#issuecomment-3330713937 are resolved
-                     see also https://docs.liquibase.com/oss/integration-guide/diff -->
-                    <diffTypes>Tables, views, columns, foreignkeys</diffTypes>
+                         see also https://docs.liquibase.com/oss/integration-guide/diff -->
+                    <diffTypes>foreignkeys</diffTypes>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
**Description**
Under Dropwizard 5, comparing tables/views/columns via liquibase-hibernate produces spurious diffs — this is a known upstream issue ([liquibase-hibernate#799](https://github.com/liquibase/liquibase-hibernate/issues/799), [liquibase#7137](https://github.com/liquibase/liquibase/issues/7137)). This PR bumps `liquibase-maven-plugin` from 4.30.0 to 5.0.4 and restricts `diffTypes` to `foreignkeys` only, so `mvn liquibase:diff` stops flagging false positives. 

Basically, I think we can re-enable tables and views as not being excluded. Running `propose_migrations.sh` works right now with no issues, enabling foreign keys causes issues. 

**Review Instructions**
Infrastructure/build-tooling change with no runtime effect on the deployed service — run `mvn liquibase:diff` locally against a target with a real schema drift to confirm foreign-key changes are still detected while unrelated column/table noise is gone.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7324

**Security and Privacy**

- [x] Security and Privacy assessed

This change only affects the local `liquibase:diff` Maven goal used during migration authoring; it does not touch runtime code, data access, or user-facing behavior.

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)