### PR TITLE
Override jline to 3.30.17 to fix SEAB-7754 CVEs

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -244,7 +244,7 @@ Lists of 349 third-party dependencies.
      (Apache License, Version 2.0) JJWT :: API (io.jsonwebtoken:jjwt-api:0.11.5 - https://github.com/jwtk/jjwt/jjwt-api)
      (Apache License, Version 2.0) JJWT :: Extensions :: Jackson (io.jsonwebtoken:jjwt-jackson:0.11.5 - https://github.com/jwtk/jjwt/jjwt-jackson)
      (Apache License, Version 2.0) JJWT :: Impl (io.jsonwebtoken:jjwt-impl:0.11.5 - https://github.com/jwtk/jjwt/jjwt-impl)
-     (The BSD License) JLine Bundle (org.jline:jline:3.21.0 - http://nexus.sonatype.org/oss-repository-hosting.html/jline-parent/jline)
+     (The BSD License) JLine Bundle (org.jline:jline:3.30.17 - https://github.com/jline/jline3/jline)
      (Apache License, Version 2.0) Joda-Time (joda-time:joda-time:2.12.5 - https://www.joda.org/joda-time/)
      (Public Domain) JSON in Java (org.json:json:20231013 - https://github.com/douglascrockford/JSON-java)
      (The MIT License) jsoup Java HTML Parser (org.jsoup:jsoup:1.23.1 - https://jsoup.org/)

--- a/bom-internal/pom.xml
+++ b/bom-internal/pom.xml
@@ -897,6 +897,13 @@ POM as their parent.
                 <artifactId>scala-compiler</artifactId>
                 <version>${scala.version}</version>
             </dependency>
+            <!-- SEAB-7754: pulled in transitively via scala-compiler; override to fix
+                 GHSA-47qp-hqvx-6r3f and GHSA-2r2c-cx56-8933 (fixed in 3.30.14+) -->
+            <dependency>
+                <groupId>org.jline</groupId>
+                <artifactId>jline</artifactId>
+                <version>3.30.17</version>
+            </dependency>
             <dependency>
                 <groupId>org.scalacheck</groupId>
                 <artifactId>scalacheck_2.12</artifactId>


### PR DESCRIPTION
**Description**
`org.jline:jline` is pulled into the build transitively (via `cromwell-wom` -> `refined` -> `scala-compiler`) at version 3.21.0. This version is affected by two Telnet-module denial-of-service vulnerabilities flagged during the 2026-08 monthly Quay.io/dockstore-support CVE review:
- [GHSA-47qp-hqvx-6r3f](https://github.com/jline/jline3/security/advisories/GHSA-47qp-hqvx-6r3f) — unbounded HashMap of Telnet NEW-ENVIRON variables can exhaust JVM heap
- [GHSA-2r2c-cx56-8933](https://github.com/jline/jline3/security/advisories/GHSA-2r2c-cx56-8933) — alternating large Telnet NAWS terminal-size values trigger expensive rendering loops, exhausting CPU

Both are fixed upstream in jline 3.30.14+. This PR adds a `dependencyManagement` override in `bom-internal/pom.xml` pinning `org.jline:jline` to `3.30.17` (the latest 3.30.x patch release), and regenerates `THIRD-PARTY-LICENSES.txt` accordingly. No application code calls jline directly, so no other changes were needed. Verified via `mvn dependency:tree` that 3.30.17 now resolves everywhere jline is pulled in, and did a full `./mvnw clean install` (unit-tests profile) build from the root, which passed.

**Review Instructions**
This is a dependency-version-only fix for CVEs surfaced by Quay.io scanning; no user-visible behavior changes. Should not need functional QA — the Snyk/Quay scan status on this PR (or a subsequent scan) should confirm the CVEs are no longer flagged. A full build (`mvn clean install`) passing is sufficient review.

**Issue**
SEAB-7754

**Security and Privacy**

No concerns, straight upgrade

- [x] Security and Privacy assessed

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)